### PR TITLE
Bump remote signer go-livepeer build (CI artifact 0a1919e0)

### DIFF
--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -118,13 +118,14 @@ FROM gateway AS signer-dmz
 
 USER root
 
-# Verify the release asset against a known-good sha256 before extraction.
-# If upstream rotates/repacks the asset, the build fails closed rather than silently pulling new bytes.
-ARG LIVEPEER_VERSION=0.8.10
-ARG LIVEPEER_SHA256=febc11b0a8951b44539f978b24e2ea85adf650b1eafe7c213f3eac7cec1043d5
+# CI-built linux-amd64 tarball mirrored at build.livepeer.live (same bytes as GitHub Actions artifacts).
+# Source artifact: https://github.com/livepeer/go-livepeer/actions/runs/25226599716/artifacts/6796975695
+# Node reports: Livepeer Node Version 0.8.10-0a1919e0
+ARG LIVEPEER_COMMIT=0a1919e0c58986375df158433445563a45a04df8
+ARG LIVEPEER_SHA256=0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget && \
-    wget -q "https://github.com/livepeer/go-livepeer/releases/download/v${LIVEPEER_VERSION}/livepeer-linux-amd64.tar.gz" && \
+    wget -q "https://build.livepeer.live/go-livepeer/${LIVEPEER_COMMIT}/livepeer-linux-amd64.tar.gz" -O livepeer-linux-amd64.tar.gz && \
     echo "${LIVEPEER_SHA256}  livepeer-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzf livepeer-linux-amd64.tar.gz && \
     mv livepeer-linux-amd64/livepeer /usr/local/bin/livepeer && \

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -11,8 +11,13 @@ RUN apt-get update && \
     ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# CI build (0.8.10-0a1919e0); mirrored from the same upload pipeline as GitHub Actions artifacts.
+ARG LIVEPEER_COMMIT=0a1919e0c58986375df158433445563a45a04df8
+ARG LIVEPEER_SHA256=0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade
+
 # Download and extract livepeer binary
-RUN wget -q https://github.com/livepeer/go-livepeer/releases/download/v0.8.10/livepeer-linux-amd64.tar.gz && \
+RUN wget -q "https://build.livepeer.live/go-livepeer/${LIVEPEER_COMMIT}/livepeer-linux-amd64.tar.gz" -O livepeer-linux-amd64.tar.gz && \
+    echo "${LIVEPEER_SHA256}  livepeer-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzf livepeer-linux-amd64.tar.gz && \
     mv livepeer-linux-amd64/livepeer /usr/local/bin/livepeer && \
     chmod +x /usr/local/bin/livepeer && \

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -23,6 +23,22 @@ docker compose -f docker/signer-dmz/docker-compose.yml up --build
 docker build -f docker/signer-dmz/Dockerfile.signer -t pymthouse-signer .
 ```
 
+### Rebuilding the image (redeployments)
+
+Docker may reuse cached layers; the layer that downloads `go-livepeer` will not run again unless it is invalidated. After changing `LIVEPEER_COMMIT`, `LIVEPEER_SHA256`, or whenever you want a full local rebuild, run **`--no-cache`** from the **repository root**:
+
+```bash
+docker build --no-cache -f docker/signer-dmz/Dockerfile -t pymthouse/signer-dmz:local .
+```
+
+For **signer-only** (`Dockerfile.signer`), the same idea applies:
+
+```bash
+docker build --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthouse-signer:local .
+```
+
+**Hosted platforms** (Railway, Render, Fly.io, etc.) typically build a new image when you push to the connected branch or trigger **Redeploy** / **Deploy**. If the service still serves an old binary, clear its **build cache** in the dashboard or use a CLI flag such as `fly deploy --no-cache` when available.
+
 Platform config (`railway.json`, `render.yaml`) builds `docker/signer-dmz/Dockerfile` (final image: Apache JWT DMZ + livepeer). For **livepeer only** (no Apache), use `Dockerfile.signer` instead. See [docs/DEPLOYMENT.md](../../docs/DEPLOYMENT.md) and [docs/signer-deployment-options.md](../../docs/signer-deployment-options.md).
 
 ## Railway networking (Docker DMZ)

--- a/docs/signer-deployment-options.md
+++ b/docs/signer-deployment-options.md
@@ -361,9 +361,19 @@ To update to a new version:
    - `docker/signer-dmz/Dockerfile` (livepeer download in the `signer-dmz` image stage)
    - `nixpacks.toml` (install phase)
 
-3. **Redeploy** on your platform
+3. **Redeploy** on your platform (push to the connected branch, or use the host’s **Redeploy** / **Deploy** button). If the previous image is still served, clear the platform **build cache** or force an uncached build (e.g. `fly deploy --no-cache` on Fly.io).
 
 4. **Test** the new version
+
+### Rebuilding the image locally
+
+From the repository root, force a full Docker rebuild (same as a fresh CI layer for the livepeer download):
+
+```bash
+docker build --no-cache -f docker/signer-dmz/Dockerfile -t pymthouse/signer-dmz:local .
+```
+
+See also [docker/signer-dmz/README.md](../docker/signer-dmz/README.md) (section **Rebuilding the image (redeployments)**).
 
 ## Next Steps
 

--- a/docs/signer-deployment-options.md
+++ b/docs/signer-deployment-options.md
@@ -121,7 +121,8 @@ app = "pymthouse-signer"
 
 [build]
   [build.args]
-    LIVEPEER_VERSION = "0.8.10"
+    LIVEPEER_COMMIT = "0a1919e0c58986375df158433445563a45a04df8"
+    LIVEPEER_SHA256 = "0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade"
 
 [env]
   SIGNER_NETWORK = "arbitrum-one-mainnet"
@@ -149,10 +150,14 @@ Create a `Dockerfile.fly`:
 ```dockerfile
 FROM debian:bookworm-slim
 
+ARG LIVEPEER_COMMIT
+ARG LIVEPEER_SHA256
+
 RUN apt-get update && \
     apt-get install -y wget ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \
-    wget -q https://github.com/livepeer/go-livepeer/releases/download/v0.8.10/livepeer-linux-amd64.tar.gz && \
+    wget -q "https://build.livepeer.live/go-livepeer/${LIVEPEER_COMMIT}/livepeer-linux-amd64.tar.gz" -O livepeer-linux-amd64.tar.gz && \
+    echo "${LIVEPEER_SHA256}  livepeer-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzf livepeer-linux-amd64.tar.gz && \
     mv livepeer-linux-amd64/livepeer /usr/local/bin/livepeer && \
     chmod +x /usr/local/bin/livepeer && \
@@ -349,15 +354,12 @@ Look for:
 
 To update to a new version:
 
-1. **Update the download URL** in:
-   - `docker/signer-dmz/Dockerfile.signer` (line with wget)
-   - `docker/signer-dmz/Dockerfile` (livepeer download in the `signer-dmz` image stage, if you use it)
+1. **Pick a build** from [go-livepeer Actions](https://github.com/livepeer/go-livepeer/actions) (or a tagged release). CI uploads linux-amd64 artifacts to **Google Cloud** at `https://build.livepeer.live/go-livepeer/<full-git-sha>/livepeer-linux-amd64.tar.gz` (same archive as the workflow artifact zip).
+
+2. **Update** `LIVEPEER_COMMIT`, `LIVEPEER_SHA256`, and the download URL in:
+   - `docker/signer-dmz/Dockerfile.signer`
+   - `docker/signer-dmz/Dockerfile` (livepeer download in the `signer-dmz` image stage)
    - `nixpacks.toml` (install phase)
-   
-2. **Change version number:**
-   ```
-   v0.8.10 → v0.8.11
-   ```
 
 3. **Redeploy** on your platform
 

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -2,11 +2,12 @@
 # Downloads and runs the livepeer binary
 
 [phases.setup]
-nixPkgs = ["wget", "gnutar"]
+nixPkgs = ["wget", "gnutar", "coreutils"]
 
 [phases.install]
 cmds = [
-  "wget -q https://github.com/livepeer/go-livepeer/releases/download/v0.8.10/livepeer-linux-amd64.tar.gz",
+  "wget -q https://build.livepeer.live/go-livepeer/0a1919e0c58986375df158433445563a45a04df8/livepeer-linux-amd64.tar.gz -O livepeer-linux-amd64.tar.gz",
+  "echo '0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade  livepeer-linux-amd64.tar.gz' | sha256sum -c -",
   "tar -xzf livepeer-linux-amd64.tar.gz",
   "mv livepeer-linux-amd64/livepeer ./livepeer",
   "chmod +x livepeer",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the pinned **linux-amd64** `go-livepeer` tarball used by the remote signer Docker/Nixpacks flows to match [GitHub Actions run 25226599716](https://github.com/livepeer/go-livepeer/actions/runs/25226599716), artifact `release-artifacts-linux-cpu-amd64`.

The same bytes are served publicly from Livepeer’s build CDN (same pipeline as CI uploads):

`https://build.livepeer.live/go-livepeer/0a1919e0c58986375df158433445563a45a04df8/livepeer-linux-amd64.tar.gz`

**SHA256:** `0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade`

Reported binary version: **0.8.10-0a1919e0** (includes feat(remote_signer): job token signing endpoint for byoc job types).

## Changes

- `docker/signer-dmz/Dockerfile` — `LIVEPEER_COMMIT` + checksum-verified download from `build.livepeer.live`
- `docker/signer-dmz/Dockerfile.signer` — same
- `nixpacks.toml` — same URL + `sha256sum -c`; added `coreutils` for checksum binary
- `docs/signer-deployment-options.md` — Fly.io example and “Updating the Binary” aligned with commit-based CDN URLs
- `docker/signer-dmz/README.md` + `docs/signer-deployment-options.md` — **how to rebuild the image** locally (`docker build --no-cache …`) and on hosted platforms (redeploy, clear cache, `fly deploy --no-cache`)

## Verification

- Confirmed tarball SHA256 matches the downloaded Actions artifact locally.
- Docker build not run in this environment (`docker` unavailable).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7fb244a-98b1-4692-ad98-f9848a4a262c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7fb244a-98b1-4692-ad98-f9848a4a262c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switch binary sourcing from GitHub releases to CI artifacts.
  * Add build arguments LIVEPEER_COMMIT and LIVEPEER_SHA256 to pin builds.
  * Apply SHA256 checksum verification for downloaded binaries where applicable.

* **Documentation**
  * Update deployment and binary update procedures to use commit-based pinning.
  * Add instructions for rebuilding images locally (including no-cache redeploy steps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->