### PR TITLE
fix(signer): Start/Stop buttons follow cli-status reachability

### DIFF
--- a/src/app/signer/page.tsx
+++ b/src/app/signer/page.tsx
@@ -7,6 +7,7 @@ import { db } from "@/db/index";
 import { signerConfig, streamSessions, transactions } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import DashboardLayout from "@/components/DashboardLayout";
+import { SignerCliStatusProvider } from "@/components/SignerCliStatusProvider";
 import SignerControlPanel from "@/components/SignerControlPanel";
 import SignerConfigForm from "@/components/SignerConfigForm";
 import SignerLogs from "@/components/SignerLogs";
@@ -156,32 +157,34 @@ export default async function SignerPage() {
         </div>
       </div>
 
-      {/* Live signer state: CLI via SIGNER_CLI_URL (DMZ → /__signer_cli) */}
-      <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30 mb-8">
-        <SignerLiveStats />
-      </div>
+      <SignerCliStatusProvider>
+        {/* Live signer state: CLI via SIGNER_CLI_URL (DMZ → /__signer_cli) */}
+        <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30 mb-8">
+          <SignerLiveStats />
+        </div>
 
-      {/* Activity stats from DB */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
-        <StatCard
-          label={`Active Streams (${ACTIVE_STREAM_PAYMENT_WINDOW_MINUTES}m)`}
-          value={activeStreamCount.toString()}
-          color="text-emerald-400"
-        />
-        <StatCard label="Total Streams" value={allSessions.length.toString()} />
-        <StatCard label="Total Volume" value={formatWei(totalFeeWei.toString())} />
-        <StatCard label="Transactions" value={allTxns.length.toString()} />
-        <StatCard
-          label="Platform Cut"
-          value={`${signer.defaultCutPercent}%`}
-        />
-        <StatCard label="Billing Mode" value={signer.billingMode} />
-      </div>
+        {/* Activity stats from DB */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+          <StatCard
+            label={`Active Streams (${ACTIVE_STREAM_PAYMENT_WINDOW_MINUTES}m)`}
+            value={activeStreamCount.toString()}
+            color="text-emerald-400"
+          />
+          <StatCard label="Total Streams" value={allSessions.length.toString()} />
+          <StatCard label="Total Volume" value={formatWei(totalFeeWei.toString())} />
+          <StatCard label="Transactions" value={allTxns.length.toString()} />
+          <StatCard
+            label="Platform Cut"
+            value={`${signer.defaultCutPercent}%`}
+          />
+          <StatCard label="Billing Mode" value={signer.billingMode} />
+        </div>
 
-      {/* Control plane */}
-      <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30 mb-8">
-        <SignerControlPanel currentStatus={signer.status} />
-      </div>
+        {/* Control plane */}
+        <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30 mb-8">
+          <SignerControlPanel />
+        </div>
+      </SignerCliStatusProvider>
 
       {/* Container logs */}
       <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30 mb-8">

--- a/src/components/SignerCliStatusProvider.tsx
+++ b/src/components/SignerCliStatusProvider.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export interface SignerCliSenderInfo {
+  deposit: string;
+  withdrawRound: string;
+  reserve: {
+    fundsRemaining: string;
+    claimedInCurrentRound: string;
+  };
+}
+
+export interface SignerCliStatusPayload {
+  reachable: boolean;
+  senderInfo: SignerCliSenderInfo | null;
+  ethBalance: string | null;
+  tokenBalance: string | null;
+  fetchedAt: string;
+}
+
+type SignerCliContextValue = {
+  data: SignerCliStatusPayload | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+};
+
+const SignerCliContext = createContext<SignerCliContextValue | null>(null);
+
+export function SignerCliStatusProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [data, setData] = useState<SignerCliStatusPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/signer/cli-status");
+      if (res.ok) {
+        setData(await res.json());
+      } else {
+        setData({
+          reachable: false,
+          senderInfo: null,
+          ethBalance: null,
+          tokenBalance: null,
+          fetchedAt: new Date().toISOString(),
+        });
+      }
+    } catch {
+      setData((prev) =>
+        prev ?? {
+          reachable: false,
+          senderInfo: null,
+          ethBalance: null,
+          tokenBalance: null,
+          fetchedAt: new Date().toISOString(),
+        },
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const poll = setInterval(() => {
+      void refresh();
+    }, 15000);
+    return () => clearInterval(poll);
+  }, [refresh]);
+
+  const value = useMemo(
+    () => ({
+      data,
+      loading,
+      refresh,
+    }),
+    [data, loading, refresh],
+  );
+
+  return (
+    <SignerCliContext.Provider value={value}>
+      {children}
+    </SignerCliContext.Provider>
+  );
+}
+
+export function useSignerCliStatus(): SignerCliContextValue {
+  const ctx = useContext(SignerCliContext);
+  if (!ctx) {
+    throw new Error(
+      "useSignerCliStatus must be used within SignerCliStatusProvider",
+    );
+  }
+  return ctx;
+}

--- a/src/components/SignerControlPanel.tsx
+++ b/src/components/SignerControlPanel.tsx
@@ -2,18 +2,16 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useSignerCliStatus } from "@/components/SignerCliStatusProvider";
 
-interface SignerControlPanelProps {
-  currentStatus: string;
-}
-
-export default function SignerControlPanel({
-  currentStatus,
-}: SignerControlPanelProps) {
+export default function SignerControlPanel() {
   const router = useRouter();
+  const { data, loading: cliLoading, refresh } = useSignerCliStatus();
   const [loading, setLoading] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const cliLive = data?.reachable === true;
 
   async function doAction(action: string) {
     setLoading(action);
@@ -27,17 +25,21 @@ export default function SignerControlPanel({
         body: JSON.stringify({ action }),
       });
 
-      const data = await res.json();
+      const payload = await res.json();
 
-      if (res.ok && data.success) {
+      if (res.ok && payload.success) {
         setMessage(
           action === "sync"
-            ? `Synced. Reachable: ${data.reachable}${data.ethAddress ? `, address: ${data.ethAddress}` : ""}`
-            : `${action} completed successfully`
+            ? `Synced. Reachable: ${payload.reachable}${payload.ethAddress ? `, address: ${payload.ethAddress}` : ""}`
+            : `${action} completed successfully`,
         );
         router.refresh();
+        const delayMs = action === "sync" ? 0 : 2000;
+        window.setTimeout(() => {
+          void refresh();
+        }, delayMs);
       } else {
-        setError(data.error || `${action} failed`);
+        setError(payload.error || `${action} failed`);
       }
     } catch {
       setError(`Failed to ${action} signer`);
@@ -46,14 +48,14 @@ export default function SignerControlPanel({
     }
   }
 
-  const isRunning = currentStatus === "running";
+  const showStartStop = data !== null && !cliLoading;
 
   return (
     <div className="space-y-4">
       <h3 className="font-semibold text-zinc-200">Control Plane</h3>
 
       <div className="flex flex-wrap gap-3">
-        {!isRunning && (
+        {showStartStop && !cliLive && (
           <button
             onClick={() => doAction("start")}
             disabled={!!loading}
@@ -63,7 +65,7 @@ export default function SignerControlPanel({
           </button>
         )}
 
-        {isRunning && (
+        {showStartStop && cliLive && (
           <button
             onClick={() => doAction("stop")}
             disabled={!!loading}
@@ -71,6 +73,12 @@ export default function SignerControlPanel({
           >
             {loading === "stop" ? "Stopping..." : "Stop Signer"}
           </button>
+        )}
+
+        {!showStartStop && (
+          <span className="text-xs text-zinc-500 py-2">
+            {cliLoading ? "Reading CLI status…" : "Waiting for CLI status…"}
+          </span>
         )}
 
         <button

--- a/src/components/SignerLiveStats.tsx
+++ b/src/components/SignerLiveStats.tsx
@@ -1,23 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-
-interface SenderInfo {
-  deposit: string;
-  withdrawRound: string;
-  reserve: {
-    fundsRemaining: string;
-    claimedInCurrentRound: string;
-  };
-}
-
-interface CliStatus {
-  reachable: boolean;
-  senderInfo: SenderInfo | null;
-  ethBalance: string | null;
-  tokenBalance: string | null;
-  fetchedAt: string;
-}
+import { useSignerCliStatus } from "@/components/SignerCliStatusProvider";
+import type { SignerCliSenderInfo } from "@/components/SignerCliStatusProvider";
 
 function formatWei(wei: string | null | undefined): string {
   if (!wei || wei === "0") return "0";
@@ -71,34 +56,15 @@ function StatCard({
 }
 
 export default function SignerLiveStats() {
-  const [data, setData] = useState<CliStatus | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { data, loading, refresh } = useSignerCliStatus();
   const [, setTick] = useState(0); // force re-render for time display
 
-  async function fetchStats() {
-    try {
-      const res = await fetch("/api/v1/signer/cli-status");
-      if (res.ok) {
-        setData(await res.json());
-      }
-    } catch {
-      // ignore — keep showing last known state
-    } finally {
-      setLoading(false);
-    }
-  }
-
   useEffect(() => {
-    fetchStats();
-    const poll = setInterval(fetchStats, 15000);
     const tick = setInterval(() => setTick((t) => t + 1), 5000);
-    return () => {
-      clearInterval(poll);
-      clearInterval(tick);
-    };
+    return () => clearInterval(tick);
   }, []);
 
-  const si = data?.senderInfo;
+  const si: SignerCliSenderInfo | null | undefined = data?.senderInfo;
   const unreachable = data !== null && !data.reachable;
 
   return (
@@ -129,7 +95,7 @@ export default function SignerLiveStats() {
             </span>
           )}
           <button
-            onClick={fetchStats}
+            onClick={() => void refresh()}
             className="px-2.5 py-1 bg-zinc-800 border border-zinc-700 rounded text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
           >
             Refresh
@@ -137,7 +103,7 @@ export default function SignerLiveStats() {
         </div>
       </div>
 
-      {loading ? (
+      {loading && !data ? (
         <p className="text-xs text-zinc-500 animate-pulse">
           Connecting to signer CLI (SIGNER_CLI_URL)…
         </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The control plane previously used the database `signer.status` flag to choose **Start Signer** vs **Stop Signer**, while **Live Signer State** used `/api/v1/signer/cli-status` (`reachable` when `senderInfo` succeeds). Those sources can diverge on first load or after out-of-band container changes, so the wrong primary action could appear.

## Changes

- Introduced `SignerCliStatusProvider`, which polls `/api/v1/signer/cli-status` every 15s (same cadence as before) and exposes `data`, `loading`, and `refresh`.
- `SignerLiveStats` and `SignerControlPanel` consume that context so there is a single source of truth.
- **Stop Signer** when `reachable === true`; **Start Signer** when the latest payload says the CLI is not reachable.
- After successful `start` / `stop` / `restart`, the UI triggers `refresh()` (with a short delay for start/stop/restart so the process can come up or tear down).
- Non-OK HTTP responses set `reachable: false`; on network error before any successful payload, a one-time unreachable placeholder is applied so Start/Stop can still render.

## Verification

`npm run lint` / `npm test` were not run in this environment (Node/npm unavailable in PATH). Please run locally if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0ba06e2-9d54-4f28-9ec7-145f549233e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0ba06e2-9d54-4f28-9ec7-145f549233e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

