### PR TITLE
refactor(signer-dmz): update CLI URL and port configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,8 +47,9 @@ DATABASE_URL=postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neond
 # Only PymtHouse-issued short-lived tokens reach go-livepeer; /status and /healthz
 # stay open for health. Match SIGNER_DMZ_HOST_PORT in docker-compose (default 8080).
 SIGNER_INTERNAL_URL=http://localhost:8080
-# Dedicated Apache CLI listener (admin scope). Separate host port so it can be
-# firewalled / monitored independently of the HTTP signer.
+# Apache CLI admin endpoint (admin scope): path-mounted on the same host/port as
+# the signer HTTP API (SIGNER_CLI_URL default path /__signer_cli). Restrict with
+# path- or host-level firewall and monitoring—not a separate listener port.
 SIGNER_CLI_URL=http://localhost:8080/__signer_cli
 # Optional: JWKS URL for signer-dmz (defaults: same issuer as NEXTAUTH_URL, host
 # rewritten to host.docker.internal inside the container). jwks_to_pem allows

--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,7 @@ DATABASE_URL=postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neond
 SIGNER_INTERNAL_URL=http://localhost:8080
 # Dedicated Apache CLI listener (admin scope). Separate host port so it can be
 # firewalled / monitored independently of the HTTP signer.
-SIGNER_CLI_URL=http://localhost:8082
+SIGNER_CLI_URL=http://localhost:8080/__signer_cli
 # Optional: JWKS URL for signer-dmz (defaults: same issuer as NEXTAUTH_URL, host
 # rewritten to host.docker.internal inside the container). jwks_to_pem allows
 # https anywhere, or http only for localhost / 127.0.0.1 / host.docker.internal.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     image: pymthouse/signer-dmz:local
     ports:
       - "127.0.0.1:${SIGNER_DMZ_HOST_PORT:-8080}:8080"
-      - "127.0.0.1:${SIGNER_CLI_HOST_PORT:-8082}:8082"
     volumes:
       - ./data:/data
     environment:

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -36,7 +36,7 @@ The image listens on **`$PORT`** (Apache HTTP + `/__signer_cli`, `/healthz`, pro
    You can use **one** public URL on **`PORT`** only: Apache already proxies **`/__signer_cli/`** on that same listener (see `apache/signer-dmz.conf.in`). Alternatively, expose **`CLI_PORT` (8082)** with a second hostname if you want the dedicated CLI vhost.
 
 3. **`/__signer_cli` and PymtHouse — not automatic**  
-   Apache serves **`https://<your-dmz-host>/__signer_cli`** on the **same** port as **`SIGNER_INTERNAL_URL`** (no extra path needed in `SIGNER_INTERNAL_URL`). The Next app **does not** infer that URL: **`getSignerCliUrl()`** uses **`SIGNER_CLI_URL`** if set, otherwise defaults to **`http://127.0.0.1:8082`** (local compose’s separate CLI port). For Railway single-port DMZ, set explicitly, for example:  
+   Apache serves **`https://<your-dmz-host>/__signer_cli`** on the **same** port as **`SIGNER_INTERNAL_URL`** (no extra path needed in `SIGNER_INTERNAL_URL`). The Next app **does not** infer that URL: **`getSignerCliUrl()`** uses **`SIGNER_CLI_URL`** if set, otherwise defaults to **`http://127.0.0.1:8080/__signer_cli`** (local compose’s single published port). For Railway single-port DMZ, set explicitly, for example:  
    `SIGNER_INTERNAL_URL=https://your-service.up.railway.app`  
    `SIGNER_CLI_URL=https://your-service.up.railway.app/__signer_cli`  
    (no trailing slash on `SIGNER_CLI_URL`.)

--- a/docker/signer-dmz/entrypoint.sh
+++ b/docker/signer-dmz/entrypoint.sh
@@ -3,7 +3,7 @@ set -eu
 
 export PORT="${PORT:-8080}"
 # Dedicated Apache listener that proxies only to livepeer CLI (admin scope).
-# In-container port; host maps it via compose (SIGNER_CLI_HOST_PORT).
+# In-container dedicated CLI vhost (optional second listener; local compose uses /__signer_cli on PORT only).
 export CLI_PORT="${CLI_PORT:-8082}"
 export SIGNER_PORT="${SIGNER_PORT:-8081}"
 # Align Apache iss/aud with DMZ JWTs from this app (getIssuer). Pass NEXTAUTH_URL

--- a/src/app/api/v1/signer/control/route.ts
+++ b/src/app/api/v1/signer/control/route.ts
@@ -192,8 +192,6 @@ function getComposeCommand(action: string): string {
   }
 }
 
-const DEFAULT_SIGNER_CLI_HOST_PORT = 8082;
-
 function buildSignerComposeEnv(
   signer:
     | {
@@ -209,9 +207,6 @@ function buildSignerComposeEnv(
 ): NodeJS.ProcessEnv {
   const rd = signer?.remoteDiscovery === 1;
   const dmzHostPort = resolveDmzHostPort(signer?.signerPort);
-  const cliHostPort = Number(
-    process.env.SIGNER_CLI_HOST_PORT || DEFAULT_SIGNER_CLI_HOST_PORT,
-  );
   // Apache iss/aud must match issueSignerDmzToken (getIssuer); JWKS must be the
   // same key material (local oidc:seed), reachable from Docker via host.docker.internal.
   const issuer = getIssuer();
@@ -222,7 +217,6 @@ function buildSignerComposeEnv(
     ETH_RPC_URL: signer?.ethRpcUrl ?? "",
     SIGNER_ETH_ADDR: signer?.ethAcctAddr || "",
     SIGNER_DMZ_HOST_PORT: String(dmzHostPort),
-    SIGNER_CLI_HOST_PORT: String(cliHostPort),
     SIGNER_REMOTE_DISCOVERY: rd ? "1" : "0",
     ORCH_WEBHOOK_URL: rd && signer?.orchWebhookUrl ? signer.orchWebhookUrl : "",
     LIVE_AI_CAP_REPORT_INTERVAL:

--- a/src/lib/signer-cli.ts
+++ b/src/lib/signer-cli.ts
@@ -6,18 +6,17 @@
  * This is the same port that livepeer_cli connects to.
  * Must only be called server-side; the port is bound to 127.0.0.1 on the host.
  *
- * When the signer sits behind the Apache DMZ, set SIGNER_CLI_URL to the public
- * base of its **dedicated admin listener** (e.g. http://localhost:8082). The
- * DMZ also exposes the CLI under /__signer_cli on the HTTP port as a fallback
- * for single-port deployments. The server mints a short-lived JWT with admin
- * scope for these requests.
+ * When the signer sits behind the Apache DMZ, set SIGNER_CLI_URL to the CLI base
+ * URL — typically the DMZ origin plus `/__signer_cli` (e.g. http://localhost:8080/__signer_cli).
+ * Alternatively, a dedicated admin listener on a second port is supported. The server
+ * mints a short-lived JWT with admin scope for these requests.
  */
 
 import { issueSignerDmzToken } from "@/lib/signer-dmz-token";
 
 export function getSignerCliUrl(): string {
   if (process.env.SIGNER_CLI_URL) return process.env.SIGNER_CLI_URL;
-  return "http://127.0.0.1:8082";
+  return "http://127.0.0.1:8080/__signer_cli";
 }
 
 let cliDmzTokenCache: { token: string; expMs: number } | null = null;


### PR DESCRIPTION
- Modified the `SIGNER_CLI_URL` in `.env.example` to reflect the new path for the CLI listener.
- Removed the deprecated CLI host port mapping from `docker-compose.yml`.
- Updated the `entrypoint.sh` script to clarify the purpose of the CLI port.
- Cleaned up the `route.ts` file by removing unused constants related to the old CLI port configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated signer CLI onto a single, path-mounted endpoint and removed redundant local port exposure.
  * Simplified local deployment defaults so the app falls back to the unified CLI path when an explicit URL is not set.

* **Documentation**
  * Updated deployment and local setup guidance to reflect the single-port, path-mounted CLI access pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->