### PR TITLE
Add domain and platform foundation modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
-    "proto:compile": "pbjs -t static-module -w es6 -o src/lib/proto-generated.js proto/lp_rpc.proto && pbts -o src/lib/proto-generated.d.ts src/lib/proto-generated.js",
+    "proto:compile": "pbjs -t static-module -w es6 -o src/platform/livepeer/proto-generated.js proto/lp_rpc.proto && pbts -o src/platform/livepeer/proto-generated.d.ts src/platform/livepeer/proto-generated.js",
     "bootstrap": "npx tsx scripts/bootstrap-admin.ts",
     "db:prepare": "npx tsx scripts/db-migrate.ts",
     "oidc:seed": "npx tsx scripts/seed-oidc.ts",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -12,7 +12,7 @@ import {
   jsonb,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
-import type { DiscoveryPolicy } from "@/lib/discovery-plans";
+import type { DiscoveryPolicy } from "@/shared/discovery/discovery-plans";
 
 // Admin/operator/developer accounts (OAuth or wallet login)
 export const users = pgTable("users", {

--- a/src/domains/developer-apps/repo/admin-apps.ts
+++ b/src/domains/developer-apps/repo/admin-apps.ts
@@ -1,0 +1,92 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients, users } from "@/db/schema";
+
+export async function listReviewableApps() {
+  return db
+    .select({
+      id: oidcClients.clientId,
+      name: developerApps.name,
+      subtitle: developerApps.subtitle,
+      category: developerApps.category,
+      status: developerApps.status,
+      developerName: developerApps.developerName,
+      submittedAt: developerApps.submittedAt,
+      pendingRevisionSubmittedAt: developerApps.pendingRevisionSubmittedAt,
+      createdAt: developerApps.createdAt,
+      ownerEmail: users.email,
+      ownerName: users.name,
+      clientId: oidcClients.clientId,
+      marketplaceFeatured: developerApps.marketplaceFeatured,
+    })
+    .from(developerApps)
+    .leftJoin(users, eq(developerApps.ownerId, users.id))
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(inArray(developerApps.status, ["submitted", "in_review", "approved", "rejected"]));
+}
+
+export async function clearPendingRevisionReview(params: {
+  appId: string;
+  notes: string | null;
+  updatedAt: string;
+  setJwksUri: string | null;
+}) {
+  await db
+    .update(developerApps)
+    .set({
+      pendingScopes: null,
+      pendingGrantTypes: null,
+      pendingRevisionSubmittedAt: null,
+      reviewerNotes: params.notes,
+      updatedAt: params.updatedAt,
+      ...(params.setJwksUri ? { jwksUri: params.setJwksUri } : {}),
+    })
+    .where(eq(developerApps.id, params.appId));
+}
+
+export async function updateInitialReviewState(params: {
+  appId: string;
+  newStatus: "approved" | "rejected";
+  notes: string | null;
+  reviewerUserId: string;
+  reviewedAt: string;
+  setJwksUri: string | null;
+}) {
+  await db
+    .update(developerApps)
+    .set({
+      status: params.newStatus,
+      reviewerNotes: params.notes,
+      reviewedBy: params.reviewerUserId,
+      reviewedAt: params.reviewedAt,
+      publishedAt: params.newStatus === "approved" ? params.reviewedAt : null,
+      updatedAt: params.reviewedAt,
+      ...(params.setJwksUri ? { jwksUri: params.setJwksUri } : {}),
+    })
+    .where(eq(developerApps.id, params.appId));
+}
+
+export async function revokeApprovedApp(appId: string, now: string) {
+  return db
+    .update(developerApps)
+    .set({
+      status: "submitted",
+      submittedAt: now,
+      updatedAt: now,
+      reviewerNotes: null,
+      reviewedBy: null,
+      reviewedAt: null,
+    })
+    .where(and(eq(developerApps.id, appId), eq(developerApps.status, "approved")))
+    .returning({ id: developerApps.id });
+}
+
+export async function setMarketplaceFeatured(appId: string, featured: boolean, updatedAt: string) {
+  await db
+    .update(developerApps)
+    .set({
+      marketplaceFeatured: featured ? 1 : 0,
+      updatedAt,
+    })
+    .where(eq(developerApps.id, appId));
+}

--- a/src/domains/developer-apps/repo/api-key-validation.ts
+++ b/src/domains/developer-apps/repo/api-key-validation.ts
@@ -1,0 +1,29 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { apiKeys, planCapabilityBundles, plans, subscriptions } from "@/db/schema";
+
+export async function getApiKeyByHash(keyHash: string) {
+  const rows = await db.select().from(apiKeys).where(eq(apiKeys.keyHash, keyHash)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getSubscriptionForApiKey(subscriptionId: string, clientId: string) {
+  const rows = await db
+    .select()
+    .from(subscriptions)
+    .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.clientId, clientId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getPlanForSubscription(planId: string) {
+  const rows = await db.select().from(plans).where(eq(plans.id, planId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listCapabilitiesForPlan(planId: string) {
+  return db
+    .select()
+    .from(planCapabilityBundles)
+    .where(eq(planCapabilityBundles.planId, planId));
+}

--- a/src/domains/developer-apps/repo/app-admins.ts
+++ b/src/domains/developer-apps/repo/app-admins.ts
@@ -1,0 +1,49 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db/index";
+import { providerAdmins, users } from "@/db/schema";
+
+export async function listAppAdminMemberships(appId: string) {
+  const memberships = await db
+    .select()
+    .from(providerAdmins)
+    .where(eq(providerAdmins.clientId, appId));
+
+  const userIds = memberships.map((m) => m.userId);
+  const adminUsers = userIds.length > 0 ? await db.select().from(users).where(inArray(users.id, userIds)) : [];
+
+  return { memberships, adminUsers };
+}
+
+export async function getUserById(userId: string) {
+  const rows = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getAppAdminMembership(appId: string, userId: string) {
+  const rows = await db
+    .select()
+    .from(providerAdmins)
+    .where(and(eq(providerAdmins.clientId, appId), eq(providerAdmins.userId, userId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function createAppAdminMembership(appId: string, userId: string, role: string) {
+  const membership = {
+    id: uuidv4(),
+    userId,
+    clientId: appId,
+    role,
+    createdAt: new Date().toISOString(),
+  };
+
+  await db.insert(providerAdmins).values(membership);
+  return membership;
+}
+
+export async function deleteAppAdminMembership(appId: string, userId: string) {
+  await db
+    .delete(providerAdmins)
+    .where(and(eq(providerAdmins.clientId, appId), eq(providerAdmins.userId, userId)));
+}

--- a/src/domains/developer-apps/repo/app-billing.ts
+++ b/src/domains/developer-apps/repo/app-billing.ts
@@ -1,0 +1,82 @@
+import { and, desc, eq, gte, inArray, lte } from "drizzle-orm";
+import { db } from "@/db/index";
+import {
+  plans,
+  signerConfig,
+  subscriptions,
+  usageBillingEvents,
+  usageRecords,
+} from "@/db/schema";
+
+export async function getPlatformCutPercent() {
+  const rows = await db
+    .select({ defaultCutPercent: signerConfig.defaultCutPercent })
+    .from(signerConfig)
+    .where(eq(signerConfig.id, "default"))
+    .limit(1);
+  return rows[0]?.defaultCutPercent ?? null;
+}
+
+export async function getOwnerActiveSubscription(appId: string, ownerId: string) {
+  const rows = await db
+    .select()
+    .from(subscriptions)
+    .where(
+      and(
+        eq(subscriptions.clientId, appId),
+        eq(subscriptions.userId, ownerId),
+        eq(subscriptions.status, "active"),
+      ),
+    )
+    .orderBy(desc(subscriptions.createdAt))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getPlanById(planId: string) {
+  const rows = await db.select().from(plans).where(eq(plans.id, planId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getLatestActivePlanForApp(appId: string) {
+  const rows = await db
+    .select()
+    .from(plans)
+    .where(and(eq(plans.clientId, appId), eq(plans.status, "active")))
+    .orderBy(desc(plans.updatedAt))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listUsageRecordsForBillingPeriod(params: {
+  appId: string;
+  periodStart: string;
+  periodEnd: string;
+}) {
+  return db
+    .select()
+    .from(usageRecords)
+    .where(
+      and(
+        eq(usageRecords.clientId, params.appId),
+        gte(usageRecords.createdAt, params.periodStart),
+        lte(usageRecords.createdAt, params.periodEnd),
+      ),
+    );
+}
+
+export async function listUsageBillingEventsForUsageRecords(params: {
+  appId: string;
+  usageRecordIds: string[];
+}) {
+  if (params.usageRecordIds.length === 0) return [];
+  return db
+    .select()
+    .from(usageBillingEvents)
+    .where(
+      and(
+        eq(usageBillingEvents.clientId, params.appId),
+        inArray(usageBillingEvents.usageRecordId, params.usageRecordIds),
+      ),
+    );
+}

--- a/src/domains/developer-apps/repo/app-core.ts
+++ b/src/domains/developer-apps/repo/app-core.ts
@@ -1,0 +1,54 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export async function updateDeveloperApp(appId: string, updates: Record<string, unknown>) {
+  await db.update(developerApps).set(updates).where(eq(developerApps.id, appId));
+}
+
+export async function getOidcClientByRowId(id: string) {
+  const rows = await db.select().from(oidcClients).where(eq(oidcClients.id, id)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getM2mClientSummaryForApp(appId: string) {
+  const refreshed = await db
+    .select({ m2mOidcClientId: developerApps.m2mOidcClientId })
+    .from(developerApps)
+    .where(eq(developerApps.id, appId))
+    .limit(1);
+  const m2mPk = refreshed[0]?.m2mOidcClientId;
+  if (!m2mPk) return null;
+
+  const rows = await db.select().from(oidcClients).where(eq(oidcClients.id, m2mPk)).limit(1);
+  const client = rows[0];
+  if (!client) return null;
+
+  return {
+    clientId: client.clientId,
+    hasSecret: !!client.clientSecretHash,
+  };
+}
+
+export async function transitionAppStatus(params: {
+  appId: string;
+  allowedCurrentStatuses: string[];
+  nextStatus: string;
+  submittedAt: string | null;
+  updatedAt: string;
+}) {
+  return db
+    .update(developerApps)
+    .set({
+      status: params.nextStatus,
+      submittedAt: params.submittedAt,
+      updatedAt: params.updatedAt,
+    })
+    .where(
+      and(
+        eq(developerApps.id, params.appId),
+        inArray(developerApps.status, params.allowedCurrentStatuses),
+      ),
+    )
+    .returning({ id: developerApps.id });
+}

--- a/src/domains/developer-apps/repo/app-create.ts
+++ b/src/domains/developer-apps/repo/app-create.ts
@@ -1,0 +1,6 @@
+import { db } from "@/db/index";
+import { developerApps } from "@/db/schema";
+
+export async function createDeveloperAppRecord(record: typeof developerApps.$inferInsert) {
+  await db.insert(developerApps).values(record);
+}

--- a/src/domains/developer-apps/repo/app-credentials.ts
+++ b/src/domains/developer-apps/repo/app-credentials.ts
@@ -1,0 +1,16 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { oidcClients } from "@/db/schema";
+
+export async function getOidcCredentialClientById(id: string) {
+  const rows = await db
+    .select({
+      id: oidcClients.id,
+      clientId: oidcClients.clientId,
+      tokenEndpointAuthMethod: oidcClients.tokenEndpointAuthMethod,
+    })
+    .from(oidcClients)
+    .where(eq(oidcClients.id, id))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/developer-apps/repo/app-domains.ts
+++ b/src/domains/developer-apps/repo/app-domains.ts
@@ -1,0 +1,41 @@
+import { and, eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db/index";
+import { appAllowedDomains } from "@/db/schema";
+
+export async function listAppDomains(appId: string) {
+  return db.select().from(appAllowedDomains).where(eq(appAllowedDomains.appId, appId));
+}
+
+export async function ensureAppDomains(appId: string, domains: string[]) {
+  const existingDomains = await listAppDomains(appId);
+  const existingSet = new Set(existingDomains.map((d) => d.domain.toLowerCase()));
+
+  for (const domain of domains) {
+    const normalized = domain.toLowerCase();
+    if (!existingSet.has(normalized)) {
+      await db.insert(appAllowedDomains).values({
+        id: uuidv4(),
+        appId,
+        domain,
+      });
+      existingSet.add(normalized);
+    }
+  }
+}
+
+export async function insertAppDomain(appId: string, domain: string) {
+  const domainId = uuidv4();
+  await db.insert(appAllowedDomains).values({
+    id: domainId,
+    appId,
+    domain,
+  });
+  return domainId;
+}
+
+export async function deleteAppDomain(appId: string, domainId: string) {
+  await db
+    .delete(appAllowedDomains)
+    .where(and(eq(appAllowedDomains.id, domainId), eq(appAllowedDomains.appId, appId)));
+}

--- a/src/domains/developer-apps/repo/app-keys.ts
+++ b/src/domains/developer-apps/repo/app-keys.ts
@@ -1,0 +1,43 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { apiKeys, subscriptions } from "@/db/schema";
+
+export async function listAppKeys(appId: string) {
+  return db
+    .select({
+      id: apiKeys.id,
+      clientId: apiKeys.clientId,
+      userId: apiKeys.userId,
+      subscriptionId: apiKeys.subscriptionId,
+      label: apiKeys.label,
+      status: apiKeys.status,
+      createdAt: apiKeys.createdAt,
+      revokedAt: apiKeys.revokedAt,
+    })
+    .from(apiKeys)
+    .where(eq(apiKeys.clientId, appId));
+}
+
+export async function getSubscriptionForApp(subscriptionId: string, appId: string) {
+  const rows = await db
+    .select()
+    .from(subscriptions)
+    .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.clientId, appId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function createAppKeyRecord(record: typeof apiKeys.$inferInsert) {
+  await db.insert(apiKeys).values(record);
+}
+
+export async function revokeAppKey(keyId: string, appId: string, revokedAt: string) {
+  return db
+    .update(apiKeys)
+    .set({
+      status: "revoked",
+      revokedAt,
+    })
+    .where(and(eq(apiKeys.id, keyId), eq(apiKeys.clientId, appId)))
+    .returning({ id: apiKeys.id });
+}

--- a/src/domains/developer-apps/repo/app-oidc.ts
+++ b/src/domains/developer-apps/repo/app-oidc.ts
@@ -1,0 +1,15 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { appAllowedDomains, oidcClients } from "@/db/schema";
+
+export async function getOidcClientByRowId(id: string) {
+  const rows = await db.select().from(oidcClients).where(eq(oidcClients.id, id)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listAppAllowedDomains(appId: string) {
+  return db
+    .select()
+    .from(appAllowedDomains)
+    .where(eq(appAllowedDomains.appId, appId));
+}

--- a/src/domains/developer-apps/repo/app-usage.ts
+++ b/src/domains/developer-apps/repo/app-usage.ts
@@ -1,0 +1,64 @@
+import { and, eq, gte, inArray, lte } from "drizzle-orm";
+import { db } from "@/db/index";
+import { appUsers, endUsers, usageBillingEvents, usageRecords } from "@/db/schema";
+
+export async function listUsageRecords(params: {
+  appId: string;
+  startDate: string | null;
+  endDate: string | null;
+  filterUserId: string | null;
+}) {
+  const conditions = [eq(usageRecords.clientId, params.appId)];
+  if (params.startDate) conditions.push(gte(usageRecords.createdAt, params.startDate));
+  if (params.endDate) conditions.push(lte(usageRecords.createdAt, params.endDate));
+  if (params.filterUserId) conditions.push(eq(usageRecords.userId, params.filterUserId));
+  const whereClause = conditions.length === 1 ? conditions[0] : and(...conditions);
+
+  return db.select().from(usageRecords).where(whereClause!);
+}
+
+export async function listUsageBillingEvents(params: {
+  appId: string;
+  usageRecordIds: string[];
+  gatewayRequestId: string | null;
+}) {
+  if (params.usageRecordIds.length === 0) return [];
+  return db
+    .select()
+    .from(usageBillingEvents)
+    .where(
+      and(
+        eq(usageBillingEvents.clientId, params.appId),
+        params.gatewayRequestId
+          ? eq(usageBillingEvents.gatewayRequestId, params.gatewayRequestId)
+          : undefined,
+        inArray(usageBillingEvents.usageRecordId, params.usageRecordIds),
+      ),
+    );
+}
+
+export async function listAppUsersByIds(ids: string[]) {
+  if (ids.length === 0) return [];
+  return db.select().from(appUsers).where(inArray(appUsers.id, ids));
+}
+
+export async function listAppUsersByExternalIds(externalIds: string[]) {
+  if (externalIds.length === 0) return [];
+  return db.select().from(appUsers).where(inArray(appUsers.externalUserId, externalIds));
+}
+
+export async function listEndUsersByIds(appId: string, ids: string[]) {
+  if (ids.length === 0) return [];
+  return db
+    .select({ id: endUsers.id, externalUserId: endUsers.externalUserId })
+    .from(endUsers)
+    .where(and(eq(endUsers.appId, appId), inArray(endUsers.id, ids)));
+}
+
+export async function listEndUsersByExternalIds(appId: string, externalIds: string[]) {
+  if (externalIds.length === 0) return [];
+  return db
+    .select({ id: endUsers.id, externalUserId: endUsers.externalUserId })
+    .from(endUsers)
+    .where(and(eq(endUsers.appId, appId), inArray(endUsers.externalUserId, externalIds)));
+}

--- a/src/domains/developer-apps/repo/app-user-tokens.ts
+++ b/src/domains/developer-apps/repo/app-user-tokens.ts
@@ -1,0 +1,23 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { appUsers, oidcClients } from "@/db/schema";
+
+export async function getPublicAllowedScopesForClient(clientId: string) {
+  const rows = await db
+    .select({ allowedScopes: oidcClients.allowedScopes })
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0]?.allowedScopes ?? "";
+}
+
+export async function getActiveAppUserByExternalUserId(appId: string, externalUserId: string) {
+  const rows = await db
+    .select()
+    .from(appUsers)
+    .where(and(eq(appUsers.clientId, appId), eq(appUsers.externalUserId, externalUserId)))
+    .limit(1);
+  const appUser = rows[0];
+  if (!appUser || appUser.status !== "active") return null;
+  return appUser;
+}

--- a/src/domains/developer-apps/repo/app-users.ts
+++ b/src/domains/developer-apps/repo/app-users.ts
@@ -1,0 +1,69 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { appUsers } from "@/db/schema";
+
+export async function listAppUsers(appId: string) {
+  return db.select().from(appUsers).where(eq(appUsers.clientId, appId));
+}
+
+export async function upsertAppUser(params: {
+  appId: string;
+  externalUserId: string;
+  email: string | null;
+  status: string;
+  hasEmail: boolean;
+  hasStatus: boolean;
+  createdAt: string;
+}) {
+  const newUser = {
+    id: crypto.randomUUID(),
+    clientId: params.appId,
+    externalUserId: params.externalUserId,
+    email: params.email,
+    status: params.status,
+    role: "user" as const,
+    createdAt: params.createdAt,
+  };
+
+  const updateSet: { email?: string | null; status?: string; role: "user" } = {
+    role: "user",
+  };
+  if (params.hasEmail) updateSet.email = params.email;
+  if (params.hasStatus) updateSet.status = params.status;
+
+  const upserted = await db
+    .insert(appUsers)
+    .values(newUser)
+    .onConflictDoUpdate({
+      target: [appUsers.clientId, appUsers.externalUserId],
+      set: updateSet,
+    })
+    .returning();
+
+  return {
+    row: upserted[0] ?? newUser,
+    created: (upserted[0] ?? newUser).id === newUser.id,
+  };
+}
+
+export async function getAppUserByExternalUserId(appId: string, externalUserId: string) {
+  const rows = await db
+    .select()
+    .from(appUsers)
+    .where(
+      and(eq(appUsers.clientId, appId), eq(appUsers.externalUserId, externalUserId)),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function updateAppUserById(
+  id: string,
+  updates: { email: string | null; status: string; role: "user" },
+) {
+  await db.update(appUsers).set(updates).where(eq(appUsers.id, id));
+}
+
+export async function deactivateAppUser(id: string) {
+  await db.update(appUsers).set({ status: "inactive" }).where(eq(appUsers.id, id));
+}

--- a/src/domains/developer-apps/repo/delete-app.ts
+++ b/src/domains/developer-apps/repo/delete-app.ts
@@ -1,0 +1,109 @@
+import { eq, inArray, or, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import {
+  apiKeys,
+  appAllowedDomains,
+  appUsers,
+  authAuditLog,
+  developerApps,
+  discoveryProfiles,
+  endUsers,
+  oidcClients,
+  oidcPayloads,
+  planCapabilityBundles,
+  plans,
+  providerAdmins,
+  sessions,
+  signerConfig,
+  streamSessions,
+  subscriptions,
+  transactions,
+  usageBillingEvents,
+  usageRecords,
+} from "@/db/schema";
+
+export async function deleteDeveloperAppAndRelatedData(
+  appInternalId: string,
+  _oidcClientPk: string | null,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    const appRow = await tx
+      .select({
+        oidcClientId: developerApps.oidcClientId,
+        m2mOidcClientId: developerApps.m2mOidcClientId,
+      })
+      .from(developerApps)
+      .where(eq(developerApps.id, appInternalId))
+      .limit(1);
+    const app = appRow[0];
+    const oidcPkList = [app?.oidcClientId, app?.m2mOidcClientId].filter(
+      (v): v is string => typeof v === "string" && v.length > 0,
+    );
+    const oauthClientIds: string[] = [];
+    for (const pk of oidcPkList) {
+      const clientRows = await tx
+        .select({ clientId: oidcClients.clientId })
+        .from(oidcClients)
+        .where(eq(oidcClients.id, pk))
+        .limit(1);
+      const cid = clientRows[0]?.clientId;
+      if (cid) oauthClientIds.push(cid);
+    }
+    for (const oauthClientId of oauthClientIds) {
+      await tx.delete(oidcPayloads).where(
+        or(
+          sql`(${oidcPayloads.payload})::jsonb->>'clientId' = ${oauthClientId}`,
+          sql`(${oidcPayloads.payload})::jsonb->>'client_id' = ${oauthClientId}`,
+        ),
+      );
+    }
+
+    await tx.delete(apiKeys).where(eq(apiKeys.clientId, appInternalId));
+    await tx.delete(subscriptions).where(eq(subscriptions.clientId, appInternalId));
+    await tx.delete(planCapabilityBundles).where(eq(planCapabilityBundles.clientId, appInternalId));
+    await tx.delete(plans).where(eq(plans.clientId, appInternalId));
+    await tx.delete(usageBillingEvents).where(eq(usageBillingEvents.clientId, appInternalId));
+    await tx.delete(discoveryProfiles).where(eq(discoveryProfiles.clientId, appInternalId));
+    await tx.delete(usageRecords).where(eq(usageRecords.clientId, appInternalId));
+    await tx.delete(authAuditLog).where(eq(authAuditLog.clientId, appInternalId));
+    await tx.delete(appAllowedDomains).where(eq(appAllowedDomains.appId, appInternalId));
+    await tx.delete(appUsers).where(eq(appUsers.clientId, appInternalId));
+    await tx.delete(providerAdmins).where(eq(providerAdmins.clientId, appInternalId));
+
+    const endUserRows = await tx
+      .select({ id: endUsers.id })
+      .from(endUsers)
+      .where(eq(endUsers.appId, appInternalId));
+    const endUserIds = endUserRows.map((row) => row.id);
+
+    const streamSessionCond =
+      endUserIds.length > 0
+        ? or(eq(streamSessions.appId, appInternalId), inArray(streamSessions.endUserId, endUserIds))
+        : eq(streamSessions.appId, appInternalId);
+
+    const sessionIdRows = await tx
+      .select({ id: streamSessions.id })
+      .from(streamSessions)
+      .where(streamSessionCond);
+    const streamSessionIds = sessionIdRows.map((row) => row.id);
+    if (streamSessionIds.length > 0) {
+      await tx.delete(transactions).where(inArray(transactions.streamSessionId, streamSessionIds));
+    }
+    await tx.delete(streamSessions).where(streamSessionCond);
+
+    await tx.delete(transactions).where(eq(transactions.clientId, appInternalId));
+    await tx.delete(transactions).where(eq(transactions.appId, appInternalId));
+    if (endUserIds.length > 0) {
+      await tx.delete(transactions).where(inArray(transactions.endUserId, endUserIds));
+    }
+
+    await tx.delete(endUsers).where(eq(endUsers.appId, appInternalId));
+    await tx.delete(sessions).where(eq(sessions.appId, appInternalId));
+    await tx.delete(signerConfig).where(eq(signerConfig.clientId, appInternalId));
+    await tx.delete(developerApps).where(eq(developerApps.id, appInternalId));
+
+    for (const pk of oidcPkList) {
+      await tx.delete(oidcClients).where(eq(oidcClients.id, pk));
+    }
+  });
+}

--- a/src/domains/developer-apps/repo/provider-access.ts
+++ b/src/domains/developer-apps/repo/provider-access.ts
@@ -1,0 +1,116 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients, providerAdmins } from "@/db/schema";
+
+export async function getProviderAppByClientId(clientId: string) {
+  const byPublic = await db
+    .select({ app: developerApps })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  if (byPublic[0]?.app) {
+    return byPublic[0].app;
+  }
+
+  const byM2m = await db
+    .select({ app: developerApps })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.m2mOidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return byM2m[0]?.app ?? null;
+}
+
+export async function getProviderApp(appIdOrClientId: string) {
+  const byClientId = await getProviderAppByClientId(appIdOrClientId);
+  if (byClientId) {
+    return byClientId;
+  }
+
+  const rows = await db
+    .select()
+    .from(developerApps)
+    .where(eq(developerApps.id, appIdOrClientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getProviderAdminMembership(userId: string, appId: string) {
+  const rows = await db
+    .select()
+    .from(providerAdmins)
+    .where(and(eq(providerAdmins.userId, userId), eq(providerAdmins.clientId, appId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function isProviderAdmin(userId: string, appId: string): Promise<boolean> {
+  return (await getProviderAdminMembership(userId, appId)) !== null;
+}
+
+export async function ensureProviderAdminMembership(userId: string, appId: string) {
+  const membership = {
+    id: crypto.randomUUID(),
+    userId,
+    clientId: appId,
+    role: "owner",
+    createdAt: new Date().toISOString(),
+  } as const;
+
+  await db.insert(providerAdmins).values(membership).onConflictDoNothing();
+  return (await getProviderAdminMembership(userId, appId)) ?? membership;
+}
+
+export async function listAppsVisibleToUser(userId: string) {
+  const memberships = await db
+    .select({ clientId: providerAdmins.clientId })
+    .from(providerAdmins)
+    .where(eq(providerAdmins.userId, userId));
+
+  const memberIds = memberships.map((membership) => membership.clientId);
+  const ownedApps = await db
+    .select({
+      id: oidcClients.clientId,
+      name: developerApps.name,
+      subtitle: developerApps.subtitle,
+      category: developerApps.category,
+      status: developerApps.status,
+      logoLightUrl: developerApps.logoLightUrl,
+      brandingMode: developerApps.brandingMode,
+      customLoginEnabled: developerApps.customLoginEnabled,
+      customLoginDomain: developerApps.customLoginDomain,
+      createdAt: developerApps.createdAt,
+      updatedAt: developerApps.updatedAt,
+      clientId: oidcClients.clientId,
+    })
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(developerApps.ownerId, userId));
+
+  const memberApps =
+    memberIds.length === 0
+      ? []
+      : await db
+          .select({
+            id: oidcClients.clientId,
+            name: developerApps.name,
+            subtitle: developerApps.subtitle,
+            category: developerApps.category,
+            status: developerApps.status,
+            logoLightUrl: developerApps.logoLightUrl,
+            brandingMode: developerApps.brandingMode,
+            customLoginEnabled: developerApps.customLoginEnabled,
+            customLoginDomain: developerApps.customLoginDomain,
+            createdAt: developerApps.createdAt,
+            updatedAt: developerApps.updatedAt,
+            clientId: oidcClients.clientId,
+          })
+          .from(developerApps)
+          .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+          .where(inArray(developerApps.id, memberIds));
+
+  return [...ownedApps, ...memberApps].filter(
+    (app, index, rows) => rows.findIndex((row) => row.id === app.id) === index,
+  );
+}

--- a/src/domains/developer-apps/repo/public-marketplace.ts
+++ b/src/domains/developer-apps/repo/public-marketplace.ts
@@ -1,0 +1,76 @@
+import { and, eq, isNotNull } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export function publishedApprovedCondition() {
+  return and(
+    eq(developerApps.status, "approved"),
+    isNotNull(developerApps.publishedAt),
+  );
+}
+
+export function getPublicMarketplaceSelect() {
+  return {
+    id: developerApps.id,
+    name: developerApps.name,
+    subtitle: developerApps.subtitle,
+    description: developerApps.description,
+    category: developerApps.category,
+    logoLightUrl: developerApps.logoLightUrl,
+    logoDarkUrl: developerApps.logoDarkUrl,
+    developerName: developerApps.developerName,
+    websiteUrl: developerApps.websiteUrl,
+    supportUrl: developerApps.supportUrl,
+    privacyPolicyUrl: developerApps.privacyPolicyUrl,
+    tosUrl: developerApps.tosUrl,
+    webOidcClientId: oidcClients.clientId,
+    grantTypes: oidcClients.grantTypes,
+    createdAt: developerApps.createdAt,
+    marketplaceFeatured: developerApps.marketplaceFeatured,
+  };
+}
+
+export async function listPublishedMarketplaceApps() {
+  return db
+    .select({
+      id: developerApps.id,
+      name: developerApps.name,
+      subtitle: developerApps.subtitle,
+      description: developerApps.description,
+      category: developerApps.category,
+      logoLightUrl: developerApps.logoLightUrl,
+      logoDarkUrl: developerApps.logoDarkUrl,
+      developerName: developerApps.developerName,
+      websiteUrl: developerApps.websiteUrl,
+      supportUrl: developerApps.supportUrl,
+      webOidcClientId: oidcClients.clientId,
+      createdAt: developerApps.createdAt,
+      marketplaceFeatured: developerApps.marketplaceFeatured,
+    })
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(publishedApprovedCondition());
+}
+
+export async function getPublishedMarketplaceAppByAppId(routeId: string) {
+  return db
+    .select(getPublicMarketplaceSelect())
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(and(eq(developerApps.id, routeId), publishedApprovedCondition()))
+    .limit(1);
+}
+
+export async function getPublishedMarketplaceAppByClientId(routeId: string) {
+  return db
+    .select(getPublicMarketplaceSelect())
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(
+      and(
+        eq(oidcClients.clientId, routeId),
+        publishedApprovedCondition(),
+      ),
+    )
+    .limit(1);
+}

--- a/src/domains/developer-apps/runtime/admin-apps.ts
+++ b/src/domains/developer-apps/runtime/admin-apps.ts
@@ -1,0 +1,122 @@
+import { getPlatformJwksUrlForDatabase } from "@/platform/oidc/issuer-urls";
+import {
+  syncBackendM2mAllowedScopesFromPublicApp,
+  updateClientConfig,
+} from "@/domains/oidc-platform/runtime/clients";
+import { resetProvider } from "@/domains/oidc-platform/runtime/provider-instance";
+import { getProviderApp } from "../repo/provider-access";
+import {
+  clearPendingRevisionReview,
+  listReviewableApps,
+  revokeApprovedApp,
+  updateInitialReviewState,
+} from "../repo/admin-apps";
+import { getOidcClientByRowId } from "../repo/app-core";
+import { parseAdminReviewInput } from "../service/admin-apps";
+
+export async function readAdminApps() {
+  return { apps: (await listReviewableApps()) || [] };
+}
+
+export async function reviewDeveloperApp(params: {
+  clientId: string;
+  reviewerUserId: string;
+  body: unknown;
+}): Promise<
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; status: 400 | 404; body: { error: string } | { error: string; message: string } }
+> {
+  const app = await getProviderApp(params.clientId);
+  if (!app) {
+    return { ok: false, status: 404, body: { error: "Not found" } };
+  }
+
+  const parsed = parseAdminReviewInput(params.body);
+  if (!parsed.ok) {
+    return parsed;
+  }
+
+  const now = new Date().toISOString();
+  const jwksUri = getPlatformJwksUrlForDatabase();
+
+  if (
+    app.status === "approved" &&
+    app.pendingRevisionSubmittedAt &&
+    app.pendingScopes &&
+    app.pendingGrantTypes &&
+    app.oidcClientId
+  ) {
+    const client = await getOidcClientByRowId(app.oidcClientId);
+    if (parsed.value.action === "approve" && client) {
+      await updateClientConfig(client.clientId, {
+        allowedScopes: app.pendingScopes,
+        grantTypes: app.pendingGrantTypes.split(",").filter(Boolean),
+      });
+      resetProvider();
+      if (await syncBackendM2mAllowedScopesFromPublicApp(app.id)) {
+        resetProvider();
+      }
+    }
+
+    await clearPendingRevisionReview({
+      appId: app.id,
+      notes: parsed.value.action === "reject" ? parsed.value.notes : null,
+      updatedAt: now,
+      setJwksUri: parsed.value.action === "approve" ? jwksUri : null,
+    });
+
+    return {
+      ok: true,
+      body: {
+        success: true,
+        status: "approved",
+        revisionApproved: parsed.value.action === "approve",
+      },
+    };
+  }
+
+  if (app.status !== "submitted" && app.status !== "in_review") {
+    return {
+      ok: false,
+      status: 400,
+      body: { error: `Cannot review app with status '${app.status}'` },
+    };
+  }
+
+  const newStatus = parsed.value.action === "approve" ? "approved" : "rejected";
+  await updateInitialReviewState({
+    appId: app.id,
+    newStatus,
+    notes: parsed.value.notes,
+    reviewerUserId: params.reviewerUserId,
+    reviewedAt: now,
+    setJwksUri: parsed.value.action === "approve" ? jwksUri : null,
+  });
+
+  return { ok: true, body: { success: true, status: newStatus } };
+}
+
+export async function revokeReviewedDeveloperApp(clientId: string): Promise<
+  | { ok: true; body: { success: true; status: "submitted" } }
+  | { ok: false; status: 404; body: { error: string } }
+> {
+  const app = await getProviderApp(clientId);
+  if (!app) {
+    return {
+      ok: false,
+      status: 404,
+      body: { error: "App not found or not in approved status" },
+    };
+  }
+
+  const updated = await revokeApprovedApp(app.id, new Date().toISOString());
+  if (updated.length === 0) {
+    return {
+      ok: false,
+      status: 404,
+      body: { error: "App not found or not in approved status" },
+    };
+  }
+
+  return { ok: true, body: { success: true, status: "submitted" } };
+}

--- a/src/domains/developer-apps/runtime/api-key-validation.ts
+++ b/src/domains/developer-apps/runtime/api-key-validation.ts
@@ -1,0 +1,51 @@
+import { hashToken } from "@/domains/identity-access/runtime/request-auth";
+import {
+  getApiKeyByHash,
+  getPlanForSubscription,
+  getSubscriptionForApiKey,
+  listCapabilitiesForPlan,
+} from "../repo/api-key-validation";
+
+export async function validateApiKeyToken(token: string) {
+  const apiKey = await getApiKeyByHash(hashToken(token));
+  if (!apiKey || apiKey.status !== "active") {
+    return { ok: false as const };
+  }
+
+  if (!apiKey.subscriptionId) {
+    return {
+      ok: true as const,
+      body: {
+        valid: true,
+        client_id: apiKey.clientId,
+        plan: null,
+        allowedModels: [],
+      },
+    };
+  }
+
+  const subscription = await getSubscriptionForApiKey(apiKey.subscriptionId, apiKey.clientId);
+  if (!subscription || subscription.status !== "active") {
+    return { ok: false as const };
+  }
+
+  const plan = await getPlanForSubscription(subscription.planId);
+  if (!plan) {
+    return { ok: false as const };
+  }
+
+  const capabilities = await listCapabilitiesForPlan(plan.id);
+  return {
+    ok: true as const,
+    body: {
+      valid: true,
+      client_id: apiKey.clientId,
+      plan: {
+        ...plan,
+        includedUnits: plan.includedUnits != null ? plan.includedUnits.toString() : null,
+        overageRateWei: plan.overageRateWei != null ? plan.overageRateWei.toString() : null,
+      },
+      allowedModels: capabilities.map((bundle) => bundle.modelId).filter(Boolean),
+    },
+  };
+}

--- a/src/domains/developer-apps/runtime/app-access.ts
+++ b/src/domains/developer-apps/runtime/app-access.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from "next/server";
+import { authenticateAppClient } from "@/domains/identity-access/runtime/request-auth";
+import { getProviderApp } from "../repo/provider-access";
+import { getAuthorizedProviderApp } from "./provider-access";
+
+export async function getProviderAppForClientOrDashboard(
+  request: NextRequest,
+  clientId: string,
+): Promise<Awaited<ReturnType<typeof getProviderApp>> | null> {
+  const clientAuth = await authenticateAppClient(request);
+  if (clientAuth?.appId === clientId) {
+    return getProviderApp(clientId);
+  }
+
+  try {
+    const providerAuth = await getAuthorizedProviderApp(clientId);
+    return providerAuth?.app ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/domains/developer-apps/runtime/app-admins.ts
+++ b/src/domains/developer-apps/runtime/app-admins.ts
@@ -1,0 +1,57 @@
+import {
+  createAppAdminMembership,
+  deleteAppAdminMembership,
+  getAppAdminMembership,
+  getUserById,
+  listAppAdminMemberships,
+} from "../repo/app-admins";
+import { parseCreateAppAdminInput, parseDeleteAppAdminInput } from "../service/app-admins";
+
+export async function readAppAdmins(clientId: string, appId: string) {
+  const { memberships, adminUsers } = await listAppAdminMemberships(appId);
+  return memberships.map((membership) => ({
+    ...membership,
+    clientId,
+    user: adminUsers.find((user) => user.id === membership.userId) || null,
+  }));
+}
+
+export async function addAppAdmin(
+  clientId: string,
+  appId: string,
+  body: unknown,
+): Promise<
+  | { ok: true; status: 200 | 201; body: Record<string, unknown> }
+  | { ok: false; status: 400 | 404; error: string }
+> {
+  const parsed = parseCreateAppAdminInput(body);
+  if (!parsed.ok) {
+    return { ok: false, status: 400, error: parsed.error };
+  }
+
+  const user = await getUserById(parsed.value.userId);
+  if (!user) {
+    return { ok: false, status: 404, error: "User not found" };
+  }
+
+  const existing = await getAppAdminMembership(appId, parsed.value.userId);
+  if (existing) {
+    return { ok: true, status: 200, body: existing };
+  }
+
+  const membership = await createAppAdminMembership(appId, parsed.value.userId, parsed.value.role);
+  return { ok: true, status: 201, body: { ...membership, clientId } };
+}
+
+export async function removeAppAdmin(
+  appId: string,
+  userIdParam: string | null,
+): Promise<{ ok: true } | { ok: false; status: 400; error: string }> {
+  const parsed = parseDeleteAppAdminInput(userIdParam);
+  if (!parsed.ok) {
+    return { ok: false, status: 400, error: parsed.error };
+  }
+
+  await deleteAppAdminMembership(appId, parsed.value);
+  return { ok: true };
+}

--- a/src/domains/developer-apps/runtime/app-billing.ts
+++ b/src/domains/developer-apps/runtime/app-billing.ts
@@ -1,0 +1,113 @@
+import type { NextRequest } from "next/server";
+import { getProviderAppForClientOrDashboard } from "./app-access";
+import {
+  getLatestActivePlanForApp,
+  getOwnerActiveSubscription,
+  getPlanById,
+  getPlatformCutPercent,
+  listUsageBillingEventsForUsageRecords,
+  listUsageRecordsForBillingPeriod,
+} from "../repo/app-billing";
+import { buildBillingCycleSummary, resolveBillingPeriod } from "../service/app-billing";
+
+export async function readAppBilling(request: NextRequest, clientId: string): Promise<
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; status: 404; body: { error: string } }
+> {
+  const app = await getProviderAppForClientOrDashboard(request, clientId);
+  if (!app) {
+    return { ok: false, status: 404, body: { error: "Not found" } };
+  }
+
+  const platformCutPercent = await getPlatformCutPercent();
+  const ownerSubscription = await getOwnerActiveSubscription(app.id, app.ownerId);
+
+  let planRow = ownerSubscription ? await getPlanById(ownerSubscription.planId) : null;
+  if (!planRow) {
+    planRow = await getLatestActivePlanForApp(app.id);
+  }
+
+  const { periodStart, periodEnd } = resolveBillingPeriod({
+    currentPeriodStart: ownerSubscription?.currentPeriodStart ?? null,
+    currentPeriodEnd: ownerSubscription?.currentPeriodEnd ?? null,
+    now: new Date(),
+  });
+
+  const usageRows = await listUsageRecordsForBillingPeriod({
+    appId: app.id,
+    periodStart,
+    periodEnd,
+  });
+  const billingEvents = await listUsageBillingEventsForUsageRecords({
+    appId: app.id,
+    usageRecordIds: usageRows.map((row) => row.id).filter(Boolean),
+  });
+
+  const cycle = buildBillingCycleSummary({
+    usageRows: usageRows.map((row) => ({
+      id: row.id,
+      createdAt: row.createdAt,
+      fee: row.fee || "0",
+      units: row.units || "0",
+    })),
+    billingEvents: billingEvents.map((event) => ({
+      pipeline: event.pipeline,
+      modelId: event.modelId,
+      networkFeeWei: event.networkFeeWei,
+      networkFeeUsdMicros: event.networkFeeUsdMicros,
+      platformFeeUsdMicros: event.platformFeeUsdMicros,
+      ownerChargeWei: event.ownerChargeWei,
+      ownerChargeUsdMicros: event.ownerChargeUsdMicros,
+      endUserBillableUsdMicros: event.endUserBillableUsdMicros,
+    })),
+    periodStart,
+    periodEnd,
+    plan: planRow
+      ? {
+          type: planRow.type,
+          includedUnits: planRow.includedUnits != null ? planRow.includedUnits.toString() : null,
+          overageRateWei: planRow.overageRateWei != null ? planRow.overageRateWei.toString() : null,
+          includedUsdMicros: planRow.includedUsdMicros ?? null,
+        }
+      : null,
+  });
+
+  return {
+    ok: true,
+    body: {
+      clientId,
+      plan: planRow
+        ? {
+            id: planRow.id,
+            type: planRow.type,
+            name: planRow.name,
+            priceAmount: planRow.priceAmount,
+            priceCurrency: planRow.priceCurrency,
+            includedUnits:
+              planRow.includedUnits != null ? planRow.includedUnits.toString() : null,
+            overageRateWei:
+              planRow.overageRateWei != null ? planRow.overageRateWei.toString() : null,
+            includedUsdMicros: planRow.includedUsdMicros ?? null,
+            generalUpchargePercentBps: planRow.generalUpchargePercentBps ?? null,
+            payPerUseUpchargePercentBps: planRow.payPerUseUpchargePercentBps ?? null,
+            billingCycle: planRow.billingCycle,
+            status: planRow.status,
+          }
+        : null,
+      subscription: ownerSubscription
+        ? {
+            id: ownerSubscription.id,
+            status: ownerSubscription.status,
+            currentPeriodStart: ownerSubscription.currentPeriodStart,
+            currentPeriodEnd: ownerSubscription.currentPeriodEnd,
+          }
+        : null,
+      cycle: {
+        periodStart,
+        periodEnd,
+        ...cycle,
+      },
+      platformCutPercent,
+    },
+  };
+}

--- a/src/domains/developer-apps/runtime/app-core.ts
+++ b/src/domains/developer-apps/runtime/app-core.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server";
+import {
+  ensureM2mBackendClient,
+  syncBackendM2mAllowedScopesFromPublicApp,
+  updateClientConfig,
+} from "@/domains/oidc-platform/runtime/clients";
+import { resetProvider } from "@/domains/oidc-platform/runtime/provider-instance";
+import { deleteDeveloperAppAndRelatedData } from "@/domains/developer-apps/repo/delete-app";
+import {
+  appEditForbiddenResponse,
+  canEditProviderApp,
+  type AuthorizedProviderApp,
+} from "./provider-access";
+import {
+  getM2mClientSummaryForApp,
+  getOidcClientByRowId,
+  transitionAppStatus,
+  updateDeveloperApp,
+} from "../repo/app-core";
+import { hasClientConfigUpdates, parseAppCoreUpdate } from "../service/app-core";
+
+export async function updateAuthorizedApp(
+  auth: AuthorizedProviderApp,
+  body: Record<string, unknown>,
+): Promise<
+  | { ok: true; body: { success: true; m2mOidcClient: { clientId: string; hasSecret: boolean } | null } }
+  | { ok: false; response: NextResponse }
+> {
+  if (!(await canEditProviderApp(auth))) {
+    return { ok: false, response: appEditForbiddenResponse() };
+  }
+
+  const existingClient = auth.app.oidcClientId
+    ? await getOidcClientByRowId(auth.app.oidcClientId)
+    : null;
+  const parsed = parseAppCoreUpdate(body, existingClient);
+
+  await updateDeveloperApp(auth.app.id, parsed.appUpdates);
+
+  if (existingClient && hasClientConfigUpdates(parsed.clientUpdates)) {
+    await updateClientConfig(existingClient.clientId, parsed.clientUpdates);
+    resetProvider();
+  }
+
+  let m2mAfter: { clientId: string; hasSecret: boolean } | null = null;
+  if (parsed.backendDeviceHelper) {
+    await ensureM2mBackendClient({
+      appInternalId: auth.app.id,
+      appDisplayName:
+        typeof body.name === "string" && body.name.trim() ? body.name.trim() : auth.app.name,
+    });
+    resetProvider();
+    m2mAfter = await getM2mClientSummaryForApp(auth.app.id);
+  }
+
+  if (await syncBackendM2mAllowedScopesFromPublicApp(auth.app.id)) {
+    resetProvider();
+  }
+
+  return { ok: true, body: { success: true, m2mOidcClient: m2mAfter } };
+}
+
+export async function deleteAuthorizedDraftApp(
+  auth: AuthorizedProviderApp,
+): Promise<
+  | { ok: true }
+  | { ok: false; status: 403 | 400; body: { error: string } }
+> {
+  if (auth.app.ownerId !== auth.userId) {
+    return {
+      ok: false,
+      status: 403,
+      body: { error: "Only the app owner can delete this app." },
+    };
+  }
+
+  if (auth.app.status !== "draft") {
+    return {
+      ok: false,
+      status: 400,
+      body: { error: "Only draft apps can be deleted." },
+    };
+  }
+
+  await deleteDeveloperAppAndRelatedData(auth.app.id, auth.app.oidcClientId ?? null);
+  return { ok: true };
+}
+
+export async function submitOwnedAppForReview(params: {
+  app: { id: string; ownerId: string; status: string };
+  userId: string;
+}): Promise<
+  | { ok: true; body: { success: true; status: "submitted"; message: string } }
+  | { ok: false; status: 403 | 409; body: { error: string; message?: string } }
+> {
+  if (params.app.ownerId !== params.userId) {
+    return {
+      ok: false,
+      status: 403,
+      body: { error: "Only the app owner can submit for review" },
+    };
+  }
+
+  const now = new Date().toISOString();
+  const updated = await transitionAppStatus({
+    appId: params.app.id,
+    allowedCurrentStatuses: ["draft", "rejected"],
+    nextStatus: "submitted",
+    submittedAt: now,
+    updatedAt: now,
+  });
+  if (updated.length === 0) {
+    return {
+      ok: false,
+      status: 409,
+      body: {
+        error: "Invalid status",
+        message: `App is currently ${params.app.status}. Only draft or rejected apps can be submitted for review.`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    body: { success: true, status: "submitted", message: "App submitted for review" },
+  };
+}
+
+export async function revertOwnedAppToDraft(params: {
+  app: { id: string; ownerId: string; status: string };
+  userId: string;
+}): Promise<
+  | { ok: true; body: { success: true; status: "draft"; message: string } }
+  | { ok: false; status: 403 | 409; body: { error: string; message?: string } }
+> {
+  if (params.app.ownerId !== params.userId) {
+    return {
+      ok: false,
+      status: 403,
+      body: { error: "Only the app owner can revert a submitted app to draft" },
+    };
+  }
+
+  const now = new Date().toISOString();
+  const updated = await transitionAppStatus({
+    appId: params.app.id,
+    allowedCurrentStatuses: ["submitted"],
+    nextStatus: "draft",
+    submittedAt: null,
+    updatedAt: now,
+  });
+  if (updated.length === 0) {
+    return {
+      ok: false,
+      status: 409,
+      body: {
+        error: "Invalid status",
+        message: `App is currently ${params.app.status}. Only submitted apps can be reverted to draft.`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    body: { success: true, status: "draft", message: "App reverted to draft" },
+  };
+}
+
+export function publishAppMarketplaceDisabled() {
+  return {
+    published: false,
+    reason: "marketplace_publish_disabled",
+  };
+}

--- a/src/domains/developer-apps/runtime/app-create.ts
+++ b/src/domains/developer-apps/runtime/app-create.ts
@@ -1,0 +1,60 @@
+import {
+  createAppClient,
+  ensureM2mBackendClient,
+  updateClientConfig,
+} from "@/domains/oidc-platform/runtime/clients";
+import { resetProvider } from "@/domains/oidc-platform/runtime/provider-instance";
+import {
+  ensureProviderAdminMembership,
+  listAppsVisibleToUser,
+} from "../repo/provider-access";
+import { createDeveloperAppRecord } from "../repo/app-create";
+import { hasClientConfigUpdates } from "../service/app-core";
+import { parseAppCreateInput } from "../service/app-create";
+
+export async function readVisibleAppsForUser(userId: string) {
+  return { apps: await listAppsVisibleToUser(userId) };
+}
+
+export async function createDeveloperAppForUser(
+  userId: string,
+  body: unknown,
+): Promise<
+  | { ok: true; body: { id: string; clientId: string; status: "draft" } }
+  | { ok: false; status: 400; body: { error: string } }
+> {
+  const parsed = parseAppCreateInput(body);
+  if (!parsed.ok) {
+    return parsed;
+  }
+
+  const { id: oidcRowId, clientId } = await createAppClient(parsed.value.name);
+  if (hasClientConfigUpdates(parsed.value.clientUpdates)) {
+    await updateClientConfig(clientId, parsed.value.clientUpdates);
+  }
+
+  const now = new Date().toISOString();
+  await createDeveloperAppRecord({
+    id: clientId,
+    ownerId: userId,
+    oidcClientId: oidcRowId,
+    name: parsed.value.name,
+    developerName: parsed.value.developerName,
+    websiteUrl: parsed.value.websiteUrl,
+    status: "draft",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  if (parsed.value.backendDeviceHelper) {
+    await ensureM2mBackendClient({
+      appInternalId: clientId,
+      appDisplayName: parsed.value.name,
+    });
+  }
+
+  resetProvider();
+  await ensureProviderAdminMembership(userId, clientId);
+
+  return { ok: true, body: { id: clientId, clientId, status: "draft" } };
+}

--- a/src/domains/developer-apps/runtime/app-credentials.ts
+++ b/src/domains/developer-apps/runtime/app-credentials.ts
@@ -1,0 +1,68 @@
+import { rotateClientSecret } from "@/domains/oidc-platform/runtime/clients";
+import { getOidcCredentialClientById } from "../repo/app-credentials";
+import {
+  resolveSecretRotationTarget,
+  validateSecretRotationClient,
+} from "../service/app-credentials";
+
+export async function rotateAppClientSecret(params: {
+  oidcClientId: string | null;
+  m2mOidcClientId: string | null;
+}): Promise<
+  | {
+      ok: true;
+      body: {
+        clientId: string;
+        clientSecret: string;
+        message: string;
+      };
+    }
+  | {
+      ok: false;
+      status: 400 | 500;
+      body: {
+        error: string;
+        error_description?: string;
+      };
+    }
+> {
+  const primaryClient = params.oidcClientId
+    ? await getOidcCredentialClientById(params.oidcClientId)
+    : null;
+
+  const target = resolveSecretRotationTarget({
+    oidcClientId: params.oidcClientId,
+    m2mOidcClientId: params.m2mOidcClientId,
+    primaryClient,
+  });
+  if (!target.ok) {
+    return target;
+  }
+
+  const targetClient =
+    primaryClient?.id === target.value
+      ? primaryClient
+      : await getOidcCredentialClientById(target.value);
+  const validated = validateSecretRotationClient(targetClient);
+  if (!validated.ok) {
+    return validated;
+  }
+
+  const secret = await rotateClientSecret(validated.value.clientId);
+  if (!secret) {
+    return {
+      ok: false,
+      status: 500,
+      body: { error: "Failed to generate secret" },
+    };
+  }
+
+  return {
+    ok: true,
+    body: {
+      clientId: validated.value.clientId,
+      clientSecret: secret,
+      message: "Store this secret securely. It will not be shown again.",
+    },
+  };
+}

--- a/src/domains/developer-apps/runtime/app-detail.ts
+++ b/src/domains/developer-apps/runtime/app-detail.ts
@@ -1,0 +1,72 @@
+import { DEFAULT_OIDC_SCOPES } from "@/platform/oidc/scopes";
+import { billingPatternFromAllowedScopesString } from "@/platform/oidc/allowed-scopes";
+import type { AuthorizedProviderApp } from "./provider-access";
+import { getOidcClientByRowId, listAppAllowedDomains } from "../repo/app-oidc";
+
+export async function readAuthorizedAppDetail(clientId: string, auth: AuthorizedProviderApp) {
+  const { app } = auth;
+
+  let clientInfo = null;
+  let m2mOidcClient: {
+    clientId: string;
+    hasSecret: boolean;
+  } | null = null;
+
+  if (app.oidcClientId) {
+    const client = await getOidcClientByRowId(app.oidcClientId);
+
+    if (client) {
+      clientInfo = {
+        clientId: client.clientId,
+        redirectUris: JSON.parse(client.redirectUris) as string[],
+        allowedScopes: client.allowedScopes,
+        grantTypes: client.grantTypes,
+        tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+        hasSecret: !!client.clientSecretHash,
+        postLogoutRedirectUris: client.postLogoutRedirectUris
+          ? (JSON.parse(client.postLogoutRedirectUris) as string[])
+          : [],
+        initiateLoginUri: client.initiateLoginUri,
+        deviceThirdPartyInitiateLogin: client.deviceThirdPartyInitiateLogin === 1,
+        logoUri: client.logoUri,
+        policyUri: client.policyUri,
+        tosUri: client.tosUri,
+        clientUri: client.clientUri,
+      };
+    }
+  }
+
+  if (app.m2mOidcClientId) {
+    const m2m = await getOidcClientByRowId(app.m2mOidcClientId);
+    if (m2m) {
+      m2mOidcClient = {
+        clientId: m2m.clientId,
+        hasSecret: !!m2m.clientSecretHash,
+      };
+    }
+  }
+
+  const domains = await listAppAllowedDomains(app.id);
+
+  const canonicalClientId = clientInfo?.clientId ?? clientId;
+  const { oidcClientId: _oidcClientId, ...appWithoutOidcClientId } = app;
+  const billingPattern = clientInfo
+    ? billingPatternFromAllowedScopesString(clientInfo.allowedScopes ?? DEFAULT_OIDC_SCOPES)
+    : "app_level";
+
+  return {
+    ...appWithoutOidcClientId,
+    billingPattern,
+    id: canonicalClientId,
+    clientId: canonicalClientId,
+    canSubmitForReview: auth.app.ownerId === auth.userId,
+    oidcClient: clientInfo
+      ? {
+          ...clientInfo,
+          allowedScopes: clientInfo.allowedScopes ?? DEFAULT_OIDC_SCOPES,
+        }
+      : null,
+    m2mOidcClient,
+    domains,
+  };
+}

--- a/src/domains/developer-apps/runtime/app-domains.ts
+++ b/src/domains/developer-apps/runtime/app-domains.ts
@@ -1,0 +1,62 @@
+import { listAppDomains, insertAppDomain, deleteAppDomain } from "../repo/app-domains";
+import {
+  domainDuplicateError,
+  parseDomainCreateInput,
+  parseDomainDeleteInput,
+} from "../service/app-domains";
+
+export async function readAppDomains(appId: string) {
+  return listAppDomains(appId);
+}
+
+export async function createAppDomain(
+  appId: string,
+  body: unknown,
+): Promise<
+  | { ok: true; value: { id: string; domain: string } }
+  | { ok: false; status: 400 | 409; error: string }
+> {
+  const parsed = parseDomainCreateInput(body);
+  if (!parsed.ok) {
+    return { ok: false, status: 400, error: parsed.error };
+  }
+
+  const existingDomains = await listAppDomains(appId);
+  const isDuplicate = existingDomains.some(
+    (d) => d.domain.toLowerCase() === parsed.value.domain.toLowerCase(),
+  );
+  if (isDuplicate) {
+    return {
+      ok: false,
+      status: 409,
+      error: domainDuplicateError(parsed.value.domain),
+    };
+  }
+
+  try {
+    const id = await insertAppDomain(appId, parsed.value.domain);
+    return { ok: true, value: { id, domain: parsed.value.domain } };
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "code" in err && (err as { code: string }).code === "23505") {
+      return {
+        ok: false,
+        status: 409,
+        error: domainDuplicateError(parsed.value.domain),
+      };
+    }
+    throw err;
+  }
+}
+
+export async function removeAppDomain(
+  appId: string,
+  domainIdParam: string | null,
+): Promise<{ ok: true } | { ok: false; status: 400; error: string }> {
+  const parsed = parseDomainDeleteInput(domainIdParam);
+  if (!parsed.ok) {
+    return { ok: false, status: 400, error: parsed.error };
+  }
+
+  await deleteAppDomain(appId, parsed.value);
+  return { ok: true };
+}

--- a/src/domains/developer-apps/runtime/app-keys.ts
+++ b/src/domains/developer-apps/runtime/app-keys.ts
@@ -1,0 +1,120 @@
+import { hashToken } from "@/domains/identity-access/runtime/request-auth";
+import { generateApiKeyValue } from "@/domains/oidc-platform/runtime/programmatic-tokens";
+import {
+  createCorrelationId,
+  writeAuditLog,
+} from "@/domains/identity-access/runtime/audit";
+import {
+  createAppKeyRecord,
+  getSubscriptionForApp,
+  listAppKeys,
+  revokeAppKey,
+} from "../repo/app-keys";
+import { parseCreateAppKeyInput, parseDeleteAppKeyInput } from "../service/app-keys";
+
+export async function readAppKeys(clientId: string, appId: string) {
+  const keys = await listAppKeys(appId);
+  return {
+    keys: keys.map((key) => ({
+      ...key,
+      clientId,
+    })),
+  };
+}
+
+export async function createAppKey(params: {
+  clientId: string;
+  appId: string;
+  actorUserId: string | null;
+  body: unknown;
+}): Promise<
+  | {
+      ok: true;
+      body: {
+        apiKey: string;
+        id: string;
+        message: string;
+        correlation_id: string;
+      };
+    }
+  | { ok: false; status: 404; body: { error: string } }
+> {
+  const parsed = parseCreateAppKeyInput(params.body);
+  const { subscriptionId, label } = parsed.value;
+
+  if (subscriptionId) {
+    const subscription = await getSubscriptionForApp(subscriptionId, params.appId);
+    if (!subscription) {
+      return { ok: false, status: 404, body: { error: "Subscription not found" } };
+    }
+  }
+
+  const apiKeyValue = generateApiKeyValue();
+  const id = crypto.randomUUID();
+  await createAppKeyRecord({
+    id,
+    keyHash: hashToken(apiKeyValue),
+    userId: params.actorUserId,
+    clientId: params.appId,
+    subscriptionId,
+    label,
+    status: "active",
+    createdAt: new Date().toISOString(),
+    revokedAt: null,
+  });
+
+  const correlationId = createCorrelationId();
+  await writeAuditLog({
+    clientId: params.appId,
+    actorUserId: params.actorUserId,
+    action: "api_key_created",
+    status: "success",
+    correlationId,
+    metadata: {
+      keyId: id,
+      subscriptionId,
+      label,
+    },
+  });
+
+  return {
+    ok: true,
+    body: {
+      apiKey: apiKeyValue,
+      id,
+      message: "Store this API key securely. It will not be shown again.",
+      correlation_id: correlationId,
+    },
+  };
+}
+
+export async function revokeExistingAppKey(params: {
+  appId: string;
+  actorUserId: string | null;
+  keyId: string | null;
+}): Promise<
+  | { ok: true; body: { success: true; correlation_id: string } }
+  | { ok: false; status: 400 | 404; body: { error: string } }
+> {
+  const parsed = parseDeleteAppKeyInput(params.keyId);
+  if (!parsed.ok) {
+    return { ok: false, status: 400, body: { error: parsed.error } };
+  }
+
+  const revoked = await revokeAppKey(parsed.value, params.appId, new Date().toISOString());
+  if (revoked.length === 0) {
+    return { ok: false, status: 404, body: { error: "Key not found" } };
+  }
+
+  const correlationId = createCorrelationId();
+  await writeAuditLog({
+    clientId: params.appId,
+    actorUserId: params.actorUserId,
+    action: "api_key_revoked",
+    status: "success",
+    correlationId,
+    metadata: { keyId: parsed.value },
+  });
+
+  return { ok: true, body: { success: true, correlation_id: correlationId } };
+}

--- a/src/domains/developer-apps/runtime/app-settings.ts
+++ b/src/domains/developer-apps/runtime/app-settings.ts
@@ -1,0 +1,88 @@
+import { updateClientConfig } from "@/domains/oidc-platform/runtime/clients";
+import { resetProvider } from "@/domains/oidc-platform/runtime/provider-instance";
+import {
+  extractOrigins,
+  maybeAugmentAllowedScopesForDeviceFlow,
+  normalizeOriginsToDomains,
+  parseAppSettingsUpdate,
+  validateDeviceInitiateLoginSettings,
+} from "../service/app-settings";
+import { ensureAppDomains } from "../repo/app-domains";
+import { getOidcClientByRowId } from "../repo/app-oidc";
+
+export async function applyAppSettingsUpdate(
+  app: {
+    id: string;
+    oidcClientId: string | null;
+    logoLightUrl: string | null;
+    websiteUrl: string | null;
+    privacyPolicyUrl: string | null;
+    tosUrl: string | null;
+  },
+  body: Record<string, unknown>,
+): Promise<
+  | { ok: true }
+  | { ok: false; status: 400 | 404; body: Record<string, unknown> }
+> {
+  if (!app.oidcClientId) {
+    return { ok: false, status: 400, body: { error: "App has no OIDC client" } };
+  }
+
+  const client = await getOidcClientByRowId(app.oidcClientId);
+  if (!client) {
+    return { ok: false, status: 404, body: { error: "OIDC client not found" } };
+  }
+
+  const parsed = parseAppSettingsUpdate(body);
+  const nextInitiateLoginUri =
+    parsed.initiateLoginUri !== undefined ? parsed.initiateLoginUri : client.initiateLoginUri;
+  const nextDeviceThirdParty =
+    parsed.deviceThirdPartyInitiateLogin !== undefined
+      ? parsed.deviceThirdPartyInitiateLogin
+      : client.deviceThirdPartyInitiateLogin === 1;
+
+  const validation = validateDeviceInitiateLoginSettings({
+    initiateLoginUri: nextInitiateLoginUri,
+    deviceThirdPartyInitiateLogin: nextDeviceThirdParty,
+  });
+  if (!validation.ok) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: validation.error,
+        error_description: validation.description,
+      },
+    };
+  }
+
+  const clientUpdates: Parameters<typeof updateClientConfig>[1] = {
+    ...parsed,
+    logoUri: app.logoLightUrl || null,
+    clientUri: app.websiteUrl || null,
+    policyUri: app.privacyPolicyUrl || null,
+    tosUri: app.tosUrl || null,
+  };
+
+  const maybeAllowedScopes = maybeAugmentAllowedScopesForDeviceFlow({
+    allowedScopes: client.allowedScopes,
+    grantTypes: client.grantTypes.split(",").filter(Boolean),
+    initiateLoginUri: nextInitiateLoginUri,
+    deviceThirdPartyInitiateLogin: nextDeviceThirdParty,
+  });
+  if (maybeAllowedScopes) {
+    clientUpdates.allowedScopes = maybeAllowedScopes;
+  }
+
+  await updateClientConfig(client.clientId, clientUpdates);
+
+  const allRedirects = [
+    ...(parsed.redirectUris ?? (JSON.parse(client.redirectUris) as string[])),
+    ...(parsed.postLogoutRedirectUris ?? []),
+  ];
+  const domains = normalizeOriginsToDomains(extractOrigins(allRedirects));
+  await ensureAppDomains(app.id, domains);
+
+  resetProvider();
+  return { ok: true };
+}

--- a/src/domains/developer-apps/runtime/app-usage.ts
+++ b/src/domains/developer-apps/runtime/app-usage.ts
@@ -1,0 +1,203 @@
+import type { NextRequest } from "next/server";
+import { weiToEthString } from "@/domains/usage-billing/service/billing-runtime";
+import { getProviderAppForClientOrDashboard } from "./app-access";
+import {
+  listAppUsersByExternalIds,
+  listAppUsersByIds,
+  listEndUsersByExternalIds,
+  listEndUsersByIds,
+  listUsageBillingEvents,
+  listUsageRecords,
+} from "../repo/app-usage";
+import { buildUsageTotals, parseUsageQuery } from "../service/app-usage";
+
+type UsageUserType = "system_managed" | "oidc_authorized" | "unknown";
+
+export async function readAppUsage(
+  request: NextRequest,
+  clientId: string,
+): Promise<
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; status: 400 | 404; body: { error: string } }
+> {
+  const app = await getProviderAppForClientOrDashboard(request, clientId);
+  if (!app) {
+    return { ok: false, status: 404, body: { error: "Not found" } };
+  }
+
+  const parsed = parseUsageQuery(new URL(request.url));
+  if (!parsed.ok) {
+    return parsed;
+  }
+
+  let rows = await listUsageRecords({
+    appId: app.id,
+    startDate: parsed.value.startDate,
+    endDate: parsed.value.endDate,
+    filterUserId: parsed.value.filterUserId,
+  });
+
+  const billingEvents = await listUsageBillingEvents({
+    appId: app.id,
+    usageRecordIds: rows.map((row) => row.id).filter(Boolean),
+    gatewayRequestId: parsed.value.filterGatewayRequestId,
+  });
+
+  if (parsed.value.filterGatewayRequestId) {
+    const allowedUsageIds = new Set(
+      billingEvents
+        .map((event) => event.usageRecordId)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    );
+    rows = rows.filter((row) => allowedUsageIds.has(row.id));
+  }
+
+  const eventByUsageRecord = new Map(billingEvents.map((event) => [event.usageRecordId, event]));
+  const response: Record<string, unknown> = {
+    clientId,
+    period: { start: parsed.value.startDate, end: parsed.value.endDate },
+    totals: buildUsageTotals({
+      usageRows: rows.map((row) => ({ id: row.id, fee: row.fee })),
+      eventByUsageRecord,
+    }),
+  };
+
+  if (parsed.value.groupBy === "user") {
+    const byUserMap = new Map<string, {
+      feeWei: bigint;
+      networkFeeUsdMicros: bigint;
+      endUserBillableUsdMicros: bigint;
+      count: number;
+    }>();
+
+    for (const row of rows) {
+      const userId = row.userId || "unknown";
+      const existing = byUserMap.get(userId) || {
+        feeWei: 0n,
+        networkFeeUsdMicros: 0n,
+        endUserBillableUsdMicros: 0n,
+        count: 0,
+      };
+      existing.feeWei += BigInt(row.fee);
+      existing.count += 1;
+      const event = eventByUsageRecord.get(row.id);
+      if (event) {
+        existing.networkFeeUsdMicros += BigInt(event.networkFeeUsdMicros);
+        existing.endUserBillableUsdMicros += BigInt(event.endUserBillableUsdMicros);
+      }
+      byUserMap.set(userId, existing);
+    }
+
+    const userIds = [...byUserMap.keys()].filter((key) => key !== "unknown");
+    const appUserMap = new Map((await listAppUsersByIds(userIds)).map((u) => [u.id, u]));
+    const appUserExternalMap = new Map(
+      (await listAppUsersByExternalIds(userIds)).map((u) => [u.externalUserId, u]),
+    );
+    const endUserMap = new Map((await listEndUsersByIds(app.id, userIds)).map((u) => [u.id, u]));
+    const endUserExternalMap = new Map(
+      (await listEndUsersByExternalIds(app.id, userIds)).map((u) => [u.externalUserId, u]),
+    );
+
+    response.byUser = [...byUserMap.entries()].map(([endUserId, data]) => {
+      const externalUserId =
+        appUserMap.get(endUserId)?.externalUserId ??
+        appUserExternalMap.get(endUserId)?.externalUserId ??
+        endUserMap.get(endUserId)?.externalUserId ??
+        endUserExternalMap.get(endUserId)?.externalUserId ??
+        null;
+      let userType: UsageUserType = "unknown";
+      if (externalUserId) userType = "system_managed";
+      else if (endUserId !== "unknown") userType = "oidc_authorized";
+
+      return {
+        endUserId,
+        externalUserId,
+        userType,
+        identifier: endUserId,
+        feeWei: data.feeWei.toString(),
+        feeEth: weiToEthString(data.feeWei),
+        networkFeeUsdMicros: data.networkFeeUsdMicros.toString(),
+        endUserBillableUsdMicros: data.endUserBillableUsdMicros.toString(),
+        requestCount: data.count,
+      };
+    });
+  }
+
+  if (parsed.value.groupBy === "pipeline_model") {
+    const byKeyMap = new Map<string, {
+      pipeline: string;
+      modelId: string;
+      feeWei: bigint;
+      networkFeeUsdMicros: bigint;
+      ownerChargeUsdMicros: bigint;
+      endUserBillableUsdMicros: bigint;
+      count: number;
+    }>();
+
+    for (const event of billingEvents) {
+      const key = `${event.pipeline}|${event.modelId}`;
+      const existing = byKeyMap.get(key) || {
+        pipeline: event.pipeline,
+        modelId: event.modelId,
+        feeWei: 0n,
+        networkFeeUsdMicros: 0n,
+        ownerChargeUsdMicros: 0n,
+        endUserBillableUsdMicros: 0n,
+        count: 0,
+      };
+      existing.feeWei += BigInt(event.networkFeeWei);
+      existing.networkFeeUsdMicros += BigInt(event.networkFeeUsdMicros);
+      existing.ownerChargeUsdMicros += BigInt(event.ownerChargeUsdMicros);
+      existing.endUserBillableUsdMicros += BigInt(event.endUserBillableUsdMicros);
+      existing.count += 1;
+      byKeyMap.set(key, existing);
+    }
+
+    response.byPipelineModel = [...byKeyMap.values()].map((data) => ({
+      pipeline: data.pipeline,
+      modelId: data.modelId,
+      requestCount: data.count,
+      networkFeeWei: data.feeWei.toString(),
+      networkFeeEth: weiToEthString(data.feeWei),
+      networkFeeUsdMicros: data.networkFeeUsdMicros.toString(),
+      ownerChargeUsdMicros: data.ownerChargeUsdMicros.toString(),
+      endUserBillableUsdMicros: data.endUserBillableUsdMicros.toString(),
+    }));
+  }
+
+  if (parsed.value.filterGatewayRequestId) {
+    response.events = billingEvents.map((event) => ({
+      id: event.id,
+      usageRecordId: event.usageRecordId,
+      pipeline: event.pipeline,
+      modelId: event.modelId,
+      attributionSource: event.attributionSource,
+      gatewayRequestId: event.gatewayRequestId,
+      paymentMetadataVersion: event.paymentMetadataVersion,
+      pipelineModelConstraintHash: event.pipelineModelConstraintHash,
+      orchAddress: event.orchAddress,
+      advertisedPriceWeiPerUnit: event.advertisedPriceWeiPerUnit,
+      advertisedPixelsPerUnit: event.advertisedPixelsPerUnit,
+      signedPriceWeiPerUnit: event.signedPriceWeiPerUnit,
+      signedPixelsPerUnit: event.signedPixelsPerUnit,
+      networkFeeWei: event.networkFeeWei,
+      networkFeeEth: weiToEthString(BigInt(event.networkFeeWei)),
+      networkFeeUsdMicros: event.networkFeeUsdMicros,
+      platformFeeWei: event.platformFeeWei,
+      platformFeeEth: weiToEthString(BigInt(event.platformFeeWei)),
+      platformFeeUsdMicros: event.platformFeeUsdMicros,
+      ownerChargeWei: event.ownerChargeWei,
+      ownerChargeEth: weiToEthString(BigInt(event.ownerChargeWei)),
+      ownerChargeUsdMicros: event.ownerChargeUsdMicros,
+      upchargePercentBps: event.upchargePercentBps,
+      pricingRuleSource: event.pricingRuleSource,
+      endUserBillableUsdMicros: event.endUserBillableUsdMicros,
+      ethUsdPrice: event.ethUsdPrice,
+      ethUsdSource: event.ethUsdSource,
+      ethUsdObservedAt: event.ethUsdObservedAt,
+      createdAt: event.createdAt,
+    }));
+  }
+
+  return { ok: true, body: response };
+}

--- a/src/domains/developer-apps/runtime/app-user-tokens.ts
+++ b/src/domains/developer-apps/runtime/app-user-tokens.ts
@@ -1,0 +1,151 @@
+import type { NextRequest } from "next/server";
+import { authenticateAppClient } from "@/domains/identity-access/runtime/request-auth";
+import {
+  createCorrelationId,
+  writeAuditLog,
+} from "@/domains/identity-access/runtime/audit";
+import {
+  issueProgrammaticTokens,
+  ProgrammaticTokenError,
+} from "@/domains/oidc-platform/runtime/programmatic-tokens";
+import { getProviderApp } from "../repo/provider-access";
+import {
+  getActiveAppUserByExternalUserId,
+  getPublicAllowedScopesForClient,
+} from "../repo/app-user-tokens";
+import {
+  parseRequestedProgrammaticScopes,
+  validateProgrammaticScopes,
+  validateProgrammaticTokenRequest,
+} from "../service/app-user-tokens";
+
+export async function issueAppUserProgrammaticToken(params: {
+  request: NextRequest;
+  clientId: string;
+  externalUserId: string;
+}): Promise<
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; status: 400 | 401 | 403 | 404; body: Record<string, unknown> }
+> {
+  const correlationId = createCorrelationId();
+  const client = await authenticateAppClient(params.request);
+
+  const requestValidation = validateProgrammaticTokenRequest({
+    authenticatedClient: client,
+    requestedClientId: params.clientId,
+    correlationId,
+  });
+  if (!requestValidation.ok) {
+    if (client && client.appId !== params.clientId) {
+      const crossApp = await getProviderApp(params.clientId);
+      await writeAuditLog({
+        clientId: crossApp?.id ?? null,
+        action: "programmatic_token_issued",
+        status: "forbidden",
+        correlationId,
+        metadata: { reason: "cross_app_request", callerAppId: client.appId },
+      });
+    }
+    return requestValidation;
+  }
+
+  const app = await getProviderApp(params.clientId);
+  if (!app) {
+    return {
+      ok: false,
+      status: 404,
+      body: {
+        error: "not_found",
+        error_description: "developer app was not found for this client_id",
+        correlation_id: correlationId,
+      },
+    };
+  }
+
+  const requestedScopes = parseRequestedProgrammaticScopes(
+    await params.request.json().catch(() => ({})),
+  );
+  const publicAllowedScopes = await getPublicAllowedScopesForClient(client!.appId);
+  const scopeValidation = validateProgrammaticScopes({
+    requestedScopes,
+    publicAllowedScopes,
+    correlationId,
+  });
+  if (!scopeValidation.ok) {
+    await writeAuditLog({
+      clientId: app.id,
+      action: "programmatic_token_issued",
+      status: "invalid_scope",
+      correlationId,
+      metadata: {
+        invalidScope: requestedScopes.find(
+          (scope) => !publicAllowedScopes || !publicAllowedScopes.split(/[,\s]+/).includes(scope),
+        ),
+      },
+    });
+    return scopeValidation;
+  }
+
+  const appUser = await getActiveAppUserByExternalUserId(app.id, params.externalUserId);
+  if (!appUser) {
+    await writeAuditLog({
+      clientId: app.id,
+      action: "programmatic_token_issued",
+      status: "not_found",
+      correlationId,
+      metadata: { externalUserId: params.externalUserId },
+    });
+    return {
+      ok: false,
+      status: 404,
+      body: {
+        error: "not_found",
+        error_description: "the provisioned user could not be resolved",
+        correlation_id: correlationId,
+      },
+    };
+  }
+
+  try {
+    const tokens = await issueProgrammaticTokens({
+      developerAppId: app.id,
+      oauthClientId: client!.appId,
+      appUserId: appUser.id,
+      scopes: requestedScopes,
+    });
+
+    await writeAuditLog({
+      clientId: app.id,
+      action: "programmatic_token_issued",
+      status: "success",
+      correlationId,
+      metadata: {
+        externalUserId: params.externalUserId,
+        scopes: requestedScopes,
+        clientId: client!.clientId,
+      },
+    });
+
+    return { ok: true, body: { ...tokens, correlation_id: correlationId } };
+  } catch (err) {
+    if (err instanceof ProgrammaticTokenError) {
+      await writeAuditLog({
+        clientId: app.id,
+        action: "programmatic_token_issued",
+        status: err.code,
+        correlationId,
+        metadata: { externalUserId: params.externalUserId, message: err.message },
+      });
+      return {
+        ok: false,
+        status: 400,
+        body: {
+          error: err.code,
+          error_description: err.message,
+          correlation_id: correlationId,
+        },
+      };
+    }
+    throw err;
+  }
+}

--- a/src/domains/developer-apps/runtime/app-users.ts
+++ b/src/domains/developer-apps/runtime/app-users.ts
@@ -1,0 +1,237 @@
+import type { NextRequest } from "next/server";
+import {
+  authenticateAppClient,
+  authenticateRequestAsync,
+  hasScope,
+} from "@/domains/identity-access/runtime/request-auth";
+import {
+  createCorrelationId,
+  writeAuditLog,
+} from "@/domains/identity-access/runtime/audit";
+import { canEditProviderApp, getAuthorizedProviderApp } from "./provider-access";
+import { getProviderApp } from "../repo/provider-access";
+import {
+  deactivateAppUser,
+  getAppUserByExternalUserId,
+  listAppUsers,
+  updateAppUserById,
+  upsertAppUser,
+} from "../repo/app-users";
+import {
+  parseCreateAppUserInput,
+  parseDeleteAppUserInput,
+  parseUpdateAppUserInput,
+} from "../service/app-users";
+
+type AppUsersAccess = {
+  app: Awaited<ReturnType<typeof getProviderApp>>;
+  actorUserId: string | null;
+};
+
+async function authorizeAppUsersAccess(
+  request: NextRequest,
+  clientId: string,
+  requiredScope: "users:read" | "users:write",
+  requireProviderEdit: boolean,
+): Promise<
+  | { ok: true; value: NonNullable<AppUsersAccess> }
+  | { ok: false; status: 401 | 403; body: { error: string } }
+> {
+  const app = await getProviderApp(clientId);
+  if (!app) {
+    return { ok: false, status: 401, body: { error: "Unauthorized" } };
+  }
+
+  const providerAuth = await getAuthorizedProviderApp(clientId);
+  if (providerAuth) {
+    if (requireProviderEdit && !(await canEditProviderApp(providerAuth))) {
+      return {
+        ok: false,
+        status: 403,
+        body: { error: "Only platform or app administrators can modify this app." },
+      };
+    }
+    return {
+      ok: true,
+      value: { app: providerAuth.app, actorUserId: providerAuth.userId },
+    };
+  }
+
+  const bearer = await authenticateRequestAsync(request);
+  if (bearer?.appId === clientId && hasScope(bearer.scopes, requiredScope)) {
+    return {
+      ok: true,
+      value: { app, actorUserId: bearer.userId },
+    };
+  }
+
+  const clientAuth = await authenticateAppClient(request);
+  if (clientAuth?.appId === clientId) {
+    const allowed = hasScope(
+      clientAuth.scopes,
+      requiredScope === "users:read" ? "users:read" : "users:write",
+    );
+    if (allowed) {
+      return {
+        ok: true,
+        value: { app, actorUserId: null },
+      };
+    }
+  }
+
+  return { ok: false, status: 401, body: { error: "Unauthorized" } };
+}
+
+export async function readAppUsers(
+  request: NextRequest,
+  clientId: string,
+): Promise<
+  | { ok: true; body: { users: Array<Record<string, unknown>> } }
+  | { ok: false; status: 401 | 403; body: { error: string } }
+> {
+  const access = await authorizeAppUsersAccess(request, clientId, "users:read", false);
+  if (!access.ok) {
+    return access;
+  }
+
+  const users = await listAppUsers(access.value.app.id);
+  return {
+    ok: true,
+    body: {
+      users: users.map((user) => ({
+        ...user,
+        clientId,
+      })),
+    },
+  };
+}
+
+export async function createOrUpdateAppUser(
+  request: NextRequest,
+  clientId: string,
+  body: unknown,
+): Promise<
+  | { ok: true; status: 200 | 201; body: Record<string, unknown> }
+  | { ok: false; status: 400 | 401 | 403; body: { error: string } }
+> {
+  const access = await authorizeAppUsersAccess(request, clientId, "users:write", true);
+  if (!access.ok) {
+    return access;
+  }
+
+  const parsed = parseCreateAppUserInput(body);
+  if (!parsed.ok) {
+    return { ok: false, status: 400, body: { error: parsed.error } };
+  }
+
+  const upserted = await upsertAppUser({
+    appId: access.value.app.id,
+    externalUserId: parsed.value.externalUserId,
+    email: parsed.value.email,
+    status: parsed.value.status,
+    hasEmail: parsed.value.hasEmail,
+    hasStatus: parsed.value.hasStatus,
+    createdAt: new Date().toISOString(),
+  });
+
+  await writeAuditLog({
+    clientId: access.value.app.id,
+    actorUserId: access.value.actorUserId,
+    action: "app_user_upserted",
+    status: "success",
+    metadata: { externalUserId: parsed.value.externalUserId },
+  });
+
+  return {
+    ok: true,
+    status: upserted.created ? 201 : 200,
+    body: {
+      ...upserted.row,
+      clientId,
+    },
+  };
+}
+
+export async function updateExistingAppUser(
+  request: NextRequest,
+  clientId: string,
+  body: unknown,
+): Promise<
+  | { ok: true; body: { success: true } }
+  | { ok: false; status: 400 | 401 | 403 | 404; body: { error: string } }
+> {
+  const access = await authorizeAppUsersAccess(request, clientId, "users:write", true);
+  if (!access.ok) {
+    return access;
+  }
+
+  const parsed = parseUpdateAppUserInput(body);
+  if (!parsed.ok) {
+    return { ok: false, status: 400, body: { error: parsed.error } };
+  }
+
+  const existing = await getAppUserByExternalUserId(
+    access.value.app.id,
+    parsed.value.externalUserId,
+  );
+  if (!existing) {
+    return { ok: false, status: 404, body: { error: "User not found" } };
+  }
+
+  await updateAppUserById(existing.id, {
+    email: parsed.value.hasEmail ? parsed.value.email : existing.email,
+    status: parsed.value.hasStatus && parsed.value.status ? parsed.value.status : existing.status,
+    role: "user",
+  });
+
+  await writeAuditLog({
+    clientId: access.value.app.id,
+    actorUserId: access.value.actorUserId,
+    action: "app_user_updated",
+    status: "success",
+    metadata: { externalUserId: parsed.value.externalUserId },
+  });
+
+  return { ok: true, body: { success: true } };
+}
+
+export async function deactivateExistingAppUser(
+  request: NextRequest,
+  clientId: string,
+  externalUserIdParam: string | null,
+): Promise<
+  | { ok: true; body: { success: true; correlation_id: string } }
+  | { ok: false; status: 400 | 401 | 403 | 404; body: { error: string } }
+> {
+  const access = await authorizeAppUsersAccess(request, clientId, "users:write", true);
+  if (!access.ok) {
+    return access;
+  }
+
+  const parsed = parseDeleteAppUserInput(externalUserIdParam);
+  if (!parsed.ok) {
+    return { ok: false, status: 400, body: { error: parsed.error } };
+  }
+
+  const existing = await getAppUserByExternalUserId(access.value.app.id, parsed.value);
+  if (!existing) {
+    return { ok: false, status: 404, body: { error: "User not found" } };
+  }
+
+  await deactivateAppUser(existing.id);
+
+  const correlationId = createCorrelationId();
+  await writeAuditLog({
+    clientId: access.value.app.id,
+    actorUserId: access.value.actorUserId,
+    action: "app_user_deactivated",
+    status: "success",
+    correlationId,
+    metadata: { externalUserId: parsed.value },
+  });
+
+  return {
+    ok: true,
+    body: { success: true, correlation_id: correlationId },
+  };
+}

--- a/src/domains/developer-apps/runtime/provider-access.ts
+++ b/src/domains/developer-apps/runtime/provider-access.ts
@@ -1,0 +1,47 @@
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+import { authOptions } from "@/platform/auth/next-auth-options";
+import {
+  getProviderAdminMembership,
+  getProviderApp,
+} from "../repo/provider-access";
+
+export async function getAuthorizedProviderApp(appId: string) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) return null;
+
+  const userId = (session.user as Record<string, unknown>).id as string | undefined;
+  const role = (session.user as Record<string, unknown>).role as string | undefined;
+  if (!userId) return null;
+
+  const app = await getProviderApp(appId);
+  if (!app) return null;
+
+  if (role === "admin" || app.ownerId === userId || (await getProviderAdminMembership(userId, app.id))) {
+    return { app, userId, role: role ?? "developer" };
+  }
+
+  return null;
+}
+
+export type AuthorizedProviderApp = NonNullable<
+  Awaited<ReturnType<typeof getAuthorizedProviderApp>>
+>;
+
+export async function canEditProviderApp(auth: AuthorizedProviderApp): Promise<boolean> {
+  if (auth.role === "admin") return true;
+  if (auth.app.ownerId === auth.userId) return true;
+
+  const membership = await getProviderAdminMembership(auth.userId, auth.app.id);
+  if (!membership) return false;
+  return membership.role === "owner" || membership.role === "admin";
+}
+
+export function appEditForbiddenResponse() {
+  return NextResponse.json(
+    {
+      error: "Only platform or app administrators can modify this app.",
+    },
+    { status: 403 },
+  );
+}

--- a/src/domains/developer-apps/runtime/public-marketplace.ts
+++ b/src/domains/developer-apps/runtime/public-marketplace.ts
@@ -1,0 +1,28 @@
+import {
+  getPublishedMarketplaceAppByAppId,
+  getPublishedMarketplaceAppByClientId,
+  listPublishedMarketplaceApps,
+} from "../repo/public-marketplace";
+
+export function shapePublicMarketplaceApp<T extends {
+  marketplaceFeatured: number | null;
+  webOidcClientId: string | null;
+}>(row: T) {
+  const { marketplaceFeatured, webOidcClientId, ...app } = row;
+  return {
+    ...app,
+    clientId: webOidcClientId,
+    featured: marketplaceFeatured === 1,
+  };
+}
+
+export async function getPublicMarketplaceApps() {
+  const rows = await listPublishedMarketplaceApps();
+  return rows.map(shapePublicMarketplaceApp);
+}
+
+export async function getPublicMarketplaceApp(routeId: string) {
+  const byAppId = await getPublishedMarketplaceAppByAppId(routeId);
+  const row = byAppId[0] ?? (await getPublishedMarketplaceAppByClientId(routeId))[0];
+  return row ? shapePublicMarketplaceApp(row) : null;
+}

--- a/src/domains/developer-apps/service/admin-apps.test.ts
+++ b/src/domains/developer-apps/service/admin-apps.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseAdminReviewInput } from "./admin-apps";
+
+test("parseAdminReviewInput validates action", () => {
+  const result = parseAdminReviewInput({ action: "nope" });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? "" : result.body.error, "action must be 'approve' or 'reject'");
+});
+
+test("parseAdminReviewInput reads notes", () => {
+  const result = parseAdminReviewInput({ action: "approve", notes: "ok" });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok ? result.value : null, { action: "approve", notes: "ok" });
+});

--- a/src/domains/developer-apps/service/admin-apps.ts
+++ b/src/domains/developer-apps/service/admin-apps.ts
@@ -1,0 +1,21 @@
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; status: 400; body: { error: string } };
+
+export function parseAdminReviewInput(body: unknown): Ok<{
+  action: "approve" | "reject";
+  notes: string | null;
+}> | Err {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, status: 400, body: { error: "action must be 'approve' or 'reject'" } };
+  }
+
+  const action = (body as Record<string, unknown>).action;
+  if (action !== "approve" && action !== "reject") {
+    return { ok: false, status: 400, body: { error: "action must be 'approve' or 'reject'" } };
+  }
+
+  const notes = typeof (body as Record<string, unknown>).notes === "string"
+    ? (body as Record<string, unknown>).notes as string
+    : null;
+  return { ok: true, value: { action, notes } };
+}

--- a/src/domains/developer-apps/service/app-admins.test.ts
+++ b/src/domains/developer-apps/service/app-admins.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseCreateAppAdminInput, parseDeleteAppAdminInput } from "./app-admins";
+
+test("parseCreateAppAdminInput requires userId", () => {
+  const parsed = parseCreateAppAdminInput({});
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.ok ? "" : parsed.error, "userId is required");
+});
+
+test("parseCreateAppAdminInput defaults role to admin", () => {
+  const parsed = parseCreateAppAdminInput({ userId: "user-1" });
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.ok);
+  assert.equal(parsed.value.userId, "user-1");
+  assert.equal(parsed.value.role, "admin");
+});
+
+test("parseDeleteAppAdminInput requires userId", () => {
+  const parsed = parseDeleteAppAdminInput(null);
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.ok ? "" : parsed.error, "userId is required");
+});

--- a/src/domains/developer-apps/service/app-admins.ts
+++ b/src/domains/developer-apps/service/app-admins.ts
@@ -1,0 +1,29 @@
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; error: string };
+
+export interface CreateAppAdminInput {
+  userId: string;
+  role: string;
+}
+
+export function parseCreateAppAdminInput(body: unknown): Ok<CreateAppAdminInput> | Err {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "userId is required" };
+  }
+
+  const userId = String((body as Record<string, unknown>).userId || "").trim();
+  if (!userId) {
+    return { ok: false, error: "userId is required" };
+  }
+
+  const rawRole = (body as Record<string, unknown>).role;
+  const role = typeof rawRole === "string" && rawRole.trim() ? rawRole.trim() : "admin";
+  return { ok: true, value: { userId, role } };
+}
+
+export function parseDeleteAppAdminInput(userId: string | null): Ok<string> | Err {
+  if (!userId) {
+    return { ok: false, error: "userId is required" };
+  }
+  return { ok: true, value: userId };
+}

--- a/src/domains/developer-apps/service/app-billing.test.ts
+++ b/src/domains/developer-apps/service/app-billing.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildBillingCycleSummary, resolveBillingPeriod } from "./app-billing";
+
+test("resolveBillingPeriod prefers subscription bounds", () => {
+  const period = resolveBillingPeriod({
+    currentPeriodStart: "2026-05-01T00:00:00.000Z",
+    currentPeriodEnd: "2026-05-31T23:59:59.999Z",
+    now: new Date("2026-05-16T12:00:00.000Z"),
+  });
+  assert.deepEqual(period, {
+    periodStart: "2026-05-01T00:00:00.000Z",
+    periodEnd: "2026-05-31T23:59:59.999Z",
+  });
+});
+
+test("buildBillingCycleSummary computes overage and timeline data", () => {
+  const summary = buildBillingCycleSummary({
+    usageRows: [
+      {
+        id: "u1",
+        createdAt: "2026-05-02T10:00:00.000Z",
+        fee: "10",
+        units: "7",
+      },
+      {
+        id: "u2",
+        createdAt: "2026-05-02T12:00:00.000Z",
+        fee: "5",
+        units: "8",
+      },
+    ],
+    billingEvents: [
+      {
+        pipeline: "image",
+        modelId: "m1",
+        networkFeeWei: "10",
+        networkFeeUsdMicros: "100",
+        platformFeeUsdMicros: "20",
+        ownerChargeWei: "12",
+        ownerChargeUsdMicros: "120",
+        endUserBillableUsdMicros: "140",
+      },
+    ],
+    periodStart: "2026-05-01T00:00:00.000Z",
+    periodEnd: "2026-05-03T23:59:59.999Z",
+    plan: {
+      type: "subscription",
+      includedUnits: "10",
+      overageRateWei: "2",
+      includedUsdMicros: "200",
+    },
+  });
+
+  assert.equal(summary.usage.requestCount, 2);
+  assert.equal(summary.usage.totalUnits, "15");
+  assert.equal(summary.overage.overageUnits, "5");
+  assert.equal(summary.overage.overageWei, "10");
+  assert.equal(summary.timeline.length, 3);
+  assert.equal(summary.retail.remainingIncludedUsdMicros, "60");
+  assert.equal(summary.byPipelineModel.length, 1);
+});

--- a/src/domains/developer-apps/service/app-billing.ts
+++ b/src/domains/developer-apps/service/app-billing.ts
@@ -1,0 +1,184 @@
+import { calendarMonthBoundsUtc, dateKeysInclusiveUtc } from "@/shared/utils/billing-utils";
+import { weiToEthString } from "@/domains/usage-billing/service/billing-runtime";
+
+function dateKeyFromIso(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+export function resolveBillingPeriod(params: {
+  currentPeriodStart: string | null;
+  currentPeriodEnd: string | null;
+  now: Date;
+}) {
+  if (params.currentPeriodStart && params.currentPeriodEnd) {
+    return {
+      periodStart: params.currentPeriodStart,
+      periodEnd: params.currentPeriodEnd,
+    };
+  }
+
+  const calendar = calendarMonthBoundsUtc(params.now);
+  return {
+    periodStart: calendar.start,
+    periodEnd: calendar.end,
+  };
+}
+
+export function buildBillingCycleSummary(params: {
+  usageRows: Array<{
+    id: string;
+    createdAt: string;
+    fee: string;
+    units: string;
+  }>;
+  billingEvents: Array<{
+    pipeline: string;
+    modelId: string;
+    networkFeeWei: string;
+    networkFeeUsdMicros: string;
+    platformFeeUsdMicros: string;
+    ownerChargeWei: string;
+    ownerChargeUsdMicros: string;
+    endUserBillableUsdMicros: string;
+  }>;
+  periodStart: string;
+  periodEnd: string;
+  plan: {
+    type: string | null;
+    includedUnits: string | null;
+    overageRateWei: string | null;
+    includedUsdMicros: string | null;
+  } | null;
+}) {
+  let totalFeeWei = 0n;
+  let totalUnits = 0n;
+  const byDay = new Map<string, { requestCount: number; feeWei: bigint }>();
+
+  for (const row of params.usageRows) {
+    const feeWei = BigInt(row.fee || "0");
+    totalFeeWei += feeWei;
+    totalUnits += BigInt(row.units || "0");
+    const day = dateKeyFromIso(row.createdAt);
+    const bucket = byDay.get(day) || { requestCount: 0, feeWei: 0n };
+    bucket.requestCount += 1;
+    bucket.feeWei += feeWei;
+    byDay.set(day, bucket);
+  }
+
+  let totalNetworkFeeWei = 0n;
+  let totalNetworkFeeUsdMicros = 0n;
+  let totalPlatformFeeUsdMicros = 0n;
+  let totalOwnerChargeWei = 0n;
+  let totalOwnerChargeUsdMicros = 0n;
+  let totalEndUserBillableUsdMicros = 0n;
+
+  const byPipelineModel = new Map<string, {
+    pipeline: string;
+    modelId: string;
+    networkFeeWei: bigint;
+    networkFeeUsdMicros: bigint;
+    ownerChargeUsdMicros: bigint;
+    endUserBillableUsdMicros: bigint;
+    count: number;
+  }>();
+
+  for (const event of params.billingEvents) {
+    totalNetworkFeeWei += BigInt(event.networkFeeWei);
+    totalNetworkFeeUsdMicros += BigInt(event.networkFeeUsdMicros);
+    totalPlatformFeeUsdMicros += BigInt(event.platformFeeUsdMicros);
+    totalOwnerChargeWei += BigInt(event.ownerChargeWei);
+    totalOwnerChargeUsdMicros += BigInt(event.ownerChargeUsdMicros);
+    totalEndUserBillableUsdMicros += BigInt(event.endUserBillableUsdMicros);
+
+    const key = `${event.pipeline}|${event.modelId}`;
+    const existing = byPipelineModel.get(key) || {
+      pipeline: event.pipeline,
+      modelId: event.modelId,
+      networkFeeWei: 0n,
+      networkFeeUsdMicros: 0n,
+      ownerChargeUsdMicros: 0n,
+      endUserBillableUsdMicros: 0n,
+      count: 0,
+    };
+    existing.networkFeeWei += BigInt(event.networkFeeWei);
+    existing.networkFeeUsdMicros += BigInt(event.networkFeeUsdMicros);
+    existing.ownerChargeUsdMicros += BigInt(event.ownerChargeUsdMicros);
+    existing.endUserBillableUsdMicros += BigInt(event.endUserBillableUsdMicros);
+    existing.count += 1;
+    byPipelineModel.set(key, existing);
+  }
+
+  const timeline = dateKeysInclusiveUtc(params.periodStart, params.periodEnd).map((date) => {
+    const bucket = byDay.get(date);
+    return {
+      date,
+      requestCount: bucket?.requestCount ?? 0,
+      feeWei: (bucket?.feeWei ?? 0n).toString(),
+    };
+  });
+
+  const planType = params.plan?.type ?? "free";
+  let overageUnits = "0";
+  let overageWei = "0";
+  if (
+    (planType === "subscription" || planType === "usage") &&
+    params.plan?.includedUnits != null &&
+    params.plan?.overageRateWei != null
+  ) {
+    const included = BigInt(params.plan.includedUnits);
+    const rate = BigInt(params.plan.overageRateWei);
+    if (totalUnits > included) {
+      const over = totalUnits - included;
+      overageUnits = over.toString();
+      overageWei = (over * rate).toString();
+    }
+  }
+
+  const includedUsdMicros = params.plan?.includedUsdMicros
+    ? BigInt(params.plan.includedUsdMicros)
+    : 0n;
+  const consumedUsdMicros =
+    totalEndUserBillableUsdMicros < includedUsdMicros
+      ? totalEndUserBillableUsdMicros
+      : includedUsdMicros;
+  const remainingUsdMicros =
+    includedUsdMicros > consumedUsdMicros
+      ? includedUsdMicros - consumedUsdMicros
+      : 0n;
+
+  return {
+    usage: {
+      requestCount: params.usageRows.length,
+      totalFeeWei: totalFeeWei.toString(),
+      totalFeeEth: weiToEthString(totalFeeWei),
+      totalUnits: totalUnits.toString(),
+    },
+    timeline,
+    overage: { overageUnits, overageWei },
+    ownerCost: {
+      networkFeeWei: totalNetworkFeeWei.toString(),
+      networkFeeEth: weiToEthString(totalNetworkFeeWei),
+      networkFeeUsdMicros: totalNetworkFeeUsdMicros.toString(),
+      platformFeeUsdMicros: totalPlatformFeeUsdMicros.toString(),
+      ownerChargeWei: totalOwnerChargeWei.toString(),
+      ownerChargeEth: weiToEthString(totalOwnerChargeWei),
+      ownerChargeUsdMicros: totalOwnerChargeUsdMicros.toString(),
+    },
+    retail: {
+      endUserBillableUsdMicros: totalEndUserBillableUsdMicros.toString(),
+      includedUsdMicros: includedUsdMicros.toString(),
+      consumedIncludedUsdMicros: consumedUsdMicros.toString(),
+      remainingIncludedUsdMicros: remainingUsdMicros.toString(),
+    },
+    byPipelineModel: [...byPipelineModel.values()].map((entry) => ({
+      pipeline: entry.pipeline,
+      modelId: entry.modelId,
+      requestCount: entry.count,
+      networkFeeWei: entry.networkFeeWei.toString(),
+      networkFeeEth: weiToEthString(entry.networkFeeWei),
+      networkFeeUsdMicros: entry.networkFeeUsdMicros.toString(),
+      ownerChargeUsdMicros: entry.ownerChargeUsdMicros.toString(),
+      endUserBillableUsdMicros: entry.endUserBillableUsdMicros.toString(),
+    })),
+  };
+}

--- a/src/domains/developer-apps/service/app-core.test.ts
+++ b/src/domains/developer-apps/service/app-core.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasClientConfigUpdates, parseAppCoreUpdate } from "./app-core";
+
+test("parseAppCoreUpdate collects app field updates", () => {
+  const parsed = parseAppCoreUpdate(
+    {
+      name: "New Name",
+      description: "Desc",
+      backendDeviceHelper: true,
+    },
+    null,
+  );
+  assert.equal(parsed.appUpdates.name, "New Name");
+  assert.equal(parsed.appUpdates.description, "Desc");
+  assert.equal(parsed.backendDeviceHelper, true);
+});
+
+test("parseAppCoreUpdate filters allowed scopes and augments users:token when required", () => {
+  const parsed = parseAppCoreUpdate(
+    {
+      allowedScopes: "openid invalid",
+      grantTypes: ["authorization_code", "urn:ietf:params:oauth:grant-type:device_code"],
+    },
+    {
+      allowedScopes: "openid profile",
+      grantTypes: "authorization_code,urn:ietf:params:oauth:grant-type:device_code",
+      initiateLoginUri: "https://example.com/login",
+      deviceThirdPartyInitiateLogin: 1,
+    },
+  );
+  assert.equal(parsed.clientUpdates.allowedScopes, "openid users:token");
+});
+
+test("hasClientConfigUpdates reflects whether any client fields changed", () => {
+  assert.equal(hasClientConfigUpdates({}), false);
+  assert.equal(hasClientConfigUpdates({ displayName: "App" }), true);
+});

--- a/src/domains/developer-apps/service/app-core.ts
+++ b/src/domains/developer-apps/service/app-core.ts
@@ -1,0 +1,94 @@
+import { DEFAULT_OIDC_SCOPES, OIDC_SCOPES } from "@/platform/oidc/scopes";
+
+const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+export interface ExistingOidcClientShape {
+  allowedScopes: string;
+  grantTypes: string;
+  initiateLoginUri: string | null;
+  deviceThirdPartyInitiateLogin: number;
+}
+
+export interface ParsedAppCoreUpdate {
+  appUpdates: Record<string, unknown>;
+  clientUpdates: {
+    displayName?: string;
+    redirectUris?: string[];
+    tokenEndpointAuthMethod?: "none" | "client_secret_post" | "client_secret_basic";
+    allowedScopes?: string;
+    grantTypes?: string[];
+  };
+  backendDeviceHelper: boolean;
+}
+
+export function parseAppCoreUpdate(
+  body: Record<string, unknown>,
+  existingClient: ExistingOidcClientShape | null,
+): ParsedAppCoreUpdate {
+  const now = new Date().toISOString();
+  const appUpdates: Record<string, unknown> = { updatedAt: now };
+  const appFields = ["name", "description", "developerName", "websiteUrl"] as const;
+
+  for (const field of appFields) {
+    if (body[field] !== undefined) {
+      appUpdates[field] = body[field];
+    }
+  }
+
+  const clientUpdates: ParsedAppCoreUpdate["clientUpdates"] = {};
+  if (typeof body.name === "string" && body.name.trim()) {
+    clientUpdates.displayName = body.name;
+  }
+  if (Array.isArray(body.redirectUris)) {
+    clientUpdates.redirectUris = body.redirectUris as string[];
+  }
+  if (
+    body.tokenEndpointAuthMethod === "none" ||
+    body.tokenEndpointAuthMethod === "client_secret_post" ||
+    body.tokenEndpointAuthMethod === "client_secret_basic"
+  ) {
+    clientUpdates.tokenEndpointAuthMethod = body.tokenEndpointAuthMethod;
+  }
+  if (body.allowedScopes !== undefined) {
+    const validScopeValues = new Set(OIDC_SCOPES.map((scope) => scope.value));
+    const filtered = String(body.allowedScopes)
+      .split(/[,\s]+/)
+      .filter((scope) => scope && validScopeValues.has(scope))
+      .join(" ");
+    clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
+  }
+  if (Array.isArray(body.grantTypes)) {
+    clientUpdates.grantTypes = body.grantTypes as string[];
+  }
+
+  if (existingClient) {
+    const nextGrantTypes =
+      clientUpdates.grantTypes ?? existingClient.grantTypes.split(",").filter(Boolean);
+    const nextInitiateLoginUri = existingClient.initiateLoginUri?.trim();
+    const nextDeviceThirdPartyInitiateLogin = existingClient.deviceThirdPartyInitiateLogin === 1;
+    if (
+      nextDeviceThirdPartyInitiateLogin &&
+      nextInitiateLoginUri &&
+      nextGrantTypes.includes(DEVICE_CODE_GRANT)
+    ) {
+      const allowedScopes = (clientUpdates.allowedScopes ?? existingClient.allowedScopes)
+        .split(/[,\s]+/)
+        .filter(Boolean);
+      if (!allowedScopes.includes("users:token")) {
+        clientUpdates.allowedScopes = [...allowedScopes, "users:token"].join(" ");
+      }
+    }
+  }
+
+  return {
+    appUpdates,
+    clientUpdates,
+    backendDeviceHelper: body.backendDeviceHelper === true,
+  };
+}
+
+export function hasClientConfigUpdates(
+  updates: ParsedAppCoreUpdate["clientUpdates"],
+): boolean {
+  return Object.keys(updates).length > 0;
+}

--- a/src/domains/developer-apps/service/app-create.test.ts
+++ b/src/domains/developer-apps/service/app-create.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseAppCreateInput } from "./app-create";
+
+test("parseAppCreateInput requires a name", () => {
+  const result = parseAppCreateInput({});
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? "" : result.body.error, "App name is required");
+});
+
+test("parseAppCreateInput normalizes create input and augments users:token", () => {
+  const result = parseAppCreateInput({
+    name: " My App ",
+    redirectUris: [" https://example.com/callback "],
+    allowedScopes: "openid invalid",
+    grantTypes: ["authorization_code", "urn:ietf:params:oauth:grant-type:device_code"],
+    deviceThirdPartyInitiateLogin: true,
+    initiateLoginUri: "https://example.com/login",
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.ok ? result.value.name : "", "My App");
+  assert.deepEqual(result.ok ? result.value.clientUpdates.redirectUris : [], [
+    "https://example.com/callback",
+  ]);
+  assert.equal(result.ok ? result.value.clientUpdates.allowedScopes : "", "openid users:token");
+});

--- a/src/domains/developer-apps/service/app-create.ts
+++ b/src/domains/developer-apps/service/app-create.ts
@@ -1,0 +1,88 @@
+import { DEFAULT_OIDC_SCOPES, OIDC_SCOPES } from "@/platform/oidc/scopes";
+
+const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; status: 400; body: { error: string } };
+
+export interface ParsedAppCreateInput {
+  name: string;
+  developerName: string | null;
+  websiteUrl: string | null;
+  backendDeviceHelper: boolean;
+  clientUpdates: {
+    redirectUris?: string[];
+    tokenEndpointAuthMethod?: "none" | "client_secret_post" | "client_secret_basic";
+    allowedScopes?: string;
+    grantTypes?: string[];
+  };
+}
+
+export function parseAppCreateInput(body: unknown): Ok<ParsedAppCreateInput> | Err {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, status: 400, body: { error: "App name is required" } };
+  }
+
+  const record = body as Record<string, unknown>;
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  if (!name) {
+    return { ok: false, status: 400, body: { error: "App name is required" } };
+  }
+
+  const clientUpdates: ParsedAppCreateInput["clientUpdates"] = {};
+  if (Array.isArray(record.redirectUris) && record.redirectUris.length > 0) {
+    const redirectUris = record.redirectUris.filter(
+      (uri): uri is string => typeof uri === "string" && uri.trim().length > 0,
+    );
+    if (redirectUris.length > 0) {
+      clientUpdates.redirectUris = redirectUris.map((uri) => uri.trim());
+    }
+  }
+  if (
+    record.tokenEndpointAuthMethod === "none" ||
+    record.tokenEndpointAuthMethod === "client_secret_post" ||
+    record.tokenEndpointAuthMethod === "client_secret_basic"
+  ) {
+    clientUpdates.tokenEndpointAuthMethod = record.tokenEndpointAuthMethod;
+  }
+  if (typeof record.allowedScopes === "string" && record.allowedScopes.trim()) {
+    const validScopeValues = new Set(OIDC_SCOPES.map((scope) => scope.value));
+    const filtered = record.allowedScopes
+      .split(/[,\s]+/)
+      .filter((scope) => scope && validScopeValues.has(scope))
+      .join(" ");
+    clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
+  }
+  if (Array.isArray(record.grantTypes) && record.grantTypes.length > 0) {
+    const grantTypes = record.grantTypes.filter(
+      (value): value is string => typeof value === "string" && value.trim().length > 0,
+    );
+    if (grantTypes.length > 0) {
+      clientUpdates.grantTypes = grantTypes;
+    }
+  }
+  if (
+    record.deviceThirdPartyInitiateLogin === true &&
+    typeof record.initiateLoginUri === "string" &&
+    record.initiateLoginUri.trim() &&
+    (clientUpdates.grantTypes ?? ["authorization_code", "refresh_token"]).includes(DEVICE_CODE_GRANT)
+  ) {
+    const allowedScopes = (clientUpdates.allowedScopes ?? DEFAULT_OIDC_SCOPES)
+      .split(/[,\s]+/)
+      .filter(Boolean);
+    if (!allowedScopes.includes("users:token")) {
+      clientUpdates.allowedScopes = [...allowedScopes, "users:token"].join(" ");
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      name,
+      developerName: typeof record.developerName === "string" ? record.developerName : null,
+      websiteUrl: typeof record.websiteUrl === "string" ? record.websiteUrl : null,
+      backendDeviceHelper: record.backendDeviceHelper === true,
+      clientUpdates,
+    },
+  };
+}

--- a/src/domains/developer-apps/service/app-credentials.test.ts
+++ b/src/domains/developer-apps/service/app-credentials.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  resolveSecretRotationTarget,
+  validateSecretRotationClient,
+} from "./app-credentials";
+
+test("resolveSecretRotationTarget rejects apps without a configured OIDC client", () => {
+  const result = resolveSecretRotationTarget({
+    oidcClientId: null,
+    m2mOidcClientId: null,
+    primaryClient: null,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? 0 : result.status, 400);
+  assert.equal(result.ok ? "" : result.body.error, "App has no OIDC client configured");
+});
+
+test("resolveSecretRotationTarget prefers the backend helper client when present", () => {
+  const result = resolveSecretRotationTarget({
+    oidcClientId: "public-row",
+    m2mOidcClientId: "m2m-row",
+    primaryClient: null,
+  });
+  assert.deepEqual(result, { ok: true, value: "m2m-row" });
+});
+
+test("resolveSecretRotationTarget rejects public interactive clients without a backend helper", () => {
+  const result = resolveSecretRotationTarget({
+    oidcClientId: "public-row",
+    m2mOidcClientId: null,
+    primaryClient: {
+      id: "public-row",
+      clientId: "app_public",
+      tokenEndpointAuthMethod: "none",
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? 0 : result.status, 400);
+  assert.equal(result.ok ? "" : result.body.error, "interactive_public_no_secret");
+});
+
+test("validateSecretRotationClient rejects public clients", () => {
+  const result = validateSecretRotationClient({
+    id: "public-row",
+    clientId: "app_public",
+    tokenEndpointAuthMethod: "none",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? 0 : result.status, 400);
+  assert.equal(result.ok ? "" : result.body.error, "public_client_no_secret");
+});
+
+test("validateSecretRotationClient returns confidential clients", () => {
+  const result = validateSecretRotationClient({
+    id: "m2m-row",
+    clientId: "m2m_public",
+    tokenEndpointAuthMethod: "client_secret_basic",
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.ok ? result.value.clientId : "", "m2m_public");
+});

--- a/src/domains/developer-apps/service/app-credentials.ts
+++ b/src/domains/developer-apps/service/app-credentials.ts
@@ -1,0 +1,81 @@
+type Ok<T> = { ok: true; value: T };
+type Err = {
+  ok: false;
+  status: 400 | 500;
+  body: {
+    error: string;
+    error_description?: string;
+  };
+};
+
+export interface OidcCredentialClient {
+  id: string;
+  clientId: string;
+  tokenEndpointAuthMethod: string;
+}
+
+export function resolveSecretRotationTarget(params: {
+  oidcClientId: string | null;
+  m2mOidcClientId: string | null;
+  primaryClient: OidcCredentialClient | null;
+}): Ok<string> | Err {
+  if (!params.oidcClientId) {
+    return {
+      ok: false,
+      status: 400,
+      body: { error: "App has no OIDC client configured" },
+    };
+  }
+
+  if (params.m2mOidcClientId) {
+    return { ok: true, value: params.m2mOidcClientId };
+  }
+
+  if (!params.primaryClient) {
+    return {
+      ok: false,
+      status: 500,
+      body: { error: "OIDC client not found" },
+    };
+  }
+
+  if (params.primaryClient.tokenEndpointAuthMethod === "none") {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: "interactive_public_no_secret",
+        error_description:
+          "Enable Backend device helper in Auth & Scopes, then generate a secret for the confidential client.",
+      },
+    };
+  }
+
+  return { ok: true, value: params.primaryClient.id };
+}
+
+export function validateSecretRotationClient(
+  client: OidcCredentialClient | null,
+): Ok<OidcCredentialClient> | Err {
+  if (!client) {
+    return {
+      ok: false,
+      status: 500,
+      body: { error: "OIDC client not found" },
+    };
+  }
+
+  if (client.tokenEndpointAuthMethod === "none") {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: "public_client_no_secret",
+        error_description:
+          "This client cannot hold a secret. Use the Backend helper client for confidential credentials.",
+      },
+    };
+  }
+
+  return { ok: true, value: client };
+}

--- a/src/domains/developer-apps/service/app-domains.test.ts
+++ b/src/domains/developer-apps/service/app-domains.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  domainDuplicateError,
+  parseDomainCreateInput,
+  parseDomainDeleteInput,
+} from "./app-domains";
+
+test("parseDomainCreateInput requires a domain string", () => {
+  const parsed = parseDomainCreateInput({});
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.ok ? "" : parsed.error, "domain is required");
+});
+
+test("parseDomainCreateInput normalizes valid domain input", () => {
+  const parsed = parseDomainCreateInput({ domain: "example.com/callback" });
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.ok);
+  assert.equal(parsed.value.domain, "https://example.com");
+});
+
+test("parseDomainDeleteInput requires domainId", () => {
+  const parsed = parseDomainDeleteInput(null);
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.ok ? "" : parsed.error, "domainId query parameter is required");
+});
+
+test("domainDuplicateError formats a stable message", () => {
+  assert.equal(
+    domainDuplicateError("https://example.com"),
+    'Domain "https://example.com" is already in the whitelist',
+  );
+});

--- a/src/domains/developer-apps/service/app-domains.ts
+++ b/src/domains/developer-apps/service/app-domains.ts
@@ -1,0 +1,33 @@
+import { normalizeDomainWhitelist } from "@/shared/utils/domain-whitelist";
+
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; error: string };
+
+export function parseDomainCreateInput(body: unknown): Ok<{ domain: string }> | Err {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "domain is required" };
+  }
+
+  const domain = (body as Record<string, unknown>).domain;
+  if (!domain || typeof domain !== "string") {
+    return { ok: false, error: "domain is required" };
+  }
+
+  const result = normalizeDomainWhitelist(domain);
+  if (!result.success) {
+    return { ok: false, error: result.error };
+  }
+
+  return { ok: true, value: { domain: result.normalized } };
+}
+
+export function parseDomainDeleteInput(domainId: string | null): Ok<string> | Err {
+  if (!domainId) {
+    return { ok: false, error: "domainId query parameter is required" };
+  }
+  return { ok: true, value: domainId };
+}
+
+export function domainDuplicateError(domain: string): string {
+  return `Domain "${domain}" is already in the whitelist`;
+}

--- a/src/domains/developer-apps/service/app-keys.test.ts
+++ b/src/domains/developer-apps/service/app-keys.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseCreateAppKeyInput, parseDeleteAppKeyInput } from "./app-keys";
+
+test("parseCreateAppKeyInput defaults invalid bodies", () => {
+  const result = parseCreateAppKeyInput(null);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok ? result.value : null, {
+    subscriptionId: null,
+    label: null,
+  });
+});
+
+test("parseCreateAppKeyInput reads optional fields", () => {
+  const result = parseCreateAppKeyInput({
+    subscriptionId: "sub_123",
+    label: "Primary key",
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok ? result.value : null, {
+    subscriptionId: "sub_123",
+    label: "Primary key",
+  });
+});
+
+test("parseDeleteAppKeyInput requires keyId", () => {
+  const result = parseDeleteAppKeyInput(null);
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? "" : result.error, "keyId is required");
+});

--- a/src/domains/developer-apps/service/app-keys.ts
+++ b/src/domains/developer-apps/service/app-keys.ts
@@ -1,0 +1,34 @@
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; error: string };
+
+export interface ParsedCreateAppKeyInput {
+  subscriptionId: string | null;
+  label: string | null;
+}
+
+export function parseCreateAppKeyInput(body: unknown): Ok<ParsedCreateAppKeyInput> {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: true, value: { subscriptionId: null, label: null } };
+  }
+
+  return {
+    ok: true,
+    value: {
+      subscriptionId:
+        typeof (body as Record<string, unknown>).subscriptionId === "string"
+          ? (body as Record<string, unknown>).subscriptionId as string
+          : null,
+      label:
+        typeof (body as Record<string, unknown>).label === "string"
+          ? (body as Record<string, unknown>).label as string
+          : null,
+    },
+  };
+}
+
+export function parseDeleteAppKeyInput(keyId: string | null): Ok<string> | Err {
+  if (!keyId) {
+    return { ok: false, error: "keyId is required" };
+  }
+  return { ok: true, value: keyId };
+}

--- a/src/domains/developer-apps/service/app-settings.test.ts
+++ b/src/domains/developer-apps/service/app-settings.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  extractOrigins,
+  maybeAugmentAllowedScopesForDeviceFlow,
+  normalizeOriginsToDomains,
+  validateDeviceInitiateLoginSettings,
+} from "./app-settings";
+
+test("validateDeviceInitiateLoginSettings requires URI when device login is enabled", () => {
+  const result = validateDeviceInitiateLoginSettings({
+    initiateLoginUri: null,
+    deviceThirdPartyInitiateLogin: true,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? "" : result.error, "invalid_request");
+});
+
+test("maybeAugmentAllowedScopesForDeviceFlow adds users:token when device flow needs it", () => {
+  const result = maybeAugmentAllowedScopesForDeviceFlow({
+    allowedScopes: "openid profile",
+    grantTypes: ["authorization_code", "urn:ietf:params:oauth:grant-type:device_code"],
+    initiateLoginUri: "https://example.com/login",
+    deviceThirdPartyInitiateLogin: true,
+  });
+  assert.equal(result, "openid profile users:token");
+});
+
+test("extractOrigins dedupes valid origins", () => {
+  const origins = extractOrigins([
+    "https://example.com/callback",
+    "https://example.com/logout",
+    "http://localhost:3000/callback",
+  ]);
+  assert.deepEqual(origins.sort(), ["http://localhost:3000", "https://example.com"]);
+});
+
+test("normalizeOriginsToDomains returns canonical origins", () => {
+  const domains = normalizeOriginsToDomains([
+    "https://example.com",
+    "http://localhost:3000",
+  ]);
+  assert.deepEqual(domains.sort(), ["http://localhost:3000", "https://example.com"]);
+});

--- a/src/domains/developer-apps/service/app-settings.ts
+++ b/src/domains/developer-apps/service/app-settings.ts
@@ -1,0 +1,113 @@
+import { normalizeDomainWhitelist } from "@/shared/utils/domain-whitelist";
+import { validateInitiateLoginUri } from "@/platform/oidc/third-party-initiate-login";
+
+const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+const TOKEN_ENDPOINT_AUTH_METHODS = [
+  "none",
+  "client_secret_post",
+  "client_secret_basic",
+] as const;
+type TokenEndpointAuthMethod = (typeof TOKEN_ENDPOINT_AUTH_METHODS)[number];
+
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; error: string; description?: string };
+
+export interface ParsedAppSettingsUpdate {
+  redirectUris?: string[];
+  postLogoutRedirectUris?: string[];
+  initiateLoginUri?: string | null;
+  deviceThirdPartyInitiateLogin?: boolean;
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+}
+
+export function extractOrigins(uris: string[]): string[] {
+  const origins = new Set<string>();
+  for (const uri of uris) {
+    try {
+      const url = new URL(uri);
+      origins.add(url.origin);
+    } catch {
+      /* skip malformed URIs */
+    }
+  }
+  return Array.from(origins);
+}
+
+export function parseAppSettingsUpdate(body: Record<string, unknown>): ParsedAppSettingsUpdate {
+  const updates: ParsedAppSettingsUpdate = {};
+  if (Array.isArray(body.redirectUris)) updates.redirectUris = body.redirectUris as string[];
+  if (Array.isArray(body.postLogoutRedirectUris)) {
+    updates.postLogoutRedirectUris = body.postLogoutRedirectUris as string[];
+  }
+  if (body.initiateLoginUri !== undefined) {
+    updates.initiateLoginUri = (body.initiateLoginUri as string) || null;
+  }
+  if (body.deviceThirdPartyInitiateLogin !== undefined) {
+    updates.deviceThirdPartyInitiateLogin = Boolean(body.deviceThirdPartyInitiateLogin);
+  }
+  if (body.tokenEndpointAuthMethod !== undefined) {
+    const method = String(body.tokenEndpointAuthMethod) as TokenEndpointAuthMethod;
+    if (TOKEN_ENDPOINT_AUTH_METHODS.includes(method)) {
+      updates.tokenEndpointAuthMethod = method;
+    }
+  }
+  return updates;
+}
+
+export function validateDeviceInitiateLoginSettings(params: {
+  initiateLoginUri: string | null;
+  deviceThirdPartyInitiateLogin: boolean;
+}): Ok<true> | Err {
+  if (!params.deviceThirdPartyInitiateLogin) {
+    return { ok: true, value: true };
+  }
+  const uri = params.initiateLoginUri?.trim();
+  if (!uri) {
+    return {
+      ok: false,
+      error: "invalid_request",
+      description:
+        "Initiate login URI is required when device third-party login is enabled",
+    };
+  }
+  try {
+    validateInitiateLoginUri(uri);
+  } catch {
+    return {
+      ok: false,
+      error: "invalid_request",
+      description:
+        "Initiate login URI must be a valid HTTPS URL (HTTP on localhost allowed in development)",
+    };
+  }
+  return { ok: true, value: true };
+}
+
+export function maybeAugmentAllowedScopesForDeviceFlow(params: {
+  allowedScopes: string;
+  grantTypes: string[];
+  initiateLoginUri: string | null;
+  deviceThirdPartyInitiateLogin: boolean;
+}): string | null {
+  if (!params.deviceThirdPartyInitiateLogin || !params.initiateLoginUri?.trim()) {
+    return null;
+  }
+  if (!params.grantTypes.includes(DEVICE_CODE_GRANT)) {
+    return null;
+  }
+  const allowedScopes = params.allowedScopes.split(/[,\s]+/).filter(Boolean);
+  if (allowedScopes.includes("users:token")) {
+    return null;
+  }
+  return [...allowedScopes, "users:token"].join(" ");
+}
+
+export function normalizeOriginsToDomains(origins: string[]): string[] {
+  const domains: string[] = [];
+  for (const origin of origins) {
+    const result = normalizeDomainWhitelist(origin);
+    if (!result.success) continue;
+    domains.push(result.normalized);
+  }
+  return domains;
+}

--- a/src/domains/developer-apps/service/app-usage.test.ts
+++ b/src/domains/developer-apps/service/app-usage.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildUsageTotals, parseUsageQuery } from "./app-usage";
+
+test("parseUsageQuery validates startDate", () => {
+  const result = parseUsageQuery(new URL("http://localhost/usage?startDate=nope"));
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? "" : result.body.error, "Invalid startDate format");
+});
+
+test("parseUsageQuery reads supported grouping and filters", () => {
+  const result = parseUsageQuery(
+    new URL("http://localhost/usage?groupBy=user&userId=u1&gatewayRequestId=gw1"),
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok ? result.value : null, {
+    startDate: null,
+    endDate: null,
+    groupBy: "user",
+    filterUserId: "u1",
+    filterGatewayRequestId: "gw1",
+  });
+});
+
+test("buildUsageTotals joins event metrics by usage record id", () => {
+  const totals = buildUsageTotals({
+    usageRows: [
+      { id: "u1", fee: "10" },
+      { id: "u2", fee: "20" },
+    ],
+    eventByUsageRecord: new Map([
+      [
+        "u1",
+        {
+          networkFeeUsdMicros: "100",
+          ownerChargeWei: "3",
+          ownerChargeUsdMicros: "120",
+          platformFeeWei: "1",
+          endUserBillableUsdMicros: "140",
+        },
+      ],
+    ]),
+  });
+  assert.equal(totals.requestCount, 2);
+  assert.equal(totals.totalFeeWei, "30");
+  assert.equal(totals.networkFeeUsdMicros, "100");
+  assert.equal(totals.platformFeeWei, "1");
+});

--- a/src/domains/developer-apps/service/app-usage.ts
+++ b/src/domains/developer-apps/service/app-usage.ts
@@ -1,0 +1,83 @@
+import { weiToEthString } from "@/domains/usage-billing/service/billing-runtime";
+
+export type UsageGroupBy = "none" | "user" | "pipeline_model";
+
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; status: 400; body: { error: string } };
+
+export interface ParsedUsageQuery {
+  startDate: string | null;
+  endDate: string | null;
+  groupBy: UsageGroupBy;
+  filterUserId: string | null;
+  filterGatewayRequestId: string | null;
+}
+
+export function parseUsageQuery(url: URL): Ok<ParsedUsageQuery> | Err {
+  const startDate = url.searchParams.get("startDate");
+  const endDate = url.searchParams.get("endDate");
+  const rawGroupBy = url.searchParams.get("groupBy") || "none";
+  const groupBy: UsageGroupBy =
+    rawGroupBy === "user" || rawGroupBy === "pipeline_model" ? rawGroupBy : "none";
+
+  if (startDate && Number.isNaN(Date.parse(startDate))) {
+    return { ok: false, status: 400, body: { error: "Invalid startDate format" } };
+  }
+  if (endDate && Number.isNaN(Date.parse(endDate))) {
+    return { ok: false, status: 400, body: { error: "Invalid endDate format" } };
+  }
+
+  return {
+    ok: true,
+    value: {
+      startDate,
+      endDate,
+      groupBy,
+      filterUserId: url.searchParams.get("userId"),
+      filterGatewayRequestId: url.searchParams.get("gatewayRequestId"),
+    },
+  };
+}
+
+export function buildUsageTotals(params: {
+  usageRows: Array<{ id: string; fee: string }>;
+  eventByUsageRecord: Map<string | null, {
+    networkFeeUsdMicros: string;
+    ownerChargeWei: string;
+    ownerChargeUsdMicros: string;
+    platformFeeWei: string;
+    endUserBillableUsdMicros: string;
+  }>;
+}) {
+  let totalFeeWei = 0n;
+  let totalNetworkFeeUsdMicros = 0n;
+  let totalOwnerChargeWei = 0n;
+  let totalOwnerChargeUsdMicros = 0n;
+  let totalPlatformFeeWei = 0n;
+  let totalEndUserBillableUsdMicros = 0n;
+
+  for (const row of params.usageRows) {
+    totalFeeWei += BigInt(row.fee);
+    const event = params.eventByUsageRecord.get(row.id);
+    if (event) {
+      totalNetworkFeeUsdMicros += BigInt(event.networkFeeUsdMicros);
+      totalOwnerChargeWei += BigInt(event.ownerChargeWei);
+      totalOwnerChargeUsdMicros += BigInt(event.ownerChargeUsdMicros);
+      totalPlatformFeeWei += BigInt(event.platformFeeWei);
+      totalEndUserBillableUsdMicros += BigInt(event.endUserBillableUsdMicros);
+    }
+  }
+
+  return {
+    requestCount: params.usageRows.length,
+    totalFeeWei: totalFeeWei.toString(),
+    totalFeeEth: weiToEthString(totalFeeWei),
+    networkFeeUsdMicros: totalNetworkFeeUsdMicros.toString(),
+    ownerChargeWei: totalOwnerChargeWei.toString(),
+    ownerChargeEth: weiToEthString(totalOwnerChargeWei),
+    ownerChargeUsdMicros: totalOwnerChargeUsdMicros.toString(),
+    platformFeeWei: totalPlatformFeeWei.toString(),
+    platformFeeEth: weiToEthString(totalPlatformFeeWei),
+    endUserBillableUsdMicros: totalEndUserBillableUsdMicros.toString(),
+  };
+}

--- a/src/domains/developer-apps/service/app-user-tokens.test.ts
+++ b/src/domains/developer-apps/service/app-user-tokens.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseRequestedProgrammaticScopes,
+  validateProgrammaticScopes,
+  validateProgrammaticTokenRequest,
+} from "./app-user-tokens";
+
+test("parseRequestedProgrammaticScopes defaults to sign:job", () => {
+  assert.deepEqual(parseRequestedProgrammaticScopes({}), ["sign:job"]);
+});
+
+test("validateProgrammaticTokenRequest rejects missing auth", () => {
+  const result = validateProgrammaticTokenRequest({
+    authenticatedClient: null,
+    requestedClientId: "app_1",
+    correlationId: "corr",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? 0 : result.status, 401);
+});
+
+test("validateProgrammaticScopes rejects admin scope", () => {
+  const result = validateProgrammaticScopes({
+    requestedScopes: ["admin"],
+    publicAllowedScopes: "openid sign:job users:token",
+    correlationId: "corr",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? 0 : result.status, 400);
+});

--- a/src/domains/developer-apps/service/app-user-tokens.ts
+++ b/src/domains/developer-apps/service/app-user-tokens.ts
@@ -1,0 +1,82 @@
+import { hasScope } from "@/domains/identity-access/runtime/request-auth";
+
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; status: 400 | 401 | 403; body: Record<string, unknown> };
+
+export function parseRequestedProgrammaticScopes(body: unknown): string[] {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return ["sign:job"];
+  }
+  const requestedScopes = String((body as Record<string, unknown>).scope || "")
+    .split(/\s+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+  return requestedScopes.length > 0 ? requestedScopes : ["sign:job"];
+}
+
+export function validateProgrammaticTokenRequest(params: {
+  authenticatedClient: { appId: string; scopes: string } | null;
+  requestedClientId: string;
+  correlationId: string;
+}): Ok<true> | Err {
+  if (!params.authenticatedClient) {
+    return {
+      ok: false,
+      status: 401,
+      body: {
+        error: "invalid_client",
+        error_description: "failed confidential-client authentication",
+        correlation_id: params.correlationId,
+      },
+    };
+  }
+
+  if (params.authenticatedClient.appId !== params.requestedClientId) {
+    return {
+      ok: false,
+      status: 403,
+      body: {
+        error: "forbidden",
+        error_description: "client_id does not match the requested app",
+        correlation_id: params.correlationId,
+      },
+    };
+  }
+
+  if (!hasScope(params.authenticatedClient.scopes, "users:token")) {
+    return {
+      ok: false,
+      status: 403,
+      body: {
+        error: "invalid_scope",
+        error_description: "users:token scope is required for this client",
+        correlation_id: params.correlationId,
+      },
+    };
+  }
+
+  return { ok: true, value: true };
+}
+
+export function validateProgrammaticScopes(params: {
+  requestedScopes: string[];
+  publicAllowedScopes: string;
+  correlationId: string;
+}): Ok<true> | Err {
+  const invalidScope = params.requestedScopes.find(
+    (scope) => !hasScope(params.publicAllowedScopes, scope) || scope === "admin",
+  );
+  if (!invalidScope) {
+    return { ok: true, value: true };
+  }
+
+  return {
+    ok: false,
+    status: 400,
+    body: {
+      error: "invalid_scope",
+      error_description: "requested scope is not allowed for this client",
+      correlation_id: params.correlationId,
+    },
+  };
+}

--- a/src/domains/developer-apps/service/app-users.test.ts
+++ b/src/domains/developer-apps/service/app-users.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseCreateAppUserInput,
+  parseDeleteAppUserInput,
+  parseUpdateAppUserInput,
+} from "./app-users";
+
+test("parseCreateAppUserInput requires externalUserId", () => {
+  const result = parseCreateAppUserInput({});
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? "" : result.error, "externalUserId is required");
+});
+
+test("parseCreateAppUserInput normalizes optional fields", () => {
+  const result = parseCreateAppUserInput({
+    externalUserId: " ext-1 ",
+    email: " user@example.com ",
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok ? result.value : null, {
+    externalUserId: "ext-1",
+    email: "user@example.com",
+    hasEmail: true,
+    status: "active",
+    hasStatus: false,
+  });
+});
+
+test("parseUpdateAppUserInput preserves field presence flags", () => {
+  const result = parseUpdateAppUserInput({
+    externalUserId: " ext-2 ",
+    status: "inactive",
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.ok ? result.value : null, {
+    externalUserId: "ext-2",
+    email: null,
+    hasEmail: false,
+    status: "inactive",
+    hasStatus: true,
+  });
+});
+
+test("parseDeleteAppUserInput requires externalUserId", () => {
+  const result = parseDeleteAppUserInput(null);
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? "" : result.error, "externalUserId is required");
+});

--- a/src/domains/developer-apps/service/app-users.ts
+++ b/src/domains/developer-apps/service/app-users.ts
@@ -1,0 +1,72 @@
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; error: string };
+
+export interface ParsedCreateAppUserInput {
+  externalUserId: string;
+  email: string | null;
+  hasEmail: boolean;
+  status: string;
+  hasStatus: boolean;
+}
+
+export interface ParsedUpdateAppUserInput {
+  externalUserId: string;
+  email: string | null;
+  hasEmail: boolean;
+  status: string | null;
+  hasStatus: boolean;
+}
+
+export function parseCreateAppUserInput(body: unknown): Ok<ParsedCreateAppUserInput> | Err {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "externalUserId is required" };
+  }
+
+  const externalUserId = String((body as Record<string, unknown>).externalUserId || "").trim();
+  if (!externalUserId) {
+    return { ok: false, error: "externalUserId is required" };
+  }
+
+  const hasEmail = typeof (body as Record<string, unknown>).email === "string";
+  const hasStatus = typeof (body as Record<string, unknown>).status === "string";
+  const email = hasEmail ? String((body as Record<string, unknown>).email).trim() : null;
+  const status = hasStatus ? String((body as Record<string, unknown>).status) : "active";
+
+  return {
+    ok: true,
+    value: { externalUserId, email, hasEmail, status, hasStatus },
+  };
+}
+
+export function parseUpdateAppUserInput(body: unknown): Ok<ParsedUpdateAppUserInput> | Err {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "externalUserId is required" };
+  }
+
+  const externalUserId = String((body as Record<string, unknown>).externalUserId || "").trim();
+  if (!externalUserId) {
+    return { ok: false, error: "externalUserId is required" };
+  }
+
+  const hasEmail = typeof (body as Record<string, unknown>).email === "string";
+  const hasStatus = typeof (body as Record<string, unknown>).status === "string";
+
+  return {
+    ok: true,
+    value: {
+      externalUserId,
+      email: hasEmail ? String((body as Record<string, unknown>).email).trim() : null,
+      hasEmail,
+      status: hasStatus ? String((body as Record<string, unknown>).status) : null,
+      hasStatus,
+    },
+  };
+}
+
+export function parseDeleteAppUserInput(externalUserId: string | null): Ok<string> | Err {
+  if (!externalUserId) {
+    return { ok: false, error: "externalUserId is required" };
+  }
+
+  return { ok: true, value: externalUserId };
+}

--- a/src/domains/end-user-accounts/repo/app-end-users.ts
+++ b/src/domains/end-user-accounts/repo/app-end-users.ts
@@ -1,0 +1,30 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { endUsers } from "@/db/schema";
+
+export async function getAppEndUser(appId: string, externalUserId: string) {
+  const rows = await db
+    .select()
+    .from(endUsers)
+    .where(
+      and(
+        eq(endUsers.appId, appId),
+        eq(endUsers.externalUserId, externalUserId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function createAppEndUser(params: {
+  id: string;
+  appId: string;
+  externalUserId: string;
+}) {
+  await db.insert(endUsers).values({
+    id: params.id,
+    appId: params.appId,
+    externalUserId: params.externalUserId,
+    creditBalanceWei: "0",
+  });
+}

--- a/src/domains/end-user-accounts/repo/end-users.ts
+++ b/src/domains/end-user-accounts/repo/end-users.ts
@@ -1,0 +1,71 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import { endUsers } from "@/db/schema";
+
+export async function listEndUsers() {
+  return db.select().from(endUsers);
+}
+
+export async function getEndUserById(endUserId: string) {
+  const rows = await db.select().from(endUsers).where(eq(endUsers.id, endUserId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getEndUserByTurnkeyUserId(turnkeyUserId: string) {
+  const rows = await db
+    .select()
+    .from(endUsers)
+    .where(eq(endUsers.turnkeyUserId, turnkeyUserId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function updateEndUserWalletAddress(endUserId: string, walletAddress: string) {
+  await db.update(endUsers).set({ walletAddress }).where(eq(endUsers.id, endUserId));
+}
+
+export async function createEndUser(params: {
+  id: string;
+  turnkeyUserId?: string | null;
+  walletAddress?: string | null;
+  creditBalanceWei?: string;
+  appId?: string | null;
+  externalUserId?: string | null;
+}) {
+  await db.insert(endUsers).values({
+    id: params.id,
+    turnkeyUserId: params.turnkeyUserId ?? null,
+    walletAddress: params.walletAddress ?? null,
+    creditBalanceWei: params.creditBalanceWei ?? "0",
+    appId: params.appId ?? null,
+    externalUserId: params.externalUserId ?? null,
+  });
+}
+
+export async function deductCredits(endUserId: string, amountWei: bigint): Promise<boolean> {
+  const updated = await db
+    .update(endUsers)
+    .set({
+      creditBalanceWei:
+        sql`(((${endUsers.creditBalanceWei})::numeric - ${amountWei.toString()}::numeric)::text)`,
+    })
+    .where(
+      and(
+        eq(endUsers.id, endUserId),
+        sql`(${endUsers.creditBalanceWei})::numeric >= ${amountWei.toString()}::numeric`,
+      ),
+    )
+    .returning({ id: endUsers.id });
+
+  return updated.length > 0;
+}
+
+export async function addCredits(endUserId: string, amountWei: bigint) {
+  await db
+    .update(endUsers)
+    .set({
+      creditBalanceWei:
+        sql`(((COALESCE(${endUsers.creditBalanceWei}, '0'))::numeric + ${amountWei.toString()}::numeric)::text)`,
+    })
+    .where(eq(endUsers.id, endUserId));
+}

--- a/src/domains/end-user-accounts/repo/transactions.ts
+++ b/src/domains/end-user-accounts/repo/transactions.ts
@@ -1,0 +1,20 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { transactions } from "@/db/schema";
+
+export async function listTransactions(params: {
+  endUserId?: string;
+  limit: number;
+  offset: number;
+}) {
+  if (params.endUserId) {
+    return db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.endUserId, params.endUserId))
+      .limit(params.limit)
+      .offset(params.offset);
+  }
+
+  return db.select().from(transactions).limit(params.limit).offset(params.offset);
+}

--- a/src/domains/end-user-accounts/runtime/billing.ts
+++ b/src/domains/end-user-accounts/runtime/billing.ts
@@ -1,0 +1,29 @@
+import { weiToEthString } from "@/domains/usage-billing/service/billing-runtime";
+import { listTransactions } from "../repo/transactions";
+
+export async function getBillingTransactions(params: {
+  endUserId?: string;
+  limit: number;
+  offset: number;
+}) {
+  const transactions = await listTransactions(params);
+  return transactions.map((tx) => ({
+    ...tx,
+    amountEth: weiToEthString(BigInt(tx.amountWei)),
+    ownerChargeEth: tx.ownerChargeWei ? weiToEthString(BigInt(tx.ownerChargeWei)) : null,
+    pipeline: tx.pipeline ?? null,
+    modelId: tx.modelId ?? null,
+    attributionSource: tx.attributionSource ?? null,
+    gatewayRequestId: tx.gatewayRequestId ?? null,
+    paymentMetadataVersion: tx.paymentMetadataVersion ?? null,
+    pipelineModelConstraintHash: tx.pipelineModelConstraintHash ?? null,
+    priceValidationStatus: tx.priceValidationStatus ?? null,
+    advertisedPriceWeiPerUnit: tx.advertisedPriceWeiPerUnit ?? null,
+    signedPriceWeiPerUnit: tx.signedPriceWeiPerUnit ?? null,
+    ethUsdPrice: tx.ethUsdPrice ?? null,
+    ethUsdSource: tx.ethUsdSource ?? null,
+    ethUsdObservedAt: tx.ethUsdObservedAt ?? null,
+    networkFeeUsdMicros: tx.networkFeeUsdMicros ?? null,
+    ownerChargeUsdMicros: tx.ownerChargeUsdMicros ?? null,
+  }));
+}

--- a/src/domains/end-user-accounts/runtime/end-users.ts
+++ b/src/domains/end-user-accounts/runtime/end-users.ts
@@ -1,0 +1,160 @@
+import { v4 as uuidv4 } from "uuid";
+import { verifyTurnkeySessionJwt } from "@/domains/identity-access/runtime/turnkey-users";
+import {
+  addCredits,
+  createEndUser,
+  deductCredits,
+  getEndUserById,
+  getEndUserByTurnkeyUserId,
+  listEndUsers,
+  updateEndUserWalletAddress,
+} from "../repo/end-users";
+import { createAppEndUser, getAppEndUser } from "../repo/app-end-users";
+
+export async function listAdminEndUsers() {
+  return listEndUsers();
+}
+
+export async function getEndUserForTurnkeySession(sessionJwt: string) {
+  const claims = await verifyTurnkeySessionJwt(sessionJwt);
+  if (!claims) {
+    return { ok: false as const, status: 401, body: { error: "Invalid Turnkey session" } };
+  }
+
+  const endUser = await getEndUserByTurnkeyUserId(claims.userId);
+  if (!endUser) {
+    return { ok: false as const, status: 404, body: { error: "End user not found" } };
+  }
+
+  return { ok: true as const, status: 200, body: { endUser } };
+}
+
+export async function createAdminEndUser(body: Record<string, unknown>) {
+  const id = uuidv4();
+  await createEndUser({
+    id,
+    turnkeyUserId:
+      typeof body.turnkeyUserId === "string" && body.turnkeyUserId.trim()
+        ? body.turnkeyUserId.trim()
+        : null,
+    walletAddress:
+      typeof body.walletAddress === "string" && body.walletAddress.trim()
+        ? body.walletAddress.trim()
+        : null,
+    creditBalanceWei:
+      typeof body.creditBalanceWei === "string" && body.creditBalanceWei.trim()
+        ? body.creditBalanceWei.trim()
+        : "0",
+  });
+
+  const endUser = await getEndUserById(id);
+  return { status: 201, body: { endUser } };
+}
+
+export async function findOrCreateEndUserFromTurnkeySession(
+  sessionJwt: string,
+  walletAddress?: string,
+) {
+  const claims = await verifyTurnkeySessionJwt(sessionJwt);
+  if (!claims) {
+    return { ok: false as const, status: 401, body: { error: "Invalid Turnkey session" } };
+  }
+
+  const existing = await getEndUserByTurnkeyUserId(claims.userId);
+  if (existing) {
+    if (walletAddress && walletAddress !== existing.walletAddress) {
+      await updateEndUserWalletAddress(existing.id, walletAddress);
+    }
+    const endUser = await getEndUserById(existing.id);
+    return { ok: true as const, status: 200, body: { endUser, isNew: false } };
+  }
+
+  const id = uuidv4();
+  await createEndUser({
+    id,
+    turnkeyUserId: claims.userId,
+    walletAddress: walletAddress || null,
+    creditBalanceWei: "0",
+  });
+  const endUser = await getEndUserById(id);
+  return { ok: true as const, status: 201, body: { endUser, isNew: true } };
+}
+
+export async function updateEndUserCredits(params: {
+  endUserId: string;
+  action: string;
+  amountWei: string;
+}) {
+  if (!params.endUserId || !params.action || !params.amountWei) {
+    return {
+      ok: false as const,
+      status: 400,
+      body: { error: "id, action, and amountWei are required" },
+    };
+  }
+
+  if (!/^\d+$/.test(String(params.amountWei))) {
+    return {
+      ok: false as const,
+      status: 400,
+      body: { error: "amountWei must be a non-negative integer string" },
+    };
+  }
+
+  const amount = BigInt(params.amountWei);
+  if (params.action === "add_credits") {
+    await addCredits(params.endUserId, amount);
+  } else if (params.action === "deduct_credits") {
+    const success = await deductCredits(params.endUserId, amount);
+    if (!success) {
+      return { ok: false as const, status: 400, body: { error: "Insufficient balance" } };
+    }
+  } else {
+    return {
+      ok: false as const,
+      status: 400,
+      body: { error: "action must be 'add_credits' or 'deduct_credits'" },
+    };
+  }
+
+  const endUser = await getEndUserById(params.endUserId);
+  return { ok: true as const, status: 200, body: { endUser } };
+}
+
+export { addCredits, deductCredits };
+
+export async function findOrCreateAppEndUser(
+  appIdOrParams: string | { appId: string; externalUserId: string },
+  externalUserIdArg?: string,
+) {
+  const params =
+    typeof appIdOrParams === "string"
+      ? { appId: appIdOrParams, externalUserId: externalUserIdArg || "" }
+      : appIdOrParams;
+
+  const existing = await getAppEndUser(params.appId, params.externalUserId);
+  if (existing) {
+    return { id: existing.id, isNew: false };
+  }
+
+  const id = uuidv4();
+  try {
+    await createAppEndUser({
+      id,
+      appId: params.appId,
+      externalUserId: params.externalUserId,
+    });
+    return { id, isNew: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const isUniqueViolation =
+      msg.includes("unique") ||
+      msg.includes("duplicate") ||
+      (err as Record<string, unknown>).code === "23505";
+    if (isUniqueViolation) {
+      const retry = await getAppEndUser(params.appId, params.externalUserId);
+      if (retry) return { id: retry.id, isNew: false };
+    }
+    throw err;
+  }
+}

--- a/src/domains/identity-access/repo/admin-invites.ts
+++ b/src/domains/identity-access/repo/admin-invites.ts
@@ -1,0 +1,46 @@
+import { and, eq, gt, isNull } from "drizzle-orm";
+import { db } from "@/db/index";
+import { adminInvites, users } from "@/db/schema";
+
+export async function createAdminInvite(params: {
+  id: string;
+  code: string;
+  createdBy: string;
+  expiresAt: string;
+}) {
+  await db.insert(adminInvites).values(params);
+}
+
+export async function listOpenAdminInvites(now: string) {
+  return db
+    .select()
+    .from(adminInvites)
+    .where(and(isNull(adminInvites.usedBy), gt(adminInvites.expiresAt, now)));
+}
+
+export async function claimAdminInviteAndPromoteUser(params: {
+  code: string;
+  userId: string;
+  now: string;
+}) {
+  return db.transaction(async (tx) => {
+    const claimed = await tx
+      .update(adminInvites)
+      .set({ usedBy: params.userId })
+      .where(
+        and(
+          eq(adminInvites.code, params.code),
+          isNull(adminInvites.usedBy),
+          gt(adminInvites.expiresAt, params.now),
+        ),
+      )
+      .returning({ id: adminInvites.id });
+
+    if (claimed.length === 0) {
+      return { ok: false as const };
+    }
+
+    await tx.update(users).set({ role: "admin" }).where(eq(users.id, params.userId));
+    return { ok: true as const };
+  });
+}

--- a/src/domains/identity-access/repo/app-clients.ts
+++ b/src/domains/identity-access/repo/app-clients.ts
@@ -1,0 +1,35 @@
+import { eq, or } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export async function getOidcClientRowByClientId(clientId: string) {
+  const rows = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getDeveloperAppForOidcClientRow(oidcRowId: string) {
+  const rows = await db
+    .select()
+    .from(developerApps)
+    .where(
+      or(
+        eq(developerApps.oidcClientId, oidcRowId),
+        eq(developerApps.m2mOidcClientId, oidcRowId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getOidcClientIdByRowId(oidcRowId: string) {
+  const rows = await db
+    .select({ clientId: oidcClients.clientId })
+    .from(oidcClients)
+    .where(eq(oidcClients.id, oidcRowId))
+    .limit(1);
+  return rows[0]?.clientId ?? null;
+}

--- a/src/domains/identity-access/repo/audit.ts
+++ b/src/domains/identity-access/repo/audit.ts
@@ -1,0 +1,15 @@
+import { db } from "@/db/index";
+import { authAuditLog } from "@/db/schema";
+
+export async function insertAuditLog(entry: {
+  id: string;
+  clientId: string | null;
+  actorUserId: string | null;
+  action: string;
+  status: string;
+  correlationId: string;
+  metadata: string | null;
+  createdAt: string;
+}) {
+  await db.insert(authAuditLog).values(entry);
+}

--- a/src/domains/identity-access/repo/sessions.ts
+++ b/src/domains/identity-access/repo/sessions.ts
@@ -1,0 +1,73 @@
+import { and, eq, gt } from "drizzle-orm";
+import { db } from "@/db/index";
+import { sessions } from "@/db/schema";
+
+export async function createStoredSession(params: {
+  id: string;
+  userId?: string;
+  endUserId?: string;
+  appId?: string;
+  label?: string;
+  tokenHash: string;
+  scopes: string;
+  expiresAt: string;
+}) {
+  await db.insert(sessions).values({
+    id: params.id,
+    userId: params.userId || null,
+    endUserId: params.endUserId || null,
+    appId: params.appId || null,
+    label: params.label || null,
+    tokenHash: params.tokenHash,
+    scopes: params.scopes,
+    expiresAt: params.expiresAt,
+  });
+}
+
+export async function deleteSessionById(sessionId: string) {
+  const deleted = await db
+    .delete(sessions)
+    .where(eq(sessions.id, sessionId))
+    .returning({ id: sessions.id });
+  return deleted.length > 0;
+}
+
+export async function consumeSessionByIdHashAndExpiry(params: {
+  sessionId: string;
+  tokenHash: string;
+  now: string;
+}) {
+  const rows = await db
+    .delete(sessions)
+    .where(
+      and(
+        eq(sessions.id, params.sessionId),
+        eq(sessions.tokenHash, params.tokenHash),
+        gt(sessions.expiresAt, params.now),
+      ),
+    )
+    .returning();
+  return rows[0] ?? null;
+}
+
+export async function getActiveSessionByTokenHash(tokenHash: string, now: string) {
+  const rows = await db
+    .select()
+    .from(sessions)
+    .where(and(eq(sessions.tokenHash, tokenHash), gt(sessions.expiresAt, now)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listSessionsForAdminView() {
+  return db
+    .select({
+      id: sessions.id,
+      label: sessions.label,
+      endUserId: sessions.endUserId,
+      scopes: sessions.scopes,
+      expiresAt: sessions.expiresAt,
+      createdAt: sessions.createdAt,
+    })
+    .from(sessions);
+}

--- a/src/domains/identity-access/repo/users.ts
+++ b/src/domains/identity-access/repo/users.ts
@@ -1,0 +1,54 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import { users } from "@/db/schema";
+
+export async function getUserById(userId: string) {
+  const rows = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getUserByTurnkeyUserId(turnkeyUserId: string) {
+  const rows = await db
+    .select()
+    .from(users)
+    .where(eq(users.turnkeyUserId, turnkeyUserId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function updateUserWalletAddress(userId: string, walletAddress: string) {
+  await db.update(users).set({ walletAddress }).where(eq(users.id, userId));
+}
+
+export async function createDeveloperUser(params: {
+  id: string;
+  turnkeyUserId: string;
+  email: string;
+  name: string | null;
+  walletAddress: string | null;
+}) {
+  await db.insert(users).values({
+    id: params.id,
+    email: params.email,
+    name: params.name,
+    oauthProvider: "turnkey-wallet",
+    oauthSubject: params.turnkeyUserId,
+    role: "developer",
+    walletAddress: params.walletAddress,
+    turnkeyUserId: params.turnkeyUserId,
+  });
+}
+
+export async function getAdminUserByNormalizedEmail(email: string) {
+  const rows = await db
+    .select()
+    .from(users)
+    .where(
+      and(
+        eq(users.role, "admin"),
+        sql`lower(${users.email}) = ${email.trim().toLowerCase()}`,
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/identity-access/runtime/admin-auth.ts
+++ b/src/domains/identity-access/runtime/admin-auth.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/platform/auth/next-auth-options";
+import { authenticateRequest, hasScope } from "./request-auth";
+import { getUserById } from "../repo/users";
+
+export async function getAdminUser(request: NextRequest) {
+  const oauthSession = await getServerSession(authOptions);
+  if (oauthSession?.user) {
+    const sessionUser = oauthSession.user as Record<string, unknown>;
+    if (sessionUser.id) {
+      const user = await getUserById(sessionUser.id as string);
+      if (user?.role === "admin") return user;
+    }
+  }
+
+  const auth = await authenticateRequest(request);
+  if (auth && hasScope(auth.scopes, "admin") && auth.userId) {
+    const user = await getUserById(auth.userId);
+    if (user?.role === "admin") return user;
+  }
+
+  return null;
+}

--- a/src/domains/identity-access/runtime/admin-invites.ts
+++ b/src/domains/identity-access/runtime/admin-invites.ts
@@ -1,0 +1,43 @@
+import crypto from "crypto";
+import { v4 as uuidv4 } from "uuid";
+import {
+  claimAdminInviteAndPromoteUser,
+  createAdminInvite,
+  listOpenAdminInvites,
+} from "../repo/admin-invites";
+
+export async function issueAdminInvite(createdBy: string) {
+  const code = crypto.randomBytes(16).toString("hex");
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  await createAdminInvite({
+    id: uuidv4(),
+    code,
+    createdBy,
+    expiresAt,
+  });
+  return { code, expiresAt };
+}
+
+export async function readOpenAdminInvites() {
+  return listOpenAdminInvites(new Date().toISOString());
+}
+
+export async function redeemAdminInvite(code: string, userId: string) {
+  const result = await claimAdminInviteAndPromoteUser({
+    code,
+    userId,
+    now: new Date().toISOString(),
+  });
+  if (!result.ok) {
+    return {
+      ok: false as const,
+      status: 400,
+      body: { error: "Invalid or expired invite code" },
+    };
+  }
+  return {
+    ok: true as const,
+    status: 200,
+    body: { success: true, role: "admin" },
+  };
+}

--- a/src/domains/identity-access/runtime/admin-tokens.ts
+++ b/src/domains/identity-access/runtime/admin-tokens.ts
@@ -1,0 +1,25 @@
+import { listActiveAdminSessions, revokeSession, createSession } from "./request-auth";
+
+export async function issueAdminToken(params: {
+  adminUserId: string;
+  scopes: string;
+  expiresInDays: number;
+  endUserId?: string;
+  label?: string;
+}) {
+  return createSession({
+    userId: params.adminUserId,
+    endUserId: params.endUserId,
+    label: params.label,
+    scopes: params.scopes,
+    expiresInDays: params.expiresInDays,
+  });
+}
+
+export async function listAdminTokens() {
+  return listActiveAdminSessions();
+}
+
+export async function revokeAdminToken(sessionId: string) {
+  return revokeSession(sessionId);
+}

--- a/src/domains/identity-access/runtime/audit.ts
+++ b/src/domains/identity-access/runtime/audit.ts
@@ -1,0 +1,26 @@
+import { v4 as uuidv4 } from "uuid";
+import { insertAuditLog } from "../repo/audit";
+
+export function createCorrelationId() {
+  return uuidv4();
+}
+
+export async function writeAuditLog(entry: {
+  clientId?: string | null;
+  actorUserId?: string | null;
+  action: string;
+  status: string;
+  correlationId?: string;
+  metadata?: Record<string, unknown>;
+}) {
+  await insertAuditLog({
+    id: uuidv4(),
+    clientId: entry.clientId || null,
+    actorUserId: entry.actorUserId || null,
+    action: entry.action,
+    status: entry.status,
+    correlationId: entry.correlationId || createCorrelationId(),
+    metadata: entry.metadata ? JSON.stringify(entry.metadata) : null,
+    createdAt: new Date().toISOString(),
+  });
+}

--- a/src/domains/identity-access/runtime/request-auth.test.ts
+++ b/src/domains/identity-access/runtime/request-auth.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const run =
+  process.env.DATABASE_URL && process.env.PYMTHOUSE_TEST_DATABASE_URL_UNSET !== "1"
+    ? test
+    : test.skip;
+
+run("authenticateRequestAsync still accepts pmth bearer tokens", async () => {
+  const { createSession, authenticateRequestAsync } = await import("@/domains/identity-access/runtime/request-auth");
+  const { token } = await createSession({
+    scopes: "sign:job",
+    expiresInDays: 1,
+  });
+
+  const request = {
+    headers: new Headers({
+      authorization: `Bearer ${token}`,
+    }),
+  } as any;
+
+  const auth = await authenticateRequestAsync(request);
+  assert.ok(auth);
+  assert.equal(auth.scopes, "sign:job");
+});

--- a/src/domains/identity-access/runtime/request-auth.ts
+++ b/src/domains/identity-access/runtime/request-auth.ts
@@ -1,0 +1,269 @@
+import { randomBytes } from "crypto";
+import { v4 as uuidv4 } from "uuid";
+import type { NextRequest } from "next/server";
+import { validateClientSecret } from "@/domains/oidc-platform/runtime/clients";
+import { verifyAccessToken } from "@/domains/oidc-platform/runtime/access-token-verify";
+import { hashToken } from "@/shared/utils/token-hash";
+import {
+  createStoredSession,
+  consumeSessionByIdHashAndExpiry,
+  deleteSessionById,
+  getActiveSessionByTokenHash,
+} from "../repo/sessions";
+import {
+  getDeveloperAppForOidcClientRow,
+  getOidcClientIdByRowId,
+  getOidcClientRowByClientId,
+} from "../repo/app-clients";
+import { listSessionsForAdminView } from "../repo/sessions";
+
+export { hashToken };
+
+const TOKEN_PREFIX = "pmth_";
+const DEBUG_OIDC_LOGS = process.env.OIDC_DEBUG_LOGS === "1";
+
+export interface AuthResult {
+  userId: string | null;
+  endUserId: string | null;
+  appId: string | null;
+  sessionId: string;
+  label?: string | null;
+  scopes: string;
+  tokenHash: string;
+}
+
+export function decodeBasicAuthComponent(value: string): string {
+  try {
+    return decodeURIComponent(value.replace(/\+/g, " "));
+  } catch {
+    return value;
+  }
+}
+
+export function generateBearerToken(): { token: string; hash: string } {
+  const raw = randomBytes(32).toString("hex");
+  const token = `${TOKEN_PREFIX}${raw}`;
+  return { token, hash: hashToken(token) };
+}
+
+async function createSessionWithExpiryMs(opts: {
+  userId?: string;
+  endUserId?: string;
+  appId?: string;
+  label?: string;
+  scopes: string;
+  expiresInMs: number;
+}): Promise<{ sessionId: string; token: string }> {
+  const { userId, endUserId, appId, label, scopes, expiresInMs } = opts;
+  const safeExpiresInMs = Math.max(1, Math.floor(expiresInMs));
+  const { token, hash } = generateBearerToken();
+  const sessionId = uuidv4();
+  const expiresAt = new Date(Date.now() + safeExpiresInMs).toISOString();
+
+  await createStoredSession({
+    id: sessionId,
+    userId,
+    endUserId,
+    appId,
+    label,
+    tokenHash: hash,
+    scopes,
+    expiresAt,
+  });
+
+  return { sessionId, token };
+}
+
+export async function createSession(opts: {
+  userId?: string;
+  endUserId?: string;
+  appId?: string;
+  label?: string;
+  scopes?: string;
+  expiresInDays?: number;
+}) {
+  return createSessionWithExpiryMs({
+    ...opts,
+    scopes: opts.scopes || "sign:job",
+    expiresInMs: (opts.expiresInDays || 90) * 24 * 60 * 60 * 1000,
+  });
+}
+
+export async function createShortLivedSession(opts: {
+  userId?: string;
+  endUserId?: string;
+  appId?: string;
+  label?: string;
+  scopes?: string;
+  expiresInMinutes: number;
+}) {
+  return createSessionWithExpiryMs({
+    ...opts,
+    scopes: opts.scopes || "sign:job",
+    expiresInMs: opts.expiresInMinutes * 60 * 1000,
+  });
+}
+
+export async function revokeSession(sessionId: string) {
+  return deleteSessionById(sessionId);
+}
+
+export async function listActiveAdminSessions() {
+  return listSessionsForAdminView();
+}
+
+export async function consumeSessionByIdAndToken(
+  sessionId: string,
+  token: string,
+): Promise<AuthResult | null> {
+  if (!token.startsWith(TOKEN_PREFIX)) return null;
+  const tokenHash = hashToken(token);
+  const row = await consumeSessionByIdHashAndExpiry({
+    sessionId,
+    tokenHash,
+    now: new Date().toISOString(),
+  });
+  if (!row) return null;
+
+  return {
+    userId: row.userId,
+    endUserId: row.endUserId,
+    appId: row.appId || null,
+    sessionId: row.id,
+    label: row.label || null,
+    scopes: row.scopes,
+    tokenHash,
+  };
+}
+
+export async function validateBearerToken(token: string): Promise<AuthResult | null> {
+  if (!token.startsWith(TOKEN_PREFIX)) return null;
+  const tokenHash = hashToken(token);
+  const session = await getActiveSessionByTokenHash(tokenHash, new Date().toISOString());
+  if (!session) return null;
+
+  return {
+    userId: session.userId,
+    endUserId: session.endUserId,
+    appId: session.appId || null,
+    sessionId: session.id,
+    label: session.label || null,
+    scopes: session.scopes,
+    tokenHash,
+  };
+}
+
+export function hasScope(scopes: string, required: string): boolean {
+  if (!scopes) return false;
+  if (scopes === "admin") return true;
+  return scopes
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .includes(required);
+}
+
+export async function authenticateRequest(request: NextRequest): Promise<AuthResult | null> {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  return validateBearerToken(authHeader.slice(7));
+}
+
+export async function authenticateRequestAsync(request: NextRequest): Promise<AuthResult | null> {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const token = authHeader.slice(7);
+
+  const sessionResult = await validateBearerToken(token);
+  if (sessionResult) return sessionResult;
+
+  const jwtPayload = await verifyAccessToken(token);
+  if (!jwtPayload) {
+    if (DEBUG_OIDC_LOGS) {
+      const parts = token.split(".");
+      const isJwtShaped = parts.length === 3;
+      console.warn(
+        "[OIDC] bearer token rejected by JWT verifier:",
+        isJwtShaped ? "JWT signature/issuer/audience mismatch" : "not a JWT (opaque token?)",
+      );
+    }
+    return null;
+  }
+
+  const scopeFromScope =
+    typeof jwtPayload.scope === "string" ? jwtPayload.scope : "";
+  const scpRaw = (jwtPayload as Record<string, unknown>).scp;
+  const scopeFromScp =
+    Array.isArray(scpRaw)
+      ? scpRaw.filter((v): v is string => typeof v === "string").join(" ")
+      : typeof scpRaw === "string"
+        ? scpRaw
+        : "";
+  const effectiveScopes = (scopeFromScope || scopeFromScp).trim().replace(/\s+/g, ",");
+
+  return {
+    userId: typeof jwtPayload.sub === "string" ? jwtPayload.sub : null,
+    endUserId: null,
+    appId: typeof jwtPayload.client_id === "string" ? jwtPayload.client_id : null,
+    sessionId: typeof jwtPayload.jti === "string" ? jwtPayload.jti : `jwt_${Date.now()}`,
+    scopes: effectiveScopes,
+    tokenHash: "",
+  };
+}
+
+export class AuthError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export async function requireAuth(request: NextRequest, requiredScope: string) {
+  const auth = await authenticateRequest(request);
+  if (!auth) {
+    throw new AuthError("Unauthorized: invalid or expired token", 401);
+  }
+  if (!hasScope(auth.scopes, requiredScope)) {
+    throw new AuthError(`Forbidden: requires '${requiredScope}' scope`, 403);
+  }
+  return auth;
+}
+
+export async function authenticateAppClient(request: NextRequest): Promise<{
+  clientId: string;
+  appId: string;
+  scopes: string;
+} | null> {
+  let clientId: string | null = null;
+  let clientSecret: string | null = null;
+
+  const authHeader = request.headers.get("authorization") || "";
+  if (authHeader.startsWith("Basic ")) {
+    const decoded = Buffer.from(authHeader.slice(6), "base64").toString("utf-8");
+    const colonIdx = decoded.indexOf(":");
+    if (colonIdx > 0) {
+      clientId = decodeBasicAuthComponent(decoded.slice(0, colonIdx));
+      clientSecret = decodeBasicAuthComponent(decoded.slice(colonIdx + 1));
+    }
+  }
+
+  if (!clientId || !clientSecret) return null;
+  if (!(await validateClientSecret(clientId, clientSecret))) return null;
+
+  const clientRow = await getOidcClientRowByClientId(clientId);
+  if (!clientRow) return null;
+
+  const app = await getDeveloperAppForOidcClientRow(clientRow.id);
+  const oidcRowIdForAppId = app?.oidcClientId ?? app?.m2mOidcClientId;
+  if (!app || !oidcRowIdForAppId) return null;
+
+  const resolvedAppOidcClientId = await getOidcClientIdByRowId(oidcRowIdForAppId);
+  if (!resolvedAppOidcClientId) return null;
+
+  return {
+    clientId,
+    appId: resolvedAppOidcClientId,
+    scopes: clientRow.allowedScopes,
+  };
+}

--- a/src/domains/identity-access/runtime/turnkey-users.test.ts
+++ b/src/domains/identity-access/runtime/turnkey-users.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { verifyTurnkeySessionJwt } from "@/domains/identity-access/runtime/turnkey-users";
+
+test("verifyTurnkeySessionJwt rejects malformed token", async () => {
+  const out = await verifyTurnkeySessionJwt("not-a-jwt");
+  assert.equal(out, null);
+});
+
+test("verifyTurnkeySessionJwt rejects empty", async () => {
+  const out = await verifyTurnkeySessionJwt("   ");
+  assert.equal(out, null);
+});

--- a/src/domains/identity-access/runtime/turnkey-users.ts
+++ b/src/domains/identity-access/runtime/turnkey-users.ts
@@ -1,0 +1,122 @@
+import { verifySessionJwtSignature } from "@turnkey/crypto";
+import { decode as base64urlDecode } from "jose/base64url";
+import { v4 as uuidv4 } from "uuid";
+import {
+  createDeveloperUser,
+  getUserByTurnkeyUserId,
+  updateUserWalletAddress,
+} from "../repo/users";
+
+export type TurnkeySessionClaims = {
+  userId: string;
+  organizationId: string;
+  expirySeconds: number;
+  sessionType: string;
+};
+
+function parseCompactJwsPayloadObject(jwt: string): Record<string, unknown> {
+  const parts = jwt.split(".");
+  if (parts.length === 5) {
+    throw new Error("only compact JWS JWTs are supported");
+  }
+  if (parts.length !== 3 || !parts[1]) {
+    throw new Error("invalid JWT");
+  }
+  const bytes = base64urlDecode(parts[1]);
+  const text = new TextDecoder().decode(bytes);
+  const parsed: unknown = JSON.parse(text);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("invalid JWT claims set");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export function isTurnkeyWalletConfigured(): boolean {
+  return !!(
+    process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
+    process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim()
+  );
+}
+
+export async function verifyTurnkeySessionJwt(
+  sessionJwt: string,
+): Promise<TurnkeySessionClaims | null> {
+  const trimmed = sessionJwt.trim();
+  if (!trimmed) return null;
+
+  try {
+    const ok = await verifySessionJwtSignature(trimmed);
+    if (!ok) return null;
+
+    const decoded = parseCompactJwsPayloadObject(trimmed);
+    const exp = decoded.exp;
+    const userId = decoded.user_id;
+    const organizationId = decoded.organization_id;
+    const sessionType = decoded.session_type;
+
+    if (
+      typeof exp !== "number" ||
+      typeof userId !== "string" ||
+      !userId ||
+      typeof organizationId !== "string" ||
+      !organizationId ||
+      typeof sessionType !== "string" ||
+      !sessionType
+    ) {
+      return null;
+    }
+
+    if (exp * 1000 < Date.now()) {
+      return null;
+    }
+
+    const allowed = process.env.TURNKEY_ALLOWED_ORGANIZATION_IDS?.trim();
+    if (allowed) {
+      const ids = new Set(allowed.split(",").map((s) => s.trim()).filter(Boolean));
+      if (!ids.has(organizationId)) {
+        return null;
+      }
+    }
+
+    return {
+      userId,
+      organizationId,
+      expirySeconds: exp,
+      sessionType,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function findOrCreateDeveloperUser(
+  turnkeyUserId: string,
+  walletAddress?: string,
+  name?: string,
+  email?: string,
+): Promise<{ id: string; isNew: boolean }> {
+  const existing = await getUserByTurnkeyUserId(turnkeyUserId);
+
+  if (existing) {
+    if (walletAddress && walletAddress !== existing.walletAddress) {
+      await updateUserWalletAddress(existing.id, walletAddress);
+    }
+    return { id: existing.id, isNew: false };
+  }
+
+  const id = uuidv4();
+  const safeEmail = email || `${turnkeyUserId}@turnkey.local`;
+  await createDeveloperUser({
+    id,
+    turnkeyUserId,
+    email: safeEmail,
+    name:
+      name ||
+      (walletAddress
+        ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`
+        : null),
+    walletAddress: walletAddress || null,
+  });
+
+  return { id, isNew: true };
+}

--- a/src/domains/oidc-platform/repo/accounts.ts
+++ b/src/domains/oidc-platform/repo/accounts.ts
@@ -1,0 +1,13 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { endUsers, users } from "@/db/schema";
+
+export async function getUserBySubject(sub: string) {
+  const rows = await db.select().from(users).where(eq(users.id, sub)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getEndUserBySubject(sub: string) {
+  const rows = await db.select().from(endUsers).where(eq(endUsers.id, sub)).limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/oidc-platform/repo/app-access.ts
+++ b/src/domains/oidc-platform/repo/app-access.ts
@@ -1,0 +1,35 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients, providerAdmins } from "@/db/schema";
+
+export async function getOidcClientIdRowByClientId(clientId: string) {
+  const rows = await db
+    .select({ id: oidcClients.id })
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getDeveloperAppAccessByOidcClientRowId(oidcClientRowId: string) {
+  const rows = await db
+    .select({
+      id: developerApps.id,
+      name: developerApps.name,
+      status: developerApps.status,
+      ownerId: developerApps.ownerId,
+    })
+    .from(developerApps)
+    .where(eq(developerApps.oidcClientId, oidcClientRowId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function hasProviderAdminAccess(appId: string, userId: string) {
+  const rows = await db
+    .select({ id: providerAdmins.id })
+    .from(providerAdmins)
+    .where(and(eq(providerAdmins.clientId, appId), eq(providerAdmins.userId, userId)))
+    .limit(1);
+  return rows.length > 0;
+}

--- a/src/domains/oidc-platform/repo/branding.ts
+++ b/src/domains/oidc-platform/repo/branding.ts
@@ -1,0 +1,31 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export async function getOidcClientByClientId(clientId: string) {
+  const rows = await db.select().from(oidcClients).where(eq(oidcClients.clientId, clientId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getDeveloperAppByOidcClientRowId(oidcClientRowId: string) {
+  const rows = await db
+    .select()
+    .from(developerApps)
+    .where(eq(developerApps.oidcClientId, oidcClientRowId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getDeveloperAppByAppId(appId: string) {
+  const rows = await db.select().from(developerApps).where(eq(developerApps.id, appId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getDeveloperAppByCustomDomain(domain: string) {
+  const rows = await db
+    .select()
+    .from(developerApps)
+    .where(eq(developerApps.customLoginDomain, domain))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/oidc-platform/repo/clients.ts
+++ b/src/domains/oidc-platform/repo/clients.ts
@@ -1,0 +1,88 @@
+import { eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "./db-conn";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export async function getOidcClientByClientId(clientId: string) {
+  const rows = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function updateOidcClientByClientId(
+  clientId: string,
+  updates: Partial<typeof oidcClients.$inferInsert>,
+) {
+  await db.update(oidcClients).set(updates).where(eq(oidcClients.clientId, clientId));
+}
+
+export async function insertOidcClient(values: typeof oidcClients.$inferInsert) {
+  await db.insert(oidcClients).values(values);
+}
+
+export async function listOidcClients() {
+  return db.select().from(oidcClients);
+}
+
+export async function getOidcClientDeviceInitiateLogin(clientId: string) {
+  const rows = await db
+    .select({
+      initiateLoginUri: oidcClients.initiateLoginUri,
+      deviceThirdPartyInitiateLogin: oidcClients.deviceThirdPartyInitiateLogin,
+    })
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function createBasicOidcClient(params: {
+  clientId: string;
+  displayName: string;
+  clientSecretHash: string | null;
+  redirectUrisJson: string;
+  allowedScopes: string;
+  grantTypes: string;
+  tokenEndpointAuthMethod: "none" | "client_secret_post" | "client_secret_basic";
+}) {
+  const id = uuidv4();
+  await insertOidcClient({
+    id,
+    clientId: params.clientId,
+    clientSecretHash: params.clientSecretHash,
+    displayName: params.displayName,
+    redirectUris: params.redirectUrisJson,
+    allowedScopes: params.allowedScopes,
+    grantTypes: params.grantTypes,
+    tokenEndpointAuthMethod: params.tokenEndpointAuthMethod,
+  });
+  return { id, clientId: params.clientId };
+}
+
+export async function getDeveloperAppById(appInternalId: string) {
+  const rows = await db
+    .select()
+    .from(developerApps)
+    .where(eq(developerApps.id, appInternalId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getOidcClientById(id: string) {
+  const rows = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.id, id))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function updateDeveloperAppM2mOidcClientId(appInternalId: string, m2mOidcClientId: string) {
+  await db
+    .update(developerApps)
+    .set({ m2mOidcClientId })
+    .where(eq(developerApps.id, appInternalId));
+}

--- a/src/domains/oidc-platform/repo/consent-page.ts
+++ b/src/domains/oidc-platform/repo/consent-page.ts
@@ -1,0 +1,28 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export async function getConsentDeveloperAppByOidcClientRowId(oidcClientRowId: string) {
+  const rows = await db
+    .select({
+      name: developerApps.name,
+      developerName: developerApps.developerName,
+      websiteUrl: developerApps.websiteUrl,
+      privacyPolicyUrl: developerApps.privacyPolicyUrl,
+      supportUrl: developerApps.supportUrl,
+      logoLightUrl: developerApps.logoLightUrl,
+    })
+    .from(developerApps)
+    .where(eq(developerApps.oidcClientId, oidcClientRowId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getConsentClientMetadataByClientId(clientId: string) {
+  const rows = await db
+    .select({ logoUri: oidcClients.logoUri })
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/oidc-platform/repo/custom-domains.ts
+++ b/src/domains/oidc-platform/repo/custom-domains.ts
@@ -1,0 +1,81 @@
+import { and, eq, isNotNull } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps } from "@/db/schema";
+
+export async function getDeveloperAppById(appId: string) {
+  const rows = await db.select().from(developerApps).where(eq(developerApps.id, appId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getAppByVerifiedCustomDomain(domain: string) {
+  const rows = await db
+    .select()
+    .from(developerApps)
+    .where(
+      and(
+        eq(developerApps.customLoginDomain, domain),
+        eq(developerApps.customLoginEnabled, 1),
+      ),
+    )
+    .limit(1);
+  const app = rows[0];
+  if (!app || !app.customDomainVerifiedAt) return null;
+  return app;
+}
+
+export async function getAppByCustomLoginDomain(domain: string) {
+  const rows = await db
+    .select()
+    .from(developerApps)
+    .where(eq(developerApps.customLoginDomain, domain))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function updateCustomDomainVerification(params: {
+  appId: string;
+  normalizedDomain: string;
+  verificationToken: string;
+  verifiedAt: string;
+  updatedAt: string;
+}) {
+  return db
+    .update(developerApps)
+    .set({
+      customDomainVerifiedAt: params.verifiedAt,
+      updatedAt: params.updatedAt,
+    })
+    .where(
+      and(
+        eq(developerApps.id, params.appId),
+        eq(developerApps.customLoginDomain, params.normalizedDomain),
+        eq(developerApps.customDomainVerificationToken, params.verificationToken),
+      ),
+    )
+    .returning({ id: developerApps.id });
+}
+
+export async function updateCustomLoginDomain(appId: string, updates: {
+  customLoginDomain?: string | null;
+  customDomainVerificationToken?: string | null;
+  customDomainVerifiedAt?: string | null;
+  customLoginEnabled?: number;
+  brandingMode?: string;
+  updatedAt: string;
+}) {
+  await db.update(developerApps).set(updates).where(eq(developerApps.id, appId));
+}
+
+export async function listVerifiedCustomLoginDomainHosts() {
+  const rows = await db
+    .select({ domain: developerApps.customLoginDomain })
+    .from(developerApps)
+    .where(
+      and(
+        eq(developerApps.customLoginEnabled, 1),
+        isNotNull(developerApps.customDomainVerifiedAt),
+        isNotNull(developerApps.customLoginDomain),
+      ),
+    );
+  return rows.map((row) => row.domain as string);
+}

--- a/src/domains/oidc-platform/repo/db-conn.ts
+++ b/src/domains/oidc-platform/repo/db-conn.ts
@@ -1,0 +1,4 @@
+import { db } from "@/db/index";
+
+export { db };
+export type DrizzleDb = typeof db;

--- a/src/domains/oidc-platform/repo/device-verification.ts
+++ b/src/domains/oidc-platform/repo/device-verification.ts
@@ -1,0 +1,15 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { oidcClients } from "@/db/schema";
+
+export async function getDeviceVerificationClientPolicy(clientId: string) {
+  const rows = await db
+    .select({
+      deviceThirdPartyInitiateLogin: oidcClients.deviceThirdPartyInitiateLogin,
+      clientSecretHash: oidcClients.clientSecretHash,
+    })
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/oidc-platform/repo/oidc-payloads.ts
+++ b/src/domains/oidc-platform/repo/oidc-payloads.ts
@@ -1,0 +1,120 @@
+import { and, eq, isNotNull, isNull, lt, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import { oidcPayloads } from "@/db/schema";
+
+export async function upsertOidcPayload(params: {
+  id: string;
+  model: string;
+  payload: string;
+  expiresAt: number | null;
+  uid: string | null;
+  userCode: string | null;
+  grantId: string | null;
+}) {
+  await db
+    .insert(oidcPayloads)
+    .values({
+      id: params.id,
+      model: params.model,
+      payload: params.payload,
+      expiresAt: params.expiresAt,
+      uid: params.uid,
+      userCode: params.userCode,
+      grantId: params.grantId,
+      consumedAt: null,
+    })
+    .onConflictDoUpdate({
+      target: [oidcPayloads.id, oidcPayloads.model],
+      set: {
+        payload: params.payload,
+        expiresAt: params.expiresAt,
+        uid: params.uid,
+        userCode: params.userCode,
+        grantId: params.grantId,
+      },
+    });
+}
+
+export async function getOidcPayloadById(id: string, model: string) {
+  const rows = await db
+    .select()
+    .from(oidcPayloads)
+    .where(and(eq(oidcPayloads.id, id), eq(oidcPayloads.model, model)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getOidcPayloadByUid(uid: string, model: string) {
+  const rows = await db
+    .select()
+    .from(oidcPayloads)
+    .where(and(eq(oidcPayloads.uid, uid), eq(oidcPayloads.model, model)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getOidcPayloadByUserCode(userCode: string, model: string) {
+  const rows = await db
+    .select()
+    .from(oidcPayloads)
+    .where(and(eq(oidcPayloads.userCode, userCode), eq(oidcPayloads.model, model)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function bindDeviceApprovalIfUnbound(params: {
+  id: string;
+  model: string;
+  payload: string;
+  expiresAt: number | null;
+  uid: string | null;
+  userCode: string | null;
+  grantId: string | null;
+}) {
+  const updated = await db
+    .update(oidcPayloads)
+    .set({
+      payload: params.payload,
+      expiresAt: params.expiresAt,
+      uid: params.uid,
+      userCode: params.userCode,
+      grantId: params.grantId,
+    })
+    .where(
+      and(
+        eq(oidcPayloads.id, params.id),
+        eq(oidcPayloads.model, params.model),
+        isNull(oidcPayloads.grantId),
+        sql`coalesce((${oidcPayloads.payload})::jsonb->>'accountId', '') = ''`,
+        sql`coalesce((${oidcPayloads.payload})::jsonb->>'grantId', '') = ''`,
+      ),
+    )
+    .returning({ id: oidcPayloads.id });
+
+  return updated.length > 0;
+}
+
+export async function consumeOidcPayload(id: string, model: string, consumedAt: number) {
+  await db
+    .update(oidcPayloads)
+    .set({ consumedAt })
+    .where(and(eq(oidcPayloads.id, id), eq(oidcPayloads.model, model)));
+}
+
+export async function deleteOidcPayload(id: string, model: string) {
+  await db
+    .delete(oidcPayloads)
+    .where(and(eq(oidcPayloads.id, id), eq(oidcPayloads.model, model)));
+}
+
+export async function deleteOidcPayloadsByGrantId(grantId: string, model: string) {
+  await db
+    .delete(oidcPayloads)
+    .where(and(eq(oidcPayloads.grantId, grantId), eq(oidcPayloads.model, model)));
+}
+
+export async function cleanupExpiredOidcPayloads(now: number) {
+  await db
+    .delete(oidcPayloads)
+    .where(and(isNotNull(oidcPayloads.expiresAt), lt(oidcPayloads.expiresAt, now)));
+}

--- a/src/domains/oidc-platform/repo/programmatic-tokens.ts
+++ b/src/domains/oidc-platform/repo/programmatic-tokens.ts
@@ -1,0 +1,63 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { appUsers, developerApps, oidcClients } from "@/db/schema";
+
+export async function getProgrammaticTokenAppPolicy(developerAppId: string) {
+  const rows = await db
+    .select({ allowedScopes: oidcClients.allowedScopes })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(developerApps.id, developerAppId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getProgrammaticTokenBinding(input: {
+  developerAppId: string;
+  oauthClientId: string;
+  appUserId: string;
+}) {
+  const rows = await db
+    .select({
+      oauthClientId: oidcClients.clientId,
+      appUserId: appUsers.id,
+    })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .innerJoin(
+      appUsers,
+      and(eq(appUsers.clientId, developerApps.id), eq(appUsers.id, input.appUserId)),
+    )
+    .where(
+      and(
+        eq(developerApps.id, input.developerAppId),
+        eq(oidcClients.clientId, input.oauthClientId),
+        eq(appUsers.status, "active"),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getRefreshTokenProgrammaticApp(sessionAppId: string) {
+  const rows = await db
+    .select({
+      appId: developerApps.id,
+      oauthClientId: oidcClients.clientId,
+      allowedScopes: oidcClients.allowedScopes,
+    })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, sessionAppId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getActiveAppUserForRefresh(appUserId: string, appId: string) {
+  const rows = await db
+    .select()
+    .from(appUsers)
+    .where(and(eq(appUsers.id, appUserId), eq(appUsers.clientId, appId)))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/oidc-platform/repo/provider-instance.ts
+++ b/src/domains/oidc-platform/repo/provider-instance.ts
@@ -1,0 +1,30 @@
+import { desc, eq, or } from "drizzle-orm";
+import { db } from "./db-conn";
+import { appAllowedDomains, developerApps, oidcClients, oidcSigningKeys } from "@/db/schema";
+
+export async function listRecentSigningKeys(limit = 5) {
+  return db
+    .select()
+    .from(oidcSigningKeys)
+    .orderBy(desc(oidcSigningKeys.createdAt))
+    .limit(limit);
+}
+
+export async function listAllOidcClients() {
+  return db.select().from(oidcClients);
+}
+
+export async function listDeveloperAppsForOidcClientRowId(oidcClientRowId: string) {
+  return db
+    .select({ id: developerApps.id })
+    .from(developerApps)
+    .where(or(eq(developerApps.oidcClientId, oidcClientRowId), eq(developerApps.m2mOidcClientId, oidcClientRowId)))
+    .limit(1);
+}
+
+export async function listAllowedDomainsForApp(appId: string) {
+  return db
+    .select({ domain: appAllowedDomains.domain })
+    .from(appAllowedDomains)
+    .where(eq(appAllowedDomains.appId, appId));
+}

--- a/src/domains/oidc-platform/repo/signing-keys.ts
+++ b/src/domains/oidc-platform/repo/signing-keys.ts
@@ -1,0 +1,44 @@
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { oidcSigningKeys } from "@/db/schema";
+
+export async function insertSigningKey(params: {
+  id: string;
+  kid: string;
+  algorithm: string;
+  publicKeyPem: string;
+  privateKeyPem: string;
+  active: number;
+}) {
+  await db.insert(oidcSigningKeys).values(params);
+}
+
+export async function deactivateActiveSigningKeys(rotatedAt: string) {
+  await db
+    .update(oidcSigningKeys)
+    .set({ active: 0, rotatedAt })
+    .where(eq(oidcSigningKeys.active, 1));
+}
+
+export async function getActiveSigningKeyRow() {
+  const rows = await db
+    .select()
+    .from(oidcSigningKeys)
+    .where(eq(oidcSigningKeys.active, 1))
+    .orderBy(desc(oidcSigningKeys.createdAt))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listRecentSigningKeyRows(limit: number) {
+  return db.select().from(oidcSigningKeys).orderBy(desc(oidcSigningKeys.createdAt)).limit(limit);
+}
+
+export async function getSigningKeyRowByKid(kid: string) {
+  const rows = await db
+    .select()
+    .from(oidcSigningKeys)
+    .where(eq(oidcSigningKeys.kid, kid))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/oidc-platform/repo/token-exchange-flows.ts
+++ b/src/domains/oidc-platform/repo/token-exchange-flows.ts
@@ -1,0 +1,83 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "./db-conn";
+import type { DrizzleDb } from "./db-conn";
+import { appUsers, developerApps, endUsers, oidcClients } from "@/db/schema";
+
+export type { DrizzleDb } from "./db-conn";
+
+export async function getConfidentialOidcClientByClientId(
+  dbConn: DrizzleDb,
+  clientId: string,
+) {
+  const rows = await dbConn
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getPublicOidcClientDevicePolicy(
+  dbConn: DrizzleDb,
+  clientId: string,
+) {
+  const rows = await dbConn
+    .select({
+      id: oidcClients.id,
+      deviceThirdPartyInitiateLogin: oidcClients.deviceThirdPartyInitiateLogin,
+    })
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getDeveloperAppIdByOidcClientRowId(
+  dbConn: DrizzleDb,
+  oidcClientRowId: string,
+) {
+  const rows = await dbConn
+    .select({ id: developerApps.id })
+    .from(developerApps)
+    .where(eq(developerApps.oidcClientId, oidcClientRowId))
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
+
+export async function getAppUserExternalUserId(
+  dbConn: DrizzleDb,
+  appUserId: string,
+) {
+  const rows = await dbConn
+    .select({ externalUserId: appUsers.externalUserId })
+    .from(appUsers)
+    .where(eq(appUsers.id, appUserId))
+    .limit(1);
+  return rows[0]?.externalUserId ?? null;
+}
+
+export async function getGatewayAppUserExternalUserId(
+  dbConn: DrizzleDb,
+  developerAppId: string,
+  appUserId: string,
+) {
+  const rows = await dbConn
+    .select({ externalUserId: appUsers.externalUserId })
+    .from(appUsers)
+    .where(and(eq(appUsers.clientId, developerAppId), eq(appUsers.id, appUserId)))
+    .limit(1);
+  return rows[0]?.externalUserId ?? null;
+}
+
+export async function getGatewayEndUserId(
+  dbConn: DrizzleDb,
+  developerAppId: string,
+  endUserId: string,
+) {
+  const rows = await dbConn
+    .select({ id: endUsers.id })
+    .from(endUsers)
+    .where(and(eq(endUsers.id, endUserId), eq(endUsers.appId, developerAppId)))
+    .limit(1);
+  return rows[0]?.id ?? null;
+}

--- a/src/domains/oidc-platform/repo/token-exchange.ts
+++ b/src/domains/oidc-platform/repo/token-exchange.ts
@@ -1,0 +1,23 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export async function getOidcClientByClientId(clientId: string) {
+  const rows = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getApprovedAppByOidcClientRowId(oidcClientRowId: string) {
+  const rows = await db
+    .select()
+    .from(developerApps)
+    .where(eq(developerApps.oidcClientId, oidcClientRowId))
+    .limit(1);
+  const app = rows[0] ?? null;
+  if (!app || app.status !== "approved") return null;
+  return app;
+}

--- a/src/domains/oidc-platform/runtime/access-token-verify.ts
+++ b/src/domains/oidc-platform/runtime/access-token-verify.ts
@@ -1,0 +1,37 @@
+import * as jose from "jose";
+import { getCanonicalIssuer } from "@/platform/oidc/issuer-urls";
+import { getPublicJWKS } from "./jwks";
+
+export async function verifyAccessToken(token: string): Promise<jose.JWTPayload | null> {
+  try {
+    const issuer = getCanonicalIssuer();
+    const jwks = await getPublicJWKS();
+    const keySet = jose.createLocalJWKSet(jwks);
+    const { payload } = await jose.jwtVerify(token, keySet, {
+      issuer,
+      audience: issuer,
+    });
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+export async function verifyAccessTokenWithIssuer(
+  token: string,
+  expectedIssuer: string,
+): Promise<jose.JWTPayload | null> {
+  try {
+    const canonicalIssuer = getCanonicalIssuer();
+    if (expectedIssuer !== canonicalIssuer) return null;
+    const jwks = await getPublicJWKS();
+    const keySet = jose.createLocalJWKSet(jwks);
+    const { payload } = await jose.jwtVerify(token, keySet, {
+      issuer: expectedIssuer,
+      audience: expectedIssuer,
+    });
+    return payload;
+  } catch {
+    return null;
+  }
+}

--- a/src/domains/oidc-platform/runtime/account.ts
+++ b/src/domains/oidc-platform/runtime/account.ts
@@ -1,0 +1,36 @@
+import type { Account, FindAccount } from "oidc-provider";
+import { getEndUserBySubject, getUserBySubject } from "../repo/accounts";
+
+export const findAccount: FindAccount = async (_ctx, sub) => {
+  const user = await getUserBySubject(sub);
+  if (user) {
+    const account: Account = {
+      accountId: user.id,
+      async claims(_use, scope) {
+        const scopes = scope ? scope.split(" ") : [];
+        const claims: { sub: string; [key: string]: unknown } = { sub: user.id };
+        if (scopes.includes("email")) claims.email = user.email;
+        if (scopes.includes("profile")) claims.name = user.name;
+        return claims;
+      },
+    };
+    return account;
+  }
+
+  const endUser = await getEndUserBySubject(sub);
+  if (endUser) {
+    const account: Account = {
+      accountId: endUser.id,
+      async claims(_use, scope) {
+        const scopes = scope ? scope.split(" ") : [];
+        const claims: { sub: string; [key: string]: unknown } = { sub: endUser.id };
+        if (scopes.includes("email")) claims.email = endUser.email;
+        if (scopes.includes("profile")) claims.name = endUser.name;
+        return claims;
+      },
+    };
+    return account;
+  }
+
+  return undefined;
+};

--- a/src/domains/oidc-platform/runtime/adapter.test.ts
+++ b/src/domains/oidc-platform/runtime/adapter.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+
+const run =
+  process.env.DATABASE_URL && process.env.PYMTHOUSE_TEST_DATABASE_URL_UNSET !== "1"
+    ? test
+    : test.skip;
+
+run("upsert preserves consumed state for existing rows", async () => {
+  const { PostgresOidcAdapter } = await import("@/domains/oidc-platform/runtime/adapter");
+  const adapter = new PostgresOidcAdapter("DeviceCode");
+  const id = `device-code-consume-test-${crypto.randomUUID()}`;
+
+  await adapter.upsert(
+    id,
+    {
+      jti: id,
+      userCode: "ABCD1234",
+      clientId: "test-client",
+    },
+    600,
+  );
+
+  await adapter.consume(id);
+  const consumed = await adapter.find(id);
+  assert.ok(consumed?.consumed);
+
+  await adapter.upsert(
+    id,
+    {
+      jti: id,
+      userCode: "ABCD1234",
+      clientId: "test-client",
+    },
+    600,
+  );
+
+  const after = await adapter.find(id);
+  assert.ok(after?.consumed, "consumed flag should not be cleared by upsert");
+});

--- a/src/domains/oidc-platform/runtime/adapter.ts
+++ b/src/domains/oidc-platform/runtime/adapter.ts
@@ -1,0 +1,100 @@
+import type { Adapter, AdapterPayload } from "oidc-provider";
+import {
+  bindDeviceApprovalIfUnbound as bindDeviceApprovalIfUnboundRepo,
+  cleanupExpiredOidcPayloads,
+  consumeOidcPayload,
+  deleteOidcPayload,
+  deleteOidcPayloadsByGrantId,
+  getOidcPayloadById,
+  getOidcPayloadByUid,
+  getOidcPayloadByUserCode,
+  upsertOidcPayload,
+} from "../repo/oidc-payloads";
+
+const GRANTABLE = new Set([
+  "AccessToken",
+  "AuthorizationCode",
+  "RefreshToken",
+  "DeviceCode",
+  "BackchannelAuthenticationRequest",
+]);
+
+function rowToPayload(row: { payload: string; consumedAt: number | null } | null): AdapterPayload | undefined {
+  if (!row) return undefined;
+  const data = JSON.parse(row.payload) as AdapterPayload;
+  if (row.consumedAt) data.consumed = row.consumedAt;
+  return data;
+}
+
+export class PostgresOidcAdapter implements Adapter {
+  private model: string;
+
+  constructor(model: string) {
+    this.model = model;
+  }
+
+  async upsert(id: string, payload: AdapterPayload, expiresIn: number): Promise<void> {
+    const expiresAt = expiresIn ? Math.floor(Date.now() / 1000) + expiresIn : null;
+    await upsertOidcPayload({
+      id,
+      model: this.model,
+      payload: JSON.stringify(payload),
+      expiresAt,
+      uid: payload.uid ?? null,
+      userCode: payload.userCode ?? null,
+      grantId: payload.grantId ?? null,
+    });
+  }
+
+  async find(id: string): Promise<AdapterPayload | undefined> {
+    return rowToPayload(await getOidcPayloadById(id, this.model));
+  }
+
+  async findByUid(uid: string): Promise<AdapterPayload | undefined> {
+    return rowToPayload(await getOidcPayloadByUid(uid, this.model));
+  }
+
+  async bindDeviceApprovalIfUnbound(id: string, payload: AdapterPayload, expiresIn: number): Promise<boolean> {
+    if (this.model !== "DeviceCode") {
+      throw new TypeError("bindDeviceApprovalIfUnbound is only for DeviceCode");
+    }
+    const expiresAt = expiresIn ? Math.floor(Date.now() / 1000) + expiresIn : null;
+    const grantIdCol =
+      typeof (payload as Record<string, unknown>).grantId === "string"
+        ? ((payload as Record<string, unknown>).grantId as string)
+        : null;
+    return bindDeviceApprovalIfUnboundRepo({
+      id,
+      model: this.model,
+      payload: JSON.stringify(payload),
+      expiresAt,
+      uid: payload.uid ?? null,
+      userCode: payload.userCode ?? null,
+      grantId: grantIdCol,
+    });
+  }
+
+  async findByUserCode(userCode: string): Promise<AdapterPayload | undefined> {
+    return rowToPayload(await getOidcPayloadByUserCode(userCode, this.model));
+  }
+
+  async consume(id: string): Promise<void> {
+    await consumeOidcPayload(id, this.model, Math.floor(Date.now() / 1000));
+  }
+
+  async destroy(id: string): Promise<void> {
+    await deleteOidcPayload(id, this.model);
+  }
+
+  async revokeByGrantId(grantId: string): Promise<void> {
+    if (GRANTABLE.has(this.model)) {
+      await deleteOidcPayloadsByGrantId(grantId, this.model);
+    }
+  }
+
+  static async cleanup(): Promise<void> {
+    await cleanupExpiredOidcPayloads(Math.floor(Date.now() / 1000));
+  }
+}
+
+export const SqliteAdapter = PostgresOidcAdapter;

--- a/src/domains/oidc-platform/runtime/app-access.ts
+++ b/src/domains/oidc-platform/runtime/app-access.ts
@@ -1,0 +1,55 @@
+import {
+  getDeveloperAppAccessByOidcClientRowId,
+  getOidcClientIdRowByClientId,
+  hasProviderAdminAccess,
+} from "../repo/app-access";
+
+export interface AppAccessCheck {
+  allowed: boolean;
+  reason?: string;
+  appStatus?: string;
+  appName?: string;
+}
+
+export async function checkAppAccess(
+  clientId: string,
+  userId: string | null,
+): Promise<AppAccessCheck> {
+  const clientRow = await getOidcClientIdRowByClientId(clientId);
+  if (!clientRow) {
+    return { allowed: false, reason: "Client not found" };
+  }
+
+  const app = await getDeveloperAppAccessByOidcClientRowId(clientRow.id);
+  if (!app) {
+    return {
+      allowed: false,
+      reason: "Client is not associated with a registered developer app",
+    };
+  }
+  if (app.status === "approved") {
+    return { allowed: true, appStatus: app.status, appName: app.name };
+  }
+  if (!userId) {
+    return {
+      allowed: false,
+      reason: `This app is ${app.status} and not yet available to the public`,
+      appStatus: app.status,
+      appName: app.name,
+    };
+  }
+  if (app.ownerId === userId) {
+    return { allowed: true, reason: "App owner", appStatus: app.status, appName: app.name };
+  }
+
+  if (await hasProviderAdminAccess(app.id, userId)) {
+    return { allowed: true, reason: "App admin", appStatus: app.status, appName: app.name };
+  }
+
+  return {
+    allowed: false,
+    reason: `This app is ${app.status} and not yet available. Only the app owner and admins can test it before approval.`,
+    appStatus: app.status,
+    appName: app.name,
+  };
+}

--- a/src/domains/oidc-platform/runtime/branding.ts
+++ b/src/domains/oidc-platform/runtime/branding.ts
@@ -1,0 +1,106 @@
+import {
+  type AppBranding,
+  type BrandingMode,
+  getDefaultBranding,
+  shouldUseWhiteLabelBranding,
+  getBrandingCssVars,
+} from "@/platform/oidc/branding-shared";
+import {
+  getDeveloperAppByAppId,
+  getDeveloperAppByCustomDomain,
+  getDeveloperAppByOidcClientRowId,
+  getOidcClientByClientId,
+} from "../repo/branding";
+
+type BrandingAppRecord = {
+  id: string;
+  name: string;
+  websiteUrl: string | null;
+  privacyPolicyUrl: string | null;
+  tosUrl: string | null;
+  supportUrl: string | null;
+  developerName: string | null;
+  brandingMode: string | null;
+  brandingLogoUrl: string | null;
+  logoLightUrl: string | null;
+  brandingPrimaryColor: string | null;
+  brandingSupportEmail: string | null;
+  customLoginEnabled: number | boolean | null;
+  customLoginDomain: string | null;
+  customDomainVerifiedAt: string | null;
+};
+
+export async function resolveAppBrandingByClientId(clientId: string): Promise<AppBranding> {
+  const oidcClient = await getOidcClientByClientId(clientId);
+  if (!oidcClient) return getDefaultBranding();
+
+  const app = await getDeveloperAppByOidcClientRowId(oidcClient.id);
+
+  if (!app) {
+    return {
+      ...getDefaultBranding(),
+      displayName: oidcClient.displayName,
+      logoUrl: oidcClient.logoUri || null,
+    };
+  }
+
+  return resolveAppBranding(app);
+}
+
+export async function resolveAppBrandingByAppId(appId: string): Promise<AppBranding> {
+  const app = await getDeveloperAppByAppId(appId);
+  if (!app) return getDefaultBranding();
+  return resolveAppBranding(app);
+}
+
+export async function resolveAppBrandingByCustomDomain(domain: string): Promise<AppBranding | null> {
+  const normalizedDomain = domain.toLowerCase().replace(/^www\./, "");
+  const app = await getDeveloperAppByCustomDomain(normalizedDomain);
+
+  if (!app || !app.customLoginEnabled || app.brandingMode !== "whiteLabel") return null;
+  if (!app.customDomainVerifiedAt) return null;
+  return resolveAppBranding(app);
+}
+
+function resolveAppBranding(app: BrandingAppRecord): AppBranding {
+  const brandingMode = (app.brandingMode as BrandingMode) || "blackLabel";
+
+  if (brandingMode === "blackLabel") {
+    return {
+      mode: "blackLabel",
+      appId: app.id,
+      appName: app.name,
+      displayName: "pymthouse",
+      logoUrl: null,
+      primaryColor: "#10b981",
+      websiteUrl: app.websiteUrl,
+      privacyPolicyUrl: app.privacyPolicyUrl,
+      tosUrl: app.tosUrl,
+      supportUrl: app.supportUrl,
+      supportEmail: null,
+      developerName: app.developerName,
+      customLoginDomain: null,
+      customLoginEnabled: false,
+    };
+  }
+
+  return {
+    mode: "whiteLabel",
+    appId: app.id,
+    appName: app.name,
+    displayName: app.name,
+    logoUrl: app.brandingLogoUrl || app.logoLightUrl || null,
+    primaryColor: app.brandingPrimaryColor || "#10b981",
+    websiteUrl: app.websiteUrl,
+    privacyPolicyUrl: app.privacyPolicyUrl,
+    tosUrl: app.tosUrl,
+    supportUrl: app.supportUrl,
+    supportEmail: app.brandingSupportEmail || null,
+    developerName: app.developerName,
+    customLoginDomain: app.customLoginEnabled ? app.customLoginDomain : null,
+    customLoginEnabled: Boolean(app.customLoginEnabled),
+  };
+}
+
+export { getDefaultBranding, shouldUseWhiteLabelBranding, getBrandingCssVars };
+export type { AppBranding, BrandingMode };

--- a/src/domains/oidc-platform/runtime/clients.ts
+++ b/src/domains/oidc-platform/runtime/clients.ts
@@ -1,0 +1,291 @@
+import { randomBytes } from "crypto";
+import { hashToken } from "@/shared/utils/token-hash";
+import { computeBackendM2mAllowedScopes } from "@/platform/oidc/backend-m2m-scopes";
+import { DEFAULT_OIDC_SCOPES } from "@/platform/oidc/scopes";
+import {
+  createBasicOidcClient,
+  getDeveloperAppById,
+  getOidcClientByClientId,
+  getOidcClientById,
+  getOidcClientDeviceInitiateLogin,
+  listOidcClients,
+  updateDeveloperAppM2mOidcClientId,
+  updateOidcClientByClientId,
+} from "../repo/clients";
+
+export { computeBackendM2mAllowedScopes };
+
+export interface OidcClientConfig {
+  clientId: string;
+  clientSecret?: string;
+  displayName: string;
+  redirectUris: string[];
+  allowedScopes?: string;
+  grantTypes?: string[];
+  tokenEndpointAuthMethod?: "none" | "client_secret_post" | "client_secret_basic";
+}
+
+export function hashClientSecret(secret: string): string {
+  return hashToken(secret);
+}
+
+export async function registerClient(config: OidcClientConfig): Promise<void> {
+  const existing = await getOidcClientByClientId(config.clientId);
+
+  if (existing) {
+    await updateOidcClientByClientId(config.clientId, {
+      displayName: config.displayName,
+      redirectUris: JSON.stringify(config.redirectUris),
+      allowedScopes: config.allowedScopes || DEFAULT_OIDC_SCOPES,
+      grantTypes: (config.grantTypes || ["authorization_code", "refresh_token"]).join(","),
+      tokenEndpointAuthMethod: config.tokenEndpointAuthMethod || "none",
+      clientSecretHash: config.clientSecret ? hashClientSecret(config.clientSecret) : null,
+    });
+    return;
+  }
+
+  await createBasicOidcClient({
+    clientId: config.clientId,
+    displayName: config.displayName,
+    clientSecretHash: config.clientSecret ? hashClientSecret(config.clientSecret) : null,
+    redirectUrisJson: JSON.stringify(config.redirectUris),
+    allowedScopes: config.allowedScopes || DEFAULT_OIDC_SCOPES,
+    grantTypes: (config.grantTypes || ["authorization_code", "refresh_token"]).join(","),
+    tokenEndpointAuthMethod: config.tokenEndpointAuthMethod || "none",
+  });
+}
+
+export async function getRegisteredRedirectOrigins(): Promise<Set<string>> {
+  const rows = await listOidcClients();
+  const origins = new Set<string>();
+  const commonPorts = [
+    "3000", "3001", "3002", "3003", "3004", "3005",
+    "4000", "4001", "4200", "5000", "5173", "5174",
+    "8000", "8080", "8081", "8888", "9000",
+  ];
+
+  for (const row of rows) {
+    const uris = JSON.parse(row.redirectUris) as string[];
+    for (const uri of uris) {
+      if (uri.includes("*")) {
+        for (const port of commonPorts) {
+          try {
+            origins.add(new URL(uri.replace(/:\*/, `:${port}`).replace(/\*/g, "")).origin);
+          } catch {}
+        }
+      } else {
+        try {
+          origins.add(new URL(uri).origin);
+        } catch {}
+      }
+    }
+  }
+
+  return origins;
+}
+
+export async function getInitiateLoginUriForDeviceFlow(clientId: string): Promise<string | null> {
+  const row = await getOidcClientDeviceInitiateLogin(clientId);
+  if (!row || row.deviceThirdPartyInitiateLogin !== 1) return null;
+  const uri = row.initiateLoginUri;
+  return typeof uri === "string" && uri.trim() ? uri.trim() : null;
+}
+
+export async function getClient(clientId: string): Promise<{
+  id: string;
+  clientId: string;
+  displayName: string;
+  redirectUris: string[];
+  allowedScopes: string[];
+  grantTypes: string[];
+  tokenEndpointAuthMethod: string;
+  clientSecretHash: string | null;
+  createdAt: string;
+} | null> {
+  const client = await getOidcClientByClientId(clientId);
+  if (!client) return null;
+
+  return {
+    id: client.id,
+    clientId: client.clientId,
+    displayName: client.displayName,
+    redirectUris: JSON.parse(client.redirectUris) as string[],
+    allowedScopes: client.allowedScopes.split(/[,\s]+/).filter(Boolean),
+    grantTypes: client.grantTypes.split(",").filter(Boolean),
+    tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+    clientSecretHash: client.clientSecretHash,
+    createdAt: client.createdAt,
+  };
+}
+
+export async function getAllClients() {
+  const rows = await listOidcClients();
+  return rows.map((client) => ({
+    id: client.id,
+    clientId: client.clientId,
+    displayName: client.displayName,
+    redirectUris: JSON.parse(client.redirectUris) as string[],
+    allowedScopes: client.allowedScopes.split(/[,\s]+/).filter(Boolean),
+    grantTypes: client.grantTypes.split(",").filter(Boolean),
+    tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+    hasSecret: !!client.clientSecretHash,
+    createdAt: client.createdAt,
+  }));
+}
+
+export async function validateRedirectUri(clientId: string, redirectUri: string): Promise<boolean> {
+  const client = await getClient(clientId);
+  if (!client) return false;
+
+  return client.redirectUris.some((pattern) => {
+    if (pattern.includes("*")) {
+      const escapedPattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const wildcardPattern = escapedPattern.replace(/\\\*/g, ".*");
+      return new RegExp(`^${wildcardPattern}$`).test(redirectUri);
+    }
+    return pattern === redirectUri;
+  });
+}
+
+export async function validateClientSecret(clientId: string, clientSecret: string): Promise<boolean> {
+  const client = await getClient(clientId);
+  if (!client || !client.clientSecretHash) return false;
+  return hashClientSecret(clientSecret) === client.clientSecretHash;
+}
+
+export async function validateScopes(clientId: string, requestedScopes: string[]): Promise<string[]> {
+  const client = await getClient(clientId);
+  if (!client) return [];
+  return requestedScopes.filter((scope) => client.allowedScopes.includes(scope));
+}
+
+export function generateClientId(): string {
+  return `app_${randomBytes(12).toString("hex")}`;
+}
+
+export function generateM2mClientId(): string {
+  return `m2m_${randomBytes(12).toString("hex")}`;
+}
+
+export function generateClientSecret(): string {
+  return `pmth_cs_${randomBytes(32).toString("hex")}`;
+}
+
+export async function createAppClient(displayName: string): Promise<{ id: string; clientId: string }> {
+  const clientId = generateClientId();
+  return createBasicOidcClient({
+    clientId,
+    displayName,
+    clientSecretHash: null,
+    redirectUrisJson: JSON.stringify([]),
+    allowedScopes: DEFAULT_OIDC_SCOPES,
+    grantTypes: "authorization_code,refresh_token",
+    tokenEndpointAuthMethod: "none",
+  });
+}
+
+export async function rotateClientSecret(clientId: string): Promise<string | null> {
+  const client = await getOidcClientByClientId(clientId);
+  if (!client) return null;
+
+  const secret = generateClientSecret();
+  await updateOidcClientByClientId(clientId, { clientSecretHash: hashClientSecret(secret) });
+  return secret;
+}
+
+function normalizeScopeListString(scopes: string): string {
+  return scopes.split(/[,\s]+/).filter(Boolean).sort().join(" ");
+}
+
+export async function syncBackendM2mAllowedScopesFromPublicApp(appInternalId: string): Promise<boolean> {
+  const app = await getDeveloperAppById(appInternalId);
+  if (!app?.oidcClientId || !app.m2mOidcClientId) return false;
+
+  const pub = await getOidcClientById(app.oidcClientId);
+  const m2m = await getOidcClientById(app.m2mOidcClientId);
+  if (!pub || !m2m) return false;
+
+  const next = computeBackendM2mAllowedScopes(pub.allowedScopes ?? DEFAULT_OIDC_SCOPES);
+  if (normalizeScopeListString(next) === normalizeScopeListString(m2m.allowedScopes)) {
+    return false;
+  }
+
+  await updateClientConfig(m2m.clientId, { allowedScopes: next });
+  return true;
+}
+
+export async function ensureM2mBackendClient(params: {
+  appInternalId: string;
+  appDisplayName: string;
+}): Promise<{ id: string; clientId: string } | null> {
+  const app = await getDeveloperAppById(params.appInternalId);
+  if (!app?.oidcClientId) return null;
+
+  if (app.m2mOidcClientId) {
+    const existing = await getOidcClientById(app.m2mOidcClientId);
+    if (existing) {
+      return { id: existing.id, clientId: existing.clientId };
+    }
+  }
+
+  const pub = await getOidcClientById(app.oidcClientId);
+  const publicScopes = pub?.allowedScopes ?? DEFAULT_OIDC_SCOPES;
+
+  const clientId = generateM2mClientId();
+  const display = params.appDisplayName.trim().slice(0, 80) || "Provider app";
+
+  const client = await createBasicOidcClient({
+    clientId,
+    displayName: `${display} - backend helper`,
+    clientSecretHash: null,
+    redirectUrisJson: JSON.stringify([]),
+    allowedScopes: computeBackendM2mAllowedScopes(publicScopes),
+    grantTypes: "client_credentials",
+    tokenEndpointAuthMethod: "client_secret_basic",
+  });
+  await updateOidcClientByClientId(clientId, {
+    deviceThirdPartyInitiateLogin: 0,
+    initiateLoginUri: null,
+  });
+  await updateDeveloperAppM2mOidcClientId(params.appInternalId, client.id);
+  return client;
+}
+
+export async function updateClientConfig(
+  clientId: string,
+  config: {
+    displayName?: string;
+    redirectUris?: string[];
+    allowedScopes?: string;
+    grantTypes?: string[];
+    tokenEndpointAuthMethod?: "none" | "client_secret_post" | "client_secret_basic";
+    postLogoutRedirectUris?: string[];
+    deviceThirdPartyInitiateLogin?: boolean;
+    initiateLoginUri?: string | null;
+    logoUri?: string | null;
+    policyUri?: string | null;
+    tosUri?: string | null;
+    clientUri?: string | null;
+  },
+): Promise<boolean> {
+  const existing = await getOidcClientByClientId(clientId);
+  if (!existing) return false;
+
+  const updates: Record<string, unknown> = {};
+  if (config.displayName !== undefined) updates.displayName = config.displayName;
+  if (config.redirectUris !== undefined) updates.redirectUris = JSON.stringify(config.redirectUris);
+  if (config.allowedScopes !== undefined) updates.allowedScopes = config.allowedScopes;
+  if (config.grantTypes !== undefined) updates.grantTypes = config.grantTypes.join(",");
+  if (config.tokenEndpointAuthMethod !== undefined) updates.tokenEndpointAuthMethod = config.tokenEndpointAuthMethod;
+  if (config.postLogoutRedirectUris !== undefined) updates.postLogoutRedirectUris = JSON.stringify(config.postLogoutRedirectUris);
+  if (config.deviceThirdPartyInitiateLogin !== undefined) updates.deviceThirdPartyInitiateLogin = config.deviceThirdPartyInitiateLogin ? 1 : 0;
+  if (config.initiateLoginUri !== undefined) updates.initiateLoginUri = config.initiateLoginUri;
+  if (config.logoUri !== undefined) updates.logoUri = config.logoUri;
+  if (config.policyUri !== undefined) updates.policyUri = config.policyUri;
+  if (config.tosUri !== undefined) updates.tosUri = config.tosUri;
+  if (config.clientUri !== undefined) updates.clientUri = config.clientUri;
+  if (Object.keys(updates).length === 0) return true;
+
+  await updateOidcClientByClientId(clientId, updates);
+  return true;
+}

--- a/src/domains/oidc-platform/runtime/consent-page.ts
+++ b/src/domains/oidc-platform/runtime/consent-page.ts
@@ -1,0 +1,26 @@
+import type { AppBranding } from "@/platform/oidc/branding-shared";
+import {
+  getConsentClientMetadataByClientId,
+  getConsentDeveloperAppByOidcClientRowId,
+} from "../repo/consent-page";
+
+export async function getConsentDisplayData(params: {
+  clientId: string;
+  oidcClientRowId: string;
+  branding: AppBranding;
+}) {
+  const [developerApp, oidcClientRow] = await Promise.all([
+    getConsentDeveloperAppByOidcClientRowId(params.oidcClientRowId),
+    getConsentClientMetadataByClientId(params.clientId),
+  ]);
+
+  const logoUrl =
+    params.branding.mode === "whiteLabel"
+      ? params.branding.logoUrl || oidcClientRow?.logoUri || developerApp?.logoLightUrl || null
+      : oidcClientRow?.logoUri || developerApp?.logoLightUrl || null;
+
+  return {
+    developerApp,
+    logoUrl,
+  };
+}

--- a/src/domains/oidc-platform/runtime/custom-domains.ts
+++ b/src/domains/oidc-platform/runtime/custom-domains.ts
@@ -1,0 +1,152 @@
+import { randomBytes } from "crypto";
+import {
+  getAppByCustomLoginDomain,
+  getAppByVerifiedCustomDomain,
+  getDeveloperAppById,
+  listVerifiedCustomLoginDomainHosts,
+  updateCustomDomainVerification,
+  updateCustomLoginDomain,
+} from "../repo/custom-domains";
+
+export interface CustomDomainConfig {
+  appId: string;
+  domain: string;
+  verified: boolean;
+  verificationToken: string | null;
+  verifiedAt: string | null;
+}
+
+export function generateVerificationToken(): string {
+  return `pmth_verify_${randomBytes(16).toString("hex")}`;
+}
+
+export function getDnsVerificationRecord(token: string): string {
+  return `_pymthouse-verification=${token}`;
+}
+
+export function normalizeDomain(domain: string): string {
+  return domain.toLowerCase().replace(/^https?:\/\//, "").replace(/\/$/, "").replace(/^www\./, "");
+}
+
+export async function getAppByCustomDomain(domain: string) {
+  return getAppByVerifiedCustomDomain(normalizeDomain(domain));
+}
+
+export async function isVerifiedCustomDomain(domain: string): Promise<boolean> {
+  return (await getAppByCustomDomain(domain)) !== null;
+}
+
+export async function verifyDomainOwnership(appId: string, domain: string) {
+  const normalized = normalizeDomain(domain);
+  const app = await getDeveloperAppById(appId);
+  if (!app) return { verified: false, error: "App not found" };
+  if (app.customLoginDomain !== normalized) {
+    return { verified: false, error: "Domain does not match configured custom login domain" };
+  }
+  const verificationToken = app.customDomainVerificationToken;
+  if (!verificationToken) {
+    return { verified: false, error: "No verification token configured" };
+  }
+
+  try {
+    const { Resolver } = await import("dns/promises");
+    const resolver = new Resolver();
+    resolver.setServers(["8.8.8.8", "1.1.1.1"]);
+    const expectedRecord = getDnsVerificationRecord(verificationToken);
+    const records = await resolver.resolveTxt(`_pymthouse.${normalized}`);
+    const flatRecords = records.map((r) => r.join(""));
+    if (flatRecords.includes(expectedRecord) || flatRecords.includes(verificationToken)) {
+      const updated = await updateCustomDomainVerification({
+        appId,
+        normalizedDomain: normalized,
+        verificationToken,
+        verifiedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      if (updated.length === 0) {
+        return { verified: false, error: "Domain verification state changed, please retry" };
+      }
+      return { verified: true };
+    }
+    return {
+      verified: false,
+      error: `DNS TXT record not found. Add a TXT record for _pymthouse.${normalized} with value: ${verificationToken}`,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "DNS lookup failed";
+    return { verified: false, error: `DNS verification failed: ${message}` };
+  }
+}
+
+export async function setupCustomLoginDomain(appId: string, domain: string) {
+  const normalized = normalizeDomain(domain);
+  if (!normalized || normalized.includes("/") || !normalized.includes(".")) {
+    return { error: "Invalid domain format" };
+  }
+  const existing = await getAppByCustomLoginDomain(normalized);
+  if (existing && existing.id !== appId) {
+    return { error: "This domain is already configured for another app" };
+  }
+  const token = generateVerificationToken();
+  const dnsRecord = getDnsVerificationRecord(token);
+  await updateCustomLoginDomain(appId, {
+    customLoginDomain: normalized,
+    customDomainVerificationToken: token,
+    customDomainVerifiedAt: null,
+    customLoginEnabled: 0,
+    updatedAt: new Date().toISOString(),
+  });
+  return { token, dnsRecord, dnsHost: `_pymthouse.${normalized}` };
+}
+
+export async function enableCustomLoginDomain(appId: string): Promise<boolean> {
+  const app = await getDeveloperAppById(appId);
+  if (!app || !app.customDomainVerifiedAt) return false;
+  await updateCustomLoginDomain(appId, {
+    customLoginEnabled: 1,
+    brandingMode: "whiteLabel",
+    updatedAt: new Date().toISOString(),
+  });
+  return true;
+}
+
+export async function disableCustomLoginDomain(appId: string): Promise<void> {
+  await updateCustomLoginDomain(appId, {
+    customLoginEnabled: 0,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export async function removeCustomLoginDomain(appId: string): Promise<void> {
+  await updateCustomLoginDomain(appId, {
+    customLoginDomain: null,
+    customDomainVerificationToken: null,
+    customDomainVerifiedAt: null,
+    customLoginEnabled: 0,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export async function getCustomDomainStatus(appId: string): Promise<CustomDomainConfig | null> {
+  const app = await getDeveloperAppById(appId);
+  if (!app || !app.customLoginDomain) return null;
+  return {
+    appId: app.id,
+    domain: app.customLoginDomain,
+    verified: !!app.customDomainVerifiedAt,
+    verificationToken: app.customDomainVerificationToken,
+    verifiedAt: app.customDomainVerifiedAt,
+  };
+}
+
+export async function getVerifiedCustomLoginDomainHosts(): Promise<string[]> {
+  return listVerifiedCustomLoginDomainHosts();
+}
+
+export async function getTrustedLoginHosts(): Promise<string[]> {
+  const baseHost = process.env.NEXTAUTH_URL
+    ? new URL(process.env.NEXTAUTH_URL).host
+    : "localhost:3000";
+  const verifiedHosts = await getVerifiedCustomLoginDomainHosts();
+  return [baseHost, ...verifiedHosts];
+}

--- a/src/domains/oidc-platform/runtime/device-approval.ts
+++ b/src/domains/oidc-platform/runtime/device-approval.ts
@@ -1,0 +1,162 @@
+import { SqliteAdapter } from "@/domains/oidc-platform/runtime/adapter";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import { getProvider } from "./provider-instance";
+
+export type DeviceApprovalFailure = {
+  ok: false;
+  error: string;
+  description: string;
+  status: number;
+};
+
+export type DeviceApprovalSuccess = { ok: true };
+
+function isDeviceCodeBound(payload: Record<string, unknown>): boolean {
+  const accountId = payload.accountId;
+  const grantId = payload.grantId;
+  return (
+    (typeof accountId === "string" && accountId.length > 0) ||
+    (typeof grantId === "string" && grantId.length > 0)
+  );
+}
+
+export async function approveDeviceCodeForAccount(
+  normalizedUserCode: string,
+  oidcClientId: string,
+  accountId: string,
+): Promise<DeviceApprovalSuccess | DeviceApprovalFailure> {
+  const adapter = new SqliteAdapter("DeviceCode");
+  const deviceCode = await adapter.findByUserCode(normalizedUserCode);
+
+  if (!deviceCode) {
+    return {
+      ok: false,
+      error: "invalid_grant",
+      description: "Invalid, expired, or already used device code",
+      status: 400,
+    };
+  }
+  if (deviceCode.consumed) {
+    return {
+      ok: false,
+      error: "invalid_grant",
+      description: "Device code already used",
+      status: 400,
+    };
+  }
+  if (deviceCode.exp && deviceCode.exp < Math.floor(Date.now() / 1000)) {
+    return {
+      ok: false,
+      error: "expired_token",
+      description: "The device code has expired",
+      status: 400,
+    };
+  }
+
+  const boundClient =
+    typeof deviceCode.clientId === "string"
+      ? deviceCode.clientId
+      : typeof deviceCode.params === "object" &&
+          deviceCode.params !== null &&
+          typeof (deviceCode.params as Record<string, unknown>).client_id === "string"
+        ? ((deviceCode.params as Record<string, unknown>).client_id as string)
+        : null;
+  if (!boundClient || boundClient !== oidcClientId) {
+    return {
+      ok: false,
+      error: "invalid_grant",
+      description: "Device code does not match this client",
+      status: 400,
+    };
+  }
+
+  const params =
+    typeof deviceCode.params === "object" && deviceCode.params !== null
+      ? (deviceCode.params as Record<string, unknown>)
+      : null;
+  const resourceFromParams = params?.resource;
+  const resource =
+    typeof resourceFromParams === "string" && resourceFromParams.length > 0
+      ? resourceFromParams
+      : typeof deviceCode.resource === "string" && deviceCode.resource.length > 0
+        ? deviceCode.resource
+        : getIssuer();
+  const scope =
+    typeof deviceCode.scope === "string"
+      ? deviceCode.scope
+      : params && typeof params.scope === "string"
+        ? params.scope
+        : "";
+
+  if (typeof deviceCode.jti !== "string" || deviceCode.jti.length === 0) {
+    return {
+      ok: false,
+      error: "invalid_grant",
+      description: "Invalid, expired, or already used device code",
+      status: 400,
+    };
+  }
+
+  const latest = await adapter.find(deviceCode.jti);
+  if (!latest) {
+    return {
+      ok: false,
+      error: "invalid_grant",
+      description: "Invalid, expired, or already used device code",
+      status: 400,
+    };
+  }
+  if (isDeviceCodeBound(latest as Record<string, unknown>)) {
+    return { ok: true };
+  }
+
+  const provider = await getProvider();
+  const grant = new provider.Grant();
+  grant.clientId = oidcClientId;
+  grant.accountId = accountId;
+  if (scope) {
+    grant.addOIDCScope(scope);
+    grant.addResourceScope(resource, scope);
+  }
+  const newGrantId = await grant.save();
+
+  const now = Math.floor(Date.now() / 1000);
+  const expiresIn = deviceCode.exp ? Math.max(deviceCode.exp - now, 1) : 600;
+
+  let bound: boolean;
+  try {
+    bound = await adapter.bindDeviceApprovalIfUnbound(
+      deviceCode.jti,
+      {
+        ...latest,
+        accountId,
+        grantId: newGrantId,
+        scope,
+        resource,
+        authTime: now,
+        acr: typeof latest.acr === "string" ? latest.acr : "urn:pmth:session",
+        amr: Array.isArray(latest.amr) ? latest.amr : ["pwd"],
+        error: undefined,
+        errorDescription: undefined,
+      },
+      expiresIn,
+    );
+  } catch (err) {
+    const after = await adapter.find(deviceCode.jti);
+    const payloadGrantId =
+      after && typeof (after as Record<string, unknown>).grantId === "string"
+        ? ((after as Record<string, unknown>).grantId as string)
+        : "";
+    if (payloadGrantId !== newGrantId) {
+      await grant.destroy();
+    }
+    throw err;
+  }
+
+  if (!bound) {
+    await grant.destroy();
+    return { ok: true };
+  }
+
+  return { ok: true };
+}

--- a/src/domains/oidc-platform/runtime/device-token-exchange.test.ts
+++ b/src/domains/oidc-platform/runtime/device-token-exchange.test.ts
@@ -1,0 +1,409 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import {
+  handleDeviceApprovalTokenExchange,
+  isDeviceApprovalTokenExchangeRequest,
+  type DrizzleDb,
+} from "@/domains/oidc-platform/runtime/device-token-exchange";
+import { TokenExchangeError } from "@/domains/oidc-platform/runtime/token-exchange";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+
+function dbMock(rows: unknown[][]): DrizzleDb {
+  let i = 0;
+  const next = () => {
+    const r = rows[i++];
+    if (!r) throw new Error(`db mock exhausted at step ${i}`);
+    return Promise.resolve(r);
+  };
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => next(),
+        }),
+      }),
+    }),
+  } as unknown as DrizzleDb;
+}
+
+/** Fails fast if any DB read runs (e.g. invalid client secret path must not query). */
+const dbMockSelectForbidden: DrizzleDb = {
+  select: () => {
+    throw new Error("unexpected db.select — validateClientSecret should short-circuit first");
+  },
+} as unknown as DrizzleDb;
+
+const M2M_ID = "m2m_test123";
+const PUBLIC_ID = "app_testpublic";
+const SUBJECT_JWT = randomUUID();
+
+const m2mRowOk = {
+  id: "int-m2m",
+  clientSecretHash: "hash",
+  allowedScopes: "users:token device:approve",
+  clientId: M2M_ID,
+};
+
+// dbMock consumes rows in strict call order; each entry is the next `.limit()` result:
+// 0: oidcClients by M2M client_id
+// 1: developerApps sibling (public oidc row id)
+// 2: oidcClients.id → client_id (resolvePublicClientIdForOidcRow)
+// 3: oidcClients by public client_id — { id, deviceThirdPartyInitiateLogin } (single merged query)
+// 4: developerApps by oidcClientId
+// 5: appUsers by subject_token.sub
+function rowsForHappyPath(): unknown[][] {
+  return [
+    [m2mRowOk],
+    [{ oidcClientId: "pub-int" }],
+    [{ clientId: PUBLIC_ID }],
+    [{ id: "pub-int", deviceThirdPartyInitiateLogin: 1 }],
+    [{ id: "dev-app-1" }],
+    [{ externalUserId: "ext-user-1" }],
+  ];
+}
+
+function baseJwtPayload() {
+  const exp = Math.floor(Date.now() / 1000) + 900;
+  return {
+    sub: "account-1",
+    client_id: PUBLIC_ID,
+    exp,
+    scope: "sign:job",
+  };
+}
+
+async function rejectsWithCode(
+  fn: () => Promise<unknown>,
+  code: string,
+): Promise<void> {
+  await assert.rejects(fn, (err: unknown) => {
+    assert.ok(err instanceof TokenExchangeError);
+    assert.equal((err as TokenExchangeError).code, code);
+    return true;
+  });
+}
+
+test("isDeviceApprovalTokenExchangeRequest is true for device resource + token exchange + access_token subject type", () => {
+  assert.equal(
+    isDeviceApprovalTokenExchangeRequest({
+      grantType: "urn:ietf:params:oauth:grant-type:token-exchange",
+      subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+      resource: "urn:pmth:device_code:ABCD-EFGH",
+    }),
+    true,
+  );
+});
+
+test("isDeviceApprovalTokenExchangeRequest is false without urn:pmth:device_code resource", () => {
+  assert.equal(
+    isDeviceApprovalTokenExchangeRequest({
+      grantType: "urn:ietf:params:oauth:grant-type:token-exchange",
+      subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+      resource: "https://issuer.example/api/v1/oidc",
+    }),
+    false,
+  );
+});
+
+test("isDeviceApprovalTokenExchangeRequest is false for wrong subject_token_type", () => {
+  assert.equal(
+    isDeviceApprovalTokenExchangeRequest({
+      grantType: "urn:ietf:params:oauth:grant-type:token-exchange",
+      subjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+      resource: "urn:pmth:device_code:ABCD",
+    }),
+    false,
+  );
+});
+
+test("handleDeviceApprovalTokenExchange returns subject_token as access_token on success", async () => {
+  const auditCalls: unknown[] = [];
+  const out = await handleDeviceApprovalTokenExchange(
+    {
+      clientId: M2M_ID,
+      clientSecret: "secret",
+      subjectToken: SUBJECT_JWT,
+      subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+      resource: "urn:pmth:device_code:ABCD-EFGH",
+      requestedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+      audience: [getIssuer()],
+    },
+    {
+      validateClientSecret: async () => true,
+      verifyAccessToken: async () => baseJwtPayload(),
+      approveDeviceCodeForAccount: async () => ({ ok: true }),
+      findOrCreateAppEndUser: async () => ({ id: "eu-1", isNew: false }),
+      db: dbMock(rowsForHappyPath()),
+      createCorrelationId: () => "cid",
+      writeAuditLog: async (entry: { action?: string }) => {
+        auditCalls.push(entry);
+      },
+    },
+  );
+  assert.equal(out.access_token, SUBJECT_JWT);
+  assert.equal(out.token_type, "Bearer");
+  assert.equal(out.issued_token_type, "urn:ietf:params:oauth:token-type:access_token");
+  assert.ok(auditCalls.some((e) => (e as { action: string }).action === "device_code_approved_token_exchange"));
+});
+
+test("handleDeviceApprovalTokenExchange invalid_client when client secret invalid", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "bad",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+        },
+        {
+          validateClientSecret: async () => false,
+          db: dbMockSelectForbidden,
+        },
+    ),
+    "invalid_client",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_request when subject_token_type is not access_token", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+        },
+        {
+          validateClientSecret: async () => true,
+          db: dbMockSelectForbidden,
+        },
+      ),
+    "invalid_request",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_scope without device:approve or users:token", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+        },
+        {
+          validateClientSecret: async () => true,
+          db: dbMock([
+            [{ ...m2mRowOk, allowedScopes: "openid" }],
+          ]),
+        },
+      ),
+    "invalid_scope",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_client when no developer app sibling", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+        },
+        {
+          validateClientSecret: async () => true,
+          db: dbMock([[m2mRowOk], []]),
+        },
+      ),
+    "invalid_client",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_target for bad resource prefix", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "https://example.com/resource",
+        },
+        {
+          validateClientSecret: async () => true,
+          db: dbMock([[m2mRowOk]]),
+        },
+      ),
+    "invalid_target",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_target when user_code missing from resource", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:",
+        },
+        {
+          validateClientSecret: async () => true,
+          db: dbMock([[m2mRowOk]]),
+        },
+      ),
+    "invalid_target",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_request when requested_token_type is not access_token", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+          requestedTokenType: "urn:ietf:params:oauth:token-type:jwt",
+        },
+        {
+          validateClientSecret: async () => true,
+          db: dbMock([[m2mRowOk]]),
+        },
+      ),
+    "invalid_request",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_target when audience does not match issuer", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+          audience: ["https://unknown-resource-server.example/"],
+        },
+        {
+          validateClientSecret: async () => true,
+          db: dbMock([[m2mRowOk]]),
+        },
+      ),
+    "invalid_target",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_grant when subject_token client_id mismatches public sibling", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+        },
+        {
+          validateClientSecret: async () => true,
+          verifyAccessToken: async () => ({
+            ...baseJwtPayload(),
+            client_id: "app_other_app",
+          }),
+          db: dbMock(rowsForHappyPath()),
+        },
+      ),
+    "invalid_grant",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_client when third-party device login disabled", async () => {
+  const rows = rowsForHappyPath();
+  rows[3] = [{ id: "pub-int", deviceThirdPartyInitiateLogin: 0 }];
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+        },
+        {
+          validateClientSecret: async () => true,
+          verifyAccessToken: async () => baseJwtPayload(),
+          db: dbMock(rows),
+        },
+      ),
+    "invalid_client",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_grant when approveDeviceCodeForAccount fails (expired)", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: SUBJECT_JWT,
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+        },
+        {
+          validateClientSecret: async () => true,
+          verifyAccessToken: async () => baseJwtPayload(),
+          approveDeviceCodeForAccount: async () => ({
+            ok: false,
+            error: "expired_token",
+            description: "The device code has expired",
+            status: 400,
+          }),
+          findOrCreateAppEndUser: async () => ({ id: "eu-1", isNew: false }),
+          db: dbMock(rowsForHappyPath()),
+        },
+      ),
+    "expired_token",
+  );
+});
+
+test("handleDeviceApprovalTokenExchange invalid_grant when subject_token verify fails", async () => {
+  await rejectsWithCode(
+    () =>
+      handleDeviceApprovalTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: "bad",
+          subjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+          resource: "urn:pmth:device_code:ABCD-EFGH",
+        },
+        {
+          validateClientSecret: async () => true,
+          verifyAccessToken: async () => null,
+          db: dbMock(rowsForHappyPath()),
+        },
+      ),
+    "invalid_grant",
+  );
+});

--- a/src/domains/oidc-platform/runtime/device-token-exchange.ts
+++ b/src/domains/oidc-platform/runtime/device-token-exchange.ts
@@ -1,0 +1,316 @@
+/**
+ * RFC 8693 token exchange: bind a pending RFC 8628 device code using a PymtHouse-issued
+ * user access_token as subject_token and resource=urn:pmth:device_code:<user_code>.
+ *
+ * Confidential (M2M) client authenticates; subject_token must have been issued to the
+ * same app's public client_id.
+ */
+
+import { eq } from "drizzle-orm";
+import { hasScope } from "@/domains/identity-access/runtime/request-auth";
+import { normalizeUserCode } from "@/platform/oidc/device";
+import { verifyAccessToken } from "@/domains/oidc-platform/runtime/access-token-verify";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import { TokenExchangeError } from "@/domains/oidc-platform/runtime/token-exchange";
+import { findOrCreateAppEndUser } from "@/domains/end-user-accounts/runtime/end-users";
+import {
+  createCorrelationId,
+  writeAuditLog,
+} from "@/domains/identity-access/runtime/audit";
+import {
+  resolvePublicClientIdForOidcRow,
+  DeveloperAppSiblingAmbiguousError,
+  type DrizzleDb,
+} from "@/platform/oidc/client-sibling";
+import { db as defaultDbConn } from "../repo/db-conn";
+import {
+  getAppUserExternalUserId,
+  getConfidentialOidcClientByClientId,
+  getDeveloperAppIdByOidcClientRowId,
+  getPublicOidcClientDevicePolicy,
+} from "../repo/token-exchange-flows";
+import { validateClientSecret } from "./clients";
+import { approveDeviceCodeForAccount } from "./device-approval";
+
+export type { DrizzleDb };
+
+export type DeviceApprovalTokenExchangeDeps = {
+  validateClientSecret: typeof validateClientSecret;
+  verifyAccessToken: typeof verifyAccessToken;
+  approveDeviceCodeForAccount: typeof approveDeviceCodeForAccount;
+  findOrCreateAppEndUser: typeof findOrCreateAppEndUser;
+  db: DrizzleDb;
+  writeAuditLog: typeof writeAuditLog;
+  createCorrelationId: typeof createCorrelationId;
+};
+
+const defaultDeviceApprovalDeps: DeviceApprovalTokenExchangeDeps = {
+  validateClientSecret,
+  verifyAccessToken,
+  approveDeviceCodeForAccount,
+  findOrCreateAppEndUser,
+  db: defaultDbConn,
+  writeAuditLog,
+  createCorrelationId,
+};
+
+const TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
+const SUBJECT_ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+const ISSUED_ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+const DEVICE_CODE_RESOURCE_PREFIX = "urn:pmth:device_code:";
+
+export function isDeviceApprovalTokenExchangeRequest(params: {
+  grantType: string;
+  subjectTokenType: string;
+  resource: string | null | undefined;
+}): boolean {
+  const resource = params.resource?.trim() ?? "";
+  return (
+    params.grantType === TOKEN_EXCHANGE_GRANT &&
+    params.subjectTokenType === SUBJECT_ACCESS_TOKEN_TYPE &&
+    resource.startsWith(DEVICE_CODE_RESOURCE_PREFIX)
+  );
+}
+
+function parseDeviceCodeFromResource(resource: string): string | null {
+  const rest = resource.slice(DEVICE_CODE_RESOURCE_PREFIX.length).trim();
+  if (!rest) return null;
+  return rest;
+}
+
+function normalizeResourceOrAudienceUri(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function assertRequestedTokenTypeForDeviceApproval(
+  requested: string | null | undefined,
+): void {
+  if (requested == null || requested.trim() === "") return;
+  if (requested.trim() === ISSUED_ACCESS_TOKEN_TYPE) return;
+  throw new TokenExchangeError(
+    "invalid_request",
+    `requested_token_type must be ${ISSUED_ACCESS_TOKEN_TYPE} or omitted`,
+    "The requested token type is not supported for this token exchange",
+  );
+}
+
+function assertDeviceApprovalAudiences(audiences: string[]): void {
+  const nonEmpty = audiences.map((a) => a.trim()).filter(Boolean);
+  if (nonEmpty.length === 0) return;
+  const issuer = normalizeResourceOrAudienceUri(getIssuer());
+  for (const raw of nonEmpty) {
+    if (normalizeResourceOrAudienceUri(raw) !== issuer) {
+      throw new TokenExchangeError(
+        "invalid_target",
+        "audience does not match this authorization server",
+        "Invalid audience for token exchange",
+      );
+    }
+  }
+}
+
+function scopeStringFromAccessPayload(payload: Record<string, unknown>): string {
+  const scopeFromScope = typeof payload.scope === "string" ? payload.scope.trim() : "";
+  if (scopeFromScope) return scopeFromScope.replace(/\s+/g, " ").trim();
+  const scpRaw = payload.scp;
+  if (Array.isArray(scpRaw)) {
+    return scpRaw.filter((v): v is string => typeof v === "string").join(" ");
+  }
+  if (typeof scpRaw === "string") return scpRaw.trim();
+  return "sign:job";
+}
+
+function expiresInFromPayload(payload: Record<string, unknown>): number {
+  const exp = payload.exp;
+  if (typeof exp !== "number") return 15 * 60;
+  const now = Math.floor(Date.now() / 1000);
+  return Math.max(1, exp - now);
+}
+
+export async function handleDeviceApprovalTokenExchange(
+  params: {
+    clientId: string;
+    clientSecret: string;
+    subjectToken: string;
+    subjectTokenType: string;
+    resource: string | null | undefined;
+    requestedTokenType?: string | null;
+    audience?: string[];
+  },
+  deps: Partial<DeviceApprovalTokenExchangeDeps> = {},
+): Promise<{
+  access_token: string;
+  token_type: "Bearer";
+  expires_in: number;
+  scope: string;
+  issued_token_type: string;
+}> {
+  const {
+    validateClientSecret: validateSecret,
+    verifyAccessToken: verifySubject,
+    approveDeviceCodeForAccount: approveDevice,
+    findOrCreateAppEndUser: resolveEndUser,
+    db: dbConn,
+    writeAuditLog: auditLog,
+    createCorrelationId: newCorrelationId,
+  } = { ...defaultDeviceApprovalDeps, ...deps };
+
+  const {
+    clientId,
+    clientSecret,
+    subjectToken,
+    subjectTokenType,
+    resource,
+    requestedTokenType,
+    audience: audienceParams,
+  } = params;
+
+  if (!(await validateSecret(clientId, clientSecret))) {
+    throw new TokenExchangeError("invalid_client", "Invalid client credentials", "Invalid client credentials");
+  }
+
+  if (subjectTokenType.trim() !== SUBJECT_ACCESS_TOKEN_TYPE) {
+    throw new TokenExchangeError(
+      "invalid_request",
+      `subject_token_type must be ${SUBJECT_ACCESS_TOKEN_TYPE}`,
+      "Invalid subject_token_type for device approval token exchange",
+    );
+  }
+
+  const m2mRow = await getConfidentialOidcClientByClientId(dbConn, clientId);
+  if (!m2mRow?.clientSecretHash) {
+    throw new TokenExchangeError("invalid_client", "Client not found or not confidential", "Invalid client credentials");
+  }
+
+  if (
+    !hasScope(m2mRow.allowedScopes, "device:approve") &&
+    !hasScope(m2mRow.allowedScopes, "users:token")
+  ) {
+    throw new TokenExchangeError(
+      "invalid_scope",
+      "Requires device:approve or users:token on the confidential client",
+      "Missing required scope for device approval token exchange",
+    );
+  }
+
+  assertRequestedTokenTypeForDeviceApproval(requestedTokenType);
+
+  const resourceStr = resource?.trim() ?? "";
+  if (!resourceStr.startsWith(DEVICE_CODE_RESOURCE_PREFIX)) {
+    throw new TokenExchangeError(
+      "invalid_target",
+      `resource must start with ${DEVICE_CODE_RESOURCE_PREFIX}`,
+      "Invalid resource for device approval",
+    );
+  }
+
+  const userCodeRaw = parseDeviceCodeFromResource(resourceStr);
+  if (!userCodeRaw) {
+    throw new TokenExchangeError(
+      "invalid_target",
+      "device user_code missing from resource",
+      "Invalid resource for device approval",
+    );
+  }
+  const normalizedUserCode = normalizeUserCode(userCodeRaw);
+
+  assertDeviceApprovalAudiences(audienceParams ?? []);
+
+  let publicClientId: string | null;
+  try {
+    publicClientId = await resolvePublicClientIdForOidcRow(dbConn, m2mRow.id);
+  } catch (err) {
+    if (err instanceof DeveloperAppSiblingAmbiguousError) {
+      console.error("[device-token-exchange] ambiguous developer app mapping", {
+        message: err.message,
+        conflictingDeveloperAppIds: err.conflictingDeveloperAppIds,
+      });
+      throw new TokenExchangeError(
+        "invalid_request",
+        "Ambiguous developer app mapping for this client",
+        "Multiple developer apps found for this client",
+      );
+    }
+    throw err;
+  }
+  if (!publicClientId) {
+    throw new TokenExchangeError("invalid_client", "No developer app linked to this client", "Invalid client credentials");
+  }
+
+  const payload = await verifySubject(subjectToken);
+  if (!payload || typeof payload.sub !== "string" || !payload.sub) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token is not a valid access token for this issuer",
+      "Invalid subject token",
+    );
+  }
+
+  const rec = payload as Record<string, unknown>;
+  const tokenClientId =
+    typeof rec.client_id === "string"
+      ? rec.client_id
+      : typeof rec.azp === "string"
+        ? rec.azp
+        : null;
+  if (!tokenClientId || tokenClientId !== publicClientId) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token must have been issued to this app's public client_id",
+      "Invalid subject token",
+    );
+  }
+
+  const publicOidc = await getPublicOidcClientDevicePolicy(dbConn, publicClientId);
+  if (!publicOidc) {
+    throw new TokenExchangeError("invalid_client", "Public client not found", "Public client not found");
+  }
+  if (publicOidc.deviceThirdPartyInitiateLogin !== 1) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "Device third-party login is not enabled for this client",
+      "Device third-party login is not enabled for this client",
+    );
+  }
+
+  const developerAppId = await getDeveloperAppIdByOidcClientRowId(dbConn, publicOidc.id);
+  if (!developerAppId) {
+    throw new TokenExchangeError("invalid_client", "Developer app not found", "Developer app not found");
+  }
+
+  const externalUserId = await getAppUserExternalUserId(dbConn, payload.sub);
+  if (!externalUserId) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token sub does not map to an app user",
+      "Invalid subject token",
+    );
+  }
+  const { id: accountId } = await resolveEndUser(developerAppId, externalUserId);
+
+  const approve = await approveDevice(normalizedUserCode, publicClientId, accountId);
+  if (!approve.ok) {
+    throw new TokenExchangeError(approve.error, approve.description, approve.description);
+  }
+
+  const correlationId = newCorrelationId();
+  await auditLog({
+    clientId: developerAppId,
+    actorUserId: null,
+    action: "device_code_approved_token_exchange",
+    status: "success",
+    correlationId,
+    metadata: {
+      oidcClientId: publicClientId,
+      m2mClientId: clientId,
+    },
+  });
+
+  return {
+    access_token: subjectToken,
+    token_type: "Bearer",
+    expires_in: expiresInFromPayload(rec),
+    scope: scopeStringFromAccessPayload(rec),
+    issued_token_type: ISSUED_ACCESS_TOKEN_TYPE,
+  };
+}

--- a/src/domains/oidc-platform/runtime/device-verification.ts
+++ b/src/domains/oidc-platform/runtime/device-verification.ts
@@ -1,0 +1,130 @@
+import type { NextRequest } from "next/server";
+import { getServerSession } from "next-auth";
+import { SqliteAdapter } from "@/domains/oidc-platform/runtime/adapter";
+import { getClient } from "@/domains/oidc-platform/runtime/clients";
+import { approveDeviceCodeForAccount } from "./device-approval";
+import { normalizeUserCode } from "@/platform/oidc/device";
+import { resolveAppBrandingByClientId } from "./branding";
+import { checkAppAccess } from "./app-access";
+import { authOptions } from "@/platform/auth/next-auth-options";
+import { getDeviceVerificationClientPolicy } from "../repo/device-verification";
+import {
+  deviceVerificationError,
+  parseDeviceVerificationInput,
+} from "../service/device-verification";
+
+export async function handleDeviceVerificationRequest(
+  request: NextRequest,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return deviceVerificationError("unauthorized", "You must be signed in", 401);
+  }
+  const userId = (session.user as Record<string, unknown>).id as string;
+  if (!userId) {
+    return deviceVerificationError("unauthorized", "You must be signed in", 401);
+  }
+
+  const parsed = parseDeviceVerificationInput(await request.json());
+  if (!parsed.ok) {
+    return { status: parsed.status, body: parsed.body };
+  }
+
+  const adapter = new SqliteAdapter("DeviceCode");
+  const normalizedUserCode = normalizeUserCode(parsed.userCode);
+  const deviceCode = await adapter.findByUserCode(normalizedUserCode);
+
+  if (!deviceCode) {
+    return deviceVerificationError(
+      "invalid_grant",
+      "Invalid, expired, or already used device code",
+    );
+  }
+  if (deviceCode.consumed) {
+    return deviceVerificationError("invalid_grant", "Device code already used");
+  }
+  if (deviceCode.exp && deviceCode.exp < Math.floor(Date.now() / 1000)) {
+    return deviceVerificationError("expired_token", "The device code has expired");
+  }
+
+  if (parsed.action === "lookup") {
+    const clientId = deviceCode.clientId || deviceCode.params?.client_id;
+    const client = typeof clientId === "string" ? await getClient(clientId) : null;
+    const branding =
+      typeof clientId === "string" ? await resolveAppBrandingByClientId(clientId) : null;
+    const scope =
+      typeof deviceCode.scope === "string"
+        ? deviceCode.scope
+        : typeof deviceCode.params?.scope === "string"
+          ? deviceCode.params.scope
+          : "";
+    let impliedDeviceConsent = false;
+    if (typeof clientId === "string") {
+      const policy = await getDeviceVerificationClientPolicy(clientId);
+      impliedDeviceConsent =
+        policy?.deviceThirdPartyInitiateLogin === 1 && !!policy?.clientSecretHash;
+    }
+
+    return {
+      status: 200,
+      body: {
+        client_name: client?.displayName || clientId || "Unknown Application",
+        scopes: scope.split(" ").filter(Boolean),
+        implied_device_consent: impliedDeviceConsent,
+        branding: branding
+          ? {
+              mode: branding.mode,
+              displayName: branding.displayName,
+              logoUrl: branding.logoUrl,
+              primaryColor: branding.primaryColor,
+            }
+          : null,
+      },
+    };
+  }
+
+  if (parsed.action === "approve") {
+    const clientId = deviceCode.clientId || deviceCode.params?.client_id;
+    if (typeof clientId !== "string" || !clientId) {
+      return deviceVerificationError(
+        "server_error",
+        "Device code is missing client binding",
+        500,
+      );
+    }
+
+    const accessCheck = await checkAppAccess(clientId, userId);
+    if (!accessCheck.allowed) {
+      return deviceVerificationError(
+        "access_denied",
+        accessCheck.reason || "You do not have access to this application",
+        403,
+      );
+    }
+
+    const approved = await approveDeviceCodeForAccount(normalizedUserCode, clientId, userId);
+    if (!approved.ok) {
+      return deviceVerificationError(
+        approved.error,
+        approved.description,
+        approved.status,
+      );
+    }
+
+    return { status: 200, body: { status: "authorized" } };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const expiresIn = deviceCode.exp ? Math.max(deviceCode.exp - now, 1) : 600;
+  await adapter.upsert(
+    deviceCode.jti!,
+    {
+      ...deviceCode,
+      error: "access_denied",
+      errorDescription: "The user denied the authorization request",
+    },
+    expiresIn,
+  );
+
+  return { status: 200, body: { status: "denied" } };
+}

--- a/src/domains/oidc-platform/runtime/gateway-token-exchange.test.ts
+++ b/src/domains/oidc-platform/runtime/gateway-token-exchange.test.ts
@@ -1,0 +1,333 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  handleGatewayTokenExchange,
+  isGatewayTokenExchangeRequest,
+  SUBJECT_ACCESS_TOKEN_TYPE,
+  type GatewayTokenExchangeDeps,
+} from "@/domains/oidc-platform/runtime/gateway-token-exchange";
+import { TokenExchangeError } from "@/domains/oidc-platform/runtime/token-exchange";
+import type { DrizzleDb } from "@/platform/oidc/client-sibling";
+
+/**
+ * Sequential `.limit()` results for each `db.select` in `handleGatewayTokenExchange` /
+ * `resolveGatewaySessionPrincipal` (order must match runtime query order).
+ */
+function dbMock(rows: unknown[][]): DrizzleDb {
+  let i = 0;
+  const next = () => {
+    const r = rows[i++];
+    if (!r) throw new Error(`db mock exhausted at step ${i}`);
+    return Promise.resolve(r);
+  };
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => next(),
+        }),
+      }),
+    }),
+  } as unknown as DrizzleDb;
+}
+
+const dbMockSelectForbidden: DrizzleDb = {
+  select: () => {
+    throw new Error("unexpected db.select");
+  },
+} as unknown as DrizzleDb;
+
+const M2M_ID = "m2m_test123";
+const PUBLIC_ID = "app_testpublic";
+
+const m2mRowOk = {
+  id: "int-m2m",
+  clientSecretHash: "hash",
+  allowedScopes: "users:token sign:job",
+  clientId: M2M_ID,
+};
+
+function baseJwtPayload(overrides: Record<string, unknown> = {}) {
+  const exp = Math.floor(Date.now() / 1000) + 900;
+  return {
+    sub: "au-1",
+    client_id: PUBLIC_ID,
+    exp,
+    scope: "sign:job",
+    ...overrides,
+  };
+}
+
+async function rejectsWithCode(
+  fn: () => Promise<unknown>,
+  code: string,
+): Promise<void> {
+  await assert.rejects(fn, (err: unknown) => {
+    assert.ok(err instanceof TokenExchangeError);
+    assert.equal((err as TokenExchangeError).code, code);
+    return true;
+  });
+}
+
+const noopDeps: Partial<GatewayTokenExchangeDeps> = {
+  validateClientSecret: async () => true,
+  verifyAccessToken: async () => baseJwtPayload(),
+  findOrCreateAppEndUser: async () => ({ id: "eu-1", isNew: false }),
+  createSession: async () => ({ sessionId: "s1", token: "pmth_testtoken" }),
+  writeAuditLog: async () => {},
+  createCorrelationId: () => "corr-1",
+  resolveDeveloperAppAndPublicClientForOidcRow: async () => ({
+    developerAppId: "dev-app-1",
+    publicClientId: PUBLIC_ID,
+  }),
+};
+
+/** Slot 0: `oidcClients` by `client_id`. Slot 1: `appUsers` by developer app + subject `sub`. */
+function rowsHappyPathSibling(): unknown[][] {
+  return [[m2mRowOk], [{ externalUserId: "ext-1" }]];
+}
+
+/** Slot 0: M2M `oidcClients`. Slot 1: `appUsers` (empty). Slot 2: `endUsers` (empty) — legacy machine `sub` path. */
+function rowsLegacyMachineSubject(): unknown[][] {
+  return [[m2mRowOk], [], []];
+}
+
+test("isGatewayTokenExchangeRequest is false for device_code resource", () => {
+  assert.equal(
+    isGatewayTokenExchangeRequest({
+      grantType: "urn:ietf:params:oauth:grant-type:token-exchange",
+      clientId: M2M_ID,
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+      resource: "urn:pmth:device_code:ABCD-EFGH",
+    }),
+    false,
+  );
+});
+
+test("isGatewayTokenExchangeRequest is true without device resource", () => {
+  assert.equal(
+    isGatewayTokenExchangeRequest({
+      grantType: "urn:ietf:params:oauth:grant-type:token-exchange",
+      clientId: M2M_ID,
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+      resource: "",
+    }),
+    true,
+  );
+});
+
+// dbMock: see `rowsHappyPathSibling` — [0] oidcClients, [1] appUsers.
+test("handleGatewayTokenExchange success when subject client_id is public sibling", async () => {
+  const out = await handleGatewayTokenExchange(
+    {
+      clientId: M2M_ID,
+      clientSecret: "secret",
+      subjectToken: "jwt",
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+    },
+    {
+      ...noopDeps,
+      db: dbMock(rowsHappyPathSibling()),
+      verifyAccessToken: async () => baseJwtPayload(),
+      findOrCreateAppEndUser: async () => ({ id: "eu-1", isNew: false }),
+    },
+  );
+  assert.equal(out.access_token, "pmth_testtoken");
+  assert.equal(out.scope, "sign:job");
+});
+
+// dbMock: see `rowsLegacyMachineSubject`.
+test("handleGatewayTokenExchange success legacy subject issued to M2M", async () => {
+  const out = await handleGatewayTokenExchange(
+    {
+      clientId: M2M_ID,
+      clientSecret: "secret",
+      subjectToken: "jwt",
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+    },
+    {
+      ...noopDeps,
+      db: dbMock(rowsLegacyMachineSubject()),
+      verifyAccessToken: async () =>
+        baseJwtPayload({ client_id: M2M_ID, sub: "machine-sub" }),
+      findOrCreateAppEndUser: async () => {
+        throw new Error("should not resolve app user for machine sub");
+      },
+    },
+  );
+  assert.equal(out.access_token, "pmth_testtoken");
+});
+
+test("handleGatewayTokenExchange invalid_client when secret invalid", async () => {
+  await rejectsWithCode(
+    () =>
+      handleGatewayTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "bad",
+          subjectToken: "jwt",
+          subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+        },
+        {
+          ...noopDeps,
+          validateClientSecret: async () => false,
+          db: dbMockSelectForbidden,
+        },
+      ),
+    "invalid_client",
+  );
+});
+
+test("handleGatewayTokenExchange invalid_scope without users:token", async () => {
+  // dbMock: [0] oidcClients — fails scope check after first select.
+  await rejectsWithCode(
+    () =>
+      handleGatewayTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: "jwt",
+          subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+        },
+        {
+          ...noopDeps,
+          db: dbMock([
+            [
+              {
+                ...m2mRowOk,
+                allowedScopes: "sign:job",
+              },
+            ],
+          ]),
+        },
+      ),
+    "invalid_scope",
+  );
+});
+
+test("handleGatewayTokenExchange invalid_grant when subject client mismatch", async () => {
+  // dbMock: [0] oidcClients — fails after verifyAccessToken + client_id check.
+  await rejectsWithCode(
+    () =>
+      handleGatewayTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: "jwt",
+          subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+        },
+        {
+          ...noopDeps,
+          db: dbMock([[m2mRowOk]]),
+          verifyAccessToken: async () =>
+            baseJwtPayload({ client_id: "app_other_app" }),
+        },
+      ),
+    "invalid_grant",
+  );
+});
+
+test("handleGatewayTokenExchange invalid_grant without sign:job on subject", async () => {
+  // dbMock: [0] oidcClients — fails scope check on subject JWT.
+  await rejectsWithCode(
+    () =>
+      handleGatewayTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: "jwt",
+          subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+        },
+        {
+          ...noopDeps,
+          db: dbMock([[m2mRowOk]]),
+          verifyAccessToken: async () =>
+            baseJwtPayload({ scope: "openid" }),
+        },
+      ),
+    "invalid_grant",
+  );
+});
+
+test("handleGatewayTokenExchange invalid_target when audience wrong", async () => {
+  // dbMock: [0] oidcClients — fails audience assertion before further selects.
+  await rejectsWithCode(
+    () =>
+      handleGatewayTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: "jwt",
+          subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+          audience: ["https://other.example.com"],
+        },
+        {
+          ...noopDeps,
+          db: dbMock([[m2mRowOk]]),
+        },
+      ),
+    "invalid_target",
+  );
+});
+
+test("handleGatewayTokenExchange invalid_target when resource not issuer", async () => {
+  // dbMock: [0] oidcClients — fails resource assertion before further selects.
+  await rejectsWithCode(
+    () =>
+      handleGatewayTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: "jwt",
+          subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+          resource: "https://wrong-resource.example.com",
+        },
+        {
+          ...noopDeps,
+          db: dbMock([[m2mRowOk]]),
+        },
+      ),
+    "invalid_target",
+  );
+});
+
+test("handleGatewayTokenExchange invalid_request when requested_token_type wrong", async () => {
+  // dbMock: [0] oidcClients — fails requested_token_type check before further selects.
+  await rejectsWithCode(
+    () =>
+      handleGatewayTokenExchange(
+        {
+          clientId: M2M_ID,
+          clientSecret: "secret",
+          subjectToken: "jwt",
+          subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+          requestedTokenType: "urn:ietf:params:oauth:token-type:refresh_token",
+        },
+        {
+          ...noopDeps,
+          db: dbMock([[m2mRowOk]]),
+        },
+      ),
+    "invalid_request",
+  );
+});
+
+// dbMock: `rowsHappyPathSibling` (issuer resource still uses two-query happy path).
+test("handleGatewayTokenExchange accepts resource when equal to issuer", async () => {
+  const issuer = (await import("@/platform/oidc/issuer-urls")).getIssuer();
+  const out = await handleGatewayTokenExchange(
+    {
+      clientId: M2M_ID,
+      clientSecret: "secret",
+      subjectToken: "jwt",
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+      resource: issuer,
+    },
+    {
+      ...noopDeps,
+      db: dbMock(rowsHappyPathSibling()),
+    },
+  );
+  assert.equal(out.access_token, "pmth_testtoken");
+});

--- a/src/domains/oidc-platform/runtime/gateway-token-exchange.ts
+++ b/src/domains/oidc-platform/runtime/gateway-token-exchange.ts
@@ -1,0 +1,307 @@
+import { and, eq } from "drizzle-orm";
+import { billingPatternFromAllowedScopesString } from "@/platform/oidc/allowed-scopes";
+import { findOrCreateAppEndUser } from "@/domains/end-user-accounts/runtime/end-users";
+import {
+  createCorrelationId,
+  writeAuditLog,
+} from "@/domains/identity-access/runtime/audit";
+import { createSession, hasScope } from "@/domains/identity-access/runtime/request-auth";
+import {
+  resolveDeveloperAppAndPublicClientForOidcRow,
+  DeveloperAppSiblingAmbiguousError,
+  type DrizzleDb,
+} from "@/platform/oidc/client-sibling";
+import { db as defaultDbConn } from "../repo/db-conn";
+import {
+  getConfidentialOidcClientByClientId,
+  getGatewayAppUserExternalUserId,
+  getGatewayEndUserId,
+} from "../repo/token-exchange-flows";
+import { verifyAccessToken } from "@/domains/oidc-platform/runtime/access-token-verify";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import { TokenExchangeError } from "@/domains/oidc-platform/runtime/token-exchange";
+import { validateClientSecret } from "./clients";
+
+export type GatewayTokenExchangeDeps = {
+  validateClientSecret: typeof validateClientSecret;
+  verifyAccessToken: typeof verifyAccessToken;
+  db: DrizzleDb;
+  findOrCreateAppEndUser: typeof findOrCreateAppEndUser;
+  createSession: typeof createSession;
+  writeAuditLog: typeof writeAuditLog;
+  createCorrelationId: typeof createCorrelationId;
+  resolveDeveloperAppAndPublicClientForOidcRow: typeof resolveDeveloperAppAndPublicClientForOidcRow;
+};
+
+const defaultGatewayDeps: GatewayTokenExchangeDeps = {
+  validateClientSecret,
+  verifyAccessToken,
+  db: defaultDbConn,
+  findOrCreateAppEndUser,
+  createSession,
+  writeAuditLog,
+  createCorrelationId,
+  resolveDeveloperAppAndPublicClientForOidcRow,
+};
+
+export const SUBJECT_ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+export const ISSUED_ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+
+function normalizeResourceOrAudienceUri(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function assertRequestedTokenTypeForGateway(requested: string | null | undefined): void {
+  if (requested == null || requested.trim() === "") return;
+  if (requested.trim() === ISSUED_ACCESS_TOKEN_TYPE) return;
+  throw new TokenExchangeError(
+    "invalid_request",
+    `requested_token_type must be ${ISSUED_ACCESS_TOKEN_TYPE} or omitted`,
+    "The requested token type is not supported for this token exchange",
+  );
+}
+
+function assertGatewayAudiences(audiences: string[] | undefined): void {
+  const nonEmpty = (audiences ?? []).map((a) => a.trim()).filter(Boolean);
+  if (nonEmpty.length === 0) return;
+  const issuer = normalizeResourceOrAudienceUri(getIssuer());
+  for (const raw of nonEmpty) {
+    if (normalizeResourceOrAudienceUri(raw) !== issuer) {
+      throw new TokenExchangeError(
+        "invalid_target",
+        "audience does not match this authorization server",
+        "Invalid audience for token exchange",
+      );
+    }
+  }
+}
+
+function assertGatewayResource(resource: string | null | undefined): void {
+  const raw = resource?.trim() ?? "";
+  if (raw === "") return;
+  const issuer = normalizeResourceOrAudienceUri(getIssuer());
+  if (normalizeResourceOrAudienceUri(raw) === issuer) return;
+  throw new TokenExchangeError(
+    "invalid_target",
+    "resource must be omitted or name this authorization server",
+    "Invalid resource for remote signer session exchange",
+  );
+}
+
+export async function handleGatewayTokenExchange(
+  params: {
+    clientId: string;
+    clientSecret: string;
+    subjectToken: string;
+    subjectTokenType: string;
+    resource?: string | null;
+    requestedTokenType?: string | null;
+    audience?: string[];
+  },
+  inject: Partial<GatewayTokenExchangeDeps> = {},
+): Promise<{
+  access_token: string;
+  token_type: "Bearer";
+  expires_in: number;
+  issued_token_type: string;
+  scope: string;
+}> {
+  const deps: GatewayTokenExchangeDeps = { ...defaultGatewayDeps, ...inject };
+  const dbConn = deps.db;
+
+  const {
+    clientId,
+    clientSecret,
+    subjectToken,
+    subjectTokenType,
+    resource,
+    requestedTokenType,
+    audience: audienceParams,
+  } = params;
+
+  if (subjectTokenType.trim() !== SUBJECT_ACCESS_TOKEN_TYPE) {
+    throw new TokenExchangeError(
+      "unsupported_token_type",
+      `For remote signer session exchange, subject_token_type must be ${SUBJECT_ACCESS_TOKEN_TYPE}`,
+    );
+  }
+
+  if (!(await deps.validateClientSecret(clientId, clientSecret))) {
+    throw new TokenExchangeError("invalid_client", "Invalid client credentials");
+  }
+
+  const callerRow = await getConfidentialOidcClientByClientId(dbConn, clientId);
+  if (!callerRow?.clientSecretHash) {
+    throw new TokenExchangeError("invalid_client", "Client not found or not confidential");
+  }
+
+  if (!hasScope(callerRow.allowedScopes, "users:token")) {
+    throw new TokenExchangeError("invalid_scope", "Requires users:token on the confidential client");
+  }
+
+  if (billingPatternFromAllowedScopesString(callerRow.allowedScopes) !== "per_user") {
+    throw new TokenExchangeError(
+      "invalid_request",
+      "Remote signer session exchange requires per-user billing (users:token scope on the OAuth client)",
+    );
+  }
+
+  assertRequestedTokenTypeForGateway(requestedTokenType);
+  assertGatewayAudiences(audienceParams);
+  assertGatewayResource(resource);
+
+  let sibling: { developerAppId: string; publicClientId: string } | null;
+  try {
+    sibling = await deps.resolveDeveloperAppAndPublicClientForOidcRow(dbConn, callerRow.id);
+  } catch (err) {
+    if (err instanceof DeveloperAppSiblingAmbiguousError) {
+      console.error("[gateway-token-exchange] ambiguous developer app mapping", {
+        message: err.message,
+        conflictingDeveloperAppIds: err.conflictingDeveloperAppIds,
+      });
+      throw new TokenExchangeError(
+        "invalid_request",
+        err.message,
+        "Ambiguous developer app mapping for this client",
+      );
+    }
+    throw err;
+  }
+  if (!sibling) {
+    throw new TokenExchangeError("invalid_client", "No developer app linked to this client");
+  }
+
+  const { publicClientId, developerAppId } = sibling;
+  const payload = await deps.verifyAccessToken(subjectToken);
+  if (!payload || typeof payload.sub !== "string" || !payload.sub) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token is not a valid OIDC access token for this issuer",
+    );
+  }
+
+  const rec = payload as Record<string, unknown>;
+  const tokenClientId =
+    typeof rec.client_id === "string"
+      ? rec.client_id
+      : typeof rec.azp === "string"
+        ? rec.azp
+        : null;
+  if (!tokenClientId) {
+    throw new TokenExchangeError("invalid_grant", "subject_token must include client_id or azp");
+  }
+
+  const callerIsM2M = clientId !== publicClientId;
+  const subjectMatchesCaller = tokenClientId === clientId;
+  const subjectMatchesPublicSibling = tokenClientId === publicClientId;
+  if (!subjectMatchesCaller && !(callerIsM2M && subjectMatchesPublicSibling)) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token must have been issued to this app's public client or to the same confidential client as this request",
+    );
+  }
+
+  const scopeFromScope = typeof payload.scope === "string" ? payload.scope : "";
+  const scpRaw = rec.scp;
+  const scopeFromScp = Array.isArray(scpRaw)
+    ? scpRaw.filter((v): v is string => typeof v === "string").join(" ")
+    : typeof scpRaw === "string"
+      ? scpRaw
+      : "";
+  const effectiveScopes = (scopeFromScope || scopeFromScp).trim().replace(/\s+/g, ",");
+  if (!hasScope(effectiveScopes, "sign:job")) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token must include sign:job scope for remote signer session exchange",
+    );
+  }
+
+  const sessionBinding = await resolveGatewaySessionPrincipal(
+    {
+      dbConn,
+      developerAppId,
+      sub: payload.sub,
+      tokenClientId,
+      clientId,
+    },
+    deps,
+  );
+
+  const { token } = await deps.createSession({
+    userId: sessionBinding.userId,
+    endUserId: sessionBinding.endUserId,
+    appId: publicClientId,
+    scopes: "sign:job",
+    label: "signer_session_token_exchange",
+    expiresInDays: 90,
+  });
+
+  const correlationId = deps.createCorrelationId();
+  await deps.writeAuditLog({
+    clientId: developerAppId,
+    action: "signer_session_token_exchange",
+    status: "success",
+    correlationId,
+    metadata: {
+      oidcClientId: publicClientId,
+      m2mClientId: clientId,
+      endUserId: sessionBinding.endUserId,
+    },
+  });
+
+  return {
+    access_token: token,
+    token_type: "Bearer",
+    expires_in: 90 * 24 * 60 * 60,
+    issued_token_type: ISSUED_ACCESS_TOKEN_TYPE,
+    scope: "sign:job",
+  };
+}
+
+async function resolveGatewaySessionPrincipal(
+  input: {
+    dbConn: DrizzleDb;
+    developerAppId: string;
+    sub: string;
+    tokenClientId: string;
+    clientId: string;
+  },
+  deps: Pick<GatewayTokenExchangeDeps, "findOrCreateAppEndUser">,
+): Promise<{ userId: string | undefined; endUserId: string | undefined }> {
+  const { dbConn, developerAppId, sub, tokenClientId, clientId } = input;
+
+  const externalUserId = await getGatewayAppUserExternalUserId(dbConn, developerAppId, sub);
+  if (externalUserId) {
+    const { id: endUserId } = await deps.findOrCreateAppEndUser(developerAppId, externalUserId);
+    return { userId: undefined, endUserId };
+  }
+
+  const endUserId = await getGatewayEndUserId(dbConn, developerAppId, sub);
+  if (endUserId) {
+    return { userId: undefined, endUserId };
+  }
+
+  if (tokenClientId === clientId) {
+    return { userId: sub, endUserId: undefined };
+  }
+
+  throw new TokenExchangeError(
+    "invalid_grant",
+    "subject_token sub does not map to an app user or end user for this developer app",
+  );
+}
+
+export function isGatewayTokenExchangeRequest(params: {
+  grantType: string;
+  clientId: string;
+  subjectTokenType: string;
+  resource: string | null | undefined;
+}): boolean {
+  const resource = params.resource?.trim() ?? "";
+  if (resource.startsWith("urn:pmth:device_code:")) return false;
+  return (
+    params.grantType === "urn:ietf:params:oauth:grant-type:token-exchange" &&
+    Boolean(params.clientId) &&
+    params.subjectTokenType.trim() === SUBJECT_ACCESS_TOKEN_TYPE
+  );
+}

--- a/src/domains/oidc-platform/runtime/host-context.ts
+++ b/src/domains/oidc-platform/runtime/host-context.ts
@@ -1,0 +1,77 @@
+import { headers } from "next/headers";
+import {
+  getAppByCustomDomain,
+  getTrustedLoginHosts,
+  normalizeDomain,
+} from "@/domains/oidc-platform/runtime/custom-domains";
+import { getPublicOrigin } from "@/platform/oidc/issuer-urls";
+import { getDefaultBranding, type AppBranding, resolveAppBrandingByAppId } from "./branding";
+
+export interface HostContext {
+  requestHost: string;
+  isCustomDomain: boolean;
+  isTrustedHost: boolean;
+  appId: string | null;
+  branding: AppBranding;
+  canonicalOrigin: string;
+}
+
+export async function resolveHostContext(): Promise<HostContext> {
+  const requestHeaders = await headers();
+  const forwardedHost = requestHeaders.get("x-forwarded-host");
+  const hostHeader = requestHeaders.get("host");
+  const requestHost = forwardedHost || hostHeader || "localhost";
+
+  if (!forwardedHost && !hostHeader) {
+    console.warn("[host-resolution] No host header found, falling back to localhost");
+  }
+
+  const canonicalOrigin = getPublicOrigin();
+  const canonicalHost = new URL(canonicalOrigin).host;
+  const normalizedRequestHost = normalizeDomain(requestHost);
+  const normalizedCanonicalHost = normalizeDomain(canonicalHost);
+  const isCanonicalHost = normalizedRequestHost === normalizedCanonicalHost;
+  const trustedHosts = await getTrustedLoginHosts();
+  const isTrustedHost = trustedHosts.some((host) => normalizeDomain(host) === normalizedRequestHost);
+
+  if (isCanonicalHost) {
+    return {
+      requestHost,
+      isCustomDomain: false,
+      isTrustedHost: true,
+      appId: null,
+      branding: getDefaultBranding(),
+      canonicalOrigin,
+    };
+  }
+
+  const app = await getAppByCustomDomain(requestHost);
+  if (app) {
+    return {
+      requestHost,
+      isCustomDomain: true,
+      isTrustedHost: true,
+      appId: app.id,
+      branding: await resolveAppBrandingByAppId(app.id),
+      canonicalOrigin,
+    };
+  }
+
+  return {
+    requestHost,
+    isCustomDomain: false,
+    isTrustedHost,
+    appId: null,
+    branding: getDefaultBranding(),
+    canonicalOrigin,
+  };
+}
+
+export function buildUrlForHost(path: string, hostContext: HostContext, useCanonical = false): string {
+  const origin = useCanonical ? hostContext.canonicalOrigin : `https://${hostContext.requestHost}`;
+  return `${origin}${path}`;
+}
+
+export function shouldForceCanonicalIssuer(_hostContext: HostContext): boolean {
+  return true;
+}

--- a/src/domains/oidc-platform/runtime/interactions.ts
+++ b/src/domains/oidc-platform/runtime/interactions.ts
@@ -1,0 +1,155 @@
+import type { NextRequest } from "next/server";
+import { getServerSession } from "next-auth";
+import { getProvider } from "./provider-instance";
+import { authOptions } from "@/platform/auth/next-auth-options";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import { buildProviderNodeRequest } from "./provider-bridge";
+
+const DEBUG_OIDC_LOGS = process.env.OIDC_DEBUG_LOGS === "1";
+
+export async function readOidcInteraction(
+  request: NextRequest,
+  uid: string,
+): Promise<
+  | {
+      ok: true;
+      body: {
+        uid: string;
+        prompt: unknown;
+        params: unknown;
+        session: unknown;
+      };
+    }
+  | { ok: false; status: 404; body: Record<string, unknown> }
+> {
+  const provider = await getProvider();
+  try {
+    const { req, res } = buildProviderNodeRequest({
+      method: "GET",
+      request,
+      path: `/interaction/${uid}`,
+    });
+    const details = await provider.interactionDetails(req, res);
+    return {
+      ok: true,
+      body: {
+        uid: details.uid,
+        prompt: details.prompt,
+        params: details.params,
+        session: details.session,
+      },
+    };
+  } catch (err) {
+    if (DEBUG_OIDC_LOGS) {
+      console.warn("[OIDC] interaction GET failed", { uid, err });
+    }
+    return {
+      ok: false,
+      status: 404,
+      body: {
+        error: "interaction_not_found",
+        error_description: "Interaction session not found or expired",
+      },
+    };
+  }
+}
+
+export async function completeOidcInteraction(params: {
+  request: NextRequest;
+  uid: string;
+}): Promise<
+  | { ok: true; redirectTo: string }
+  | { ok: false; status: 401 | 500; body: Record<string, unknown> }
+> {
+  const provider = await getProvider();
+  let body: { action?: "approve" | "deny" } = {};
+  try {
+    const contentType = params.request.headers.get("content-type") ?? "";
+    if (contentType.includes("application/x-www-form-urlencoded")) {
+      const formData = await params.request.formData();
+      const action = formData.get("action");
+      if (action === "approve" || action === "deny") {
+        body = { action };
+      }
+    } else {
+      body = await params.request.json();
+    }
+  } catch {
+    // Allow login interactions without JSON.
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return {
+      ok: false,
+      status: 401,
+      body: {
+        error: "unauthorized",
+        error_description: "You must be signed in",
+      },
+    };
+  }
+  const userId = (session.user as Record<string, unknown>).id as string;
+  if (!userId) {
+    return {
+      ok: false,
+      status: 401,
+      body: {
+        error: "unauthorized",
+        error_description: "Invalid session",
+      },
+    };
+  }
+
+  try {
+    const { req, res } = buildProviderNodeRequest({
+      method: "POST",
+      request: params.request,
+      path: `/interaction/${params.uid}`,
+    });
+    const details = await provider.interactionDetails(req, res);
+    const { prompt } = details;
+
+    let result: Record<string, unknown>;
+    if (prompt.name === "login") {
+      result = { login: { accountId: userId, remember: true } };
+    } else if (prompt.name === "consent") {
+      if (body.action === "deny") {
+        result = {
+          error: "access_denied",
+          error_description: "User denied the authorization request",
+        };
+      } else {
+        const grant = new provider.Grant();
+        grant.clientId = details.params.client_id as string;
+        grant.accountId = userId;
+        const requestedScopes = details.params.scope as string;
+        if (requestedScopes) {
+          grant.addOIDCScope(requestedScopes);
+          grant.addResourceScope(getIssuer(), requestedScopes);
+        }
+        await grant.save();
+        result = { consent: { grantId: grant.jti } };
+      }
+    } else {
+      result = {};
+    }
+
+    const redirectTo = await provider.interactionResult(req, res, result, {
+      mergeWithLastSubmission: false,
+    });
+    return { ok: true, redirectTo };
+  } catch (err) {
+    if (DEBUG_OIDC_LOGS) {
+      console.warn("[OIDC] interaction POST failed", { uid: params.uid, err });
+    }
+    return {
+      ok: false,
+      status: 500,
+      body: {
+        error: "interaction_failed",
+        error_description: "Failed to process interaction",
+      },
+    };
+  }
+}

--- a/src/domains/oidc-platform/runtime/jwks.ts
+++ b/src/domains/oidc-platform/runtime/jwks.ts
@@ -1,0 +1,97 @@
+import { v4 as uuidv4 } from "uuid";
+import * as jose from "jose";
+import {
+  deactivateActiveSigningKeys,
+  getActiveSigningKeyRow,
+  getSigningKeyRowByKid,
+  insertSigningKey,
+  listRecentSigningKeyRows,
+} from "../repo/signing-keys";
+
+const KEY_ALGORITHM = "RS256";
+const KEY_SIZE = 2048;
+
+export interface SigningKeyPair {
+  kid: string;
+  publicKey: jose.CryptoKey;
+  privateKey: jose.CryptoKey;
+}
+
+export async function generateKeyPair(): Promise<{
+  kid: string;
+  publicKeyPem: string;
+  privateKeyPem: string;
+}> {
+  const kid = uuidv4();
+  const { publicKey, privateKey } = await jose.generateKeyPair(KEY_ALGORITHM, {
+    modulusLength: KEY_SIZE,
+    extractable: true,
+  });
+
+  return {
+    kid,
+    publicKeyPem: await jose.exportSPKI(publicKey),
+    privateKeyPem: await jose.exportPKCS8(privateKey),
+  };
+}
+
+export async function createSigningKey(): Promise<string> {
+  const { kid, publicKeyPem, privateKeyPem } = await generateKeyPair();
+  await insertSigningKey({
+    id: uuidv4(),
+    kid,
+    algorithm: KEY_ALGORITHM,
+    publicKeyPem,
+    privateKeyPem,
+    active: 1,
+  });
+  return kid;
+}
+
+export async function rotateSigningKey(): Promise<string> {
+  await deactivateActiveSigningKeys(new Date().toISOString());
+  return createSigningKey();
+}
+
+export async function getActiveSigningKey(): Promise<SigningKeyPair | null> {
+  const key = await getActiveSigningKeyRow();
+  if (!key) return null;
+  return {
+    kid: key.kid,
+    publicKey: await jose.importSPKI(key.publicKeyPem, KEY_ALGORITHM),
+    privateKey: await jose.importPKCS8(key.privateKeyPem, KEY_ALGORITHM),
+  };
+}
+
+export async function ensureSigningKey(): Promise<SigningKeyPair> {
+  let keyPair = await getActiveSigningKey();
+  if (!keyPair) {
+    await createSigningKey();
+    keyPair = await getActiveSigningKey();
+  }
+  if (!keyPair) throw new Error("Failed to create or retrieve signing key");
+  return keyPair;
+}
+
+export async function getPublicJWKS(): Promise<jose.JSONWebKeySet> {
+  const keys = await listRecentSigningKeyRows(10);
+  const sorted = [...keys].sort((a, b) => {
+    if (a.active === 1 && b.active !== 1) return -1;
+    if (b.active === 1 && a.active !== 1) return 1;
+    return 0;
+  });
+  const chosen = sorted.slice(0, 5);
+  const jwks: jose.JWK[] = [];
+  for (const key of chosen) {
+    const publicKey = await jose.importSPKI(key.publicKeyPem, KEY_ALGORITHM);
+    const jwk = await jose.exportJWK(publicKey);
+    jwks.push({ ...jwk, kid: key.kid, alg: KEY_ALGORITHM, use: "sig" });
+  }
+  return { keys: jwks };
+}
+
+export async function getSigningKeyByKid(kid: string): Promise<jose.CryptoKey | null> {
+  const key = await getSigningKeyRowByKid(kid);
+  if (!key) return null;
+  return jose.importSPKI(key.publicKeyPem, KEY_ALGORITHM);
+}

--- a/src/domains/oidc-platform/runtime/programmatic-tokens.ts
+++ b/src/domains/oidc-platform/runtime/programmatic-tokens.ts
@@ -1,0 +1,129 @@
+import { randomBytes } from "crypto";
+import { v4 as uuidv4 } from "uuid";
+import { SignJWT } from "jose";
+import { ensureSigningKey } from "@/domains/oidc-platform/runtime/jwks";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import { billingPatternFromAllowedScopesString } from "@/platform/oidc/allowed-scopes";
+import {
+  consumeSessionByIdAndToken,
+  createSession,
+  validateBearerToken,
+} from "@/domains/identity-access/runtime/request-auth";
+import {
+  getActiveAppUserForRefresh,
+  getProgrammaticTokenAppPolicy,
+  getProgrammaticTokenBinding,
+  getRefreshTokenProgrammaticApp,
+} from "../repo/programmatic-tokens";
+import { validateClientSecret } from "./clients";
+
+const ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
+const REFRESH_TOKEN_TTL_DAYS = 30;
+
+export class ProgrammaticTokenError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export async function issueProgrammaticTokens(input: {
+  developerAppId: string;
+  oauthClientId: string;
+  appUserId: string;
+  scopes: string[];
+}) {
+  const app = await getProgrammaticTokenAppPolicy(input.developerAppId);
+  if (!app) throw new ProgrammaticTokenError("invalid_client", "App not found");
+
+  if (billingPatternFromAllowedScopesString(app.allowedScopes) !== "per_user") {
+    throw new ProgrammaticTokenError(
+      "invalid_request",
+      "Programmatic user tokens require the users:token scope on the OAuth client",
+    );
+  }
+
+  const binding = await getProgrammaticTokenBinding(input);
+  if (!binding) {
+    throw new ProgrammaticTokenError(
+      "invalid_client",
+      "OAuth client, app, and app user are not bound as expected",
+    );
+  }
+
+  const issuer = getIssuer();
+  const keyPair = await ensureSigningKey();
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const scope = input.scopes.join(" ").trim();
+
+  const accessToken = await new SignJWT({
+    scope,
+    scp: input.scopes,
+    client_id: binding.oauthClientId,
+    user_type: "app_user",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: keyPair.kid, typ: "JWT" })
+    .setIssuer(issuer)
+    .setAudience(issuer)
+    .setSubject(binding.appUserId)
+    .setJti(uuidv4())
+    .setIssuedAt(nowSeconds)
+    .setNotBefore(nowSeconds)
+    .setExpirationTime(nowSeconds + ACCESS_TOKEN_TTL_SECONDS)
+    .sign(keyPair.privateKey);
+
+  const refresh = await createSession({
+    appId: binding.oauthClientId,
+    label: `app_user_refresh:${binding.appUserId}`,
+    scopes: scope,
+    expiresInDays: REFRESH_TOKEN_TTL_DAYS,
+  });
+
+  return {
+    access_token: accessToken,
+    refresh_token: refresh.token,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+    scope,
+    subject_type: "app_user",
+  };
+}
+
+export async function rotateProgrammaticRefreshToken(input: {
+  refreshToken: string;
+  clientId: string;
+  clientSecret: string;
+}) {
+  const session = await validateBearerToken(input.refreshToken);
+  if (!session?.label?.startsWith("app_user_refresh:") || !session.appId) {
+    return null;
+  }
+  if (!input.clientId || !input.clientSecret) return null;
+
+  const appUserId = session.label.replace("app_user_refresh:", "");
+  const app = await getRefreshTokenProgrammaticApp(session.appId);
+
+  if (!app || billingPatternFromAllowedScopesString(app.allowedScopes) !== "per_user") {
+    return null;
+  }
+  if (input.clientId !== app.oauthClientId) return null;
+  if (!(await validateClientSecret(input.clientId, input.clientSecret))) return null;
+
+  const appUser = await getActiveAppUserForRefresh(appUserId, app.appId);
+  if (!appUser || appUser.status !== "active") return null;
+
+  const consumed = await consumeSessionByIdAndToken(session.sessionId, input.refreshToken);
+  if (!consumed) return null;
+
+  return issueProgrammaticTokens({
+    developerAppId: app.appId,
+    oauthClientId: app.oauthClientId,
+    appUserId: appUser.id,
+    scopes: session.scopes.split(/[\s,]+/).map((scope) => scope.trim()).filter(Boolean),
+  });
+}
+
+export function generateApiKeyValue() {
+  return `pmth_${randomBytes(32).toString("hex")}`;
+}

--- a/src/domains/oidc-platform/runtime/provider-bridge.ts
+++ b/src/domains/oidc-platform/runtime/provider-bridge.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from "next/server";
+import { IncomingMessage, ServerResponse } from "http";
+import { Socket } from "net";
+import { OIDC_MOUNT_PATH, getPublicOrigin } from "@/platform/oidc/issuer-urls";
+
+export function buildProviderNodeRequest(params: {
+  method: "GET" | "POST";
+  request: NextRequest;
+  path: string;
+}) {
+  const socket = new Socket();
+  const req = new IncomingMessage(socket);
+  req.method = params.method;
+  req.url = `${OIDC_MOUNT_PATH}${params.path}`;
+  params.request.headers.forEach((value, key) => {
+    req.headers[key.toLowerCase()] = value;
+  });
+  const publicUrl = new URL(getPublicOrigin());
+  req.headers.host = publicUrl.host;
+  if (!req.headers["x-forwarded-proto"]) {
+    req.headers["x-forwarded-proto"] = publicUrl.protocol.replace(":", "");
+  }
+  req.push(null);
+  const res = new ServerResponse(req);
+  return { req, res };
+}

--- a/src/domains/oidc-platform/runtime/provider-catchall.ts
+++ b/src/domains/oidc-platform/runtime/provider-catchall.ts
@@ -1,0 +1,166 @@
+import type { NextRequest, NextResponse } from "next/server";
+import { getProvider } from "./provider-instance";
+import { normalizeProviderPath } from "@/platform/oidc/routes";
+import { OIDC_MOUNT_PATH, getIssuer } from "@/platform/oidc/issuer-urls";
+import { getRegisteredRedirectOrigins } from "@/domains/oidc-platform/runtime/clients";
+import { isVerifiedCustomDomain } from "@/domains/oidc-platform/runtime/custom-domains";
+import { getSecureHeaders } from "@/platform/oidc/security";
+import { IncomingMessage, ServerResponse } from "http";
+import { Socket } from "net";
+import {
+  deriveExternalOriginFromHeaders,
+  resolveRedirectLocation,
+} from "../service/provider-redirects";
+import { interceptOidcTokenRequest } from "./token-request";
+import { getTrustedOidcOrigins } from "./provider-origins";
+
+export async function handleOidcCatchall(request: NextRequest): Promise<NextResponse> {
+  const provider = await getProvider();
+  const registeredRedirectOriginsList = await getRegisteredRedirectOrigins();
+  const trustedOidcOriginsSet = await getTrustedOidcOrigins();
+
+  const url = new URL(request.url);
+  let path = url.pathname;
+  if (path.startsWith(OIDC_MOUNT_PATH)) {
+    path = path.slice(OIDC_MOUNT_PATH.length) || "/";
+  }
+  path = normalizeProviderPath(path);
+
+  let body: Buffer<ArrayBufferLike> | null = request.body
+    ? Buffer.from(await request.arrayBuffer())
+    : null;
+  const contentType = request.headers.get("content-type") || "";
+  const intercepted = await interceptOidcTokenRequest({
+    request,
+    path,
+    contentType,
+    body,
+  });
+  if (intercepted.response) {
+    return intercepted.response;
+  }
+  body = intercepted.body;
+
+  const socket = new Socket();
+  const req = new IncomingMessage(socket);
+  req.method = request.method;
+  req.url = path + url.search;
+  (req as IncomingMessage & { baseUrl?: string }).baseUrl = OIDC_MOUNT_PATH;
+  request.headers.forEach((value, key) => {
+    req.headers[key.toLowerCase()] = value;
+  });
+
+  const externalOrigin = deriveExternalOriginFromHeaders(request.headers);
+  const externalUrl = new URL(externalOrigin);
+  req.headers.host = externalUrl.host;
+  req.headers["x-forwarded-proto"] = externalUrl.protocol.replace(":", "");
+  req.headers["x-forwarded-host"] = externalUrl.host;
+
+  if (body && body.length > 0) {
+    req.headers["content-length"] = String(body.length);
+    req.push(body);
+  }
+  req.push(null);
+
+  const res = new ServerResponse(req);
+  const chunks: Buffer[] = [];
+  const originalWrite = res.write.bind(res);
+  const originalEnd = res.end.bind(res);
+
+  res.write = function (chunk: any, ...args: any[]) {
+    if (chunk) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    return originalWrite(chunk, ...args);
+  } as any;
+
+  return new Promise<NextResponse>((resolve) => {
+    res.end = async function (chunk?: any, ...args: any[]) {
+      if (chunk) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+
+      const responseBody = Buffer.concat(chunks);
+      const statusCode = res.statusCode || 200;
+      const headers = new Headers();
+      const rawHeaders = res.getHeaders();
+      for (const [key, value] of Object.entries(rawHeaders)) {
+        if (value !== undefined) {
+          if (Array.isArray(value)) {
+            for (const v of value) headers.append(key, String(v));
+          } else {
+            headers.set(key, String(value));
+          }
+        }
+      }
+
+      if ([301, 302, 303, 307, 308].includes(statusCode)) {
+        const location = headers.get("location");
+        if (location) {
+          const allowedOrigins = new Set([
+            new URL(externalOrigin).origin,
+            ...registeredRedirectOriginsList,
+            ...trustedOidcOriginsSet,
+          ]);
+          const redirectResponse = Response.redirect(
+            resolveRedirectLocation(location, externalOrigin, allowedOrigins),
+            statusCode,
+          ) as unknown as NextResponse;
+          const setCookies = rawHeaders["set-cookie"];
+          if (setCookies) {
+            const cookies = Array.isArray(setCookies) ? setCookies : [setCookies];
+            for (const cookie of cookies) {
+              redirectResponse.headers.append("Set-Cookie", cookie);
+            }
+          }
+          for (const [key, value] of Object.entries(getSecureHeaders(false))) {
+            redirectResponse.headers.set(key, value);
+          }
+          resolve(redirectResponse);
+          return originalEnd(chunk, ...args);
+        }
+      }
+
+      let finalBody: Buffer | null = responseBody.length > 0 ? responseBody : null;
+      const ct = headers.get("content-type") || "";
+      if (finalBody && ct.includes("application/json") && path === "/device/auth") {
+        try {
+          const json = JSON.parse(finalBody.toString("utf-8"));
+          if (json.verification_uri) {
+            const deviceParams = new URLSearchParams();
+            if (json.user_code) deviceParams.set("user_code", json.user_code);
+            if (body && body.length > 0) {
+              try {
+                const form = new URLSearchParams(body.toString("utf-8"));
+                const deviceClientId = form.get("client_id");
+                if (deviceClientId) deviceParams.set("client_id", deviceClientId);
+              } catch {}
+            }
+            deviceParams.set("iss", getIssuer());
+            const qs = deviceParams.toString();
+            const verificationBase = `${externalOrigin}/oidc/device`;
+            json.verification_uri = verificationBase;
+            if (json.user_code) {
+              json.verification_uri_complete = qs ? `${verificationBase}?${qs}` : verificationBase;
+            }
+            finalBody = Buffer.from(JSON.stringify(json), "utf-8");
+            headers.set("content-length", String(finalBody.length));
+          }
+        } catch {}
+      }
+
+      const requestHost = req.headers["x-forwarded-host"] || req.headers.host || "";
+      const hostStr = Array.isArray(requestHost) ? requestHost[0] : requestHost;
+      const isCustomDomain = await isVerifiedCustomDomain(hostStr);
+      for (const [key, value] of Object.entries(getSecureHeaders(isCustomDomain))) {
+        headers.set(key, value);
+      }
+
+      const nextResponse = new Response(finalBody ? new Uint8Array(finalBody) : null, {
+        status: statusCode,
+        headers,
+      }) as unknown as NextResponse;
+      resolve(nextResponse);
+      return originalEnd(chunk, ...args);
+    } as any;
+
+    const callback = provider.callback();
+    callback(req, res);
+  });
+}

--- a/src/domains/oidc-platform/runtime/provider-instance.ts
+++ b/src/domains/oidc-platform/runtime/provider-instance.ts
@@ -1,0 +1,378 @@
+/**
+ * node-oidc-provider configuration.
+ *
+ * Replaces the 7 custom OIDC route files with a single certified provider.
+ */
+
+import { Provider, interactionPolicy } from "oidc-provider";
+import type { Configuration, ClientMetadata, KoaContextWithOIDC } from "oidc-provider";
+import { timingSafeEqual } from "crypto";
+import * as jose from "jose";
+import { PostgresOidcAdapter } from "@/domains/oidc-platform/runtime/adapter";
+import { findAccount } from "@/domains/oidc-platform/runtime/account";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import { ensureSigningKey } from "@/domains/oidc-platform/runtime/jwks";
+import {
+  getTrustedLoginHosts,
+  normalizeDomain,
+} from "@/domains/oidc-platform/runtime/custom-domains";
+import { initiateLoginUriAcceptedByOidcProvider } from "@/platform/oidc/third-party-initiate-login";
+import {
+  listAllowedDomainsForApp,
+  listAllOidcClients,
+  listDeveloperAppsForOidcClientRowId,
+  listRecentSigningKeys,
+} from "../repo/provider-instance";
+import { hashClientSecret } from "./clients";
+
+const KEY_ALGORITHM = "RS256";
+
+async function loadJWKS(): Promise<{ keys: jose.JWK[] }> {
+  await ensureSigningKey();
+
+  const keys = await listRecentSigningKeys(5);
+
+  const jwks: jose.JWK[] = [];
+  for (const key of keys) {
+    const privateKey = await jose.importPKCS8(key.privateKeyPem, KEY_ALGORITHM, {
+      extractable: true,
+    });
+    const jwk = await jose.exportJWK(privateKey);
+    jwks.push({
+      ...jwk,
+      kid: key.kid,
+      alg: KEY_ALGORITHM,
+      use: "sig",
+    });
+  }
+
+  return { keys: jwks };
+}
+
+async function loadClients(): Promise<ClientMetadata[]> {
+  const rows = await listAllOidcClients();
+
+  return rows.map((row) => {
+    const redirectUris = (JSON.parse(row.redirectUris) as string[]).flatMap((uri) => {
+      if (!uri.includes("*")) return [uri];
+      const expanded: string[] = [];
+      const commonPorts = [
+        "3000", "3001", "3002", "3003", "3004", "3005",
+        "4000", "4001", "4200", "5000", "5173", "5174",
+        "8000", "8080", "8081", "8888", "9000",
+      ];
+      for (const port of commonPorts) {
+        expanded.push(uri.replace(/:\*/, `:${port}`).replace(/\*/g, ""));
+      }
+      return expanded;
+    });
+
+    const grantTypes = row.grantTypes.split(",").filter(Boolean);
+    const effectiveRedirectUris =
+      redirectUris.length > 0 ? redirectUris : [`${getIssuer()}/cb`];
+
+    const meta: ClientMetadata = {
+      client_id: row.clientId,
+      client_name: row.displayName,
+      redirect_uris: effectiveRedirectUris,
+      grant_types: grantTypes,
+      token_endpoint_auth_method: row.tokenEndpointAuthMethod as
+        | "none"
+        | "client_secret_post"
+        | "client_secret_basic",
+      scope: row.allowedScopes,
+    };
+    meta.response_types = grantTypes.includes("authorization_code") ? ["code"] : [];
+
+    if (row.clientSecretHash) {
+      meta.client_secret = row.clientSecretHash;
+      meta.client_secret_expires_at = 0;
+    }
+
+    if (row.postLogoutRedirectUris) {
+      try {
+        const parsed = JSON.parse(row.postLogoutRedirectUris) as string[];
+        if (parsed.length > 0) meta.post_logout_redirect_uris = parsed;
+      } catch {}
+    }
+    if (row.initiateLoginUri && initiateLoginUriAcceptedByOidcProvider(row.initiateLoginUri)) {
+      meta.initiate_login_uri = row.initiateLoginUri;
+    }
+    if (row.logoUri) meta.logo_uri = row.logoUri;
+    if (row.policyUri) meta.policy_uri = row.policyUri;
+    if (row.tosUri) meta.tos_uri = row.tosUri;
+    if (row.clientUri) meta.client_uri = row.clientUri;
+
+    return meta;
+  });
+}
+
+function patchHashedClientSecretComparison(provider: Provider): void {
+  const clientPrototype = (
+    provider.Client as unknown as {
+      prototype?: {
+        compareClientSecret?: (actual: string) => Promise<boolean> | boolean;
+        __pmthHashedSecretPatchApplied?: boolean;
+      };
+    }
+  ).prototype;
+
+  if (!clientPrototype?.compareClientSecret || clientPrototype.__pmthHashedSecretPatchApplied) {
+    return;
+  }
+
+  const originalCompare = clientPrototype.compareClientSecret;
+  clientPrototype.compareClientSecret = async function patchedCompare(actual: string) {
+    const storedSecret = (this as { clientSecret?: string }).clientSecret;
+    if (typeof storedSecret === "string" && /^[a-f0-9]{64}$/i.test(storedSecret)) {
+      const actualHash = hashClientSecret(actual ?? "");
+      const stored = Buffer.from(storedSecret);
+      const provided = Buffer.from(actualHash);
+      if (stored.length !== provided.length) return false;
+      return timingSafeEqual(stored, provided);
+    }
+    return originalCompare.call(this, actual);
+  };
+
+  clientPrototype.__pmthHashedSecretPatchApplied = true;
+}
+
+function buildInteractionPolicy() {
+  const basePolicy = interactionPolicy.base();
+  const consent = basePolicy.find((p) => p.name === "consent");
+  if (consent) {
+    const { Check } = interactionPolicy;
+    consent.checks.clear();
+    consent.checks.add(
+      new Check(
+        "native_client_prompt",
+        "consent required for third-party clients",
+        async (ctx) => {
+          const requestedScopes = Array.from(ctx.oidc.requestParamScopes ?? []);
+          const grantId = ctx.oidc.session?.grantIdFor(ctx.oidc.client!.clientId);
+          if (!grantId) return Check.REQUEST_PROMPT;
+          const grant = await ctx.oidc.provider.Grant.find(grantId);
+          if (!grant) return Check.REQUEST_PROMPT;
+
+          const grantedScopeSet = new Set(
+            grant
+              .getOIDCScope()
+              .split(/\s+/)
+              .map((scope) => scope.trim())
+              .filter(Boolean),
+          );
+          const covered = requestedScopes.every((scope) => grantedScopeSet.has(scope));
+          return covered ? Check.NO_NEED_TO_PROMPT : Check.REQUEST_PROMPT;
+        },
+        (ctx) => ({ scopes: ctx.oidc.requestParamScopes }),
+      ),
+    );
+  }
+
+  return basePolicy;
+}
+
+let providerInstance: Provider | null = null;
+let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+let corsCache: { trustedHosts: string[]; clientOrigins: Map<string, Set<string>> } | null = null;
+let corsCacheExpiry = 0;
+const CORS_CACHE_TTL_MS = 60_000;
+
+async function buildCorsSnapshot(): Promise<{
+  trustedHosts: string[];
+  clientOrigins: Map<string, Set<string>>;
+}> {
+  const trustedHosts = await getTrustedLoginHosts();
+  const oidcRows = await listAllOidcClients();
+  const clientOrigins = new Map<string, Set<string>>();
+
+  for (const oc of oidcRows) {
+    const appRows = await listDeveloperAppsForOidcClientRowId(oc.id);
+    const app = appRows[0];
+    if (!app) continue;
+    const domains = await listAllowedDomainsForApp(app.id);
+    clientOrigins.set(oc.clientId, new Set(domains.map((domain) => domain.domain)));
+  }
+
+  return { trustedHosts, clientOrigins };
+}
+
+async function getCorsSnapshot() {
+  const now = Date.now();
+  if (corsCache && now < corsCacheExpiry) return corsCache;
+  corsCache = await buildCorsSnapshot();
+  corsCacheExpiry = now + CORS_CACHE_TTL_MS;
+  return corsCache;
+}
+
+export async function getProvider(): Promise<Provider> {
+  if (providerInstance) return providerInstance;
+
+  const issuer = getIssuer();
+  const jwks = await loadJWKS();
+  const clients = await loadClients();
+
+  const configuration: Configuration = {
+    adapter: PostgresOidcAdapter,
+    clients,
+    findAccount,
+    jwks: jwks as Configuration["jwks"],
+    clientBasedCORS: (_ctx, origin, client) => {
+      const issuerOrigin = new URL(issuer).origin;
+      if (origin === issuerOrigin) return true;
+
+      const snapshot = corsCache;
+      try {
+        const originUrl = new URL(origin);
+        const originHost = normalizeDomain(originUrl.host);
+        if (snapshot?.trustedHosts.some((host) => normalizeDomain(host) === originHost)) {
+          return true;
+        }
+      } catch {}
+
+      const matchesRedirectUri = (client.redirectUris ?? []).some((uri) => {
+        try {
+          return new URL(uri).origin === origin;
+        } catch {
+          return false;
+        }
+      });
+      if (matchesRedirectUri) return true;
+
+      const allowed = snapshot?.clientOrigins.get(client.clientId);
+      if (allowed?.has(origin)) return true;
+      void getCorsSnapshot();
+      return false;
+    },
+    scopes: ["openid", "sign:job", "users:read", "users:write", "users:token", "device:approve", "admin"],
+    claims: {
+      openid: ["sub"],
+      "sign:job": ["sub"],
+      "users:read": ["sub"],
+      "users:write": ["sub"],
+      "users:token": ["sub"],
+      "device:approve": ["sub"],
+      admin: ["sub"],
+    },
+    responseTypes: ["code"],
+    clientAuthMethods: ["none", "client_secret_post", "client_secret_basic"],
+    pkce: { required: (_ctx, client) => client.tokenEndpointAuthMethod === "none" },
+    rotateRefreshToken: true,
+    issueRefreshToken: async (_ctx, client) => client.grantTypeAllowed("refresh_token"),
+    features: {
+      devInteractions: { enabled: false },
+      clientCredentials: { enabled: true },
+      deviceFlow: {
+        enabled: true,
+        charset: "base-20",
+        mask: "****-****",
+        userCodeInputSource: async (ctx) => {
+          const u = new URL(`${issuer.replace(/\/api\/v1\/oidc$/, "")}/oidc/device`);
+          const cid = ctx.oidc?.client?.clientId;
+          if (cid) u.searchParams.set("client_id", cid);
+          u.searchParams.set("iss", getIssuer());
+          ctx.redirect(u.toString());
+        },
+        userCodeConfirmSource: async (ctx, _form, client, _deviceInfo, userCode) => {
+          const u = new URL(`${issuer.replace(/\/api\/v1\/oidc$/, "")}/oidc/device`);
+          u.searchParams.set("user_code", userCode);
+          const cid = client?.clientId ?? ctx.oidc?.client?.clientId;
+          if (cid) u.searchParams.set("client_id", cid);
+          u.searchParams.set("iss", getIssuer());
+          ctx.redirect(u.toString());
+        },
+        successSource: async (ctx) => {
+          ctx.body = "<!DOCTYPE html><html><head><title>Device Authorized</title></head><body><h1>Device Authorized</h1><p>You can close this window and return to your device.</p></body></html>";
+        },
+      },
+      rpInitiatedLogout: { enabled: true },
+      userinfo: { enabled: true },
+      revocation: { enabled: true },
+      introspection: { enabled: true },
+      resourceIndicators: {
+        enabled: true,
+        defaultResource: async (_ctx, _client, oneOf) => {
+          if (typeof oneOf === "string") return oneOf;
+          if (Array.isArray(oneOf) && oneOf.length === 1) return oneOf[0];
+          return issuer;
+        },
+        getResourceServerInfo: async (_ctx, resourceIndicator) => {
+          if (resourceIndicator !== issuer) {
+            throw new Error(`Unknown resource indicator: ${resourceIndicator}`);
+          }
+          return {
+            scope: "openid sign:job users:read users:write users:token device:approve admin",
+            audience: issuer,
+            accessTokenFormat: "jwt" as const,
+            accessTokenTTL: 3600,
+            jwt: { sign: { alg: "RS256" as const } },
+          };
+        },
+        useGrantedResource: async () => true,
+      },
+    },
+    ttl: {
+      AccessToken: 3600,
+      AuthorizationCode: 600,
+      DeviceCode: 600,
+      IdToken: 3600,
+      RefreshToken: 30 * 24 * 3600,
+      Interaction: 600,
+      Session: 14 * 24 * 3600,
+      Grant: 14 * 24 * 3600,
+    },
+    interactions: {
+      policy: buildInteractionPolicy(),
+      url: async (_ctx: KoaContextWithOIDC, interaction) => `/oidc/interaction?uid=${interaction.uid}`,
+    },
+    cookies: {
+      keys: (() => {
+        const secret = process.env.NEXTAUTH_SECRET;
+        if (!secret && process.env.NODE_ENV === "production") {
+          throw new Error("NEXTAUTH_SECRET must be set in production. Generate one with: openssl rand -base64 32");
+        }
+        return [secret ?? "dev-secret-change-me"];
+      })(),
+      short: {
+        httpOnly: true,
+        sameSite: "lax" as const,
+        path: "/",
+      },
+    },
+    conformIdTokenClaims: false,
+    enabledJWA: { idTokenSigningAlgValues: ["RS256"] },
+    loadExistingGrant: async (ctx) => {
+      const grantId =
+        ctx.oidc.result?.consent?.grantId ||
+        ctx.oidc.session!.grantIdFor(ctx.oidc.client!.clientId);
+
+      if (grantId) {
+        const grant = await ctx.oidc.provider.Grant.find(grantId);
+        if (grant) return grant;
+      }
+      return undefined;
+    },
+  };
+
+  providerInstance = new Provider(issuer, configuration);
+  patchHashedClientSecretComparison(providerInstance);
+  providerInstance.proxy = true;
+  await getCorsSnapshot();
+
+  if (cleanupInterval) clearInterval(cleanupInterval);
+  cleanupInterval = setInterval(() => {
+    PostgresOidcAdapter.cleanup().catch((err) => console.error("Oidc cleanup failed", err));
+  }, 10 * 60 * 1000);
+
+  return providerInstance;
+}
+
+export function resetProvider(): void {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+  }
+  corsCache = null;
+  corsCacheExpiry = 0;
+  providerInstance = null;
+}

--- a/src/domains/oidc-platform/runtime/provider-origins.ts
+++ b/src/domains/oidc-platform/runtime/provider-origins.ts
@@ -1,0 +1,20 @@
+import { getPublicOrigin } from "@/platform/oidc/issuer-urls";
+
+export async function getTrustedOidcOrigins(): Promise<Set<string>> {
+  const publicOrigin = getPublicOrigin();
+  const { getTrustedLoginHosts } = await import("@/domains/oidc-platform/runtime/custom-domains");
+  const trustedHosts = await getTrustedLoginHosts();
+
+  const origins = new Set<string>();
+  origins.add(new URL(publicOrigin).origin);
+
+  for (const host of trustedHosts) {
+    if (host.includes("localhost") || host.startsWith("127.")) {
+      origins.add(`http://${host}`);
+    } else {
+      origins.add(`https://${host}`);
+    }
+  }
+
+  return origins;
+}

--- a/src/domains/oidc-platform/runtime/token-exchange.ts
+++ b/src/domains/oidc-platform/runtime/token-exchange.ts
@@ -1,0 +1,144 @@
+import * as jose from "jose";
+import { findOrCreateAppEndUser } from "@/domains/end-user-accounts/runtime/end-users";
+import { billingPatternFromAllowedScopesString } from "@/platform/oidc/allowed-scopes";
+import { getIssuer, getPlatformJwksUrlForDatabase } from "@/platform/oidc/issuer-urls";
+import { fetchPlatformJWKS } from "@/platform/oidc/jwks-fetch";
+import { validateClientSecret } from "./clients";
+import { ensureSigningKey } from "./jwks";
+import {
+  getApprovedAppByOidcClientRowId,
+  getOidcClientByClientId,
+} from "../repo/token-exchange";
+
+const TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
+const JWT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+
+export interface TokenExchangeResult {
+  access_token: string;
+  token_type: "Bearer";
+  expires_in: number;
+  scope: string;
+  issued_token_type: string;
+}
+
+export function isTokenExchangeGrant(grantType: string): boolean {
+  return grantType === TOKEN_EXCHANGE_GRANT;
+}
+
+export async function handleTokenExchange(params: {
+  clientId: string;
+  clientSecret: string;
+  subjectToken: string;
+  subjectTokenType: string;
+  scope?: string;
+  resource?: string;
+}): Promise<TokenExchangeResult> {
+  const { clientId, clientSecret, subjectToken, subjectTokenType, scope } = params;
+  if (subjectTokenType !== JWT_TOKEN_TYPE) {
+    throw new TokenExchangeError(
+      "unsupported_token_type",
+      `subject_token_type must be ${JWT_TOKEN_TYPE}`,
+      "Unsupported subject token type",
+    );
+  }
+  if (!(await validateClientSecret(clientId, clientSecret))) {
+    throw new TokenExchangeError("invalid_client", "Invalid client credentials", "Invalid client credentials");
+  }
+
+  const clientRow = await getOidcClientByClientId(clientId);
+  if (!clientRow) {
+    throw new TokenExchangeError("invalid_client", "Client not found", "Invalid client credentials");
+  }
+
+  const app = await getApprovedAppByOidcClientRowId(clientRow.id);
+  if (!app) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "App is not approved for token exchange",
+      "Client is not approved for token exchange",
+    );
+  }
+  if (billingPatternFromAllowedScopesString(clientRow.allowedScopes) !== "per_user") {
+    throw new TokenExchangeError(
+      "invalid_request",
+      "Token exchange requires the users:token scope on the OAuth client",
+      "Token exchange requires per-user billing (users:token scope)",
+    );
+  }
+
+  const jwksUriForExchange =
+    !app.jwksUri?.trim() || app.jwksUri.includes("localhost") || app.jwksUri.includes("127.0.0.1")
+      ? getPlatformJwksUrlForDatabase()
+      : app.jwksUri.trim();
+
+  let platformJWKS: jose.JSONWebKeySet;
+  try {
+    platformJWKS = await fetchPlatformJWKS(jwksUriForExchange);
+  } catch (err) {
+    throw new TokenExchangeError(
+      "invalid_request",
+      `Failed to fetch platform JWKS: ${err instanceof Error ? err.message : "unknown error"}`,
+      "Unable to validate subject token",
+    );
+  }
+
+  let payload: jose.JWTPayload;
+  try {
+    const keySet = jose.createLocalJWKSet(platformJWKS);
+    ({ payload } = await jose.jwtVerify(subjectToken, keySet));
+  } catch (err) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      `Subject token verification failed: ${err instanceof Error ? err.message : "invalid signature"}`,
+      "Invalid subject token",
+    );
+  }
+
+  const externalSub = payload.sub;
+  if (!externalSub) {
+    throw new TokenExchangeError("invalid_grant", "Subject token missing sub claim", "Invalid subject token");
+  }
+
+  const { id: endUserId } = await findOrCreateAppEndUser(app.id, externalSub);
+  const requestedScopes = (scope || "").split(/\s+/).filter(Boolean);
+  const allowedScopes = clientRow.allowedScopes.split(/[,\s]+/).filter(Boolean);
+  const grantedScopes = requestedScopes.filter((s) => allowedScopes.includes(s));
+  const scopeString = grantedScopes.join(" ") || "sign:job";
+
+  const issuer = getIssuer();
+  const signingKey = await ensureSigningKey();
+  const expiresIn = 3600;
+
+  const accessToken = await new jose.SignJWT({
+    client_id: clientId,
+    scope: scopeString,
+    token_exchange: true,
+  })
+    .setProtectedHeader({ alg: "RS256", kid: signingKey.kid })
+    .setSubject(endUserId)
+    .setIssuer(issuer)
+    .setAudience(issuer)
+    .setIssuedAt()
+    .setExpirationTime(`${expiresIn}s`)
+    .setJti(`te_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`)
+    .sign(signingKey.privateKey);
+
+  return {
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: expiresIn,
+    scope: scopeString,
+    issued_token_type: ACCESS_TOKEN_TYPE,
+  };
+}
+
+export class TokenExchangeError extends Error {
+  code: string;
+  publicDescription: string;
+  constructor(code: string, message: string, publicDescription?: string) {
+    super(message);
+    this.code = code;
+    this.publicDescription = publicDescription || message;
+  }
+}

--- a/src/domains/oidc-platform/runtime/token-request.ts
+++ b/src/domains/oidc-platform/runtime/token-request.ts
@@ -1,0 +1,150 @@
+import type { NextRequest, NextResponse } from "next/server";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import {
+  handleTokenExchange,
+  isTokenExchangeGrant,
+  TokenExchangeError,
+} from "@/domains/oidc-platform/runtime/token-exchange";
+import {
+  handleGatewayTokenExchange,
+  isGatewayTokenExchangeRequest,
+} from "@/domains/oidc-platform/runtime/gateway-token-exchange";
+import {
+  handleDeviceApprovalTokenExchange,
+  isDeviceApprovalTokenExchangeRequest,
+} from "@/domains/oidc-platform/runtime/device-token-exchange";
+import { rotateProgrammaticRefreshToken } from "@/domains/oidc-platform/runtime/programmatic-tokens";
+import {
+  clientCredentialsFromTokenRequest,
+  ensureResourceIndicator,
+} from "../service/token-request";
+
+export async function interceptOidcTokenRequest(params: {
+  request: NextRequest;
+  path: string;
+  contentType: string;
+  body: Buffer<ArrayBufferLike> | null;
+}): Promise<{ response: NextResponse | null; body: Buffer<ArrayBufferLike> | null }> {
+  const { request, path, contentType } = params;
+  let body = params.body;
+
+  if (
+    request.method === "POST" &&
+    path === "/token" &&
+    contentType.includes("application/x-www-form-urlencoded") &&
+    body &&
+    body.length > 0
+  ) {
+    const exchangeParams = new URLSearchParams(body.toString("utf-8"));
+    const grantType = exchangeParams.get("grant_type") || "";
+
+    if (grantType === "refresh_token") {
+      const refreshToken = exchangeParams.get("refresh_token") || "";
+      const { clientId, clientSecret } = clientCredentialsFromTokenRequest(request, exchangeParams);
+      const refreshed = await rotateProgrammaticRefreshToken({
+        refreshToken,
+        clientId,
+        clientSecret,
+      });
+      if (refreshed) {
+        return {
+          response: Response.json(refreshed, {
+            headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
+          }) as unknown as NextResponse,
+          body,
+        };
+      }
+    }
+
+    if (isTokenExchangeGrant(grantType)) {
+      const { clientId, clientSecret } = clientCredentialsFromTokenRequest(request, exchangeParams);
+      const subjectTokenType = exchangeParams.get("subject_token_type") || "";
+      const resourceParam = exchangeParams.get("resource");
+      try {
+        let result: unknown;
+        if (
+          isDeviceApprovalTokenExchangeRequest({
+            grantType,
+            subjectTokenType,
+            resource: resourceParam,
+          })
+        ) {
+          result = await handleDeviceApprovalTokenExchange({
+            clientId,
+            clientSecret,
+            subjectToken: exchangeParams.get("subject_token") || "",
+            subjectTokenType,
+            resource: resourceParam,
+            requestedTokenType: exchangeParams.get("requested_token_type"),
+            audience: exchangeParams.getAll("audience"),
+          });
+        } else if (
+          isGatewayTokenExchangeRequest({
+            grantType,
+            clientId,
+            subjectTokenType,
+            resource: resourceParam,
+          })
+        ) {
+          result = await handleGatewayTokenExchange({
+            clientId,
+            clientSecret,
+            subjectToken: exchangeParams.get("subject_token") || "",
+            subjectTokenType,
+            resource: resourceParam,
+            requestedTokenType: exchangeParams.get("requested_token_type"),
+            audience: exchangeParams.getAll("audience"),
+          });
+        } else {
+          result = await handleTokenExchange({
+            clientId,
+            clientSecret,
+            subjectToken: exchangeParams.get("subject_token") || "",
+            subjectTokenType,
+            scope: exchangeParams.get("scope") || undefined,
+            resource: exchangeParams.get("resource") || undefined,
+          });
+        }
+        return {
+          response: Response.json(result, {
+            headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
+          }) as unknown as NextResponse,
+          body,
+        };
+      } catch (err) {
+        if (err instanceof TokenExchangeError) {
+          return {
+            response: Response.json(
+              { error: err.code, error_description: err.publicDescription },
+              { status: 400 },
+            ) as unknown as NextResponse,
+            body,
+          };
+        }
+        return {
+          response: Response.json(
+            {
+              error: "server_error",
+              error_description: "Internal error during token exchange",
+            },
+            { status: 500 },
+          ) as unknown as NextResponse,
+          body,
+        };
+      }
+    }
+  }
+
+  if (
+    request.method === "POST" &&
+    contentType.includes("application/x-www-form-urlencoded") &&
+    body &&
+    body.length > 0 &&
+    (path === "/device/auth" || path === "/token")
+  ) {
+    const form = new URLSearchParams(body.toString("utf-8"));
+    body = ensureResourceIndicator(form, path, getIssuer());
+  }
+
+  return { response: null, body };
+}

--- a/src/domains/oidc-platform/service/device-verification.test.ts
+++ b/src/domains/oidc-platform/service/device-verification.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deviceVerificationError,
+  parseDeviceVerificationInput,
+} from "./device-verification";
+
+test("parseDeviceVerificationInput validates required fields", () => {
+  const result = parseDeviceVerificationInput({});
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? 0 : result.status, 400);
+});
+
+test("parseDeviceVerificationInput accepts supported actions", () => {
+  const result = parseDeviceVerificationInput({ user_code: "abc", action: "approve" });
+  assert.equal(result.ok, true);
+  assert.equal(result.ok ? result.action : "", "approve");
+});
+
+test("deviceVerificationError shapes standard error body", () => {
+  const result = deviceVerificationError("invalid_request", "bad");
+  assert.deepEqual(result, {
+    status: 400,
+    body: { error: "invalid_request", error_description: "bad" },
+  });
+});

--- a/src/domains/oidc-platform/service/device-verification.ts
+++ b/src/domains/oidc-platform/service/device-verification.ts
@@ -1,0 +1,44 @@
+export function deviceVerificationError(
+  error: string,
+  description: string,
+  status = 400,
+) {
+  return {
+    status,
+    body: {
+      error,
+      error_description: description,
+    },
+  };
+}
+
+export function parseDeviceVerificationInput(body: unknown):
+  | { ok: true; userCode: string; action: "lookup" | "approve" | "deny" }
+  | { ok: false; status: number; body: { error: string; error_description: string } } {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      ...deviceVerificationError("invalid_request", "user_code and action are required"),
+    };
+  }
+
+  const userCode = (body as Record<string, unknown>).user_code;
+  const action = (body as Record<string, unknown>).action;
+  if (!userCode || !action) {
+    return {
+      ok: false,
+      ...deviceVerificationError("invalid_request", "user_code and action are required"),
+    };
+  }
+  if (action !== "lookup" && action !== "approve" && action !== "deny") {
+    return {
+      ok: false,
+      ...deviceVerificationError(
+        "invalid_request",
+        "action must be lookup, approve, or deny",
+      ),
+    };
+  }
+
+  return { ok: true, userCode: String(userCode), action };
+}

--- a/src/domains/oidc-platform/service/provider-redirects.test.ts
+++ b/src/domains/oidc-platform/service/provider-redirects.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  deriveExternalOriginFromHeaders,
+  resolveRedirectLocation,
+} from "./provider-redirects";
+
+test("deriveExternalOriginFromHeaders prefers forwarded host+proto", () => {
+  const headers = new Headers({
+    "x-forwarded-host": "pymthouse.com",
+    "x-forwarded-proto": "https",
+  });
+  assert.equal(deriveExternalOriginFromHeaders(headers), "https://pymthouse.com");
+});
+
+test("deriveExternalOriginFromHeaders handles proxy header chains", () => {
+  const headers = new Headers({
+    "x-forwarded-host": "pymthouse.com, 127.0.0.1:3001",
+    "x-forwarded-proto": "https, http",
+  });
+  assert.equal(deriveExternalOriginFromHeaders(headers), "https://pymthouse.com");
+});
+
+test("resolveRedirectLocation resolves provider relative redirects against external origin", () => {
+  const redirect = resolveRedirectLocation("/auth/abc123", "https://pymthouse.com");
+  assert.equal(redirect.href, "https://pymthouse.com/api/v1/oidc/auth/abc123");
+});
+
+test("resolveRedirectLocation passes absolute URL when origin is in allowed set", () => {
+  const allowed = new Set(["https://app.example.com"]);
+  const redirect = resolveRedirectLocation(
+    "https://app.example.com/callback?code=abc",
+    "https://pymthouse.com",
+    allowed,
+  );
+  assert.equal(redirect.href, "https://app.example.com/callback?code=abc");
+});

--- a/src/domains/oidc-platform/service/provider-redirects.ts
+++ b/src/domains/oidc-platform/service/provider-redirects.ts
@@ -1,0 +1,43 @@
+import { PROVIDER_ENDPOINT_PATHS } from "@/platform/oidc/routes";
+import { OIDC_MOUNT_PATH, getPublicOrigin } from "@/platform/oidc/issuer-urls";
+
+export function deriveExternalOriginFromHeaders(headers: Headers): string {
+  const publicFallback = getPublicOrigin();
+  const xfHostRaw = headers.get("x-forwarded-host");
+  if (!xfHostRaw) return publicFallback;
+
+  const xfProtoRaw = headers.get("x-forwarded-proto");
+  const host = xfHostRaw.split(",")[0]?.trim();
+  const protoCandidate = xfProtoRaw?.split(",")[0]?.trim().toLowerCase();
+  const proto =
+    protoCandidate === "http" || protoCandidate === "https"
+      ? protoCandidate
+      : new URL(publicFallback).protocol.replace(":", "");
+
+  if (!host) return publicFallback;
+  return `${proto}://${host}`;
+}
+
+export function resolveRedirectLocation(
+  location: string,
+  origin: string,
+  allowedOrigins?: Set<string>,
+): URL {
+  if (/^https?:\/\//i.test(location)) {
+    const redirectUrl = new URL(location);
+    if (allowedOrigins && !allowedOrigins.has(redirectUrl.origin)) {
+      throw new Error(`[OIDC] Redirect to unregistered origin blocked: ${redirectUrl.origin}`);
+    }
+    return redirectUrl;
+  }
+
+  if (
+    location.startsWith("/") &&
+    !location.startsWith(OIDC_MOUNT_PATH) &&
+    Object.values(PROVIDER_ENDPOINT_PATHS).some((path) => location.startsWith(path))
+  ) {
+    return new URL(`${OIDC_MOUNT_PATH}${location}`, origin);
+  }
+
+  return new URL(location, origin);
+}

--- a/src/domains/oidc-platform/service/token-request.ts
+++ b/src/domains/oidc-platform/service/token-request.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from "next/server";
+import { decodeBasicAuthComponent } from "@/domains/identity-access/runtime/request-auth";
+
+export const RESOURCE_REQUIRED_GRANTS = new Set([
+  "urn:ietf:params:oauth:grant-type:device_code",
+  "authorization_code",
+  "refresh_token",
+]);
+
+export function clientCredentialsFromTokenRequest(
+  request: NextRequest,
+  params: URLSearchParams,
+): { clientId: string; clientSecret: string } {
+  const auth = request.headers.get("authorization") || "";
+  if (auth.startsWith("Basic ")) {
+    try {
+      const decoded = Buffer.from(auth.slice(6), "base64").toString("utf-8");
+      const idx = decoded.indexOf(":");
+      if (idx > 0) {
+        return {
+          clientId: decodeBasicAuthComponent(decoded.slice(0, idx)),
+          clientSecret: decodeBasicAuthComponent(decoded.slice(idx + 1)),
+        };
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  return {
+    clientId: params.get("client_id") || "",
+    clientSecret: params.get("client_secret") || "",
+  };
+}
+
+export function ensureResourceIndicator(params: URLSearchParams, path: string, issuer: string): Buffer {
+  const grantType = params.get("grant_type");
+  const needsResource =
+    path === "/device/auth" || (grantType && RESOURCE_REQUIRED_GRANTS.has(grantType));
+  if (needsResource && !params.has("resource")) {
+    params.set("resource", issuer);
+  }
+  return Buffer.from(params.toString(), "utf-8");
+}

--- a/src/domains/plans-discovery/repo/discovery-profiles.ts
+++ b/src/domains/plans-discovery/repo/discovery-profiles.ts
@@ -1,0 +1,189 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db/index";
+import { discoveryProfileBundles, discoveryProfiles, plans } from "@/db/schema";
+import type {
+  CreateDiscoveryProfileInput,
+  UpdateDiscoveryProfileInput,
+} from "../types/discovery-profiles";
+
+export class DiscoveryProfileDuplicateNameError extends Error {}
+
+function isDuplicateNameError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes("idx_discovery_profiles_client_name") || msg.includes("unique");
+}
+
+export async function listDiscoveryProfiles(appId: string) {
+  const profs = await db.select().from(discoveryProfiles).where(eq(discoveryProfiles.clientId, appId));
+  const bundles = await db
+    .select()
+    .from(discoveryProfileBundles)
+    .where(eq(discoveryProfileBundles.clientId, appId));
+  return { profs, bundles };
+}
+
+export async function getDiscoveryProfile(appId: string, profileId: string) {
+  const rows = await db
+    .select()
+    .from(discoveryProfiles)
+    .where(and(eq(discoveryProfiles.id, profileId), eq(discoveryProfiles.clientId, appId)))
+    .limit(1);
+  const profile = rows[0] ?? null;
+  if (!profile) return null;
+
+  const bundles = await db
+    .select()
+    .from(discoveryProfileBundles)
+    .where(
+      and(eq(discoveryProfileBundles.profileId, profileId), eq(discoveryProfileBundles.clientId, appId)),
+    );
+  return { profile, bundles };
+}
+
+export async function listDiscoveryProfilesByIds(profileIds: string[]) {
+  if (profileIds.length === 0) return [];
+  return db
+    .select()
+    .from(discoveryProfiles)
+    .where(inArray(discoveryProfiles.id, profileIds));
+}
+
+export async function listDiscoveryProfileBundlesByProfileIds(profileIds: string[]) {
+  if (profileIds.length === 0) return [];
+  return db
+    .select()
+    .from(discoveryProfileBundles)
+    .where(inArray(discoveryProfileBundles.profileId, profileIds));
+}
+
+export async function createDiscoveryProfile(appId: string, input: CreateDiscoveryProfileInput) {
+  const profileId = uuidv4();
+  const now = new Date().toISOString();
+
+  try {
+    await db.transaction(async (tx) => {
+      await tx.insert(discoveryProfiles).values({
+        id: profileId,
+        clientId: appId,
+        name: input.name,
+        policy: input.policy,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      for (const cap of input.capabilities) {
+        await tx.insert(discoveryProfileBundles).values({
+          id: uuidv4(),
+          profileId,
+          clientId: appId,
+          pipeline: cap.pipeline,
+          modelId: cap.modelId,
+          discoveryPolicy: cap.discoveryPolicy,
+          createdAt: now,
+        });
+      }
+    });
+  } catch (error) {
+    if (isDuplicateNameError(error)) {
+      throw new DiscoveryProfileDuplicateNameError(
+        "A discovery profile with this name already exists",
+      );
+    }
+    throw error;
+  }
+
+  return profileId;
+}
+
+export async function updateDiscoveryProfile(
+  appId: string,
+  profileId: string,
+  input: UpdateDiscoveryProfileInput,
+): Promise<{ ok: true } | { ok: false; status: 404; error: string }> {
+  const existingRows = await db
+    .select()
+    .from(discoveryProfiles)
+    .where(and(eq(discoveryProfiles.id, profileId), eq(discoveryProfiles.clientId, appId)))
+    .limit(1);
+  if (!existingRows[0]) {
+    return { ok: false, status: 404, error: "Not found" };
+  }
+
+  const now = new Date().toISOString();
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .update(discoveryProfiles)
+        .set({
+          name: input.name,
+          updatedAt: now,
+          ...(input.policy !== undefined ? { policy: input.policy } : {}),
+        })
+        .where(and(eq(discoveryProfiles.id, profileId), eq(discoveryProfiles.clientId, appId)));
+
+      if (input.capabilities) {
+        await tx
+          .delete(discoveryProfileBundles)
+          .where(
+            and(
+              eq(discoveryProfileBundles.profileId, profileId),
+              eq(discoveryProfileBundles.clientId, appId),
+            ),
+          );
+        for (const cap of input.capabilities) {
+          await tx.insert(discoveryProfileBundles).values({
+            id: uuidv4(),
+            profileId,
+            clientId: appId,
+            pipeline: cap.pipeline,
+            modelId: cap.modelId,
+            discoveryPolicy: cap.discoveryPolicy,
+            createdAt: now,
+          });
+        }
+      }
+    });
+  } catch (error) {
+    if (isDuplicateNameError(error)) {
+      throw new DiscoveryProfileDuplicateNameError(
+        "A discovery profile with this name already exists",
+      );
+    }
+    throw error;
+  }
+
+  return { ok: true };
+}
+
+export async function deleteDiscoveryProfile(
+  appId: string,
+  profileId: string,
+): Promise<{ ok: true } | { ok: false; status: 404 | 409; error: string }> {
+  const existingRows = await db
+    .select({ id: discoveryProfiles.id })
+    .from(discoveryProfiles)
+    .where(and(eq(discoveryProfiles.id, profileId), eq(discoveryProfiles.clientId, appId)))
+    .limit(1);
+  if (!existingRows[0]) {
+    return { ok: false, status: 404, error: "Not found" };
+  }
+
+  const ref = await db
+    .select({ id: plans.id })
+    .from(plans)
+    .where(eq(plans.discoveryProfileId, profileId))
+    .limit(1);
+  if (ref[0]) {
+    return {
+      ok: false,
+      status: 409,
+      error: "Profile is attached to one or more billing plans; detach before deleting",
+    };
+  }
+
+  await db
+    .delete(discoveryProfiles)
+    .where(and(eq(discoveryProfiles.id, profileId), eq(discoveryProfiles.clientId, appId)));
+  return { ok: true };
+}

--- a/src/domains/plans-discovery/repo/plans.ts
+++ b/src/domains/plans-discovery/repo/plans.ts
@@ -1,0 +1,232 @@
+import { and, eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db/index";
+import { discoveryProfiles, planCapabilityBundles, plans } from "@/db/schema";
+import type { CreatePlanInput, UpdatePlanInput } from "../types/plans";
+
+async function requireOwnedDiscoveryProfile(
+  appId: string,
+  discoveryProfileId: string | null,
+  executor: Pick<typeof db, "select"> = db,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (discoveryProfileId === null) {
+    return { ok: true };
+  }
+  const row = await executor
+    .select({ id: discoveryProfiles.id })
+    .from(discoveryProfiles)
+    .where(
+      and(eq(discoveryProfiles.id, discoveryProfileId), eq(discoveryProfiles.clientId, appId)),
+    )
+    .limit(1);
+  if (!row[0]) {
+    return { ok: false, error: "discoveryProfileId not found for this app" };
+  }
+  return { ok: true };
+}
+
+export async function createPlan(appId: string, input: CreatePlanInput): Promise<string> {
+  const planId = uuidv4();
+  const now = new Date().toISOString();
+
+  try {
+    await db.transaction(async (tx) => {
+      const profCheck = await requireOwnedDiscoveryProfile(appId, input.discoveryProfileId, tx);
+      if (!profCheck.ok) {
+        throw Object.assign(new Error(profCheck.error), { code: "DISCOVERY_PROFILE" as const });
+      }
+      await tx.insert(plans).values({
+        id: planId,
+        clientId: appId,
+        name: input.name,
+        type: input.type,
+        priceAmount: input.priceAmount,
+        priceCurrency: input.priceCurrency,
+        status: input.status,
+        includedUnits: input.includedUnits !== null ? BigInt(input.includedUnits) : null,
+        overageRateWei: input.overageRateWei !== null ? BigInt(input.overageRateWei) : null,
+        includedUsdMicros: input.includedUsdMicros,
+        generalUpchargePercentBps: input.generalUpchargePercentBps,
+        payPerUseUpchargePercentBps: input.payPerUseUpchargePercentBps,
+        billingCycle: input.billingCycle,
+        discoveryProfileId: input.discoveryProfileId,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      for (const capability of input.capabilities) {
+        await tx.insert(planCapabilityBundles).values({
+          id: uuidv4(),
+          planId,
+          clientId: appId,
+          pipeline: capability.pipeline,
+          modelId: capability.modelId,
+          slaTargetScore: capability.slaTargetScore ?? null,
+          slaTargetP95Ms: capability.slaTargetP95Ms ?? null,
+          maxPricePerUnit: capability.maxPricePerUnit,
+          upchargePercentBps: capability.upchargePercentBps,
+          createdAt: now,
+        });
+      }
+    });
+  } catch (e: unknown) {
+    if (
+      e &&
+      typeof e === "object" &&
+      "code" in e &&
+      (e as { code?: string }).code === "DISCOVERY_PROFILE" &&
+      e instanceof Error
+    ) {
+      throw new PlanValidationError(e.message);
+    }
+    throw e;
+  }
+
+  return planId;
+}
+
+export async function getPlanForApp(appId: string, planId: string) {
+  const rows = await db
+    .select()
+    .from(plans)
+    .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listPlansByClientId(clientId: string) {
+  return db.select().from(plans).where(eq(plans.clientId, clientId));
+}
+
+export async function listPlanCapabilityBundlesByClientId(clientId: string) {
+  return db
+    .select()
+    .from(planCapabilityBundles)
+    .where(eq(planCapabilityBundles.clientId, clientId));
+}
+
+export async function updatePlan(
+  appId: string,
+  input: UpdatePlanInput,
+): Promise<{ ok: true } | { ok: false; status: 400 | 404; error: string }> {
+  const now = new Date().toISOString();
+  const txnResult = await db.transaction(async (tx) => {
+    const existingRows = await tx
+      .select()
+      .from(plans)
+      .where(and(eq(plans.id, input.id), eq(plans.clientId, appId)))
+      .limit(1);
+    const existing = existingRows[0];
+    if (!existing) {
+      return { tag: "notfound" as const };
+    }
+
+    if (input.discoveryProfileId !== undefined && input.discoveryProfileId !== null) {
+      const profCheck = await requireOwnedDiscoveryProfile(appId, input.discoveryProfileId, tx);
+      if (!profCheck.ok) {
+        return { tag: "validation" as const, error: profCheck.error };
+      }
+    }
+
+    const updated = await tx
+      .update(plans)
+      .set({
+        name: input.name !== undefined ? input.name : existing.name,
+        type: input.type !== undefined ? input.type : existing.type,
+        priceAmount: input.priceAmount !== undefined ? input.priceAmount : existing.priceAmount,
+        priceCurrency:
+          input.priceCurrency !== undefined ? input.priceCurrency : existing.priceCurrency,
+        status: input.status !== undefined ? input.status : existing.status,
+        includedUnits: input.includedUnits !== null ? BigInt(input.includedUnits ?? "0") : null,
+        overageRateWei:
+          input.overageRateWei !== null ? BigInt(input.overageRateWei ?? "0") : null,
+        ...(input.generalUpchargePercentBps !== undefined
+          ? { generalUpchargePercentBps: input.generalUpchargePercentBps }
+          : {}),
+        ...(input.payPerUseUpchargePercentBps !== undefined
+          ? { payPerUseUpchargePercentBps: input.payPerUseUpchargePercentBps }
+          : {}),
+        ...(input.includedUsdMicros !== undefined
+          ? { includedUsdMicros: input.includedUsdMicros }
+          : {}),
+        ...(input.billingCycle !== undefined ? { billingCycle: input.billingCycle } : {}),
+        ...(input.discoveryProfileId !== undefined
+          ? { discoveryProfileId: input.discoveryProfileId }
+          : {}),
+        updatedAt: now,
+      })
+      .where(and(eq(plans.id, input.id), eq(plans.clientId, appId)))
+      .returning({ id: plans.id });
+
+    if (updated.length === 0) {
+      return { tag: "notfound" as const };
+    }
+
+    if (input.capabilities) {
+      await tx
+        .delete(planCapabilityBundles)
+        .where(
+          and(eq(planCapabilityBundles.planId, input.id), eq(planCapabilityBundles.clientId, appId)),
+        );
+      for (const capability of input.capabilities) {
+        await tx.insert(planCapabilityBundles).values({
+          id: uuidv4(),
+          planId: input.id,
+          clientId: appId,
+          pipeline: capability.pipeline,
+          modelId: capability.modelId,
+          slaTargetScore: capability.slaTargetScore ?? null,
+          slaTargetP95Ms: capability.slaTargetP95Ms ?? null,
+          maxPricePerUnit: capability.maxPricePerUnit,
+          upchargePercentBps: capability.upchargePercentBps,
+          createdAt: now,
+        });
+      }
+    }
+
+    return { tag: "ok" as const };
+  });
+
+  if (txnResult.tag === "notfound") {
+    return { ok: false, status: 404, error: "Plan not found" };
+  }
+  if (txnResult.tag === "validation") {
+    return { ok: false, status: 400, error: txnResult.error };
+  }
+  return { ok: true };
+}
+
+export async function deletePlan(
+  appId: string,
+  planId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const deleted = await db.transaction(async (tx) => {
+    const planRows = await tx
+      .select({ id: plans.id })
+      .from(plans)
+      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
+      .limit(1);
+
+    if (!planRows[0]) {
+      return false;
+    }
+
+    await tx
+      .delete(planCapabilityBundles)
+      .where(
+        and(eq(planCapabilityBundles.planId, planId), eq(planCapabilityBundles.clientId, appId)),
+      );
+    const removed = await tx
+      .delete(plans)
+      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
+      .returning({ id: plans.id });
+    return removed.length > 0;
+  });
+
+  if (!deleted) {
+    return { ok: false, error: "Plan not found" };
+  }
+  return { ok: true };
+}
+
+export class PlanValidationError extends Error {}

--- a/src/domains/plans-discovery/repo/subscriptions.ts
+++ b/src/domains/plans-discovery/repo/subscriptions.ts
@@ -1,0 +1,84 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { plans, subscriptions } from "@/db/schema";
+
+export async function listSubscriptionsForUser(userId: string) {
+  return db.select().from(subscriptions).where(eq(subscriptions.userId, userId));
+}
+
+export async function getPlanById(planId: string) {
+  const rows = await db.select().from(plans).where(eq(plans.id, planId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getActiveSubscriptionForUserAndClient(userId: string, clientId: string) {
+  const rows = await db
+    .select()
+    .from(subscriptions)
+    .where(
+      and(
+        eq(subscriptions.userId, userId),
+        eq(subscriptions.clientId, clientId),
+        eq(subscriptions.status, "active"),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function createSubscriptionIfMissing(params: {
+  subscription: {
+    id: string;
+    userId: string;
+    clientId: string;
+    planId: string;
+    status: "active";
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+    createdAt: string;
+    cancelledAt: null;
+  };
+}) {
+  return db.transaction(async (tx) => {
+    const recheck = await tx
+      .select()
+      .from(subscriptions)
+      .where(
+        and(
+          eq(subscriptions.userId, params.subscription.userId),
+          eq(subscriptions.clientId, params.subscription.clientId),
+          eq(subscriptions.status, "active"),
+        ),
+      )
+      .limit(1);
+    if (recheck[0]) {
+      return { row: recheck[0], isNew: false };
+    }
+    await tx.insert(subscriptions).values(params.subscription);
+    return { row: params.subscription, isNew: true };
+  });
+}
+
+export async function getUserSubscriptionById(subscriptionId: string, userId: string) {
+  const rows = await db
+    .select()
+    .from(subscriptions)
+    .where(
+      and(
+        eq(subscriptions.id, subscriptionId),
+        eq(subscriptions.userId, userId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function cancelSubscription(subscriptionId: string, userId: string, cancelledAt: string) {
+  await db
+    .update(subscriptions)
+    .set({
+      status: "cancelled",
+      cancelledAt,
+    })
+    .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.userId, userId)));
+}

--- a/src/domains/plans-discovery/runtime/discovery-profiles-read.ts
+++ b/src/domains/plans-discovery/runtime/discovery-profiles-read.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from "next/server";
+import { discoveryPolicyFromDb } from "@/shared/discovery/discovery-plans";
+import { getDiscoveryProfile, listDiscoveryProfiles } from "../repo/discovery-profiles";
+import { resolveReadablePlansApp } from "./plans-read";
+
+export async function resolveReadableDiscoveryProfilesApp(clientId: string, request: NextRequest) {
+  return resolveReadablePlansApp(clientId, request);
+}
+
+export async function readDiscoveryProfiles(clientId: string, appId: string) {
+  const { profs, bundles } = await listDiscoveryProfiles(appId);
+  return profs.map((p) => ({
+    id: p.id,
+    clientId,
+    name: p.name,
+    policy: discoveryPolicyFromDb(p.policy),
+    createdAt: p.createdAt,
+    updatedAt: p.updatedAt,
+    capabilities: bundles
+      .filter((b) => b.profileId === p.id)
+      .map((b) => ({
+        pipeline: b.pipeline,
+        modelId: b.modelId,
+        discoveryPolicy: discoveryPolicyFromDb(b.discoveryPolicy),
+      })),
+  }));
+}
+
+export async function readDiscoveryProfile(clientId: string, appId: string, profileId: string) {
+  const result = await getDiscoveryProfile(appId, profileId);
+  if (!result) return null;
+  return {
+    id: result.profile.id,
+    clientId,
+    name: result.profile.name,
+    policy: discoveryPolicyFromDb(result.profile.policy),
+    createdAt: result.profile.createdAt,
+    updatedAt: result.profile.updatedAt,
+    capabilities: result.bundles.map((b) => ({
+      pipeline: b.pipeline,
+      modelId: b.modelId,
+      discoveryPolicy: discoveryPolicyFromDb(b.discoveryPolicy),
+    })),
+  };
+}

--- a/src/domains/plans-discovery/runtime/discovery-resolution.ts
+++ b/src/domains/plans-discovery/runtime/discovery-resolution.ts
@@ -1,0 +1,95 @@
+import {
+  listDiscoveryProfileBundlesByProfileIds,
+  listDiscoveryProfilesByIds,
+} from "../repo/discovery-profiles";
+import {
+  listPlanCapabilityBundlesByClientId,
+  listPlansByClientId,
+} from "../repo/plans";
+import type { DiscoveryPolicy } from "@/shared/discovery/discovery-plans";
+import { discoveryPolicyFromDb } from "@/shared/discovery/discovery-plans";
+
+export type ResolvedPlanCapability = {
+  id: string;
+  planId: string;
+  clientId: string;
+  pipeline: string;
+  modelId: string;
+  slaTargetScore: number | null;
+  slaTargetP95Ms: number | null;
+  maxPricePerUnit: string | null;
+  upchargePercentBps: number | null;
+  createdAt: string;
+  discoveryPolicy: DiscoveryPolicy | null;
+};
+
+export type ResolvedPlanRow = {
+  plan: Awaited<ReturnType<typeof listPlansByClientId>>[number];
+  discoveryProfileId: string | null;
+  discoveryPolicy: DiscoveryPolicy | null;
+  capabilities: ResolvedPlanCapability[];
+};
+
+function bundleLookupKey(pipeline: string, modelId: string): string {
+  return `${pipeline}\0${modelId}`;
+}
+
+export async function resolvePlansDiscoveryForApp(appId: string): Promise<ResolvedPlanRow[]> {
+  const planRows = await listPlansByClientId(appId);
+  const billingBundles = await listPlanCapabilityBundlesByClientId(appId);
+
+  const profileIds = [
+    ...new Set(planRows.map((p) => p.discoveryProfileId).filter(Boolean)),
+  ] as string[];
+
+  const profiles = await listDiscoveryProfilesByIds(profileIds);
+  const profById = new Map(profiles.map((p) => [p.id, p]));
+
+  const discBundles = await listDiscoveryProfileBundlesByProfileIds(profileIds);
+  const discByProfile = new Map<string, Map<string, (typeof discBundles)[0]>>();
+  for (const row of discBundles) {
+    if (!discByProfile.has(row.profileId)) {
+      discByProfile.set(row.profileId, new Map());
+    }
+    discByProfile.get(row.profileId)!.set(bundleLookupKey(row.pipeline, row.modelId), row);
+  }
+
+  const bundlesByPlan = new Map<string, (typeof billingBundles)[number][]>();
+  for (const b of billingBundles) {
+    const list = bundlesByPlan.get(b.planId);
+    if (list) list.push(b);
+    else bundlesByPlan.set(b.planId, [b]);
+  }
+
+  return planRows.map((plan) => {
+    const prof = plan.discoveryProfileId ? profById.get(plan.discoveryProfileId) : undefined;
+    const planLevel = prof ? discoveryPolicyFromDb(prof.policy) : null;
+    const dMap = plan.discoveryProfileId ? discByProfile.get(plan.discoveryProfileId) : undefined;
+
+    const capabilities: ResolvedPlanCapability[] = (bundlesByPlan.get(plan.id) ?? []).map(
+      (bundle) => {
+        const discRow = dMap?.get(bundleLookupKey(bundle.pipeline, bundle.modelId));
+        return {
+          id: bundle.id,
+          planId: bundle.planId,
+          clientId: bundle.clientId,
+          pipeline: bundle.pipeline,
+          modelId: bundle.modelId,
+          slaTargetScore: bundle.slaTargetScore,
+          slaTargetP95Ms: bundle.slaTargetP95Ms,
+          maxPricePerUnit: bundle.maxPricePerUnit,
+          upchargePercentBps: bundle.upchargePercentBps,
+          createdAt: bundle.createdAt,
+          discoveryPolicy: discRow ? discoveryPolicyFromDb(discRow.discoveryPolicy) : null,
+        };
+      },
+    );
+
+    return {
+      plan,
+      discoveryProfileId: plan.discoveryProfileId ?? null,
+      discoveryPolicy: planLevel,
+      capabilities,
+    };
+  });
+}

--- a/src/domains/plans-discovery/runtime/plans-read.ts
+++ b/src/domains/plans-discovery/runtime/plans-read.ts
@@ -1,0 +1,58 @@
+import type { NextRequest } from "next/server";
+import { authenticateAppClient } from "@/domains/identity-access/runtime/request-auth";
+import { getProviderApp } from "@/domains/developer-apps/repo/provider-access";
+import { getAuthorizedProviderApp } from "@/domains/developer-apps/runtime/provider-access";
+import { resolvePlansDiscoveryForApp } from "./discovery-resolution";
+
+export async function resolveReadablePlansApp(clientId: string, request: NextRequest) {
+  const clientAuth = await authenticateAppClient(request);
+  if (clientAuth?.appId === clientId) {
+    return getProviderApp(clientId);
+  }
+  if (clientAuth) return null;
+
+  const auth = await getAuthorizedProviderApp(clientId);
+  return auth?.app ?? null;
+}
+
+export async function readResolvedPlans(clientId: string, appId: string) {
+  const resolved = await resolvePlansDiscoveryForApp(appId);
+  return resolved.map((r) => {
+    const plan = r.plan;
+    return {
+      ...plan,
+      discoveryProfileId: plan.discoveryProfileId ?? null,
+      discoveryPolicy: r.discoveryPolicy,
+      includedUnits:
+        plan.includedUnits !== null && plan.includedUnits !== undefined
+          ? plan.includedUnits.toString()
+          : null,
+      overageRateWei:
+        plan.overageRateWei !== null && plan.overageRateWei !== undefined
+          ? plan.overageRateWei.toString()
+          : null,
+      clientId,
+      capabilities: r.capabilities.map((c) => ({
+        ...c,
+        clientId,
+      })),
+    };
+  });
+}
+
+export async function readActiveDiscoveryPlans(appId: string) {
+  const resolved = await resolvePlansDiscoveryForApp(appId);
+  return resolved
+    .filter((r) => r.plan.status === "active")
+    .map((r) => ({
+      id: r.plan.id,
+      name: r.plan.name,
+      status: r.plan.status,
+      discoveryPolicy: r.discoveryPolicy,
+      capabilities: r.capabilities.map((c) => ({
+        pipeline: c.pipeline,
+        modelId: c.modelId,
+        discoveryPolicy: c.discoveryPolicy,
+      })),
+    }));
+}

--- a/src/domains/plans-discovery/runtime/subscriptions.ts
+++ b/src/domains/plans-discovery/runtime/subscriptions.ts
@@ -1,0 +1,60 @@
+import { v4 as uuidv4 } from "uuid";
+import { calendarMonthBoundsUtc } from "@/shared/utils/billing-utils";
+import {
+  cancelSubscription,
+  createSubscriptionIfMissing,
+  getActiveSubscriptionForUserAndClient,
+  getPlanById,
+  getUserSubscriptionById,
+  listSubscriptionsForUser,
+} from "../repo/subscriptions";
+
+export async function listUserSubscriptions(userId: string) {
+  return listSubscriptionsForUser(userId);
+}
+
+export async function createUserSubscription(userId: string, planId: string) {
+  const plan = await getPlanById(planId);
+  if (!plan) {
+    return { ok: false as const, status: 404, body: { error: "Plan not found" } };
+  }
+
+  const existing = await getActiveSubscriptionForUserAndClient(userId, plan.clientId);
+  if (existing) {
+    return { ok: true as const, status: 200, body: existing };
+  }
+
+  const cal = calendarMonthBoundsUtc(new Date());
+  const subscription = {
+    id: uuidv4(),
+    userId,
+    clientId: plan.clientId,
+    planId,
+    status: "active" as const,
+    currentPeriodStart: cal.start,
+    currentPeriodEnd: cal.end,
+    createdAt: cal.start,
+    cancelledAt: null,
+  };
+
+  const result = await createSubscriptionIfMissing({ subscription });
+  return {
+    ok: true as const,
+    status: result.isNew ? 201 : 200,
+    body: result.row,
+  };
+}
+
+export async function cancelUserSubscription(userId: string, subscriptionId: string) {
+  const existing = await getUserSubscriptionById(subscriptionId, userId);
+  if (!existing) {
+    return {
+      ok: false as const,
+      status: 404,
+      body: { error: "Subscription not found" },
+    };
+  }
+
+  await cancelSubscription(subscriptionId, userId, new Date().toISOString());
+  return { ok: true as const, status: 200, body: { success: true } };
+}

--- a/src/domains/plans-discovery/service/discovery-profile-input.test.ts
+++ b/src/domains/plans-discovery/service/discovery-profile-input.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseCreateDiscoveryProfileInput,
+  parseUpdateDiscoveryProfileInput,
+} from "./discovery-profile-input";
+
+test("parseCreateDiscoveryProfileInput validates duplicate capabilities", () => {
+  const parsed = parseCreateDiscoveryProfileInput({
+    name: "Profile A",
+    capabilities: [
+      { pipeline: "llm", modelId: "*", discoveryPolicy: { topN: 2 } },
+      { pipeline: "llm", modelId: "*", discoveryPolicy: { topN: 3 } },
+    ],
+  });
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.ok ? "" : parsed.error, /duplicate capability/);
+});
+
+test("parseCreateDiscoveryProfileInput validates nested discovery policy", () => {
+  const parsed = parseCreateDiscoveryProfileInput({
+    name: "Profile A",
+    capabilities: [{ pipeline: "llm", modelId: "*", discoveryPolicy: { sortBy: "nope" } }],
+  });
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.ok ? "" : parsed.error, /sortBy/);
+});
+
+test("parseCreateDiscoveryProfileInput parses valid payload", () => {
+  const parsed = parseCreateDiscoveryProfileInput({
+    name: "Profile A",
+    policy: { topN: 8, sortBy: "price" },
+    capabilities: [{ pipeline: "vid", modelId: "*", discoveryPolicy: { topN: 2 } }],
+  });
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.ok);
+  assert.equal(parsed.value.name, "Profile A");
+  assert.equal(parsed.value.policy?.topN, 8);
+  assert.equal(parsed.value.capabilities[0]?.pipeline, "vid");
+});
+
+test("parseUpdateDiscoveryProfileInput preserves existing name when omitted", () => {
+  const parsed = parseUpdateDiscoveryProfileInput(
+    { policy: { topN: 4 } },
+    { name: "Existing", policy: null },
+  );
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.ok);
+  assert.equal(parsed.value.name, "Existing");
+  assert.equal(parsed.value.policy?.topN, 4);
+});

--- a/src/domains/plans-discovery/service/discovery-profile-input.ts
+++ b/src/domains/plans-discovery/service/discovery-profile-input.ts
@@ -1,0 +1,123 @@
+import type { DiscoveryPolicy } from "@/shared/discovery/discovery-plans";
+import { parseDiscoveryPolicyInput } from "@/shared/discovery/discovery-plans";
+import type {
+  CreateDiscoveryProfileInput,
+  DiscoveryProfileCapabilityInput,
+  UpdateDiscoveryProfileInput,
+} from "../types/discovery-profiles";
+
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; error: string };
+
+function parseDiscoveryProfileCapabilities(
+  input: unknown,
+): Ok<DiscoveryProfileCapabilityInput[]> | Err {
+  if (input === undefined) {
+    return { ok: true, value: [] };
+  }
+  if (!Array.isArray(input)) {
+    return { ok: false, error: "capabilities must be an array" };
+  }
+  try {
+    const seen = new Set<string>();
+    const capabilities = input.map((raw, index) => {
+      const value = (raw ?? {}) as Record<string, unknown>;
+      const pipeline = typeof value.pipeline === "string" ? value.pipeline.trim() : "";
+      const modelId = typeof value.modelId === "string" ? value.modelId.trim() : "";
+      if (!pipeline) {
+        throw new Error(`capabilities[${index}].pipeline is required`);
+      }
+      if (!modelId) {
+        throw new Error(`capabilities[${index}].modelId is required`);
+      }
+      const capKey = `${pipeline}::${modelId}`;
+      if (seen.has(capKey)) {
+        throw new Error(
+          `duplicate capability at capabilities[${index}] for pipeline "${pipeline}" and modelId "${modelId}"`,
+        );
+      }
+      seen.add(capKey);
+      const dp = parseDiscoveryPolicyInput(
+        value.discoveryPolicy,
+        `capabilities[${index}].discoveryPolicy`,
+      );
+      if (!dp.ok) {
+        throw new Error(dp.error);
+      }
+      return { pipeline, modelId, discoveryPolicy: dp.policy };
+    });
+    return { ok: true, value: capabilities };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Invalid capabilities",
+    };
+  }
+}
+
+export function parseCreateDiscoveryProfileInput(
+  body: unknown,
+): Ok<CreateDiscoveryProfileInput> | Err {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "invalid JSON" };
+  }
+  const record = body as Record<string, unknown>;
+  const name = String(record.name || "").trim();
+  if (!name) {
+    return { ok: false, error: "name is required" };
+  }
+
+  const policyParsed = parseDiscoveryPolicyInput(record.policy, "policy");
+  if (!policyParsed.ok) {
+    return { ok: false, error: policyParsed.error };
+  }
+
+  const parsedCaps = parseDiscoveryProfileCapabilities(record.capabilities);
+  if (!parsedCaps.ok) {
+    return parsedCaps;
+  }
+
+  return {
+    ok: true,
+    value: {
+      name,
+      policy: policyParsed.policy,
+      capabilities: parsedCaps.value,
+    },
+  };
+}
+
+export function parseUpdateDiscoveryProfileInput(
+  body: unknown,
+  existing: { name: string; policy: DiscoveryPolicy | null },
+): Ok<UpdateDiscoveryProfileInput> | Err {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "invalid JSON" };
+  }
+  const record = body as Record<string, unknown>;
+
+  const name = record.name !== undefined ? String(record.name || "").trim() : existing.name;
+  if (!name) {
+    return { ok: false, error: "name is required" };
+  }
+
+  const value: UpdateDiscoveryProfileInput = { name };
+
+  if (record.policy !== undefined) {
+    const parsed = parseDiscoveryPolicyInput(record.policy, "policy");
+    if (!parsed.ok) {
+      return { ok: false, error: parsed.error };
+    }
+    value.policy = parsed.policy;
+  }
+
+  if (record.capabilities !== undefined) {
+    const parsedCaps = parseDiscoveryProfileCapabilities(record.capabilities);
+    if (!parsedCaps.ok) {
+      return parsedCaps;
+    }
+    value.capabilities = parsedCaps.value;
+  }
+
+  return { ok: true, value };
+}

--- a/src/domains/plans-discovery/service/plan-input.test.ts
+++ b/src/domains/plans-discovery/service/plan-input.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseCreatePlanInput, parseUpdatePlanInput } from "./plan-input";
+
+test("parseCreatePlanInput validates required subscription billing fields", () => {
+  const parsed = parseCreatePlanInput({
+    name: "Subscription",
+    type: "subscription",
+    priceAmount: "20",
+  });
+  assert.equal(parsed.ok, false);
+  assert.equal(
+    parsed.ok ? "" : parsed.error,
+    "includedUnits and overageRateWei are required for subscription plans",
+  );
+});
+
+test("parseCreatePlanInput parses capabilities and pricing fields", () => {
+  const parsed = parseCreatePlanInput({
+    name: "Usage plan",
+    type: "usage",
+    overageRateWei: "25",
+    includedUnits: "100",
+    includedUsdMicros: "20000000",
+    generalUpchargePercentBps: 2000,
+    capabilities: [{ pipeline: "llm", modelId: "*", upchargePercentBps: 500 }],
+  });
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.ok);
+  assert.equal(parsed.value.name, "Usage plan");
+  assert.equal(parsed.value.capabilities[0]?.pipeline, "llm");
+  assert.equal(parsed.value.capabilities[0]?.upchargePercentBps, 500);
+  assert.equal(parsed.value.includedUsdMicros, "20000000");
+});
+
+test("parseUpdatePlanInput preserves existing type semantics for partial updates", () => {
+  const parsed = parseUpdatePlanInput(
+    { id: "plan-1", priceAmount: "30" },
+    { type: "subscription", includedUnits: "1000", overageRateWei: "25" },
+  );
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.ok);
+  assert.equal(parsed.value.id, "plan-1");
+  assert.equal(parsed.value.type, "subscription");
+  assert.equal(parsed.value.includedUnits, "1000");
+  assert.equal(parsed.value.overageRateWei, "25");
+});
+
+test("parseUpdatePlanInput rejects malformed capabilities", () => {
+  const parsed = parseUpdatePlanInput(
+    { id: "plan-1", capabilities: [{ modelId: "*" }] },
+    { type: "free", includedUnits: null, overageRateWei: null },
+  );
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.ok ? "" : parsed.error, "capabilities[0].pipeline is required");
+});

--- a/src/domains/plans-discovery/service/plan-input.ts
+++ b/src/domains/plans-discovery/service/plan-input.ts
@@ -1,0 +1,341 @@
+import type { UpdatePlanInput, CreatePlanInput, PlanCapabilityInput } from "../types/plans";
+
+type Ok<T> = { ok: true; value: T };
+type Err = { ok: false; error: string };
+
+function isNonNegativeIntegerString(s: string): boolean {
+  return /^\d+$/.test(s);
+}
+
+function parseOptionalNonNegativeBps(raw: unknown, fieldName: string): Ok<number | null> | Err {
+  if (raw === undefined || raw === null) return { ok: true, value: null };
+  const n = typeof raw === "number" ? raw : Number(String(raw).trim());
+  if (!Number.isInteger(n) || n < 0) {
+    return { ok: false, error: `${fieldName} must be a non-negative integer (basis points)` };
+  }
+  return { ok: true, value: n };
+}
+
+function parseOptionalNonNegativeIntString(
+  raw: unknown,
+  fieldName: string,
+): Ok<string | null> | Err {
+  if (raw === undefined || raw === null) {
+    return { ok: true, value: null };
+  }
+  const s = String(raw).trim();
+  if (s === "") {
+    return { ok: true, value: null };
+  }
+  if (!isNonNegativeIntegerString(s)) {
+    return { ok: false, error: `${fieldName} must be a non-negative integer string` };
+  }
+  return { ok: true, value: s };
+}
+
+function resolveBillingFieldsForPost(
+  planType: string,
+  body: Record<string, unknown>,
+): Ok<{ includedUnits: string | null; overageRateWei: string | null }> | Err {
+  if (planType === "free") {
+    return { ok: true, value: { includedUnits: null, overageRateWei: null } };
+  }
+  if (planType === "subscription") {
+    const inc = parseOptionalNonNegativeIntString(body.includedUnits, "includedUnits");
+    const ovr = parseOptionalNonNegativeIntString(body.overageRateWei, "overageRateWei");
+    if (!inc.ok) return inc;
+    if (!ovr.ok) return ovr;
+    if (inc.value === null || ovr.value === null) {
+      return {
+        ok: false,
+        error: "includedUnits and overageRateWei are required for subscription plans",
+      };
+    }
+    return { ok: true, value: { includedUnits: inc.value, overageRateWei: ovr.value } };
+  }
+  if (planType === "usage") {
+    const inc = parseOptionalNonNegativeIntString(body.includedUnits, "includedUnits");
+    const ovr = parseOptionalNonNegativeIntString(body.overageRateWei, "overageRateWei");
+    if (!inc.ok) return inc;
+    if (!ovr.ok) return ovr;
+    return { ok: true, value: { includedUnits: inc.value, overageRateWei: ovr.value } };
+  }
+  return { ok: true, value: { includedUnits: null, overageRateWei: null } };
+}
+
+function mergeBillingFieldForPut(
+  rawBody: unknown,
+  existing: string | null,
+  fieldName: string,
+): Ok<string | null> | Err {
+  if (rawBody === undefined) {
+    if (existing === null || existing === undefined) {
+      return { ok: true, value: null };
+    }
+    const t = String(existing).trim();
+    if (t === "") {
+      return { ok: true, value: null };
+    }
+    if (!isNonNegativeIntegerString(t)) {
+      return { ok: false, error: `${fieldName} must be a non-negative integer string` };
+    }
+    return { ok: true, value: t };
+  }
+  return parseOptionalNonNegativeIntString(rawBody, fieldName);
+}
+
+function resolveBillingFieldsForPut(
+  effectiveType: string,
+  body: Record<string, unknown>,
+  existing: { includedUnits: string | null; overageRateWei: string | null },
+): Ok<{ includedUnits: string | null; overageRateWei: string | null }> | Err {
+  if (effectiveType === "free") {
+    return { ok: true, value: { includedUnits: null, overageRateWei: null } };
+  }
+  if (effectiveType === "subscription") {
+    const inc = mergeBillingFieldForPut(body.includedUnits, existing.includedUnits, "includedUnits");
+    const ovr = mergeBillingFieldForPut(body.overageRateWei, existing.overageRateWei, "overageRateWei");
+    if (!inc.ok) return inc;
+    if (!ovr.ok) return ovr;
+    if (inc.value === null || ovr.value === null) {
+      return {
+        ok: false,
+        error: "includedUnits and overageRateWei are required for subscription plans",
+      };
+    }
+    return { ok: true, value: { includedUnits: inc.value, overageRateWei: ovr.value } };
+  }
+  if (effectiveType === "usage") {
+    const inc = mergeBillingFieldForPut(body.includedUnits, existing.includedUnits, "includedUnits");
+    const ovr = mergeBillingFieldForPut(body.overageRateWei, existing.overageRateWei, "overageRateWei");
+    if (!inc.ok) return inc;
+    if (!ovr.ok) return ovr;
+    return { ok: true, value: { includedUnits: inc.value, overageRateWei: ovr.value } };
+  }
+  return { ok: true, value: { includedUnits: null, overageRateWei: null } };
+}
+
+function parseCapabilities(input: unknown): Ok<PlanCapabilityInput[]> | Err {
+  if (input === undefined) {
+    return { ok: true, value: [] };
+  }
+  if (!Array.isArray(input)) {
+    return { ok: false, error: "capabilities must be an array" };
+  }
+
+  const capabilities = input.map((raw, index) => {
+    const value = (raw ?? {}) as Record<string, unknown>;
+    const pipeline = typeof value.pipeline === "string" ? value.pipeline.trim() : "";
+    const modelId = typeof value.modelId === "string" ? value.modelId.trim() : "";
+
+    if (!pipeline) {
+      throw new Error(`capabilities[${index}].pipeline is required`);
+    }
+    if (!modelId) {
+      throw new Error(`capabilities[${index}].modelId is required`);
+    }
+
+    const rawSlaTargetScore = value.slaTargetScore;
+    const rawSlaTargetP95Ms = value.slaTargetP95Ms;
+    const parsedSlaTargetScore =
+      rawSlaTargetScore === null || rawSlaTargetScore === undefined
+        ? null
+        : Number(rawSlaTargetScore);
+    const parsedSlaTargetP95Ms =
+      rawSlaTargetP95Ms === null || rawSlaTargetP95Ms === undefined
+        ? null
+        : Number(rawSlaTargetP95Ms);
+
+    if (parsedSlaTargetScore !== null && !Number.isFinite(parsedSlaTargetScore)) {
+      throw new Error(`capabilities[${index}].slaTargetScore must be numeric`);
+    }
+    if (parsedSlaTargetP95Ms !== null && !Number.isFinite(parsedSlaTargetP95Ms)) {
+      throw new Error(`capabilities[${index}].slaTargetP95Ms must be numeric`);
+    }
+
+    const rawUpcharge = value.upchargePercentBps;
+    let parsedUpchargeBps: number | null = null;
+    if (rawUpcharge !== null && rawUpcharge !== undefined) {
+      const n = typeof rawUpcharge === "number" ? rawUpcharge : Number(String(rawUpcharge).trim());
+      if (!Number.isInteger(n) || n < 0) {
+        throw new Error(
+          `capabilities[${index}].upchargePercentBps must be a non-negative integer`,
+        );
+      }
+      parsedUpchargeBps = n;
+    }
+
+    return {
+      pipeline,
+      modelId,
+      slaTargetScore: parsedSlaTargetScore,
+      slaTargetP95Ms: parsedSlaTargetP95Ms,
+      maxPricePerUnit:
+        value.maxPricePerUnit === null || value.maxPricePerUnit === undefined
+          ? null
+          : String(value.maxPricePerUnit),
+      upchargePercentBps: parsedUpchargeBps,
+    };
+  });
+
+  return { ok: true, value: capabilities };
+}
+
+function normalizeDiscoveryProfileId(raw: unknown): Ok<string | null | undefined> | Err {
+  if (raw === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (raw === null || raw === "") {
+    return { ok: true, value: null };
+  }
+  if (typeof raw === "string" && raw.trim()) {
+    return { ok: true, value: raw.trim() };
+  }
+  return { ok: false, error: "discoveryProfileId must be a non-empty string or null" };
+}
+
+function parseIncludedUsdMicrosForPost(raw: unknown): Ok<string | null> | Err {
+  if (raw === undefined || raw === null) {
+    return { ok: true, value: null };
+  }
+  const s = String(raw).trim();
+  if (s !== "" && !isNonNegativeIntegerString(s)) {
+    return { ok: false, error: "includedUsdMicros must be a non-negative integer string" };
+  }
+  return { ok: true, value: s || null };
+}
+
+function parseIncludedUsdMicrosForPut(raw: unknown): Ok<string | null | undefined> | Err {
+  if (raw === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (raw === null) {
+    return { ok: true, value: null };
+  }
+  const s = String(raw).trim();
+  if (s !== "" && !isNonNegativeIntegerString(s)) {
+    return { ok: false, error: "includedUsdMicros must be a non-negative integer string" };
+  }
+  return { ok: true, value: s || null };
+}
+
+export function parseCreatePlanInput(body: Record<string, unknown>): Ok<CreatePlanInput> | Err {
+  const name = String(body.name || "").trim();
+  if (!name) {
+    return { ok: false, error: "name is required" };
+  }
+
+  let capabilities: PlanCapabilityInput[];
+  try {
+    const parsed = parseCapabilities(body.capabilities);
+    if (!parsed.ok) return parsed;
+    capabilities = parsed.value;
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Invalid capabilities" };
+  }
+
+  const discoveryProfileId = normalizeDiscoveryProfileId(body.discoveryProfileId);
+  if (!discoveryProfileId.ok) return discoveryProfileId;
+
+  const type = String(body.type || "free");
+  const billing = resolveBillingFieldsForPost(type, body);
+  if (!billing.ok) return billing;
+
+  const generalUpcharge = parseOptionalNonNegativeBps(
+    body.generalUpchargePercentBps,
+    "generalUpchargePercentBps",
+  );
+  if (!generalUpcharge.ok) return generalUpcharge;
+  const payPerUseUpcharge = parseOptionalNonNegativeBps(
+    body.payPerUseUpchargePercentBps,
+    "payPerUseUpchargePercentBps",
+  );
+  if (!payPerUseUpcharge.ok) return payPerUseUpcharge;
+  const includedUsdMicros = parseIncludedUsdMicrosForPost(body.includedUsdMicros);
+  if (!includedUsdMicros.ok) return includedUsdMicros;
+
+  return {
+    ok: true,
+    value: {
+      name,
+      type,
+      priceAmount: String(body.priceAmount || "0"),
+      priceCurrency: String(body.priceCurrency || "USD"),
+      status: String(body.status || "active"),
+      includedUnits: billing.value.includedUnits,
+      overageRateWei: billing.value.overageRateWei,
+      includedUsdMicros: includedUsdMicros.value,
+      generalUpchargePercentBps: generalUpcharge.value,
+      payPerUseUpchargePercentBps: payPerUseUpcharge.value,
+      billingCycle: typeof body.billingCycle === "string" ? body.billingCycle : "monthly",
+      discoveryProfileId: discoveryProfileId.value ?? null,
+      capabilities,
+    },
+  };
+}
+
+export function parseUpdatePlanInput(
+  body: Record<string, unknown>,
+  existing: { type: string; includedUnits: string | null; overageRateWei: string | null },
+): Ok<UpdatePlanInput> | Err {
+  if (!body || typeof body.id !== "string" || !body.id.trim()) {
+    return { ok: false, error: "id is required and must be a string" };
+  }
+
+  const discoveryProfileId = normalizeDiscoveryProfileId(body.discoveryProfileId);
+  if (!discoveryProfileId.ok) return discoveryProfileId;
+
+  let capabilities: PlanCapabilityInput[] | undefined;
+  if (body.capabilities !== undefined) {
+    try {
+      const parsed = parseCapabilities(body.capabilities);
+      if (!parsed.ok) return parsed;
+      capabilities = parsed.value;
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : "Invalid capabilities" };
+    }
+  }
+
+  const nextType = body.type !== undefined ? String(body.type) : existing.type;
+  const billing = resolveBillingFieldsForPut(nextType, body, existing);
+  if (!billing.ok) return billing;
+
+  const generalUpcharge = parseOptionalNonNegativeBps(
+    body.generalUpchargePercentBps,
+    "generalUpchargePercentBps",
+  );
+  if (!generalUpcharge.ok) return generalUpcharge;
+  const payPerUseUpcharge = parseOptionalNonNegativeBps(
+    body.payPerUseUpchargePercentBps,
+    "payPerUseUpchargePercentBps",
+  );
+  if (!payPerUseUpcharge.ok) return payPerUseUpcharge;
+  const includedUsdMicros = parseIncludedUsdMicrosForPut(body.includedUsdMicros);
+  if (!includedUsdMicros.ok) return includedUsdMicros;
+
+  const value: UpdatePlanInput = {
+    id: String(body.id),
+    type: nextType,
+    includedUnits: billing.value.includedUnits,
+    overageRateWei: billing.value.overageRateWei,
+  };
+
+  if (body.name !== undefined) value.name = String(body.name);
+  if (body.priceAmount !== undefined) value.priceAmount = String(body.priceAmount);
+  if (body.priceCurrency !== undefined) value.priceCurrency = String(body.priceCurrency);
+  if (body.status !== undefined) value.status = String(body.status);
+  if (body.generalUpchargePercentBps !== undefined) {
+    value.generalUpchargePercentBps = generalUpcharge.value;
+  }
+  if (body.payPerUseUpchargePercentBps !== undefined) {
+    value.payPerUseUpchargePercentBps = payPerUseUpcharge.value;
+  }
+  if (includedUsdMicros.value !== undefined) {
+    value.includedUsdMicros = includedUsdMicros.value;
+  }
+  if (body.billingCycle !== undefined) value.billingCycle = String(body.billingCycle);
+  if (discoveryProfileId.value !== undefined) value.discoveryProfileId = discoveryProfileId.value;
+  if (capabilities !== undefined) value.capabilities = capabilities;
+
+  return { ok: true, value };
+}

--- a/src/domains/plans-discovery/types/discovery-profiles.ts
+++ b/src/domains/plans-discovery/types/discovery-profiles.ts
@@ -1,0 +1,19 @@
+import type { DiscoveryPolicy } from "@/shared/discovery/discovery-plans";
+
+export interface DiscoveryProfileCapabilityInput {
+  pipeline: string;
+  modelId: string;
+  discoveryPolicy: DiscoveryPolicy | null;
+}
+
+export interface CreateDiscoveryProfileInput {
+  name: string;
+  policy: DiscoveryPolicy | null;
+  capabilities: DiscoveryProfileCapabilityInput[];
+}
+
+export interface UpdateDiscoveryProfileInput {
+  name: string;
+  policy?: DiscoveryPolicy | null;
+  capabilities?: DiscoveryProfileCapabilityInput[];
+}

--- a/src/domains/plans-discovery/types/plans.ts
+++ b/src/domains/plans-discovery/types/plans.ts
@@ -1,0 +1,41 @@
+export interface PlanCapabilityInput {
+  pipeline: string;
+  modelId: string;
+  slaTargetScore: number | null;
+  slaTargetP95Ms: number | null;
+  maxPricePerUnit: string | null;
+  upchargePercentBps: number | null;
+}
+
+export interface CreatePlanInput {
+  name: string;
+  type: string;
+  priceAmount: string;
+  priceCurrency: string;
+  status: string;
+  includedUnits: string | null;
+  overageRateWei: string | null;
+  includedUsdMicros: string | null;
+  generalUpchargePercentBps: number | null;
+  payPerUseUpchargePercentBps: number | null;
+  billingCycle: string;
+  discoveryProfileId: string | null;
+  capabilities: PlanCapabilityInput[];
+}
+
+export interface UpdatePlanInput {
+  id: string;
+  name?: string;
+  type?: string;
+  priceAmount?: string;
+  priceCurrency?: string;
+  status?: string;
+  includedUnits?: string | null;
+  overageRateWei?: string | null;
+  includedUsdMicros?: string | null;
+  generalUpchargePercentBps?: number | null;
+  payPerUseUpchargePercentBps?: number | null;
+  billingCycle?: string;
+  discoveryProfileId?: string | null;
+  capabilities?: PlanCapabilityInput[];
+}

--- a/src/domains/signer-runtime/repo/admin-auth.ts
+++ b/src/domains/signer-runtime/repo/admin-auth.ts
@@ -1,0 +1,8 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { users } from "@/db/schema";
+
+export async function getUserById(id: string) {
+  const rows = await db.select().from(users).where(eq(users.id, id)).limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/signer-runtime/repo/signer-admin-page.ts
+++ b/src/domains/signer-runtime/repo/signer-admin-page.ts
@@ -1,0 +1,10 @@
+import { db } from "@/db/index";
+import { streamSessions, transactions } from "@/db/schema";
+
+export async function listSignerStreamSessions() {
+  return db.select().from(streamSessions);
+}
+
+export async function listSignerTransactionIds() {
+  return db.select({ id: transactions.id }).from(transactions);
+}

--- a/src/domains/signer-runtime/repo/signer-config.ts
+++ b/src/domains/signer-runtime/repo/signer-config.ts
@@ -1,0 +1,12 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { signerConfig } from "@/db/schema";
+
+export async function getDefaultSignerConfig() {
+  const rows = await db.select().from(signerConfig).where(eq(signerConfig.id, "default")).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function updateDefaultSignerConfig(updates: Record<string, unknown>) {
+  await db.update(signerConfig).set(updates).where(eq(signerConfig.id, "default"));
+}

--- a/src/domains/signer-runtime/repo/signer-payments.ts
+++ b/src/domains/signer-runtime/repo/signer-payments.ts
@@ -1,0 +1,88 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import {
+  planCapabilityBundles,
+  plans,
+  streamSessions,
+  transactions,
+  usageBillingEvents,
+  usageRecords,
+} from "@/db/schema";
+
+export async function getActiveStreamSessionByManifestId(manifestId: string) {
+  const rows = await db
+    .select()
+    .from(streamSessions)
+    .where(and(eq(streamSessions.manifestId, manifestId), eq(streamSessions.status, "active")))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function createStreamSession(values: typeof streamSessions.$inferInsert) {
+  await db.insert(streamSessions).values(values);
+}
+
+export async function findExistingUsageRecord(params: {
+  clientId: string;
+  requestId: string;
+}) {
+  const rows = await db
+    .select()
+    .from(usageRecords)
+    .where(and(eq(usageRecords.clientId, params.clientId), eq(usageRecords.requestId, params.requestId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getLatestActivePlanWithBundles(clientId: string) {
+  const planRows = await db
+    .select()
+    .from(plans)
+    .where(and(eq(plans.clientId, clientId), eq(plans.status, "active")))
+    .orderBy(desc(plans.updatedAt))
+    .limit(1);
+  const plan = planRows[0] ?? null;
+  if (!plan) return { plan: null, bundles: [] };
+
+  const bundles = await db
+    .select()
+    .from(planCapabilityBundles)
+    .where(and(eq(planCapabilityBundles.planId, plan.id), eq(planCapabilityBundles.clientId, clientId)));
+  return { plan, bundles };
+}
+
+export async function recordSignerPaymentLedger(params: {
+  streamSessionId: string | null;
+  feeWei: bigint;
+  nowIso: string;
+  pricePerUnit: bigint;
+  pixelsPerUnit: bigint;
+  transaction: typeof transactions.$inferInsert;
+  usageRecord?: typeof usageRecords.$inferInsert;
+  usageBillingEvent?: typeof usageBillingEvents.$inferInsert;
+}) {
+  await db.transaction(async (tx) => {
+    if (params.streamSessionId) {
+      await tx
+        .update(streamSessions)
+        .set({
+          signerPaymentCount: sql`${streamSessions.signerPaymentCount} + 1`,
+          totalFeeWei: sql`(${streamSessions.totalFeeWei}::numeric + ${params.feeWei.toString()}::numeric)::bigint::text`,
+          lastPaymentAt: params.nowIso,
+          pricePerUnit: params.pricePerUnit.toString(),
+          pixelsPerUnit: params.pixelsPerUnit.toString(),
+        })
+        .where(eq(streamSessions.id, params.streamSessionId));
+    }
+
+    await tx.insert(transactions).values(params.transaction);
+
+    if (params.usageRecord) {
+      await tx.insert(usageRecords).values(params.usageRecord);
+    }
+
+    if (params.usageBillingEvent) {
+      await tx.insert(usageBillingEvents).values(params.usageBillingEvent);
+    }
+  });
+}

--- a/src/domains/signer-runtime/repo/signer-routing.ts
+++ b/src/domains/signer-runtime/repo/signer-routing.ts
@@ -1,0 +1,75 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import {
+  appUsers,
+  developerApps,
+  endUsers,
+  oidcClients,
+  signerConfig,
+} from "@/db/schema";
+
+export async function getDefaultSigner() {
+  const rows = await db.select().from(signerConfig).where(eq(signerConfig.id, "default")).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function resolveDeveloperAppIdFromAuthAppId(
+  authAppId: string | null | undefined,
+): Promise<string | null> {
+  if (!authAppId?.trim()) return null;
+  const trimmed = authAppId.trim();
+
+  const rows = await db
+    .select({ id: developerApps.id })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, trimmed))
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
+
+export async function resolveUsageUserIdentifier(params: {
+  auth: {
+    userId: string | null;
+    endUserId: string | null;
+  };
+  providerAppId: string | null;
+}): Promise<string | null> {
+  const { auth, providerAppId } = params;
+  if (!providerAppId) return auth.userId || auth.endUserId || null;
+
+  if (auth.endUserId) {
+    const rows = await db
+      .select({ externalUserId: endUsers.externalUserId })
+      .from(endUsers)
+      .where(and(eq(endUsers.id, auth.endUserId), eq(endUsers.appId, providerAppId)))
+      .limit(1);
+    return rows[0]?.externalUserId || auth.endUserId;
+  }
+
+  if (auth.userId) {
+    const rows = await db
+      .select({ externalUserId: appUsers.externalUserId })
+      .from(appUsers)
+      .where(and(eq(appUsers.id, auth.userId), eq(appUsers.clientId, providerAppId)))
+      .limit(1);
+    return rows[0]?.externalUserId || auth.userId;
+  }
+
+  return null;
+}
+
+export async function readSignerAppApproval(authAppId: string) {
+  const trimmed = authAppId.trim();
+  const rows = await db
+    .select({
+      id: developerApps.id,
+      status: developerApps.status,
+      ownerId: developerApps.ownerId,
+    })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, trimmed))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/domains/signer-runtime/runtime/admin-auth.ts
+++ b/src/domains/signer-runtime/runtime/admin-auth.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/platform/auth/next-auth-options";
+import { authenticateRequest, hasScope } from "@/domains/identity-access/runtime/request-auth";
+import { getUserById } from "../repo/admin-auth";
+
+export async function getSignerAdminUser(request: NextRequest) {
+  const oauthSession = await getServerSession(authOptions);
+  if (oauthSession?.user) {
+    const sessionUser = oauthSession.user as Record<string, unknown>;
+    if (sessionUser.id) {
+      const user = await getUserById(sessionUser.id as string);
+      if (user?.role === "admin") return user;
+    }
+  }
+
+  const auth = await authenticateRequest(request);
+  if (auth && hasScope(auth.scopes, "admin") && auth.userId) {
+    const user = await getUserById(auth.userId);
+    if (user?.role === "admin") return user;
+  }
+
+  return null;
+}

--- a/src/domains/signer-runtime/runtime/health.ts
+++ b/src/domains/signer-runtime/runtime/health.ts
@@ -1,0 +1,23 @@
+import { getDefaultSigner } from "../repo/signer-routing";
+import { getSignerUrl, probeSignerHttpReachability } from "./signer-status";
+
+export async function getHealthStatus() {
+  const signer = await getDefaultSigner();
+  let signerReachable = false;
+  try {
+    const probe = await probeSignerHttpReachability(getSignerUrl(signer));
+    signerReachable = probe.reachable;
+  } catch {}
+
+  return {
+    status: "ok" as const,
+    timestamp: new Date().toISOString(),
+    version: "0.1.0",
+    database: "connected" as const,
+    signer: {
+      status: signer?.status || "unknown",
+      reachable: signerReachable,
+      ethAddress: signer?.ethAddress || null,
+    },
+  };
+}

--- a/src/domains/signer-runtime/runtime/signer-admin-page.ts
+++ b/src/domains/signer-runtime/runtime/signer-admin-page.ts
@@ -1,0 +1,59 @@
+import {
+  ACTIVE_STREAM_PAYMENT_WINDOW_MINUTES,
+  countActiveStreamsByRecentPayment,
+} from "@/platform/ops/active-streams";
+import {
+  getIssuer,
+  getJwksUrlForLocalSignerDmzContainer,
+} from "@/platform/oidc/issuer-urls";
+import { resolveDmzHostPort } from "@/platform/signer/dmz-host-port";
+import { getDefaultSignerConfig } from "../repo/signer-config";
+import { listSignerStreamSessions, listSignerTransactionIds } from "../repo/signer-admin-page";
+import { getSignerUrl } from "./signer-status";
+
+export { ACTIVE_STREAM_PAYMENT_WINDOW_MINUTES };
+
+export function formatSignerWei(wei: string | null): string {
+  if (!wei || wei === "0") return "0 WEI";
+  const value = BigInt(wei);
+  const eth = Number(value) / 1e18;
+  if (eth < 0.001) return `${wei} WEI`;
+  return `${eth.toFixed(6)} ETH`;
+}
+
+export async function getSignerAdminPageData() {
+  const signer = await getDefaultSignerConfig();
+  if (!signer) {
+    return null;
+  }
+
+  const [activeStreamCount, allSessions, allTxns] = await Promise.all([
+    countActiveStreamsByRecentPayment(),
+    listSignerStreamSessions(),
+    listSignerTransactionIds(),
+  ]);
+
+  let totalFeeWei = 0n;
+  for (const session of allSessions) {
+    totalFeeWei += BigInt(session.totalFeeWei);
+  }
+
+  const oidcIssuer = getIssuer();
+  return {
+    signer,
+    activeStreamCount,
+    allSessions,
+    allTxns,
+    totalFeeWei,
+    oidcIssuer,
+    oidcAudience: oidcIssuer,
+    oidcJwksUrl: getJwksUrlForLocalSignerDmzContainer(),
+    dmzHostPort: resolveDmzHostPort(signer.signerPort),
+    effectiveSignerUrl: getSignerUrl(signer),
+    signerUrlSource: (signer.signerUrl
+      ? "saved"
+      : process.env.SIGNER_INTERNAL_URL
+        ? "env"
+        : "default") as "default" | "saved" | "env",
+  };
+}

--- a/src/domains/signer-runtime/runtime/signer-admin.ts
+++ b/src/domains/signer-runtime/runtime/signer-admin.ts
@@ -1,0 +1,263 @@
+import type { NextRequest } from "next/server";
+import { spawn } from "child_process";
+import { DOCKER_COMPOSE_LOCAL_SIGNER_SERVICE } from "@/platform/signer/local-compose";
+import { fetchSignerCliStatus } from "@/platform/signer/cli";
+import {
+  getIssuer,
+  getJwksUrlForLocalSignerDmzContainer,
+  getPublicOrigin,
+} from "@/platform/oidc/issuer-urls";
+import { resolveDmzHostPort } from "@/platform/signer/dmz-host-port";
+import {
+  getDefaultSignerConfig,
+  updateDefaultSignerConfig,
+} from "../repo/signer-config";
+import { parseSignerConfigUpdate, parseTail } from "../service/signer-config";
+import { syncSignerStatus } from "./signer-status";
+
+const COMPOSE_START_TIMEOUT_MS = 15 * 60 * 1000;
+const LOG_FETCH_TIMEOUT_MS = 10000;
+
+function runShellWithStreamingOutput(options: {
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+}): Promise<{ stdout: string; stderr: string }> {
+  const { command, cwd, env, timeoutMs } = options;
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, {
+      cwd,
+      env,
+      shell: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      const forceKill = setTimeout(() => child.kill("SIGKILL"), 10_000);
+      forceKill.unref?.();
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      if (timedOut) return reject(new Error(`docker compose timed out after ${timeoutMs}ms`));
+      if (signal) return reject(new Error(`docker compose exited via signal ${signal}`));
+      if (code !== 0) {
+        return reject(
+          new Error((stderr || stdout || "").trim() || `docker compose failed (exit ${code ?? "unknown"})`),
+        );
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function getComposeCommand(action: string): string {
+  const svc = DOCKER_COMPOSE_LOCAL_SIGNER_SERVICE;
+  switch (action) {
+    case "start":
+    case "restart":
+      return `docker compose up -d --build --force-recreate --remove-orphans ${svc}`;
+    case "stop":
+      return `docker compose stop ${svc}`;
+    default:
+      throw new Error(`Unknown action: ${action}`);
+  }
+}
+
+function buildSignerComposeEnv(
+  signer:
+    | {
+        ethRpcUrl: string;
+        ethAcctAddr: string | null;
+        signerPort: number;
+        remoteDiscovery: number;
+        orchWebhookUrl: string | null;
+        liveAICapReportInterval: string | null;
+      }
+    | null,
+): NodeJS.ProcessEnv {
+  const rd = signer?.remoteDiscovery === 1;
+  const dmzHostPort = resolveDmzHostPort(signer?.signerPort);
+  const issuer = getIssuer();
+  return {
+    ...process.env,
+    NEXTAUTH_URL: process.env.NEXTAUTH_URL || getPublicOrigin(),
+    SIGNER_NETWORK: "arbitrum-one-mainnet",
+    ETH_RPC_URL: signer?.ethRpcUrl ?? "",
+    SIGNER_ETH_ADDR: signer?.ethAcctAddr || "",
+    SIGNER_DMZ_HOST_PORT: String(dmzHostPort),
+    SIGNER_REMOTE_DISCOVERY: rd ? "1" : "0",
+    ORCH_WEBHOOK_URL: rd && signer?.orchWebhookUrl ? signer.orchWebhookUrl : "",
+    LIVE_AI_CAP_REPORT_INTERVAL:
+      rd && signer?.liveAICapReportInterval ? signer.liveAICapReportInterval : "",
+    OIDC_ISSUER: issuer,
+    OIDC_AUDIENCE: issuer,
+    JWKS_URI: getJwksUrlForLocalSignerDmzContainer(),
+  };
+}
+
+export async function readSignerStatus() {
+  const liveStatus = await syncSignerStatus();
+  const signer = await getDefaultSignerConfig();
+  return {
+    signer,
+    live: {
+      reachable: liveStatus.reachable,
+      ethAddress: liveStatus.ethAddress,
+    },
+  };
+}
+
+export async function updateSignerStatusConfig(body: Record<string, unknown>) {
+  const current = await getDefaultSignerConfig();
+  const parsed = parseSignerConfigUpdate({ body, current: current ?? undefined });
+  if (!parsed.ok) return parsed;
+
+  await updateDefaultSignerConfig(parsed.updates);
+  const updated = await getDefaultSignerConfig();
+  return {
+    ok: true as const,
+    body: {
+      signer: updated,
+      message: "Config updated. Restart the signer for changes to take effect.",
+    },
+  };
+}
+
+export async function controlSigner(body: Record<string, unknown>) {
+  const action = typeof body.action === "string" ? body.action : "";
+  const validActions = ["start", "stop", "restart", "sync"] as const;
+  if (!validActions.includes(action as (typeof validActions)[number])) {
+    return {
+      ok: false as const,
+      status: 400,
+      body: { error: `Invalid action. Must be one of: ${validActions.join(", ")}` },
+    };
+  }
+
+  try {
+    if (action === "sync") {
+      const result = await syncSignerStatus();
+      return {
+        ok: true as const,
+        body: {
+          action: "sync",
+          success: true,
+          reachable: result.reachable,
+          ethAddress: result.ethAddress,
+        },
+      };
+    }
+
+    const signer = await getDefaultSignerConfig();
+    const composeEnv = buildSignerComposeEnv(signer);
+    const timeoutMs = action === "start" || action === "restart" ? COMPOSE_START_TIMEOUT_MS : 30000;
+    const { stdout, stderr } = await runShellWithStreamingOutput({
+      command: getComposeCommand(action),
+      cwd: process.cwd(),
+      env: composeEnv,
+      timeoutMs,
+    });
+
+    const now = new Date().toISOString();
+    if (action === "stop") {
+      await updateDefaultSignerConfig({ status: "stopped" });
+    } else {
+      await updateDefaultSignerConfig({ status: "running", lastStartedAt: now, lastError: null });
+      setTimeout(async () => {
+        await syncSignerStatus();
+      }, 3000);
+    }
+
+    return {
+      ok: true as const,
+      body: {
+        action,
+        success: true,
+        output: stdout || stderr || "OK",
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    await updateDefaultSignerConfig({ status: "error", lastError: message });
+    return {
+      ok: false as const,
+      status: 500,
+      body: { action, success: false, error: message },
+    };
+  }
+}
+
+export async function readSignerLogs(request: NextRequest) {
+  try {
+    const responseTail = parseTail(request.nextUrl.searchParams.get("tail"));
+    const child = spawn(
+      "docker",
+      ["compose", "logs", "--no-color", "--tail", String(1000), DOCKER_COMPOSE_LOCAL_SIGNER_SERVICE],
+      { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const result = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      const timeout = setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error("Timed out while fetching signer logs"));
+      }, LOG_FETCH_TIMEOUT_MS);
+      child.on("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.on("close", (code, signal) => {
+        clearTimeout(timeout);
+        if (code === 0) return resolve({ stdout, stderr });
+        const details =
+          stderr.trim() ||
+          stdout.trim() ||
+          (code === null && signal
+            ? `docker compose logs terminated by signal ${signal}`
+            : `docker compose logs exited with code ${String(code)}`);
+        reject(new Error(details));
+      });
+    });
+
+    const raw = result.stdout && result.stderr ? `${result.stdout}\n${result.stderr}` : `${result.stdout}${result.stderr}`;
+    const lines = raw
+      .split("\n")
+      .map((line) => line.replace(/^[a-z0-9._-]+-\d+\s+\|\s*/i, ""))
+      .filter((line) => line.trim())
+      .slice(-responseTail);
+    return { lines, count: lines.length };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch logs";
+    return { lines: [message], count: 1, error: true };
+  }
+}
+
+export async function readSignerCliStatus() {
+  return fetchSignerCliStatus();
+}

--- a/src/domains/signer-runtime/runtime/signer-forwarding.ts
+++ b/src/domains/signer-runtime/runtime/signer-forwarding.ts
@@ -1,0 +1,108 @@
+import type { AuthResult } from "@/domains/identity-access/runtime/request-auth";
+import { issueSignerDmzToken } from "@/platform/signer/dmz-token";
+import { formatDmzTokenForLog, getSignerUrl } from "./signer-status";
+
+const httpDmzTokenCache = new Map<string, { token: string; expMs: number }>();
+const HTTP_DMZ_TOKEN_MAX_ENTRIES = 100;
+const HTTP_DMZ_TOKEN_TTL_MS = 3.5 * 60 * 1000;
+
+export interface ProxyResult {
+  status: number;
+  body: unknown;
+}
+
+interface ForwardToSignerResult {
+  response: Response;
+  requestUrl: string;
+  authorizationHeader?: string;
+}
+
+async function getHttpDmzBearerForSubject(subject: string): Promise<string> {
+  const now = Date.now();
+  const cached = httpDmzTokenCache.get(subject);
+  if (cached && cached.expMs > now + 15_000) {
+    httpDmzTokenCache.delete(subject);
+    httpDmzTokenCache.set(subject, cached);
+    return cached.token;
+  }
+
+  const token = await issueSignerDmzToken({ gate: "http", subject });
+  httpDmzTokenCache.set(subject, { token, expMs: now + HTTP_DMZ_TOKEN_TTL_MS });
+
+  if (httpDmzTokenCache.size > HTTP_DMZ_TOKEN_MAX_ENTRIES) {
+    const oldest = httpDmzTokenCache.keys().next().value;
+    if (oldest !== undefined) httpDmzTokenCache.delete(oldest);
+  }
+
+  return token;
+}
+
+export async function forwardToSigner(params: {
+  signer: { signerPort: number; signerUrl: string | null } | null | undefined;
+  path: string;
+  method: string;
+  body: unknown | undefined;
+  auth: AuthResult;
+}): Promise<ForwardToSignerResult> {
+  const url = `${getSignerUrl(params.signer)}${params.path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (process.env.SIGNER_DMZ_FORWARD_JWT !== "false") {
+    const sub =
+      params.auth.endUserId || params.auth.userId || params.auth.appId || params.auth.sessionId;
+    const token = await getHttpDmzBearerForSubject(sub);
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: params.method,
+      headers,
+      body: params.body !== undefined ? JSON.stringify(params.body) : undefined,
+      signal: controller.signal,
+    });
+    return {
+      response,
+      requestUrl: url,
+      authorizationHeader: headers.Authorization,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function readSignerUpstreamBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text.trim()) return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return {
+      error: "Signer DMZ returned a non-JSON body (often Apache auth failure)",
+      upstreamStatus: response.status,
+      detail: text.slice(0, 800),
+    };
+  }
+}
+
+export function logSignerDmzFailure(params: {
+  route: string;
+  response: Response;
+  requestUrl: string;
+  authorizationHeader?: string;
+  responseBody: unknown;
+}) {
+  if (params.response.status !== 401 && params.response.status !== 403) return;
+
+  console.error(`[proxy] ${params.route} signer DMZ ${params.response.status}`, {
+    upstream_url: params.requestUrl,
+    upstream_content_type: params.response.headers.get("content-type") ?? null,
+    upstream_www_authenticate: params.response.headers.get("www-authenticate") ?? null,
+    dmz_token: formatDmzTokenForLog(params.authorizationHeader),
+    body_preview:
+      typeof params.responseBody === "object" && params.responseBody !== null
+        ? JSON.stringify(params.responseBody).slice(0, 500)
+        : String(params.responseBody).slice(0, 500),
+  });
+}

--- a/src/domains/signer-runtime/runtime/signer-payments.ts
+++ b/src/domains/signer-runtime/runtime/signer-payments.ts
@@ -1,0 +1,307 @@
+import { v4 as uuidv4 } from "uuid";
+import type { AuthResult } from "@/domains/identity-access/runtime/request-auth";
+import {
+  buildSignedTicketConstraintHash,
+  computeUsdMicrosFromWei,
+  resolveGatewayAttribution,
+  resolvePaymentPipelineModelConstraint,
+  resolveUpcharge,
+} from "@/domains/usage-billing/service/billing-runtime";
+import {
+  calculateFeeWei,
+  calculateLv2vPixels,
+  calculatePlatformCut,
+  decodeOrchestratorInfo,
+} from "@/platform/livepeer/proto";
+import { getEthUsdOracle } from "@/platform/ops/prices/eth-usd-oracle";
+import {
+  createStreamSession,
+  findExistingUsageRecord,
+  getActiveStreamSessionByManifestId,
+  getLatestActivePlanWithBundles,
+  recordSignerPaymentLedger,
+} from "../repo/signer-payments";
+import { readSignerAppApproval, resolveUsageUserIdentifier } from "../repo/signer-routing";
+import { parseSignerPaymentRequest } from "../service/signer-payment";
+import { forwardToSigner, readSignerUpstreamBody, type ProxyResult } from "./signer-forwarding";
+import { getSignerRoutingContext } from "./signer-routing";
+
+export async function assertSignerAppApproved(auth: AuthResult) {
+  if (!auth.appId?.trim()) {
+    return { ok: true as const };
+  }
+
+  const app = await readSignerAppApproval(auth.appId);
+  if (app && app.status !== "approved") {
+    if (auth.userId !== app.ownerId) {
+      return {
+        ok: false as const,
+        status: 403,
+        body: {
+          error: "app_not_approved",
+          error_description:
+            "This application has not been approved and cannot process live payments",
+        },
+      };
+    }
+
+    console.warn(
+      `[api] generate-live-payment: unapproved app ${app.id} accessed by owner ${auth.userId} (status: ${app.status})`,
+    );
+  }
+
+  return { ok: true as const };
+}
+
+export async function proxyGenerateLivePayment(
+  requestBody: Record<string, unknown>,
+  auth: AuthResult,
+): Promise<ProxyResult> {
+  const { signer, providerAppId } = await getSignerRoutingContext(auth.appId);
+  if (!signer || signer.status !== "running") {
+    return { status: 503, body: { error: "Signer is not running" } };
+  }
+
+  const parsed = parseSignerPaymentRequest(requestBody);
+  if (!parsed.ok) {
+    return { status: 400, body: { error: parsed.message } };
+  }
+
+  const {
+    manifestId,
+    inPixels,
+    preloadSeconds,
+    jobType,
+    orchestratorData,
+  } = parsed.value;
+  const normalizedJobType = jobType?.trim().toLowerCase();
+
+  let pricePerUnit = 0n;
+  let pixelsPerUnit = 1n;
+  let orchestratorAddress: string | undefined;
+
+  if (orchestratorData) {
+    try {
+      const orchInfo = await decodeOrchestratorInfo(orchestratorData);
+      if (orchInfo.priceInfo) {
+        pricePerUnit = BigInt(orchInfo.priceInfo.pricePerUnit);
+        pixelsPerUnit = BigInt(orchInfo.priceInfo.pixelsPerUnit || 1);
+      }
+      if (orchInfo.address) {
+        orchestratorAddress = `0x${Buffer.from(orchInfo.address).toString("hex")}`;
+      }
+    } catch (err) {
+      console.warn("[proxy] Failed to decode OrchestratorInfo:", err);
+    }
+  }
+
+  let pixels: bigint;
+  if (inPixels && inPixels > 0) {
+    pixels = BigInt(inPixels);
+  } else if (normalizedJobType === "lv2v") {
+    pixels = calculateLv2vPixels(1);
+  } else if (normalizedJobType === "byoc" && preloadSeconds && preloadSeconds > 0) {
+    pixels = BigInt(Math.ceil(preloadSeconds));
+  } else {
+    pixels = 0n;
+  }
+
+  const feeWei = calculateFeeWei(pixels, pricePerUnit, pixelsPerUnit);
+  const platformCutWei = calculatePlatformCut(feeWei, signer.defaultCutPercent);
+  const usageUserId = await resolveUsageUserIdentifier({ auth, providerAppId });
+  const nowIso = new Date().toISOString();
+  let streamSessionId: string | null = null;
+
+  if (manifestId) {
+    const existingSession = await getActiveStreamSessionByManifestId(manifestId);
+    if (existingSession) {
+      streamSessionId = existingSession.id;
+    } else {
+      streamSessionId = uuidv4();
+      await createStreamSession({
+        id: streamSessionId,
+        endUserId: auth.endUserId || null,
+        appId: providerAppId ?? auth.appId ?? null,
+        bearerTokenHash: auth.tokenHash,
+        manifestId,
+        orchestratorAddress,
+        signerPaymentCount: 0,
+        totalFeeWei: "0",
+        pricePerUnit: pricePerUnit.toString(),
+        pixelsPerUnit: pixelsPerUnit.toString(),
+        status: "active",
+        lastPaymentAt: null,
+      });
+    }
+  }
+
+  const constraint = await resolvePaymentPipelineModelConstraint(requestBody);
+  const attribution = resolveGatewayAttribution(requestBody);
+
+  try {
+    const result = await forwardToSigner({
+      signer,
+      path: "/generate-live-payment",
+      method: "POST",
+      body: requestBody,
+      auth,
+    });
+    const responseBody = await readSignerUpstreamBody(result.response);
+
+    if (result.response.ok) {
+      const orchAddrForConstraint =
+        orchestratorAddress && orchestratorAddress.length > 0 ? orchestratorAddress : "0x";
+      const signedPriceStr = pricePerUnit.toString();
+      const signedPixelsStr = pixelsPerUnit.toString();
+      const pipelineModelConstraintHash =
+        constraint !== null
+          ? buildSignedTicketConstraintHash({
+              pipeline: constraint.pipeline,
+              modelId: constraint.modelId,
+              orchAddress: orchAddrForConstraint,
+              signedPriceWeiPerUnit: signedPriceStr,
+              signedPixelsPerUnit: signedPixelsStr,
+            })
+          : null;
+
+      const priceValidationStatus = constraint ? "matched" : "missing_constraint";
+      const priceValidationReason = constraint
+        ? undefined
+        : "No pipeline/model in request (add pipeline and modelId or capabilities with PerCapability models) for full attribution.";
+
+      const rawReq =
+        (typeof requestBody.requestId === "string" && requestBody.requestId.trim()) ||
+        (typeof requestBody.RequestID === "string" && requestBody.RequestID.trim());
+      const requestId = rawReq || uuidv4();
+
+      const existingUsage =
+        providerAppId ? await findExistingUsageRecord({ clientId: providerAppId, requestId }) : null;
+
+      if (!existingUsage) {
+        const ethUsd = await getEthUsdOracle();
+        const networkFeeUsdMicros = computeUsdMicrosFromWei(feeWei, ethUsd.priceUsd);
+        const ownerChargeWei = feeWei + platformCutWei;
+        const ownerPlatformFeeUsdMicros = computeUsdMicrosFromWei(platformCutWei, ethUsd.priceUsd);
+        const ownerChargeUsdMicros = computeUsdMicrosFromWei(ownerChargeWei, ethUsd.priceUsd);
+
+        let upchargeResult: {
+          bps: number;
+          source: "pipeline_model" | "general" | "pay_per_use" | "subscription_included" | "unpriced";
+        } = { bps: 0, source: "unpriced" };
+        if (providerAppId && constraint) {
+          try {
+            const planState = await getLatestActivePlanWithBundles(providerAppId);
+            upchargeResult = resolveUpcharge({
+              plan: planState.plan,
+              bundles: planState.bundles,
+              pipeline: constraint.pipeline,
+              modelId: constraint.modelId,
+            });
+          } catch (err) {
+            console.warn("[proxy] Plan upcharge lookup failed:", err);
+          }
+        }
+
+        const endUserBillableUsdMicros =
+          upchargeResult.bps > 0
+            ? networkFeeUsdMicros + (networkFeeUsdMicros * BigInt(upchargeResult.bps)) / 10000n
+            : networkFeeUsdMicros;
+
+        const transactionId = uuidv4();
+        const usageRecordId = uuidv4();
+
+        await recordSignerPaymentLedger({
+          streamSessionId,
+          feeWei,
+          nowIso,
+          pricePerUnit,
+          pixelsPerUnit,
+          transaction: {
+            id: transactionId,
+            endUserId: auth.endUserId || null,
+            appId: providerAppId ?? auth.appId ?? null,
+            clientId: providerAppId,
+            streamSessionId,
+            type: "usage",
+            amountWei: feeWei.toString(),
+            platformCutPercent: signer.defaultCutPercent,
+            platformCutWei: platformCutWei.toString(),
+            status: "confirmed",
+            pipeline: constraint?.pipeline ?? null,
+            modelId: constraint?.modelId ?? null,
+            attributionSource: attribution.attributionSource,
+            gatewayRequestId: attribution.gatewayRequestId,
+            paymentMetadataVersion: attribution.paymentMetadataVersion,
+            pipelineModelConstraintHash,
+            advertisedPriceWeiPerUnit: constraint ? signedPriceStr : null,
+            advertisedPixelsPerUnit: constraint ? signedPixelsStr : null,
+            signedPriceWeiPerUnit: pricePerUnit.toString(),
+            signedPixelsPerUnit: pixelsPerUnit.toString(),
+            priceValidationStatus,
+            priceValidationReason: priceValidationReason ?? null,
+            ethUsdPrice: ethUsd.priceUsd.toString(),
+            ethUsdSource: ethUsd.source,
+            ethUsdObservedAt: ethUsd.observedAt,
+            networkFeeUsdMicros: networkFeeUsdMicros.toString(),
+            ownerPlatformFeeWei: platformCutWei.toString(),
+            ownerPlatformFeeUsdMicros: ownerPlatformFeeUsdMicros.toString(),
+            ownerChargeWei: ownerChargeWei.toString(),
+            ownerChargeUsdMicros: ownerChargeUsdMicros.toString(),
+          },
+          usageRecord: providerAppId
+            ? {
+                id: usageRecordId,
+                requestId,
+                userId: usageUserId,
+                clientId: providerAppId,
+                modelId: constraint?.modelId ?? null,
+                units: pixels.toString(),
+                fee: feeWei.toString(),
+                createdAt: new Date().toISOString(),
+              }
+            : undefined,
+          usageBillingEvent:
+            providerAppId && constraint && pipelineModelConstraintHash
+              ? {
+                  id: uuidv4(),
+                  usageRecordId,
+                  transactionId,
+                  streamSessionId,
+                  clientId: providerAppId,
+                  userId: usageUserId,
+                  pipeline: constraint.pipeline,
+                  modelId: constraint.modelId,
+                  attributionSource: attribution.attributionSource,
+                  gatewayRequestId: attribution.gatewayRequestId,
+                  paymentMetadataVersion: attribution.paymentMetadataVersion,
+                  pipelineModelConstraintHash,
+                  orchAddress: orchestratorAddress ?? null,
+                  advertisedPriceWeiPerUnit: signedPriceStr,
+                  advertisedPixelsPerUnit: signedPixelsStr,
+                  signedPriceWeiPerUnit: pricePerUnit.toString(),
+                  signedPixelsPerUnit: pixelsPerUnit.toString(),
+                  networkFeeWei: feeWei.toString(),
+                  networkFeeUsdMicros: networkFeeUsdMicros.toString(),
+                  platformFeeWei: platformCutWei.toString(),
+                  platformFeeUsdMicros: ownerPlatformFeeUsdMicros.toString(),
+                  ownerChargeWei: ownerChargeWei.toString(),
+                  ownerChargeUsdMicros: ownerChargeUsdMicros.toString(),
+                  upchargePercentBps: upchargeResult.bps,
+                  pricingRuleSource: upchargeResult.source,
+                  endUserBillableUsdMicros: endUserBillableUsdMicros.toString(),
+                  ethUsdPrice: ethUsd.priceUsd.toString(),
+                  ethUsdSource: ethUsd.source,
+                  ethUsdObservedAt: ethUsd.observedAt,
+                  createdAt: new Date().toISOString(),
+                }
+              : undefined,
+        });
+      }
+    }
+
+    return { status: result.response.status, body: responseBody };
+  } catch (error) {
+    console.error("[proxy] Failed to forward generate-live-payment:", error);
+    return { status: 502, body: { error: "Failed to reach signer" } };
+  }
+}

--- a/src/domains/signer-runtime/runtime/signer-proxy.ts
+++ b/src/domains/signer-runtime/runtime/signer-proxy.ts
@@ -1,0 +1,101 @@
+import type { AuthResult } from "@/domains/identity-access/runtime/request-auth";
+import { forwardToSigner, logSignerDmzFailure, readSignerUpstreamBody, type ProxyResult } from "./signer-forwarding";
+import { getSignerRoutingContext } from "./signer-routing";
+
+export async function proxySignOrchestratorInfo(
+  requestBody: unknown,
+  auth: AuthResult,
+): Promise<ProxyResult> {
+  const { signer } = await getSignerRoutingContext(auth.appId);
+  if (!signer || signer.status !== "running") {
+    return { status: 503, body: { error: "Signer is not running" } };
+  }
+
+  try {
+    const result = await forwardToSigner({
+      signer,
+      path: "/sign-orchestrator-info",
+      method: "POST",
+      body: requestBody,
+      auth,
+    });
+    const responseBody = await readSignerUpstreamBody(result.response);
+
+    if (result.response.ok) {
+      const who = auth.endUserId || auth.userId || "unknown";
+      console.log(`[proxy] sign-orchestrator-info forwarded for ${who}`);
+    } else {
+      logSignerDmzFailure({
+        route: "sign-orchestrator-info",
+        response: result.response,
+        requestUrl: result.requestUrl,
+        authorizationHeader: result.authorizationHeader,
+        responseBody,
+      });
+    }
+
+    return { status: result.response.status, body: responseBody };
+  } catch (error) {
+    console.error("[proxy] Failed to forward sign-orchestrator-info:", error);
+    return { status: 502, body: { error: "Failed to reach signer" } };
+  }
+}
+
+export async function proxySignByocJob(
+  requestBody: unknown,
+  auth: AuthResult,
+): Promise<ProxyResult> {
+  const { signer } = await getSignerRoutingContext(auth.appId);
+  if (!signer || signer.status !== "running") {
+    return { status: 503, body: { error: "Signer is not running" } };
+  }
+
+  try {
+    const result = await forwardToSigner({
+      signer,
+      path: "/sign-byoc-job",
+      method: "POST",
+      body: requestBody,
+      auth,
+    });
+    const responseBody = await readSignerUpstreamBody(result.response);
+
+    if (result.response.ok) {
+      const who = auth.endUserId || auth.userId || "unknown";
+      console.log(`[proxy] sign-byoc-job forwarded for ${who}`);
+    }
+
+    return { status: result.response.status, body: responseBody };
+  } catch (error) {
+    console.error("[proxy] Failed to forward sign-byoc-job:", error);
+    return { status: 502, body: { error: "Failed to reach signer" } };
+  }
+}
+
+export async function proxyDiscoverOrchestrators(auth: AuthResult): Promise<ProxyResult> {
+  const { signer } = await getSignerRoutingContext(auth.appId);
+  if (!signer || signer.status !== "running") {
+    return { status: 503, body: { error: "Signer is not running" } };
+  }
+
+  try {
+    const result = await forwardToSigner({
+      signer,
+      path: "/discover-orchestrators",
+      method: "GET",
+      body: undefined,
+      auth,
+    });
+    const responseBody = await readSignerUpstreamBody(result.response);
+
+    if (result.response.ok) {
+      const who = auth.endUserId || auth.userId || "unknown";
+      console.log(`[proxy] discover-orchestrators forwarded for ${who}`);
+    }
+
+    return { status: result.response.status, body: responseBody };
+  } catch (error) {
+    console.error("[proxy] Failed to forward discover-orchestrators:", error);
+    return { status: 502, body: { error: "Failed to reach signer" } };
+  }
+}

--- a/src/domains/signer-runtime/runtime/signer-routing.ts
+++ b/src/domains/signer-runtime/runtime/signer-routing.ts
@@ -1,0 +1,7 @@
+import { getDefaultSigner, resolveDeveloperAppIdFromAuthAppId } from "../repo/signer-routing";
+
+export async function getSignerRoutingContext(authAppId?: string | null) {
+  const signer = await getDefaultSigner();
+  const providerAppId = await resolveDeveloperAppIdFromAuthAppId(authAppId);
+  return { signer, providerAppId };
+}

--- a/src/domains/signer-runtime/runtime/signer-status.ts
+++ b/src/domains/signer-runtime/runtime/signer-status.ts
@@ -1,0 +1,235 @@
+import { eq } from "drizzle-orm";
+import { getSenderInfo } from "@/platform/signer/cli";
+import { issueSignerDmzToken } from "@/platform/signer/dmz-token";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import { DOCKER_COMPOSE_LOCAL_SIGNER_SERVICE } from "@/platform/signer/local-compose";
+import { updateDefaultSignerConfig } from "../repo/signer-config";
+import { getDefaultSigner } from "../repo/signer-routing";
+
+const SIGNER_SYNC_DMZ_SUBJECT = "pymthouse-signer-sync";
+
+export function getSignerUrl(signer?: {
+  signerPort: number;
+  signerUrl: string | null;
+} | null): string {
+  const testSignerUrl =
+    process.env.NODE_ENV === "test"
+      ? process.env.PYMTHOUSE_TEST_SIGNER_URL
+      : undefined;
+  if (testSignerUrl && testSignerUrl.trim() !== "") {
+    return testSignerUrl.replace(/\/+$/, "");
+  }
+
+  const legacyBareSignerPort = 8081;
+  const rawPort = signer?.signerPort ?? 8080;
+  const port = rawPort === legacyBareSignerPort ? 8080 : rawPort;
+  const base = signer?.signerUrl || process.env.SIGNER_INTERNAL_URL || `http://127.0.0.1:${port}`;
+  return base.replace(/\/+$/, "");
+}
+
+async function readSignerUpstreamBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text.trim()) return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return {
+      error: "Signer DMZ returned a non-JSON body (often Apache auth failure)",
+      upstreamStatus: response.status,
+      detail: text.slice(0, 800),
+    };
+  }
+}
+
+export async function probeSignerHttpReachability(
+  signerUrl: string,
+): Promise<{ reachable: boolean; ethAddress?: string }> {
+  const timeoutMs = 5000;
+
+  const parseEthFromStatus = async (response: Response): Promise<string | undefined> => {
+    if (!response.ok) return undefined;
+    const data = (await readSignerUpstreamBody(response)) as Record<string, unknown>;
+    return (
+      (typeof data.Address === "string" && data.Address) ||
+      (typeof data.address === "string" && data.address) ||
+      undefined
+    );
+  };
+
+  const fetchStatus = async (headers: Record<string, string>) => {
+    const response = await fetch(`${signerUrl}/status`, {
+      headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const addr = await parseEthFromStatus(response);
+    return { ok: response.ok, addr };
+  };
+
+  try {
+    const health = await fetch(`${signerUrl}/healthz`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (health.ok) {
+      if (process.env.SIGNER_DMZ_FORWARD_JWT !== "false") {
+        try {
+          const token = await issueSignerDmzToken({
+            gate: "http",
+            subject: SIGNER_SYNC_DMZ_SUBJECT,
+          });
+          const { ok, addr } = await fetchStatus({ Authorization: `Bearer ${token}` });
+          if (ok) return { reachable: true, ethAddress: addr };
+        } catch {
+          // continue
+        }
+      }
+      try {
+        const { ok, addr } = await fetchStatus({});
+        if (ok) return { reachable: true, ethAddress: addr };
+      } catch {
+        // continue
+      }
+      return { reachable: false, ethAddress: undefined };
+    }
+  } catch {
+    // try /status without healthz
+  }
+
+  if (process.env.SIGNER_DMZ_FORWARD_JWT !== "false") {
+    try {
+      const token = await issueSignerDmzToken({
+        gate: "http",
+        subject: SIGNER_SYNC_DMZ_SUBJECT,
+      });
+      const { ok, addr } = await fetchStatus({ Authorization: `Bearer ${token}` });
+      if (ok) return { reachable: true, ethAddress: addr };
+    } catch {
+      // continue
+    }
+  }
+
+  try {
+    const { ok, addr } = await fetchStatus({});
+    if (ok) return { reachable: true, ethAddress: addr };
+  } catch {
+    // unreachable
+  }
+
+  return { reachable: false, ethAddress: undefined };
+}
+
+export async function syncSignerStatus(): Promise<{
+  reachable: boolean;
+  ethAddress?: string;
+  containerRunning?: boolean;
+}> {
+  let reachable = false;
+  let ethAddress: string | undefined;
+
+  try {
+    const defaultSigner = await getDefaultSigner();
+    const probe = await probeSignerHttpReachability(getSignerUrl(defaultSigner));
+    reachable = probe.reachable;
+    ethAddress = probe.ethAddress;
+  } catch {
+    // ignore
+  }
+
+  let containerRunning = false;
+  let lastError: string | null = null;
+  try {
+    const { exec } = await import("child_process");
+    const { promisify } = await import("util");
+    const execAsync = promisify(exec);
+
+    const { stdout } = await execAsync(
+      `docker compose ps --format json ${DOCKER_COMPOSE_LOCAL_SIGNER_SERVICE}`,
+      { cwd: process.cwd(), timeout: 5000 },
+    );
+
+    if (stdout.trim()) {
+      const info = JSON.parse(stdout.trim()) as Record<string, unknown>;
+      const state = String(info.State || info.state || "").toLowerCase();
+      containerRunning = state === "running";
+
+      if (!containerRunning && state) {
+        lastError = `Container state: ${state}`;
+        try {
+          const { stdout: logs } = await execAsync(
+            `docker compose logs --no-color --tail=3 ${DOCKER_COMPOSE_LOCAL_SIGNER_SERVICE} 2>&1`,
+            { cwd: process.cwd(), timeout: 5000 },
+          );
+          const errorLine = logs
+            .split("\n")
+            .filter((line) => line.includes("Error") || line.includes("error"))
+            .pop();
+          if (errorLine) {
+            lastError = errorLine.replace(/^[a-z0-9._-]+-\d+\s+\|\s*/i, "");
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  const status = reachable ? "running" : containerRunning ? "running" : "stopped";
+  if (reachable) lastError = null;
+
+  const dbSet: Record<string, unknown> = {
+    status,
+    ethAddress: ethAddress || null,
+    lastError,
+  };
+  const senderInfo = await getSenderInfo();
+  if (senderInfo) {
+    dbSet.depositWei = senderInfo.deposit;
+    dbSet.reserveWei = senderInfo.reserve.fundsRemaining;
+  }
+
+  await updateDefaultSignerConfig(dbSet);
+  return { reachable, ethAddress, containerRunning };
+}
+
+export function formatDmzTokenForLog(authz: string | undefined) {
+  const token = authz?.startsWith("Bearer ") ? authz.slice(7) : undefined;
+  if (!token) {
+    return { expected_issuer: getIssuer() };
+  }
+
+  const parts = token.split(".");
+  const decodePart = (segment: string): Record<string, unknown> | undefined => {
+    try {
+      const b64 = segment.replace(/-/g, "+").replace(/_/g, "/");
+      const pad = b64.length % 4 === 0 ? "" : "=".repeat(4 - (b64.length % 4));
+      return JSON.parse(Buffer.from(b64 + pad, "base64").toString("utf8")) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  };
+  const header = parts.length >= 1 ? decodePart(parts[0]) : undefined;
+  const payload = parts.length >= 2 ? decodePart(parts[1]) : undefined;
+  const now = Math.floor(Date.now() / 1000);
+  const exp = typeof payload?.exp === "number" ? payload.exp : undefined;
+  const nbf = typeof payload?.nbf === "number" ? payload.nbf : undefined;
+  const sub = payload?.sub;
+  const subString = sub === undefined || sub === null ? "" : String(sub);
+
+  return {
+    expected_issuer: getIssuer(),
+    header_kid: header?.kid,
+    header_alg: header?.alg,
+    claim_iss: payload?.iss,
+    claim_aud: payload?.aud,
+    claim_sub_masked:
+      subString.length === 0 ? undefined : subString.length <= 4 ? "****" : `…${subString.slice(-4)}`,
+    claim_sub_length: subString.length || undefined,
+    claim_scope: payload?.scope,
+    claim_exp: exp,
+    claim_nbf: nbf,
+    now,
+    exp_in_seconds: exp !== undefined ? exp - now : undefined,
+    nbf_delta_seconds: nbf !== undefined ? nbf - now : undefined,
+  };
+}

--- a/src/domains/signer-runtime/service/signer-config.test.ts
+++ b/src/domains/signer-runtime/service/signer-config.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseSignerConfigUpdate, parseTail } from "./signer-config";
+
+test("parseTail clamps and defaults", () => {
+  assert.equal(parseTail(null), 50);
+  assert.equal(parseTail("5000"), 1000);
+});
+
+test("parseSignerConfigUpdate validates signerUrl", () => {
+  const result = parseSignerConfigUpdate({
+    body: { signerUrl: "nope" },
+    current: undefined,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? "" : result.body.error, "signerUrl must be a valid http(s) URL or empty");
+});
+
+test("parseSignerConfigUpdate accepts remote discovery interval", () => {
+  const result = parseSignerConfigUpdate({
+    body: { remoteDiscovery: true, liveAICapReportInterval: "5m" },
+    current: { remoteDiscovery: 0 },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.ok ? result.updates.liveAICapReportInterval : "", "5m");
+});

--- a/src/domains/signer-runtime/service/signer-config.ts
+++ b/src/domains/signer-runtime/service/signer-config.ts
@@ -1,0 +1,132 @@
+const SUPPORTED_NETWORK = "arbitrum-one-mainnet";
+const DURATION_REGEX = /^\d+[smh]$/;
+const GO_DURATION_REGEX = /^\d+(ns|us|µs|ms|s|m|h)$/;
+
+function isValidUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return value.startsWith("http://") || value.startsWith("https://");
+  } catch {
+    return false;
+  }
+}
+
+export function parseTail(value: string | null): number {
+  const defaultTail = 50;
+  const maxTail = 1000;
+  if (!value || !/^\d+$/.test(value)) return defaultTail;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return defaultTail;
+  return Math.min(parsed, maxTail);
+}
+
+export function parseSignerConfigUpdate(params: {
+  body: Record<string, unknown>;
+  current:
+    | {
+        remoteDiscovery: number;
+      }
+    | undefined;
+}):
+  | { ok: true; updates: Record<string, unknown> }
+  | { ok: false; status: 400; body: { error: string } } {
+  const { body, current } = params;
+  const updates: Record<string, unknown> = {};
+
+  if (body.name !== undefined) updates.name = body.name;
+  if (body.signerUrl !== undefined) {
+    const raw = typeof body.signerUrl === "string" ? body.signerUrl.trim() : "";
+    if (raw === "") {
+      updates.signerUrl = null;
+    } else if (!isValidUrl(raw)) {
+      return {
+        ok: false,
+        status: 400,
+        body: { error: "signerUrl must be a valid http(s) URL or empty" },
+      };
+    } else {
+      updates.signerUrl = raw;
+    }
+  }
+  if (body.signerApiKey !== undefined) {
+    const trimmed = typeof body.signerApiKey === "string" ? body.signerApiKey.trim() : "";
+    updates.signerApiKey = trimmed === "" ? null : trimmed;
+  }
+  if (body.signerPort !== undefined) {
+    const port = Number(body.signerPort);
+    if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+      return {
+        ok: false,
+        status: 400,
+        body: { error: "signerPort must be an integer between 1024 and 65535" },
+      };
+    }
+    updates.signerPort = port;
+  }
+  if (body.network !== undefined) {
+    if (body.network !== SUPPORTED_NETWORK) {
+      return {
+        ok: false,
+        status: 400,
+        body: { error: `Invalid network. Must be: ${SUPPORTED_NETWORK}` },
+      };
+    }
+    updates.network = SUPPORTED_NETWORK;
+  }
+  if (body.ethRpcUrl !== undefined) updates.ethRpcUrl = body.ethRpcUrl;
+  if (body.ethAcctAddr !== undefined) updates.ethAcctAddr = body.ethAcctAddr;
+  if (body.defaultCutPercent !== undefined) updates.defaultCutPercent = body.defaultCutPercent;
+  if (body.billingMode !== undefined) updates.billingMode = body.billingMode;
+
+  if (body.remoteDiscovery !== undefined) {
+    const enabled = body.remoteDiscovery === true || body.remoteDiscovery === "true";
+    updates.remoteDiscovery = enabled ? 1 : 0;
+    if (!enabled) {
+      updates.orchWebhookUrl = null;
+      updates.liveAICapReportInterval = null;
+    }
+  }
+  const effectiveRemoteDiscovery =
+    updates.remoteDiscovery !== undefined
+      ? updates.remoteDiscovery === 1
+      : current?.remoteDiscovery === 1;
+
+  if (body.orchWebhookUrl !== undefined && effectiveRemoteDiscovery) {
+    const url = typeof body.orchWebhookUrl === "string" ? body.orchWebhookUrl.trim() : "";
+    if (url && !isValidUrl(url)) {
+      return {
+        ok: false,
+        status: 400,
+        body: { error: "orchWebhookUrl must be a valid http(s) URL" },
+      };
+    }
+    updates.orchWebhookUrl = url || null;
+  }
+  if (body.liveAICapReportInterval !== undefined && effectiveRemoteDiscovery) {
+    const value =
+      typeof body.liveAICapReportInterval === "string"
+        ? body.liveAICapReportInterval.trim()
+        : "";
+    if (value && !GO_DURATION_REGEX.test(value)) {
+      return {
+        ok: false,
+        status: 400,
+        body: {
+          error:
+            "liveAICapReportInterval must be a valid duration (e.g. 5m, 10s, 1h)",
+        },
+      };
+    }
+    updates.liveAICapReportInterval = value || null;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { ok: false, status: 400, body: { error: "No valid fields to update" } };
+  }
+
+  return { ok: true, updates };
+}
+
+export function isValidDuration(value: string): boolean {
+  return DURATION_REGEX.test(value);
+}

--- a/src/domains/signer-runtime/service/signer-payment.test.ts
+++ b/src/domains/signer-runtime/service/signer-payment.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseSignerPaymentRequest } from "./signer-payment";
+
+test("parseSignerPaymentRequest rejects conflicting aliases", () => {
+  const parsed = parseSignerPaymentRequest({
+    ManifestID: "a",
+    manifestId: "b",
+  });
+  assert.equal(parsed.ok, false);
+  if (!parsed.ok) {
+    assert.match(parsed.message, /Conflicting manifestId\/ManifestID\/manifestID/);
+  }
+});
+
+test("parseSignerPaymentRequest normalizes alias fields", () => {
+  const parsed = parseSignerPaymentRequest({
+    ManifestID: "manifest-1",
+    InPixels: "42",
+    PreloadSeconds: 5,
+    Type: "lv2v",
+    Orchestrator: "orch-payload",
+  });
+  assert.equal(parsed.ok, true);
+  if (parsed.ok) {
+    assert.deepEqual(parsed.value, {
+      manifestId: "manifest-1",
+      inPixels: 42,
+      preloadSeconds: 5,
+      jobType: "lv2v",
+      orchestratorData: "orch-payload",
+    });
+  }
+});

--- a/src/domains/signer-runtime/service/signer-payment.ts
+++ b/src/domains/signer-runtime/service/signer-payment.ts
@@ -1,0 +1,91 @@
+export function pickConflictingStringAliases(
+  body: Record<string, unknown>,
+  ...keys: string[]
+):
+  | { ok: true; value: string | undefined }
+  | { ok: false; message: string } {
+  const values = keys
+    .map((key) => {
+      const raw = body[key];
+      const defined = raw !== undefined && raw !== null && `${raw}`.length > 0;
+      return defined ? { key, value: String(raw) } : null;
+    })
+    .filter((entry): entry is { key: string; value: string } => entry !== null);
+  const first = values[0];
+  const conflict = values.find((entry) => entry.value !== first?.value);
+  if (first && conflict) {
+    return {
+      ok: false,
+      message: `Conflicting ${keys.join("/")} in request body`,
+    };
+  }
+  return { ok: true, value: first?.value };
+}
+
+export function pickConflictingNumberAliases(
+  body: Record<string, unknown>,
+  ...keys: string[]
+):
+  | { ok: true; value: number | undefined }
+  | { ok: false; message: string } {
+  const parseNum = (v: unknown): number | undefined => {
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (typeof v === "string" && v.trim() !== "") {
+      const n = Number(v);
+      return Number.isFinite(n) ? n : undefined;
+    }
+    return undefined;
+  };
+  const values = keys
+    .map((key) => {
+      const value = parseNum(body[key]);
+      return value !== undefined ? { key, value } : null;
+    })
+    .filter((entry): entry is { key: string; value: number } => entry !== null);
+  const first = values[0];
+  const conflict = values.find((entry) => entry.value !== first?.value);
+  if (first && conflict) {
+    return {
+      ok: false,
+      message: `Conflicting ${keys.join("/")} in request body`,
+    };
+  }
+  return { ok: true, value: first?.value };
+}
+
+export function parseSignerPaymentRequest(requestBody: Record<string, unknown>) {
+  const manifestPick = pickConflictingStringAliases(
+    requestBody,
+    "manifestId",
+    "ManifestID",
+    "manifestID",
+  );
+  if (!manifestPick.ok) return manifestPick;
+
+  const inPixelsPick = pickConflictingNumberAliases(requestBody, "inPixels", "InPixels");
+  if (!inPixelsPick.ok) return inPixelsPick;
+
+  const preloadSecondsPick = pickConflictingNumberAliases(
+    requestBody,
+    "preloadSeconds",
+    "PreloadSeconds",
+  );
+  if (!preloadSecondsPick.ok) return preloadSecondsPick;
+
+  const jobTypePick = pickConflictingStringAliases(requestBody, "type", "Type");
+  if (!jobTypePick.ok) return jobTypePick;
+
+  const orchPick = pickConflictingStringAliases(requestBody, "orchestrator", "Orchestrator");
+  if (!orchPick.ok) return orchPick;
+
+  return {
+    ok: true as const,
+    value: {
+      manifestId: manifestPick.value,
+      inPixels: inPixelsPick.value,
+      preloadSeconds: preloadSecondsPick.value,
+      jobType: jobTypePick.value,
+      orchestratorData: orchPick.value,
+    },
+  };
+}

--- a/src/domains/usage-billing/service/billing-runtime.test.ts
+++ b/src/domains/usage-billing/service/billing-runtime.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import protobuf from "protobufjs";
+
+import {
+  buildConstraintHash,
+  buildSignedTicketConstraintHash,
+  computeUsdMicrosFromWei,
+  resolveGatewayAttribution,
+  resolvePaymentPipelineModelConstraint,
+  resolveRequestPipelineModelConstraint,
+  resolveUpcharge,
+  weiToEthString,
+} from "./billing-runtime";
+
+test("resolveRequestPipelineModelConstraint returns canonical fields", () => {
+  const result = resolveRequestPipelineModelConstraint({
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+  });
+  assert.deepEqual(result, { pipeline: "text-to-image", modelId: "stabilityai/sdxl" });
+});
+
+test("resolveRequestPipelineModelConstraint accepts legacy Model alias", () => {
+  const result = resolveRequestPipelineModelConstraint({
+    pipeline: "text-to-image",
+    model: "some/model",
+  });
+  assert.ok(result);
+  assert.equal(result!.modelId, "some/model");
+});
+
+test("resolveRequestPipelineModelConstraint returns null when pipeline is missing", () => {
+  assert.equal(resolveRequestPipelineModelConstraint({ modelId: "some/model" }), null);
+});
+
+test("resolveRequestPipelineModelConstraint returns null when modelId is missing", () => {
+  assert.equal(resolveRequestPipelineModelConstraint({ pipeline: "text-to-image" }), null);
+});
+
+test("resolveRequestPipelineModelConstraint returns null for empty body", () => {
+  assert.equal(resolveRequestPipelineModelConstraint({}), null);
+});
+
+async function lv2vCapabilitiesBase64(modelId: string): Promise<string> {
+  const protoPath = path.resolve(process.cwd(), "proto/lp_rpc.proto");
+  const root = await protobuf.load(protoPath);
+  const Capabilities = root.lookupType("net.Capabilities");
+  const payload = {
+    capacities: { 35: 1 },
+    constraints: {
+      PerCapability: {
+        35: {
+          models: {
+            [modelId]: {},
+          },
+        },
+      },
+    },
+  };
+  const err = Capabilities.verify(payload);
+  if (err) throw new Error(err);
+  const msg = Capabilities.create(payload);
+  return Buffer.from(Capabilities.encode(msg).finish()).toString("base64");
+}
+
+test("resolvePaymentPipelineModelConstraint reads capabilities base64", async () => {
+  const caps = await lv2vCapabilitiesBase64("streamdiffusion-sdxl");
+  const result = await resolvePaymentPipelineModelConstraint({ capabilities: caps });
+  assert.deepEqual(result, {
+    pipeline: "live-video-to-video",
+    modelId: "streamdiffusion-sdxl",
+  });
+});
+
+test("resolvePaymentPipelineModelConstraint prefers explicit pipeline over capabilities", async () => {
+  const caps = await lv2vCapabilitiesBase64("streamdiffusion-sdxl");
+  const result = await resolvePaymentPipelineModelConstraint({
+    capabilities: caps,
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+  });
+  assert.deepEqual(result, { pipeline: "text-to-image", modelId: "stabilityai/sdxl" });
+});
+
+test("resolvePaymentPipelineModelConstraint returns null for invalid capabilities", async () => {
+  const result = await resolvePaymentPipelineModelConstraint({
+    capabilities: "not-valid-base64!!!",
+  });
+  assert.equal(result, null);
+});
+
+test("resolveGatewayAttribution reads all three fields", () => {
+  const result = resolveGatewayAttribution({
+    attributionSource: "pymthouse_gateway",
+    gatewayRequestId: "job-123",
+    paymentMetadataVersion: "2026-04-usage-attribution-v1",
+  });
+  assert.equal(result.attributionSource, "pymthouse_gateway");
+  assert.equal(result.gatewayRequestId, "job-123");
+  assert.equal(result.paymentMetadataVersion, "2026-04-usage-attribution-v1");
+});
+
+test("resolveGatewayAttribution defaults attributionSource to direct_api", () => {
+  const result = resolveGatewayAttribution({});
+  assert.equal(result.attributionSource, "direct_api");
+  assert.equal(result.gatewayRequestId, null);
+  assert.equal(result.paymentMetadataVersion, null);
+});
+
+test("buildSignedTicketConstraintHash matches buildConstraintHash for same tuple", () => {
+  const params = {
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+    orchAddress: "0xABCDEF1234567890ABCDEF1234567890ABCDEF12",
+    signedPriceWeiPerUnit: "1000000000",
+    signedPixelsPerUnit: "1",
+  };
+  assert.equal(
+    buildSignedTicketConstraintHash(params),
+    buildConstraintHash({
+      pipeline: params.pipeline,
+      modelId: params.modelId,
+      orchAddress: params.orchAddress,
+      priceWeiPerUnit: params.signedPriceWeiPerUnit,
+      pixelsPerUnit: params.signedPixelsPerUnit,
+    }),
+  );
+});
+
+test("buildSignedTicketConstraintHash is deterministic", () => {
+  const params = {
+    pipeline: "p",
+    modelId: "m",
+    orchAddress: "0xabcd",
+    signedPriceWeiPerUnit: "1",
+    signedPixelsPerUnit: "1",
+  };
+  assert.equal(buildSignedTicketConstraintHash(params), buildSignedTicketConstraintHash(params));
+});
+
+test("buildConstraintHash is deterministic", () => {
+  const params = {
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+    orchAddress: "0xABCDEF1234567890ABCDEF1234567890ABCDEF12",
+    priceWeiPerUnit: "1000000000",
+    pixelsPerUnit: "1",
+  };
+  assert.equal(buildConstraintHash(params), buildConstraintHash(params));
+});
+
+test("buildConstraintHash differs for different params", () => {
+  const base = {
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+    orchAddress: "0xABCDEF",
+    priceWeiPerUnit: "1000000000",
+    pixelsPerUnit: "1",
+  };
+  assert.notEqual(buildConstraintHash(base), buildConstraintHash({ ...base, priceWeiPerUnit: "2000000000" }));
+});
+
+test("buildConstraintHash normalises orchAddress to lowercase", () => {
+  const lower = buildConstraintHash({ pipeline: "p", modelId: "m", orchAddress: "0xabcd", priceWeiPerUnit: "1", pixelsPerUnit: "1" });
+  const upper = buildConstraintHash({ pipeline: "p", modelId: "m", orchAddress: "0XABCD", priceWeiPerUnit: "1", pixelsPerUnit: "1" });
+  assert.equal(lower, upper);
+});
+
+test("computeUsdMicrosFromWei: 1 ETH at $3000 = 3_000_000_000 micros", () => {
+  assert.equal(computeUsdMicrosFromWei(10n ** 18n, 3000), 3_000_000_000n);
+});
+
+test("computeUsdMicrosFromWei: zero wei returns 0", () => {
+  assert.equal(computeUsdMicrosFromWei(0n, 3000), 0n);
+});
+
+test("computeUsdMicrosFromWei: negative price returns 0", () => {
+  assert.equal(computeUsdMicrosFromWei(10n ** 18n, -1), 0n);
+});
+
+test("computeUsdMicrosFromWei: non-finite price returns 0", () => {
+  assert.equal(computeUsdMicrosFromWei(10n ** 18n, NaN), 0n);
+  assert.equal(computeUsdMicrosFromWei(10n ** 18n, Infinity), 0n);
+});
+
+test("computeUsdMicrosFromWei: small wei amount stays integer", () => {
+  assert.equal(typeof computeUsdMicrosFromWei(1_000_000n, 3000), "bigint");
+});
+
+test("weiToEthString: 0 returns '0'", () => {
+  assert.equal(weiToEthString(0n), "0");
+});
+
+test("weiToEthString: 1 ETH", () => {
+  assert.equal(weiToEthString(10n ** 18n), "1");
+});
+
+test("weiToEthString: 1.5 ETH", () => {
+  assert.equal(weiToEthString(15n * 10n ** 17n), "1.5");
+});
+
+test("weiToEthString: strips trailing zeros", () => {
+  const result = weiToEthString(10n ** 18n + 100_000_000n);
+  assert.ok(!result.endsWith("0"), `Expected no trailing zeros, got: ${result}`);
+});
+
+const basePlan = {
+  id: "plan-1",
+  clientId: "app-1",
+  name: "Test",
+  type: "subscription",
+  priceAmount: "0",
+  priceCurrency: "USD",
+  status: "active",
+  includedUnits: null,
+  overageRateWei: null,
+  includedUsdMicros: null,
+  generalUpchargePercentBps: 2000,
+  payPerUseUpchargePercentBps: 1000,
+  billingCycle: "monthly",
+  discoveryProfileId: null,
+  createdAt: "",
+  updatedAt: "",
+} as const;
+
+const baseBundle = {
+  id: "bundle-1",
+  planId: "plan-1",
+  clientId: "app-1",
+  pipeline: "text-to-image",
+  modelId: "stabilityai/sdxl",
+  slaTargetScore: null,
+  slaTargetP95Ms: null,
+  maxPricePerUnit: null,
+  upchargePercentBps: 5000,
+  createdAt: "",
+} as const;
+
+test("resolveUpcharge prefers exact bundle override", () => {
+  const result = resolveUpcharge({
+    plan: basePlan,
+    bundles: [baseBundle],
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+  });
+  assert.deepEqual(result, { bps: 5000, source: "pipeline_model" });
+});
+
+test("resolveUpcharge falls back to plan general upcharge", () => {
+  const result = resolveUpcharge({
+    plan: basePlan,
+    bundles: [],
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+  });
+  assert.deepEqual(result, { bps: 2000, source: "general" });
+});
+
+test("resolveUpcharge falls back to pay_per_use", () => {
+  const result = resolveUpcharge({
+    plan: { ...basePlan, generalUpchargePercentBps: null },
+    bundles: [],
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+  });
+  assert.deepEqual(result, { bps: 1000, source: "pay_per_use" });
+});
+
+test("resolveUpcharge returns unpriced when no pricing rules apply", () => {
+  const result = resolveUpcharge({
+    plan: {
+      ...basePlan,
+      generalUpchargePercentBps: null,
+      payPerUseUpchargePercentBps: null,
+    },
+    bundles: [],
+    pipeline: "text-to-image",
+    modelId: "stabilityai/sdxl",
+  });
+  assert.deepEqual(result, { bps: 0, source: "unpriced" });
+});

--- a/src/domains/usage-billing/service/billing-runtime.ts
+++ b/src/domains/usage-billing/service/billing-runtime.ts
@@ -1,0 +1,172 @@
+/**
+ * Runtime billing engine for PymtHouse.
+ *
+ * Provides small, independently testable functions that are called from
+ * signer and usage-reporting flows after the remote signer succeeds.
+ */
+
+import crypto from "crypto";
+import { extractPipelineModelFromCapabilitiesBase64 } from "@/platform/livepeer/proto";
+
+export interface PipelineModelConstraint {
+  pipeline: string;
+  modelId: string;
+}
+
+export interface GatewayAttribution {
+  attributionSource: string;
+  gatewayRequestId: string | null;
+  paymentMetadataVersion: string | null;
+}
+
+export interface BillingContext {
+  planId: string | null;
+  subscriptionId: string | null;
+  upchargePercentBps: number;
+  pricingRuleSource: "pipeline_model" | "general" | "pay_per_use" | "subscription_included" | "unpriced";
+}
+
+interface UsageBillingPlanLike {
+  generalUpchargePercentBps: number | null;
+  payPerUseUpchargePercentBps: number | null;
+}
+
+interface UsageBillingBundleLike {
+  pipeline: string;
+  modelId: string;
+  upchargePercentBps: number | null;
+}
+
+function pickString(body: Record<string, unknown>, key: string): string | null {
+  const value = body[key];
+  if (typeof value === "string" && value.trim()) return value.trim();
+  return null;
+}
+
+export function resolveRequestPipelineModelConstraint(
+  requestBody: Record<string, unknown>,
+): PipelineModelConstraint | null {
+  const pipeline =
+    pickString(requestBody, "pipeline") ??
+    pickString(requestBody, "Pipeline") ??
+    null;
+  const modelId =
+    pickString(requestBody, "modelId") ??
+    pickString(requestBody, "ModelID") ??
+    pickString(requestBody, "modelID") ??
+    pickString(requestBody, "model") ??
+    pickString(requestBody, "Model") ??
+    null;
+
+  if (!pipeline || !modelId) return null;
+  return { pipeline, modelId };
+}
+
+export async function resolvePaymentPipelineModelConstraint(
+  requestBody: Record<string, unknown>,
+): Promise<PipelineModelConstraint | null> {
+  const direct = resolveRequestPipelineModelConstraint(requestBody);
+  if (direct) return direct;
+
+  const capsB64 =
+    pickString(requestBody, "capabilities") ??
+    pickString(requestBody, "Capabilities");
+  if (!capsB64) return null;
+
+  const fromCaps = await extractPipelineModelFromCapabilitiesBase64(capsB64);
+  if (!fromCaps) return null;
+  return { pipeline: fromCaps.pipeline, modelId: fromCaps.modelId };
+}
+
+export function resolveGatewayAttribution(
+  requestBody: Record<string, unknown>,
+): GatewayAttribution {
+  const attributionSource =
+    pickString(requestBody, "attributionSource") ?? "direct_api";
+  const gatewayRequestId = pickString(requestBody, "gatewayRequestId") ?? null;
+  const paymentMetadataVersion =
+    pickString(requestBody, "paymentMetadataVersion") ?? null;
+  return { attributionSource, gatewayRequestId, paymentMetadataVersion };
+}
+
+export function buildConstraintHash(params: {
+  pipeline: string;
+  modelId: string;
+  orchAddress: string;
+  priceWeiPerUnit: string;
+  pixelsPerUnit: string;
+}): string {
+  const canonical = JSON.stringify([
+    params.pipeline,
+    params.modelId,
+    params.orchAddress.toLowerCase(),
+    params.priceWeiPerUnit,
+    params.pixelsPerUnit,
+  ]);
+  return crypto.createHash("sha256").update(canonical).digest("hex");
+}
+
+export function buildSignedTicketConstraintHash(params: {
+  pipeline: string;
+  modelId: string;
+  orchAddress: string;
+  signedPriceWeiPerUnit: string;
+  signedPixelsPerUnit: string;
+}): string {
+  return buildConstraintHash({
+    pipeline: params.pipeline,
+    modelId: params.modelId,
+    orchAddress: params.orchAddress,
+    priceWeiPerUnit: params.signedPriceWeiPerUnit,
+    pixelsPerUnit: params.signedPixelsPerUnit,
+  });
+}
+
+export function resolveUpcharge(params: {
+  plan: UsageBillingPlanLike | null;
+  bundles: Array<UsageBillingBundleLike>;
+  pipeline: string;
+  modelId: string;
+}): { bps: number; source: BillingContext["pricingRuleSource"] } {
+  const { plan, bundles, pipeline, modelId } = params;
+
+  const bundle =
+    bundles.find((entry) => entry.pipeline === pipeline && entry.modelId === modelId) ??
+    bundles.find((entry) => entry.pipeline === pipeline && entry.modelId === "*");
+  if (bundle?.upchargePercentBps != null && bundle.upchargePercentBps >= 0) {
+    return { bps: bundle.upchargePercentBps, source: "pipeline_model" };
+  }
+
+  if (plan?.generalUpchargePercentBps != null && plan.generalUpchargePercentBps >= 0) {
+    return { bps: plan.generalUpchargePercentBps, source: "general" };
+  }
+
+  if (
+    plan?.payPerUseUpchargePercentBps != null &&
+    plan.payPerUseUpchargePercentBps >= 0
+  ) {
+    return { bps: plan.payPerUseUpchargePercentBps, source: "pay_per_use" };
+  }
+
+  return { bps: 0, source: "unpriced" };
+}
+
+export function computeUsdMicrosFromWei(weiAmt: bigint, ethUsdPriceUsd: number): bigint {
+  if (weiAmt <= 0n || !Number.isFinite(ethUsdPriceUsd) || ethUsdPriceUsd <= 0) {
+    return 0n;
+  }
+  const ethUsdMicros = BigInt(Math.floor(ethUsdPriceUsd * 1_000_000));
+  const divisor = 10n ** 18n;
+  return (weiAmt * ethUsdMicros) / divisor;
+}
+
+export function weiToEthString(weiAmt: bigint): string {
+  if (weiAmt === 0n) return "0";
+  const negative = weiAmt < 0n;
+  const abs = negative ? -weiAmt : weiAmt;
+  const whole = abs / 10n ** 18n;
+  const frac = abs % 10n ** 18n;
+  const fracStr = frac.toString().padStart(18, "0").replace(/0+$/, "");
+  const result = fracStr ? `${whole}.${fracStr}` : whole.toString();
+  return negative ? `-${result}` : result;
+}

--- a/src/platform/auth/next-auth-options.ts
+++ b/src/platform/auth/next-auth-options.ts
@@ -1,0 +1,224 @@
+import type { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import GoogleProvider from "next-auth/providers/google";
+import GitHubProvider from "next-auth/providers/github";
+import { and, eq, sql } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db/index";
+import { users } from "@/db/schema";
+import { validateBearerToken, hasScope } from "@/domains/identity-access/runtime/request-auth";
+import {
+  findOrCreateDeveloperUser,
+  verifyTurnkeySessionJwt,
+} from "@/domains/identity-access/runtime/turnkey-users";
+import { getNextAuthSecret } from "@/platform/auth/next-auth-secret";
+
+const nextAuthSecret = getNextAuthSecret();
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    CredentialsProvider({
+      id: "token",
+      name: "Admin Token",
+      credentials: {
+        token: { label: "Bearer Token", type: "text", placeholder: "pmth_..." },
+      },
+      async authorize(credentials) {
+        if (!credentials?.token) return null;
+
+        const auth = await validateBearerToken(credentials.token);
+        if (!auth) return null;
+        if (!hasScope(auth.scopes, "admin")) return null;
+        if (!auth.userId) return null;
+
+        const userRows = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, auth.userId))
+          .limit(1);
+        const user = userRows[0];
+
+        if (!user) return null;
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name || user.email,
+        };
+      },
+    }),
+
+    CredentialsProvider({
+      id: "turnkey-wallet",
+      name: "Turnkey Wallet",
+      credentials: {
+        turnkeySessionJwt: { label: "Turnkey Session JWT", type: "text" },
+        walletAddress: { label: "Wallet Address", type: "text" },
+        email: { label: "Email", type: "text" },
+        name: { label: "Name", type: "text" },
+      },
+      async authorize(credentials) {
+        if (!credentials?.turnkeySessionJwt) return null;
+
+        const claims = await verifyTurnkeySessionJwt(credentials.turnkeySessionJwt);
+        if (!claims) return null;
+
+        const walletRaw = credentials.walletAddress?.trim();
+        const emailRaw = credentials.email?.trim();
+        const nameRaw = credentials.name?.trim();
+
+        const { id } = await findOrCreateDeveloperUser(
+          claims.userId,
+          walletRaw || undefined,
+          nameRaw || undefined,
+          emailRaw || undefined,
+        );
+
+        const userRows = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, id))
+          .limit(1);
+        const user = userRows[0];
+
+        if (!user) return null;
+
+        return {
+          id: user.id,
+          email: user.email || undefined,
+          name: user.name || user.walletAddress || "Developer",
+        };
+      },
+    }),
+
+    ...(process.env.GOOGLE_CLIENT_ID
+      ? [
+          GoogleProvider({
+            clientId: process.env.GOOGLE_CLIENT_ID!,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+          }),
+        ]
+      : []),
+    ...(process.env.GITHUB_CLIENT_ID
+      ? [
+          GitHubProvider({
+            clientId: process.env.GITHUB_CLIENT_ID!,
+            clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+          }),
+        ]
+      : []),
+  ],
+  callbacks: {
+    async signIn({ user, account }) {
+      if (!account) return false;
+      if (account.provider === "token" || account.provider === "turnkey-wallet") return true;
+      if (!user.email) return false;
+
+      const provider = account.provider;
+      const subject = account.providerAccountId;
+
+      const existingRows = await db
+        .select()
+        .from(users)
+        .where(and(eq(users.oauthProvider, provider), eq(users.oauthSubject, subject)))
+        .limit(1);
+      const existing = existingRows[0];
+
+      if (provider === "google" || provider === "github") {
+        if (existing && existing.role === "admin") {
+          return false;
+        }
+        if (existing) {
+          return true;
+        }
+        const normalizedEmail = user.email.trim().toLowerCase();
+        const adminByEmailRows = await db
+          .select()
+          .from(users)
+          .where(
+            and(eq(users.role, "admin"), sql`lower(${users.email}) = ${normalizedEmail}`),
+          )
+          .limit(1);
+        if (adminByEmailRows[0]) {
+          return false;
+        }
+        await db.insert(users).values({
+          id: uuidv4(),
+          email: user.email,
+          name: user.name || null,
+          oauthProvider: provider,
+          oauthSubject: subject,
+          role: "developer",
+        });
+        return true;
+      }
+
+      if (!existing) {
+        await db.insert(users).values({
+          id: uuidv4(),
+          email: user.email,
+          name: user.name || null,
+          oauthProvider: provider,
+          oauthSubject: subject,
+          role: "developer",
+        });
+      }
+
+      return true;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        if (token.userId) {
+          const pmthRows = await db
+            .select()
+            .from(users)
+            .where(eq(users.id, token.userId as string))
+            .limit(1);
+          const pmthUser = pmthRows[0];
+
+          if (pmthUser) {
+            (session.user as Record<string, unknown>).id = pmthUser.id;
+            (session.user as Record<string, unknown>).role = pmthUser.role;
+            return session;
+          }
+        }
+
+        if (token.provider && token.sub) {
+          const pmthRows = await db
+            .select()
+            .from(users)
+            .where(
+              and(
+                eq(users.oauthProvider, token.provider as string),
+                eq(users.oauthSubject, token.sub),
+              ),
+            )
+            .limit(1);
+          const pmthUser = pmthRows[0];
+
+          if (pmthUser) {
+            (session.user as Record<string, unknown>).id = pmthUser.id;
+            (session.user as Record<string, unknown>).role = pmthUser.role;
+          }
+        }
+      }
+      return session;
+    },
+    async jwt({ token, user, account }) {
+      if (account) {
+        token.provider = account.provider;
+      }
+      if (user?.id) {
+        token.userId = user.id;
+      }
+      return token;
+    },
+  },
+  session: {
+    strategy: "jwt",
+  },
+  pages: {
+    signIn: "/login",
+  },
+  secret: nextAuthSecret,
+};

--- a/src/platform/auth/next-auth-secret.ts
+++ b/src/platform/auth/next-auth-secret.ts
@@ -1,0 +1,43 @@
+const DISALLOWED_DEV_SECRETS = new Set([
+  "generate-a-random-secret-here",
+  "replace-with-random-base64-secret",
+  "dev-secret-change-me",
+  "changeme",
+  "change-me",
+]);
+
+let hasWarnedInvalidSecret = false;
+
+function isLikelyPlaceholder(secret: string): boolean {
+  const normalized = secret.trim().toLowerCase();
+  if (!normalized) return true;
+  if (DISALLOWED_DEV_SECRETS.has(normalized)) return true;
+  return normalized.includes("random-secret") || normalized.includes("changeme");
+}
+
+export function getNextAuthSecret(opts?: {
+  suppressDevWarning?: boolean;
+}): string | undefined {
+  const raw = process.env.NEXTAUTH_SECRET;
+  const secret = typeof raw === "string" ? raw.trim() : "";
+  const missingSecret = !secret;
+  const placeholderSecret = !missingSecret && isLikelyPlaceholder(secret);
+
+  if (!missingSecret && !placeholderSecret) return secret;
+
+  const message =
+    "[auth] NEXTAUTH_SECRET is missing or looks like a placeholder. " +
+    "Set one stable value (for example: `openssl rand -base64 32`) and avoid " +
+    "conflicting values between .env and .env.local.";
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(message);
+  }
+
+  if (!opts?.suppressDevWarning && !hasWarnedInvalidSecret) {
+    console.error(message);
+    hasWarnedInvalidSecret = true;
+  }
+
+  return missingSecret ? undefined : secret;
+}

--- a/src/platform/catalog/naap-catalog.test.ts
+++ b/src/platform/catalog/naap-catalog.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { filterPricingRows } from "@/platform/catalog/naap-catalog";
+import type { PricingRow } from "@/platform/catalog/naap-catalog";
+
+const rows: PricingRow[] = [
+  { orchAddress: "0xaaa", pipeline: "text-to-image", model: "sdxl", priceWeiPerUnit: "1000", pixelsPerUnit: "1" },
+  { orchAddress: "0xbbb", pipeline: "text-to-image", model: "sdxl", priceWeiPerUnit: "900", pixelsPerUnit: "1" },
+  { orchAddress: "0xaaa", pipeline: "image-to-image", model: "controlnet", priceWeiPerUnit: "500", pixelsPerUnit: "2" },
+];
+
+test("filterPricingRows: returns rows matching pipeline and model", () => {
+  const result = filterPricingRows(rows, "text-to-image", "sdxl");
+  assert.equal(result.length, 2);
+  assert.ok(result.every((r) => r.pipeline === "text-to-image" && r.model === "sdxl"));
+});
+
+test("filterPricingRows: further filters by orchAddress when provided", () => {
+  const result = filterPricingRows(rows, "text-to-image", "sdxl", "0xaaa");
+  assert.equal(result.length, 1);
+  assert.equal(result[0].orchAddress, "0xaaa");
+});
+
+test("filterPricingRows: orchAddress match is case-insensitive", () => {
+  const result = filterPricingRows(rows, "text-to-image", "sdxl", "0xAAA");
+  assert.equal(result.length, 1);
+  assert.equal(result[0].orchAddress, "0xaaa");
+});
+
+test("filterPricingRows: returns empty when no pipeline match", () => {
+  const result = filterPricingRows(rows, "audio-generation", "model");
+  assert.equal(result.length, 0);
+});
+
+test("filterPricingRows: returns empty for empty rows", () => {
+  const result = filterPricingRows([], "text-to-image", "sdxl");
+  assert.equal(result.length, 0);
+});
+
+test("filterPricingRows: correct model filtering", () => {
+  const result = filterPricingRows(rows, "image-to-image", "controlnet");
+  assert.equal(result.length, 1);
+  assert.equal(result[0].model, "controlnet");
+});

--- a/src/platform/catalog/naap-catalog.ts
+++ b/src/platform/catalog/naap-catalog.ts
@@ -1,0 +1,180 @@
+/**
+ * NaaP pipeline catalog and pricing client.
+ *
+ * Provides access to two NaaP endpoints:
+ *  - /v1/dashboard/pipeline-catalog  → pipeline list with models (short TTL cache)
+ *  - /v1/dashboard/pricing           → per-orchestrator pricing rows (uncached; each call fetches)
+ *
+ * Signing / `generate-live-payment` does not use this module for validation; it uses
+ * the negotiated ticket facts from the request body (python-gateway + signer).
+ */
+
+const NAAP_API_BASE_URL =
+  process.env.NAAP_API_BASE_URL?.replace(/\/+$/, "") ??
+  "https://naap-api.cloudspe.com/v1";
+
+const REQUEST_TIMEOUT_MS = 3000;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface PipelineCatalogEntry {
+  id: string;
+  name: string;
+  models: string[];
+  regions?: string[];
+}
+
+export interface PricingRow {
+  orchAddress: string;
+  orchName?: string;
+  pipeline: string;
+  model: string;
+  /** Wei per pricing unit as a bigint-compatible string. */
+  priceWeiPerUnit: string;
+  /** Pixels per pricing unit as a bigint-compatible string. */
+  pixelsPerUnit: string;
+  isWarm?: boolean;
+}
+
+// ─── In-memory TTL cache (pipeline catalog only) ────────────────────────────
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+const CATALOG_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+let catalogCache: CacheEntry<PipelineCatalogEntry[]> | null = null;
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+function parseCatalogEntry(raw: unknown, index: number): PipelineCatalogEntry | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const id = typeof r.id === "string" && r.id.trim() ? r.id.trim() : null;
+  const name = typeof r.name === "string" && r.name.trim() ? r.name.trim() : null;
+  if (!id || !name) return null;
+  const models = Array.isArray(r.models)
+    ? (r.models as unknown[])
+        .filter((m): m is string => typeof m === "string" && m.trim() !== "")
+        .map((m) => m.trim())
+    : [];
+  const regions = Array.isArray(r.regions)
+    ? (r.regions as unknown[])
+        .filter((m): m is string => typeof m === "string" && m.trim() !== "")
+        .map((m) => m.trim())
+    : undefined;
+  return { id, name, models, regions };
+}
+
+function parsePricingRow(raw: unknown): PricingRow | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const orchAddress = typeof r.orchAddress === "string" ? r.orchAddress.trim() : "";
+  const pipeline = typeof r.pipeline === "string" ? r.pipeline.trim() : "";
+  const model = typeof r.model === "string" ? r.model.trim() : "";
+  if (!orchAddress || !pipeline || !model) return null;
+
+  const rawPrice = r.priceWeiPerUnit ?? r.price_wei_per_unit;
+  const rawPixels = r.pixelsPerUnit ?? r.pixels_per_unit;
+
+  const priceWeiPerUnit =
+    typeof rawPrice === "string" || typeof rawPrice === "number"
+      ? String(rawPrice).trim()
+      : null;
+  const pixelsPerUnit =
+    typeof rawPixels === "string" || typeof rawPixels === "number"
+      ? String(rawPixels).trim()
+      : null;
+
+  if (!priceWeiPerUnit || !pixelsPerUnit) return null;
+
+  // Validate that both values are positive BigInt-compatible integers
+  try {
+    const price = BigInt(priceWeiPerUnit);
+    const pixels = BigInt(pixelsPerUnit);
+    if (price <= 0n || pixels <= 0n) return null;
+  } catch {
+    return null;
+  }
+
+  return {
+    orchAddress,
+    orchName: typeof r.orchName === "string" ? r.orchName : undefined,
+    pipeline,
+    model,
+    priceWeiPerUnit,
+    pixelsPerUnit,
+    isWarm: typeof r.isWarm === "boolean" ? r.isWarm : undefined,
+  };
+}
+
+// ─── HTTP helpers ─────────────────────────────────────────────────────────────
+
+async function naapGet(path: string): Promise<unknown> {
+  const url = `${NAAP_API_BASE_URL}${path}`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`NaaP API ${path} returned ${res.status}`);
+  }
+  return res.json();
+}
+
+async function fetchDashboardPricingFromNetwork(): Promise<PricingRow[]> {
+  const raw = await naapGet("/dashboard/pricing");
+  if (!Array.isArray(raw)) {
+    throw new Error("NaaP pricing response is not an array");
+  }
+  const rows: PricingRow[] = [];
+  for (const item of raw) {
+    const row = parsePricingRow(item);
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/** Fetch (and cache) the NaaP pipeline catalog. */
+export async function fetchPipelineCatalog(): Promise<PipelineCatalogEntry[]> {
+  if (catalogCache && catalogCache.expiresAt > Date.now()) {
+    return catalogCache.data;
+  }
+  const raw = await naapGet("/dashboard/pipeline-catalog");
+  if (!Array.isArray(raw)) {
+    throw new Error("NaaP pipeline-catalog response is not an array");
+  }
+  const entries: PipelineCatalogEntry[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const entry = parseCatalogEntry(raw[i], i);
+    if (entry) entries.push(entry);
+  }
+  catalogCache = { data: entries, expiresAt: Date.now() + CATALOG_TTL_MS };
+  return entries;
+}
+
+/** Fetch NaaP per-orchestrator pricing rows (always hits NaaP; no in-process cache). */
+export async function fetchDashboardPricing(): Promise<PricingRow[]> {
+  return fetchDashboardPricingFromNetwork();
+}
+
+/**
+ * Find pricing rows that match a pipeline/model, optionally filtered to a
+ * specific orchestrator address.  Returns only valid rows.
+ */
+export function filterPricingRows(
+  rows: PricingRow[],
+  pipeline: string,
+  model: string,
+  orchAddress?: string,
+): PricingRow[] {
+  return rows.filter((r) => {
+    if (r.pipeline !== pipeline || r.model !== model) return false;
+    if (orchAddress && r.orchAddress.toLowerCase() !== orchAddress.toLowerCase()) return false;
+    return true;
+  });
+}

--- a/src/platform/docs/base-url.ts
+++ b/src/platform/docs/base-url.ts
@@ -1,0 +1,38 @@
+/**
+ * Public Mintlify docs (https://docs.pymthouse.com) — not served from this repo.
+ * Override with NEXT_PUBLIC_DOCS_URL for previews or forks.
+ *
+ * Integration guides use paths like `/integration/device-flow` and
+ * `/integration/interactive-login` (see https://docs.pymthouse.com/llms.txt).
+ */
+export function getDocsBaseUrl(): string {
+  const defaultDocsUrl = "https://docs.pymthouse.com";
+  const fromEnv = process.env.NEXT_PUBLIC_DOCS_URL?.trim().replace(/\/+$/, "");
+  if (!fromEnv) return defaultDocsUrl;
+
+  try {
+    const url = new URL(fromEnv);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return fromEnv;
+    }
+  } catch {
+    /* fall through to default */
+  }
+
+  return defaultDocsUrl;
+}
+
+/** Stable paths on the docs site (see docs.pymthouse.com/llms.txt). */
+export function docsDeviceFlowUrl(): string {
+  return `${getDocsBaseUrl()}/integration/device-flow`;
+}
+
+/** OAuth 2.0 authorization code + PKCE (browser redirect flow). */
+export function docsInteractiveLoginUrl(): string {
+  return `${getDocsBaseUrl()}/integration/interactive-login`;
+}
+
+/** OIDC discovery, issuer layout, and API surface overview (not under /integration/*). */
+export function docsOidcUrl(): string {
+  return `${getDocsBaseUrl()}/api-reference/introduction`;
+}

--- a/src/platform/livepeer/proto.ts
+++ b/src/platform/livepeer/proto.ts
@@ -1,0 +1,253 @@
+import protobuf from "protobufjs";
+import path from "path";
+
+let orchestratorInfoType: protobuf.Type | null = null;
+let capabilitiesType: protobuf.Type | null = null;
+
+async function loadOrchestratorInfoType(): Promise<protobuf.Type> {
+  if (orchestratorInfoType) return orchestratorInfoType;
+
+  const protoPath = path.resolve(process.cwd(), "proto/lp_rpc.proto");
+  const root = await protobuf.load(protoPath);
+  orchestratorInfoType = root.lookupType("net.OrchestratorInfo");
+  return orchestratorInfoType;
+}
+
+async function loadCapabilitiesType(): Promise<protobuf.Type> {
+  if (capabilitiesType) return capabilitiesType;
+
+  const protoPath = path.resolve(process.cwd(), "proto/lp_rpc.proto");
+  const root = await protobuf.load(protoPath);
+  capabilitiesType = root.lookupType("net.Capabilities");
+  return capabilitiesType;
+}
+
+/**
+ * Map numeric capability id (livepeer `CapabilityId`) to pipeline slug used in
+ * discovery and NaaP pricing (matches python-gateway `capability_pipeline_id`).
+ */
+export function capabilityIdToPipelineId(capId: number): string | null {
+  const names: Record<number, string> = {
+    [-2]: "INVALID",
+    [-1]: "UNUSED",
+    0: "H264",
+    1: "MPEGTS",
+    2: "MP4",
+    3: "FRACTIONAL_FRAMERATES",
+    4: "STORAGE_DIRECT",
+    5: "STORAGE_S3",
+    6: "STORAGE_GCS",
+    7: "H264_BASELINE_PROFILE",
+    8: "H264_MAIN_PROFILE",
+    9: "H264_HIGH_PROFILE",
+    10: "H264_CONSTRAINED_CONTAINED_HIGH_PROFILE",
+    11: "GOP",
+    12: "AUTH_TOKEN",
+    14: "MPEG7_SIGNATURE",
+    15: "HEVC_DECODE",
+    16: "HEVC_ENCODE",
+    17: "VP8_DECODE",
+    18: "VP9_DECODE",
+    19: "VP8_ENCODE",
+    20: "VP9_ENCODE",
+    21: "H264_DECODE_YUV444_8BIT",
+    22: "H264_DECODE_YUV422_8BIT",
+    23: "H264_DECODE_YUV444_10BIT",
+    24: "H264_DECODE_YUV422_10BIT",
+    25: "H264_DECODE_YUV420_10BIT",
+    26: "SEGMENT_SLICING",
+    27: "TEXT_TO_IMAGE",
+    28: "IMAGE_TO_IMAGE",
+    29: "IMAGE_TO_VIDEO",
+    30: "UPSCALE",
+    31: "AUDIO_TO_TEXT",
+    32: "SEGMENT_ANYTHING_2",
+    33: "LLM",
+    34: "IMAGE_TO_TEXT",
+    35: "LIVE_VIDEO_TO_VIDEO",
+    36: "TEXT_TO_SPEECH",
+    37: "BYOC",
+  };
+  const enumName = names[capId];
+  if (!enumName) return null;
+  return enumName.toLowerCase().replace(/_/g, "-");
+}
+
+export interface PriceInfo {
+  pricePerUnit: number;
+  pixelsPerUnit: number;
+  capability?: number;
+  constraint?: string;
+}
+
+export interface DecodedOrchestratorInfo {
+  transcoder?: string;
+  address?: Uint8Array;
+  priceInfo?: PriceInfo;
+  capabilitiesPrices?: PriceInfo[];
+}
+
+/**
+ * Decode an OrchestratorInfo protobuf from base64-encoded bytes.
+ * The gateway sends this as a base64 string in the JSON request body.
+ */
+export async function decodeOrchestratorInfo(
+  orchestratorBytes: Buffer | Uint8Array | string
+): Promise<DecodedOrchestratorInfo> {
+  const type = await loadOrchestratorInfoType();
+
+  let buf: Uint8Array;
+  if (typeof orchestratorBytes === "string") {
+    buf = Buffer.from(orchestratorBytes, "base64");
+  } else {
+    buf = orchestratorBytes;
+  }
+
+  const message = type.decode(buf);
+  const obj = type.toObject(message, {
+    longs: Number,
+    bytes: Buffer,
+    defaults: true,
+  });
+
+  return {
+    transcoder: obj.transcoder || undefined,
+    address: obj.address || undefined,
+    priceInfo: obj.priceInfo
+      ? {
+          pricePerUnit: obj.priceInfo.pricePerUnit || 0,
+          pixelsPerUnit: obj.priceInfo.pixelsPerUnit || 1,
+          capability: obj.priceInfo.capability,
+          constraint: obj.priceInfo.constraint,
+        }
+      : undefined,
+    capabilitiesPrices: obj.capabilitiesPrices?.map(
+      (p: Record<string, unknown>) => ({
+        pricePerUnit: (p.pricePerUnit as number) || 0,
+        pixelsPerUnit: (p.pixelsPerUnit as number) || 1,
+        capability: p.capability as number | undefined,
+        constraint: p.constraint as string | undefined,
+      })
+    ),
+  };
+}
+
+export interface PipelineModelFromCapabilities {
+  pipeline: string;
+  modelId: string;
+}
+
+/**
+ * Decode `net.Capabilities` from base64 (same wire format python-gateway sends).
+ */
+export async function decodeCapabilities(
+  capabilitiesBytes: Buffer | Uint8Array | string,
+): Promise<Record<string, unknown>> {
+  const type = await loadCapabilitiesType();
+
+  let buf: Uint8Array;
+  if (typeof capabilitiesBytes === "string") {
+    buf = Buffer.from(capabilitiesBytes, "base64");
+  } else {
+    buf = capabilitiesBytes;
+  }
+
+  const message = type.decode(buf);
+  return type.toObject(message, {
+    longs: Number,
+    bytes: Buffer,
+    defaults: true,
+  }) as Record<string, unknown>;
+}
+
+/**
+ * Extract the first constrained pipeline/model from decoded Capabilities
+ * (`constraints.PerCapability[*].models`), deterministic order matching
+ * python-gateway `capabilities_to_query`.
+ */
+export function extractPipelineModelFromCapabilitiesObject(
+  obj: Record<string, unknown>,
+): PipelineModelFromCapabilities | null {
+  const constraints = obj.constraints as Record<string, unknown> | undefined;
+  if (!constraints || typeof constraints !== "object") return null;
+
+  const perRaw =
+    constraints.PerCapability ??
+    (constraints as { perCapability?: unknown }).perCapability;
+  if (!perRaw || typeof perRaw !== "object") return null;
+
+  const per = perRaw as Record<string, unknown>;
+  const capIds = Object.keys(per)
+    .map((k) => Number(k))
+    .filter((n) => Number.isFinite(n))
+    .sort((a, b) => a - b);
+
+  for (const capId of capIds) {
+    const pipeline = capabilityIdToPipelineId(capId);
+    if (!pipeline) continue;
+
+    const capBlock = per[String(capId)] as Record<string, unknown> | undefined;
+    if (!capBlock || typeof capBlock !== "object") continue;
+
+    const models = capBlock.models as Record<string, unknown> | undefined;
+    if (!models || typeof models !== "object") continue;
+
+    const modelKeys = Object.keys(models)
+      .filter((m) => typeof m === "string" && m.trim())
+      .sort();
+    if (modelKeys.length === 0) continue;
+
+    return { pipeline, modelId: modelKeys[0]! };
+  }
+
+  return null;
+}
+
+export async function extractPipelineModelFromCapabilitiesBase64(
+  base64: string,
+): Promise<PipelineModelFromCapabilities | null> {
+  try {
+    const obj = await decodeCapabilities(base64.trim());
+    return extractPipelineModelFromCapabilitiesObject(obj);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calculate fee in wei from pixel count and price info.
+ *
+ * feeWei = pixels * pricePerUnit / pixelsPerUnit
+ */
+export function calculateFeeWei(
+  pixels: bigint,
+  pricePerUnit: bigint,
+  pixelsPerUnit: bigint
+): bigint {
+  if (pixelsPerUnit === 0n) return 0n;
+  return (pixels * pricePerUnit) / pixelsPerUnit;
+}
+
+/**
+ * Calculate platform cut from fee.
+ *
+ * platformCutWei = feeWei * cutPercent / 100
+ */
+export function calculatePlatformCut(
+  feeWei: bigint,
+  cutPercent: number
+): bigint {
+  const cutBasis = BigInt(Math.round(cutPercent * 100));
+  return (feeWei * cutBasis) / 10000n;
+}
+
+/**
+ * For lv2v (live video-to-video) jobs without explicit InPixels,
+ * calculate pixels from elapsed time.
+ *
+ * Default: 1280x720 @ 30fps = 27,648,000 pixels/sec
+ */
+export function calculateLv2vPixels(secondsElapsed: number): bigint {
+  const PIXELS_PER_SEC = 1280 * 720 * 30; // 27,648,000
+  return BigInt(Math.floor(PIXELS_PER_SEC * secondsElapsed));
+}

--- a/src/platform/marketplace/constants.ts
+++ b/src/platform/marketplace/constants.ts
@@ -1,0 +1,10 @@
+export const CATEGORY_COLORS: Record<string, string> = {
+  "AI Video": "bg-purple-500/15 text-purple-400 border-purple-500/20",
+  Streaming: "bg-blue-500/15 text-blue-400 border-blue-500/20",
+  Gaming: "bg-red-500/15 text-red-400 border-red-500/20",
+  Social: "bg-pink-500/15 text-pink-400 border-pink-500/20",
+  Tools: "bg-amber-500/15 text-amber-400 border-amber-500/20",
+};
+
+export const DEFAULT_CATEGORY_COLOR =
+  "bg-zinc-500/15 text-zinc-400 border-zinc-500/20";

--- a/src/platform/oidc/allowed-scopes.ts
+++ b/src/platform/oidc/allowed-scopes.ts
@@ -1,0 +1,20 @@
+/** Tokens from a space- and/or comma-separated OIDC scopes field. */
+export function parseAllowedScopes(allowedScopes: string): string[] {
+  return allowedScopes
+    .split(/[,\s]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+export function deriveBillingPatternFromScopes(
+  tokens: string[],
+): "per_user" | "app_level" {
+  return tokens.includes("users:token") ? "per_user" : "app_level";
+}
+
+/** Billing mode for an app follows OIDC `allowed_scopes` (presence of `users:token`). */
+export function billingPatternFromAllowedScopesString(
+  allowedScopes: string,
+): "per_user" | "app_level" {
+  return deriveBillingPatternFromScopes(parseAllowedScopes(allowedScopes));
+}

--- a/src/platform/oidc/backend-m2m-scopes.ts
+++ b/src/platform/oidc/backend-m2m-scopes.ts
@@ -1,0 +1,26 @@
+import { OIDC_SCOPES } from "./scopes";
+
+const BACKEND_M2M_REQUIRED_SCOPES = [
+  "users:token",
+  "users:write",
+  "device:approve",
+] as const;
+
+const BACKEND_M2M_INHERIT_FROM_PUBLIC = ["sign:job", "users:read"] as const;
+
+export function computeBackendM2mAllowedScopes(publicAllowedScopes: string): string {
+  const publicSet = new Set(
+    publicAllowedScopes
+      .split(/[,\s]+/)
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  const selected = new Set<string>([...BACKEND_M2M_REQUIRED_SCOPES]);
+  for (const scope of BACKEND_M2M_INHERIT_FROM_PUBLIC) {
+    if (publicSet.has(scope)) {
+      selected.add(scope);
+    }
+  }
+  const ordered = OIDC_SCOPES.map((d) => d.value).filter((v) => selected.has(v));
+  return ordered.join(" ");
+}

--- a/src/platform/oidc/branding-shared.ts
+++ b/src/platform/oidc/branding-shared.ts
@@ -1,0 +1,64 @@
+export type BrandingMode = "blackLabel" | "whiteLabel";
+
+export interface AppBranding {
+  mode: BrandingMode;
+  appId: string | null;
+  appName: string;
+  displayName: string;
+  logoUrl: string | null;
+  primaryColor: string;
+  websiteUrl: string | null;
+  privacyPolicyUrl: string | null;
+  tosUrl: string | null;
+  supportUrl: string | null;
+  supportEmail: string | null;
+  developerName: string | null;
+  customLoginDomain: string | null;
+  customLoginEnabled: boolean;
+}
+
+const DEFAULT_BRANDING: AppBranding = {
+  mode: "blackLabel",
+  appId: null,
+  appName: "pymthouse",
+  displayName: "pymthouse",
+  logoUrl: null,
+  primaryColor: "#10b981",
+  websiteUrl: null,
+  privacyPolicyUrl: null,
+  tosUrl: null,
+  supportUrl: null,
+  supportEmail: null,
+  developerName: null,
+  customLoginDomain: null,
+  customLoginEnabled: false,
+};
+
+export function getDefaultBranding(): AppBranding {
+  return { ...DEFAULT_BRANDING };
+}
+
+export function shouldUseWhiteLabelBranding(branding: AppBranding): boolean {
+  return branding.mode === "whiteLabel";
+}
+
+export function getBrandingCssVars(branding: AppBranding): Record<string, string> {
+  const color = isValidHexColor(branding.primaryColor) ? branding.primaryColor : "#10b981";
+  return {
+    "--branding-primary": color,
+    "--branding-primary-hover": adjustColorBrightness(color, -10),
+    "--branding-primary-muted": `${color}1a`,
+  };
+}
+
+function isValidHexColor(value: string): boolean {
+  return /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+function adjustColorBrightness(hex: string, amount: number): string {
+  const num = parseInt(hex.replace("#", ""), 16);
+  const r = Math.min(255, Math.max(0, (num >> 16) + amount));
+  const g = Math.min(255, Math.max(0, ((num >> 8) & 0x00ff) + amount));
+  const b = Math.min(255, Math.max(0, (num & 0x0000ff) + amount));
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, "0")}`;
+}

--- a/src/platform/oidc/client-sibling.ts
+++ b/src/platform/oidc/client-sibling.ts
@@ -1,0 +1,64 @@
+import { eq, or } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export type DrizzleDb = typeof db;
+
+export class DeveloperAppSiblingAmbiguousError extends Error {
+  readonly conflictingDeveloperAppIds: string[];
+
+  constructor(conflictingDeveloperAppIds: string[]) {
+    super(
+      `Ambiguous developer_apps mapping for OIDC client row: expected exactly one row, found ${conflictingDeveloperAppIds.length} (ids: ${conflictingDeveloperAppIds.join(", ")}).`,
+    );
+    this.name = "DeveloperAppSiblingAmbiguousError";
+    this.conflictingDeveloperAppIds = conflictingDeveloperAppIds;
+  }
+}
+
+export async function resolveDeveloperAppAndPublicClientForOidcRow(
+  dbConn: DrizzleDb,
+  oidcClientRowId: string,
+): Promise<{ developerAppId: string; publicClientId: string } | null> {
+  const appRows = await dbConn
+    .select({
+      id: developerApps.id,
+      oidcClientId: developerApps.oidcClientId,
+    })
+    .from(developerApps)
+    .where(
+      or(
+        eq(developerApps.oidcClientId, oidcClientRowId),
+        eq(developerApps.m2mOidcClientId, oidcClientRowId),
+      ),
+    )
+    .limit(2);
+  if (appRows.length === 0) return null;
+  if (appRows.length > 1) {
+    const ids = appRows.map((r) => r.id);
+    console.error(
+      "[client-sibling] multiple developer_apps rows match oidcClientRowId=%s (developerApps.oidcClientId / developerApps.m2mOidcClientId); conflicting ids=%s",
+      oidcClientRowId,
+      ids.join(", "),
+    );
+    throw new DeveloperAppSiblingAmbiguousError(ids);
+  }
+  const app = appRows[0];
+  if (!app?.oidcClientId) return null;
+  const publicRows = await dbConn
+    .select({ clientId: oidcClients.clientId })
+    .from(oidcClients)
+    .where(eq(oidcClients.id, app.oidcClientId))
+    .limit(1);
+  const publicClientId = publicRows[0]?.clientId;
+  if (!publicClientId) return null;
+  return { developerAppId: app.id, publicClientId };
+}
+
+export async function resolvePublicClientIdForOidcRow(
+  dbConn: DrizzleDb,
+  clientRowId: string,
+): Promise<string | null> {
+  const ctx = await resolveDeveloperAppAndPublicClientForOidcRow(dbConn, clientRowId);
+  return ctx?.publicClientId ?? null;
+}

--- a/src/platform/oidc/device.ts
+++ b/src/platform/oidc/device.ts
@@ -1,0 +1,5 @@
+export function normalizeUserCode(value: string): string {
+  return value
+    .replace(/[a-z]/g, (char) => char.toUpperCase())
+    .replace(/\W/g, "");
+}

--- a/src/platform/oidc/issuer-resolution.ts
+++ b/src/platform/oidc/issuer-resolution.ts
@@ -1,0 +1,160 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps } from "@/db/schema";
+import { getCanonicalIssuer, getPublicOrigin } from "./issuer-urls";
+
+export interface IssuerConfig {
+  issuer: string;
+  origin: string;
+  isCanonical: boolean;
+  appId: string | null;
+  appName: string | null;
+}
+
+export function resolveIssuer(host?: string): IssuerConfig {
+  const canonicalIssuer = getCanonicalIssuer();
+  const canonicalOrigin = getPublicOrigin();
+
+  return {
+    issuer: canonicalIssuer,
+    origin: canonicalOrigin,
+    isCanonical: true,
+    appId: null,
+    appName: null,
+  };
+}
+
+export async function resolveIssuerForApp(appId: string): Promise<IssuerConfig> {
+  const appRows = await db
+    .select()
+    .from(developerApps)
+    .where(eq(developerApps.id, appId))
+    .limit(1);
+  const app = appRows[0];
+
+  const canonicalIssuer = getCanonicalIssuer();
+  const canonicalOrigin = getPublicOrigin();
+
+  if (!app) {
+    return {
+      issuer: canonicalIssuer,
+      origin: canonicalOrigin,
+      isCanonical: true,
+      appId: null,
+      appName: null,
+    };
+  }
+
+  if (app.customIssuerEnabled && app.customIssuerUrl) {
+    let origin = "";
+    try {
+      origin = new URL(app.customIssuerUrl).origin;
+    } catch (err) {
+      console.error(
+        `[issuer-resolution] Malformed customIssuerUrl for app ${app.id}: ${app.customIssuerUrl}`,
+        err,
+      );
+    }
+    return {
+      issuer: app.customIssuerUrl,
+      origin,
+      isCanonical: false,
+      appId: app.id,
+      appName: app.name,
+    };
+  }
+
+  return {
+    issuer: canonicalIssuer,
+    origin: canonicalOrigin,
+    isCanonical: true,
+    appId: app.id,
+    appName: app.name,
+  };
+}
+
+export function resolveIssuerForClientId(clientId: string): IssuerConfig {
+  return {
+    issuer: getCanonicalIssuer(),
+    origin: getPublicOrigin(),
+    isCanonical: true,
+    appId: null,
+    appName: null,
+  };
+}
+
+export function getEffectiveIssuer(): string {
+  return getCanonicalIssuer();
+}
+
+export function isIssuerTrusted(issuer: string): boolean {
+  const canonicalIssuer = getCanonicalIssuer();
+  try {
+    const issuerUrl = new URL(issuer);
+    const canonicalUrl = new URL(canonicalIssuer);
+    return issuerUrl.origin === canonicalUrl.origin && issuerUrl.pathname === canonicalUrl.pathname;
+  } catch {
+    return false;
+  }
+}
+
+export function getIssuerForTokenValidation(): string {
+  return getCanonicalIssuer();
+}
+
+export function buildDiscoveryUrl(issuerConfig: IssuerConfig): string {
+  return `${issuerConfig.issuer}/.well-known/openid-configuration`;
+}
+
+export function buildJwksUrl(issuerConfig: IssuerConfig): string {
+  return `${issuerConfig.issuer}/jwks`;
+}
+
+export function buildAuthorizationUrl(issuerConfig: IssuerConfig): string {
+  return `${issuerConfig.issuer}/auth`;
+}
+
+export function buildTokenUrl(issuerConfig: IssuerConfig): string {
+  return `${issuerConfig.issuer}/token`;
+}
+
+export function buildUserinfoUrl(issuerConfig: IssuerConfig): string {
+  return `${issuerConfig.issuer}/userinfo`;
+}
+
+export interface MultiIssuerConfig {
+  enabled: boolean;
+  supportedIssuers: string[];
+  defaultIssuer: string;
+}
+
+export function getMultiIssuerConfig(): MultiIssuerConfig {
+  const canonicalIssuer = getCanonicalIssuer();
+  return {
+    enabled: false,
+    supportedIssuers: [canonicalIssuer],
+    defaultIssuer: canonicalIssuer,
+  };
+}
+
+export function canEnableCustomIssuer(_appId: string): { allowed: boolean; reason?: string } {
+  return {
+    allowed: false,
+    reason: "Custom per-tenant issuers are not yet supported. This feature is planned for a future release.",
+  };
+}
+
+export function validateCustomIssuerUrl(url: string): { valid: boolean; error?: string } {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") {
+      return { valid: false, error: "Custom issuer URL must use HTTPS" };
+    }
+    if (parsed.pathname !== "/" && !parsed.pathname.endsWith("/")) {
+      return { valid: false, error: "Custom issuer URL should end with a trailing slash" };
+    }
+    return { valid: true };
+  } catch {
+    return { valid: false, error: "Invalid URL format" };
+  }
+}

--- a/src/platform/oidc/issuer-urls.ts
+++ b/src/platform/oidc/issuer-urls.ts
@@ -1,0 +1,124 @@
+/**
+ * Issuer / origin URL helpers only — safe to import from Client Components.
+ * Do not import DB-backed JWKS or token verification from here.
+ */
+
+export const OIDC_MOUNT_PATH = "/api/v1/oidc";
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+/** HTTP may stay http for loopback, RFC1918, IPv6 link-local, and *.local dev hosts. */
+function isLocalOrPrivateHost(hostname: string): boolean {
+  let h = hostname.trim().toLowerCase();
+  if (h.startsWith("[") && h.endsWith("]")) {
+    h = h.slice(1, -1);
+  }
+  h = h.split("%")[0] ?? h;
+
+  if (h === "localhost" || h === "::1" || h === "127.0.0.1") return true;
+  if (h.endsWith(".local")) return true;
+
+  const dottedQuad = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+  const plain4 = h.match(dottedQuad);
+  if (plain4) {
+    const a = Number(plain4[1]);
+    const b = Number(plain4[2]);
+    const c = Number(plain4[3]);
+    const d = Number(plain4[4]);
+    if (![a, b, c, d].every((x) => x >= 0 && x <= 255)) return false;
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    return false;
+  }
+
+  const embedded4 = h.match(/(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (embedded4) {
+    const a = Number(embedded4[1]);
+    const b = Number(embedded4[2]);
+    const c = Number(embedded4[3]);
+    const d = Number(embedded4[4]);
+    if ([a, b, c, d].every((x) => x >= 0 && x <= 255)) {
+      if (a === 10) return true;
+      if (a === 127) return true;
+      if (a === 192 && b === 168) return true;
+      if (a === 172 && b >= 16 && b <= 31) return true;
+    }
+  }
+
+  const firstHextet = h.split(":")[0];
+  if (firstHextet) {
+    const n = parseInt(firstHextet, 16);
+    if (!Number.isNaN(n) && n >= 0xfe80 && n <= 0xfebf) return true;
+  }
+
+  return false;
+}
+
+function ensureHttpsForProduction(url: string): string {
+  try {
+    const u = new URL(url);
+    if (!isLocalOrPrivateHost(u.hostname) && u.protocol === "http:") {
+      u.protocol = "https:";
+      return u.toString();
+    }
+  } catch {
+    /* ignore */
+  }
+  return url;
+}
+
+export function getPublicOrigin(): string {
+  const raw = process.env.NEXTAUTH_URL || "http://localhost:3001";
+  return trimTrailingSlash(ensureHttpsForProduction(raw));
+}
+
+export function getIssuer(): string {
+  const configured =
+    process.env.OIDC_ISSUER || process.env.NEXTAUTH_URL || "http://localhost:3001";
+  const normalized = trimTrailingSlash(ensureHttpsForProduction(configured));
+  return normalized.endsWith(OIDC_MOUNT_PATH)
+    ? normalized
+    : `${normalized}${OIDC_MOUNT_PATH}`;
+}
+
+export function getCanonicalIssuer(): string {
+  return getIssuer();
+}
+
+export function getOidcJwksUrl(): string {
+  return `${getIssuer()}/jwks`;
+}
+
+export function getPlatformJwksUrlForDatabase(): string {
+  const fromEnv = process.env.PLATFORM_JWKS_URL?.trim();
+  if (fromEnv) return fromEnv;
+  return `https://pymthouse.com${OIDC_MOUNT_PATH}/jwks`;
+}
+
+export function getPlatformPublicOidcIssuer(): string {
+  const jwks = getPlatformJwksUrlForDatabase();
+  if (jwks.endsWith("/jwks")) {
+    return jwks.slice(0, -"/jwks".length);
+  }
+  try {
+    const u = new URL(jwks);
+    u.pathname = u.pathname.replace(/\/jwks\/?$/, "") || OIDC_MOUNT_PATH;
+    return trimTrailingSlash(u.toString());
+  } catch {
+    return `https://pymthouse.com${OIDC_MOUNT_PATH}`;
+  }
+}
+
+export function getJwksUrlForLocalSignerDmzContainer(): string {
+  const trimmed = process.env.SIGNER_DMZ_JWKS_URL?.trim();
+  if (trimmed) return trimmed;
+  const u = new URL(`${getIssuer()}/jwks`);
+  if (u.hostname === "localhost" || u.hostname === "127.0.0.1") {
+    u.hostname = "host.docker.internal";
+  }
+  return u.toString();
+}

--- a/src/platform/oidc/jwks-fetch.ts
+++ b/src/platform/oidc/jwks-fetch.ts
@@ -1,0 +1,250 @@
+import * as jose from "jose";
+import * as http from "node:http";
+import * as https from "node:https";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+interface CachedJWKS {
+  jwks: jose.JSONWebKeySet;
+  fetchedAt: number;
+}
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 128;
+const cache = new Map<string, CachedJWKS>();
+const MAX_REDIRECTS = 5;
+const DEFAULT_MAX_RESPONSE_BODY_BYTES = 1 * 1024 * 1024;
+
+export interface SafeJwksResolution {
+  url: URL;
+  dnsRecords: { family: 4 | 6; address: string }[];
+}
+
+function isPrivateOrReservedIpv4(ip: string): boolean {
+  const octets = ip.split(".").map((part) => Number.parseInt(part, 10));
+  if (octets.length !== 4 || octets.some((n) => Number.isNaN(n))) {
+    return true;
+  }
+  const [a, b, c] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 192 && b === 0 && c === 0) ||
+    (a === 192 && b === 0 && c === 2) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+function isPrivateOrReservedIpv6(ip: string): boolean {
+  const normalized = ip.toLowerCase().split("%")[0];
+  if (normalized === "::" || normalized === "::1") return true;
+  if (/^fe[89ab]/.test(normalized)) return true;
+  if (
+    normalized.startsWith("fc") ||
+    normalized.startsWith("fd") ||
+    normalized.startsWith("ff") ||
+    normalized.startsWith("2001:db8")
+  ) {
+    return true;
+  }
+  if (normalized.startsWith("::ffff:")) {
+    const mapped = normalized.slice("::ffff:".length);
+    return isIP(mapped) === 4 ? isPrivateOrReservedIpv4(mapped) : true;
+  }
+  return false;
+}
+
+function isPrivateOrReservedIp(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isPrivateOrReservedIpv4(ip);
+  if (family === 6) return isPrivateOrReservedIpv6(ip);
+  return true;
+}
+
+function assertDnsRecordsSafe(
+  records: { family: number; address: string }[],
+): { family: 4 | 6; address: string }[] {
+  const out: { family: 4 | 6; address: string }[] = [];
+  for (const record of records) {
+    if (record.family !== 4 && record.family !== 6) continue;
+    if (isPrivateOrReservedIp(record.address)) {
+      throw new Error("JWKS URI resolves to a disallowed IP range");
+    }
+    out.push({ family: record.family, address: record.address });
+  }
+  return out;
+}
+
+export async function assertSafeJwksUri(jwksUri: string): Promise<SafeJwksResolution> {
+  let parsed: URL;
+  try {
+    parsed = new URL(jwksUri);
+  } catch {
+    throw new Error("JWKS URI is not a valid URL");
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  if (protocol !== "https:" && protocol !== "http:") {
+    throw new Error("JWKS URI must use http or https");
+  }
+  if (process.env.NODE_ENV === "production" && protocol !== "https:") {
+    throw new Error("JWKS URI must use https in production");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("JWKS URI must not include credentials");
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
+    throw new Error("JWKS URI points to a disallowed host");
+  }
+
+  const ipKind = isIP(hostname);
+  if (ipKind === 4 || ipKind === 6) {
+    if (isPrivateOrReservedIp(hostname)) {
+      throw new Error("JWKS URI resolves to a disallowed IP range");
+    }
+    return { url: parsed, dnsRecords: [{ family: ipKind, address: hostname }] };
+  }
+
+  const records = await lookup(hostname, { all: true, verbatim: true });
+  if (records.length === 0) {
+    throw new Error("JWKS URI host has no DNS records");
+  }
+  const dnsRecords = assertDnsRecordsSafe(records);
+  if (dnsRecords.length === 0) {
+    throw new Error("JWKS URI host has no usable DNS records");
+  }
+  return { url: parsed, dnsRecords };
+}
+
+async function readResponseBody(
+  res: http.IncomingMessage,
+  maxBytes: number = DEFAULT_MAX_RESPONSE_BODY_BYTES,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of res) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    if (total + buf.length > maxBytes) {
+      res.destroy();
+      throw new Error("Response body too large");
+    }
+    chunks.push(buf);
+    total += buf.length;
+  }
+  return Buffer.concat(chunks);
+}
+
+function requestOnceBound(
+  target: SafeJwksResolution,
+  record: { family: 4 | 6; address: string },
+): Promise<{ statusCode: number; headers: http.IncomingHttpHeaders; body: Buffer }> {
+  const { url } = target;
+  const isHttps = url.protocol === "https:";
+  const defaultPort = isHttps ? 443 : 80;
+  const port = url.port ? Number(url.port) : defaultPort;
+  const path = `${url.pathname}${url.search}` || "/";
+  const hostHeader = url.host || url.hostname;
+  const tcpHost = record.family === 6 ? `[${record.address}]` : record.address;
+  const sniHostname = isIP(url.hostname) === 0 ? url.hostname : undefined;
+
+  return new Promise((resolve, reject) => {
+    const lib = isHttps ? https : http;
+    const req = lib.request(
+      {
+        method: "GET",
+        host: tcpHost,
+        port,
+        path,
+        ...(isHttps && sniHostname ? { servername: sniHostname } : {}),
+        headers: {
+          Host: hostHeader,
+          Accept: "application/json",
+        },
+        timeout: 10_000,
+        ...(isHttps ? { rejectUnauthorized: true } : {}),
+      },
+      (res) => {
+        void readResponseBody(res)
+          .then((body) => {
+            resolve({
+              statusCode: res.statusCode ?? 0,
+              headers: res.headers,
+              body,
+            });
+          })
+          .catch(reject);
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("JWKS request timed out"));
+    });
+    req.end();
+  });
+}
+
+async function fetchJwksWithRedirects(
+  target: SafeJwksResolution,
+  redirectsRemaining: number,
+): Promise<jose.JSONWebKeySet> {
+  const responses = await Promise.allSettled(
+    target.dnsRecords.map((record) => requestOnceBound(target, record)),
+  );
+  const fulfilled = responses.find(
+    (response): response is PromiseFulfilledResult<Awaited<ReturnType<typeof requestOnceBound>>> =>
+      response.status === "fulfilled",
+  );
+  if (!fulfilled) {
+    throw (responses[0] as PromiseRejectedResult).reason ?? new Error("JWKS request failed");
+  }
+
+  const { statusCode, headers, body } = fulfilled.value;
+  if (statusCode >= 300 && statusCode < 400) {
+    if (redirectsRemaining <= 0) {
+      throw new Error("Too many JWKS redirects");
+    }
+    const location = headers.location;
+    if (!location) {
+      throw new Error("JWKS redirect missing location header");
+    }
+    const redirected = await assertSafeJwksUri(new URL(location, target.url).toString());
+    return fetchJwksWithRedirects(redirected, redirectsRemaining - 1);
+  }
+  if (statusCode !== 200) {
+    throw new Error(`JWKS request failed with status ${statusCode}`);
+  }
+  const parsed = JSON.parse(body.toString("utf8")) as jose.JSONWebKeySet;
+  if (!parsed || !Array.isArray(parsed.keys)) {
+    throw new Error("JWKS response is not a valid JWKS document");
+  }
+  return parsed;
+}
+
+export async function fetchPlatformJWKS(jwksUri: string): Promise<jose.JSONWebKeySet> {
+  const cached = cache.get(jwksUri);
+  const now = Date.now();
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.jwks;
+  }
+
+  const target = await assertSafeJwksUri(jwksUri);
+  const jwks = await fetchJwksWithRedirects(target, MAX_REDIRECTS);
+  cache.set(jwksUri, { jwks, fetchedAt: now });
+
+  if (cache.size > CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey) cache.delete(oldestKey);
+  }
+  return jwks;
+}

--- a/src/platform/oidc/routes.test.ts
+++ b/src/platform/oidc/routes.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+import { normalizeProviderPath, PROVIDER_ENDPOINT_PATHS } from "@/platform/oidc/routes";
+
+test("OIDC issuer is mounted under /api/v1/oidc", () => {
+  const issuer = getIssuer();
+  assert.match(issuer, /\/api\/v1\/oidc$/);
+});
+
+test("legacy aliases map to provider endpoints", () => {
+  assert.equal(
+    normalizeProviderPath("/authorize"),
+    PROVIDER_ENDPOINT_PATHS.authorization,
+  );
+  assert.equal(
+    normalizeProviderPath("/userinfo"),
+    PROVIDER_ENDPOINT_PATHS.userinfo,
+  );
+  assert.equal(
+    normalizeProviderPath("/device_authorization"),
+    PROVIDER_ENDPOINT_PATHS.deviceAuthorization,
+  );
+});

--- a/src/platform/oidc/routes.ts
+++ b/src/platform/oidc/routes.ts
@@ -1,0 +1,20 @@
+export const PROVIDER_ENDPOINT_PATHS = {
+  authorization: "/auth",
+  token: "/token",
+  userinfo: "/me",
+  jwks: "/jwks",
+  deviceAuthorization: "/device/auth",
+  endSession: "/session/end",
+  introspection: "/token/introspection",
+  revocation: "/token/revocation",
+} as const;
+
+export const LEGACY_ROUTE_ALIASES: Record<string, string> = {
+  "/authorize": PROVIDER_ENDPOINT_PATHS.authorization,
+  "/userinfo": PROVIDER_ENDPOINT_PATHS.userinfo,
+  "/device_authorization": PROVIDER_ENDPOINT_PATHS.deviceAuthorization,
+};
+
+export function normalizeProviderPath(path: string): string {
+  return LEGACY_ROUTE_ALIASES[path] ?? path;
+}

--- a/src/platform/oidc/scopes.ts
+++ b/src/platform/oidc/scopes.ts
@@ -1,0 +1,57 @@
+export interface ScopeDefinition {
+  value: string;
+  label: string;
+  description: string;
+  required?: boolean;
+}
+
+export const DEFAULT_OIDC_SCOPES = "openid sign:job";
+
+export const OIDC_SCOPES: ScopeDefinition[] = [
+  {
+    value: "openid",
+    label: "OpenID",
+    description: "Confirm which PymtHouse account you are signed in with",
+    required: true,
+  },
+  {
+    value: "sign:job",
+    label: "Sign Jobs",
+    description: "Access all remote signer endpoints, including discovery and payment signing",
+  },
+  {
+    value: "users:read",
+    label: "Read Users",
+    description: "Read provisioned provider-managed application users",
+  },
+  {
+    value: "users:write",
+    label: "Write Users",
+    description: "Create, update, and deactivate provisioned application users",
+  },
+  {
+    value: "users:token",
+    label: "Issue User Tokens",
+    description:
+      "Issue app-user access tokens for provider-managed backends. Enables per-user usage attribution.",
+  },
+  {
+    value: "device:approve",
+    label: "Approve device codes",
+    description:
+      "RFC 8693 token exchange to bind RFC 8628 device codes after third-party login (confidential client only).",
+  },
+  {
+    value: "admin",
+    label: "Admin",
+    description: "Administrative access to provider configuration surfaces",
+  },
+];
+
+export const OIDC_SCOPE_MAP: Record<string, ScopeDefinition> = Object.fromEntries(
+  OIDC_SCOPES.map((scope) => [scope.value, scope]),
+);
+
+export function getScopeDefinition(scope: string): ScopeDefinition | undefined {
+  return OIDC_SCOPE_MAP[scope];
+}

--- a/src/platform/oidc/security.ts
+++ b/src/platform/oidc/security.ts
@@ -1,0 +1,207 @@
+import { getPublicOrigin, getIssuer } from "./issuer-urls";
+import { getTrustedLoginHosts, normalizeDomain } from "@/domains/oidc-platform/runtime/custom-domains";
+
+export interface SecurityContext {
+  requestOrigin: string;
+  canonicalOrigin: string;
+  canonicalIssuer: string;
+  isTrustedOrigin: boolean;
+  isCanonicalOrigin: boolean;
+}
+
+export async function buildSecurityContext(requestHost: string): Promise<SecurityContext> {
+  const canonicalOrigin = getPublicOrigin();
+  const canonicalIssuer = getIssuer();
+  const canonicalHost = new URL(canonicalOrigin).host;
+
+  const normalizedRequestHost = normalizeDomain(requestHost);
+  const normalizedCanonicalHost = normalizeDomain(canonicalHost);
+
+  const isCanonicalOrigin = normalizedRequestHost === normalizedCanonicalHost;
+  const trustedHosts = await getTrustedLoginHosts();
+  const isTrustedOrigin = trustedHosts.some((h) => normalizeDomain(h) === normalizedRequestHost);
+
+  const isLocalhost = requestHost.includes("localhost") || requestHost.startsWith("127.");
+  const requestOrigin = isLocalhost ? `http://${requestHost}` : `https://${requestHost}`;
+
+  return {
+    requestOrigin,
+    canonicalOrigin,
+    canonicalIssuer,
+    isTrustedOrigin,
+    isCanonicalOrigin,
+  };
+}
+
+export function validateRedirectUri(
+  redirectUri: string,
+  allowedUris: string[],
+  strictMode: boolean = true,
+): boolean {
+  try {
+    const redirectUrl = new URL(redirectUri);
+
+    for (const allowedUri of allowedUris) {
+      if (allowedUri.includes("*")) {
+        const wildcardCount = (allowedUri.match(/\*/g) || []).length;
+        if (wildcardCount !== 1) continue;
+
+        const starIdx = allowedUri.indexOf("*");
+        const prefix = allowedUri.slice(0, starIdx);
+        const suffix = allowedUri.slice(starIdx + 1);
+
+        if (prefix && suffix) {
+          try {
+            const templateUrl = new URL(allowedUri.replace(/\*/g, "WILDCARD"));
+            if (templateUrl.host.includes("WILDCARD")) {
+              const hostSuffix = templateUrl.host.replace("WILDCARD", "");
+              if (
+                redirectUrl.protocol === templateUrl.protocol &&
+                (redirectUrl.host === hostSuffix.replace(/^\./, "") ||
+                  redirectUrl.host.endsWith(hostSuffix)) &&
+                redirectUrl.pathname === templateUrl.pathname &&
+                redirectUrl.search === templateUrl.search
+              ) {
+                return true;
+              }
+            } else if (templateUrl.pathname.includes("WILDCARD")) {
+              const pathPrefix = templateUrl.pathname.split("WILDCARD")[0];
+              if (
+                redirectUrl.protocol === templateUrl.protocol &&
+                redirectUrl.host === templateUrl.host &&
+                redirectUrl.pathname.startsWith(pathPrefix)
+              ) {
+                return true;
+              }
+            }
+          } catch {
+            continue;
+          }
+        } else if (prefix) {
+          if (redirectUrl.href.startsWith(prefix)) return true;
+        } else if (suffix) {
+          if (
+            redirectUrl.host === suffix.replace(/^\./, "") ||
+            redirectUrl.host.endsWith(suffix)
+          ) {
+            return true;
+          }
+        }
+      } else if (redirectUri === allowedUri) {
+        return true;
+      } else if (!strictMode) {
+        try {
+          const allowedUrl = new URL(allowedUri);
+          if (
+            redirectUrl.origin === allowedUrl.origin &&
+            redirectUrl.pathname === allowedUrl.pathname
+          ) {
+            return true;
+          }
+        } catch {
+          continue;
+        }
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function validatePostLogoutUri(
+  postLogoutUri: string,
+  allowedUris: string[],
+): boolean {
+  return validateRedirectUri(postLogoutUri, allowedUris, true);
+}
+
+export function sanitizeOrigin(origin: string): string | null {
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function isSafeRedirectUrl(url: string, allowedOrigins: Set<string>): boolean {
+  try {
+    const parsed = new URL(url);
+    const sanitized = sanitizeOrigin(parsed.origin);
+    if (!sanitized) return false;
+    return allowedOrigins.has(sanitized);
+  } catch {
+    return false;
+  }
+}
+
+export function getCookieOptions(isCustomDomain: boolean): {
+  sameSite: "lax" | "none" | "strict";
+  secure: boolean;
+  httpOnly: boolean;
+  path: string;
+} {
+  const isProduction = process.env.NODE_ENV === "production";
+
+  return {
+    sameSite: isCustomDomain ? "none" : "lax",
+    secure: isProduction || isCustomDomain,
+    httpOnly: true,
+    path: "/",
+  };
+}
+
+export function validateCorsOrigin(
+  origin: string,
+  clientRedirectUris: string[],
+  trustedOrigins: Set<string>,
+): boolean {
+  const sanitized = sanitizeOrigin(origin);
+  if (!sanitized) return false;
+
+  if (trustedOrigins.has(sanitized)) {
+    return true;
+  }
+
+  for (const uri of clientRedirectUris) {
+    try {
+      const uriOrigin = new URL(uri).origin;
+      if (sanitized === uriOrigin) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return false;
+}
+
+export async function assertTrustedHost(host: string): Promise<void> {
+  const trustedHosts = await getTrustedLoginHosts();
+  const normalized = normalizeDomain(host);
+
+  if (!trustedHosts.some((h) => normalizeDomain(h) === normalized)) {
+    throw new Error(`Untrusted host: ${host}`);
+  }
+}
+
+export function getSecureHeaders(isCustomDomain: boolean): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "X-XSS-Protection": "1; mode=block",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+  };
+
+  if (process.env.NODE_ENV === "production") {
+    headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
+  }
+
+  return headers;
+}

--- a/src/platform/oidc/third-party-initiate-login.test.ts
+++ b/src/platform/oidc/third-party-initiate-login.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  issuerMatchesExpected,
+  normalizeIssuerUrl,
+  validateInitiateLoginUri,
+  validateDeviceFlowTargetLinkUri,
+  buildInitiateLoginRedirectUrl,
+  thirdPartyInitiateSkipCookieName,
+  userCodeFromDeviceTargetLinkUri,
+} from "@/platform/oidc/third-party-initiate-login";
+import { getIssuer, getPublicOrigin } from "@/platform/oidc/issuer-urls";
+
+test("normalizeIssuerUrl trims trailing slashes", () => {
+  assert.equal(
+    normalizeIssuerUrl("https://op.example/api/v1/oidc/"),
+    "https://op.example/api/v1/oidc",
+  );
+});
+
+test("issuerMatchesExpected compares normalized issuers", () => {
+  const iss = getIssuer();
+  assert.equal(issuerMatchesExpected(iss, iss), true);
+  assert.equal(issuerMatchesExpected("https://wrong.example", iss), false);
+  assert.equal(issuerMatchesExpected(null, iss), false);
+});
+
+test("validateInitiateLoginUri accepts HTTPS without fragment", () => {
+  assert.doesNotThrow(() =>
+    validateInitiateLoginUri("https://rp.example/oidc/start"),
+  );
+});
+
+test("validateInitiateLoginUri rejects fragments", () => {
+  assert.throws(() => validateInitiateLoginUri("https://rp.example/start#frag"));
+});
+
+test("validateDeviceFlowTargetLinkUri enforces /oidc/device on public origin", () => {
+  const origin = getPublicOrigin();
+  const ok = `${origin}/oidc/device?user_code=ABCD-EFGH&client_id=app_x&iss=${encodeURIComponent(getIssuer())}`;
+  assert.doesNotThrow(() => validateDeviceFlowTargetLinkUri(ok));
+  assert.throws(() => validateDeviceFlowTargetLinkUri(`${origin}/login`));
+});
+
+test("thirdPartyInitiateSkipCookieName differs by user_code for same client", () => {
+  const a = thirdPartyInitiateSkipCookieName("app_x", "ABCD-EFGH");
+  const b = thirdPartyInitiateSkipCookieName("app_x", "WXYZ-1234");
+  assert.notEqual(a, b);
+  assert.equal(
+    thirdPartyInitiateSkipCookieName("app_x", "abcd-efgh"),
+    thirdPartyInitiateSkipCookieName("app_x", "ABCD-EFGH"),
+  );
+});
+
+test("userCodeFromDeviceTargetLinkUri reads user_code query", () => {
+  const origin = getPublicOrigin();
+  const u = `${origin}/oidc/device?user_code=AA-BB&client_id=app_1`;
+  assert.equal(userCodeFromDeviceTargetLinkUri(u), "AA-BB");
+  assert.equal(userCodeFromDeviceTargetLinkUri("not-a-url"), undefined);
+});
+
+test("buildInitiateLoginRedirectUrl validates both URIs", () => {
+  const origin = getPublicOrigin();
+  const target = `${origin}/oidc/device?foo=1`;
+  const dest = buildInitiateLoginRedirectUrl("https://rp.example/start", {
+    iss: getIssuer(),
+    target_link_uri: target,
+  });
+  assert.match(dest, /^https:\/\/rp\.example\/start\?/);
+  assert.ok(dest.includes("target_link_uri="));
+});

--- a/src/platform/oidc/third-party-initiate-login.ts
+++ b/src/platform/oidc/third-party-initiate-login.ts
@@ -1,0 +1,152 @@
+import { createHash } from "crypto";
+import { normalizeUserCode } from "./device";
+import { getPublicOrigin } from "./issuer-urls";
+
+const INITIATE_SKIP_MAX_AGE_SEC = 120;
+
+function isLocalhostHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+export function normalizeIssuerUrl(iss: string): string {
+  try {
+    const u = new URL(iss);
+    return u.href.replace(/\/+$/, "");
+  } catch {
+    return iss.trim();
+  }
+}
+
+export function issuerMatchesExpected(iss: string | null, expectedIssuer: string): boolean {
+  if (!iss || !iss.trim()) return false;
+  try {
+    return normalizeIssuerUrl(iss) === normalizeIssuerUrl(expectedIssuer);
+  } catch {
+    return false;
+  }
+}
+
+export function buildDeviceFlowTargetLinkUri(searchParams: {
+  user_code?: string | null;
+  client_id?: string | null;
+  iss?: string | null;
+  login_hint?: string | null;
+}): string {
+  const base = new URL("/oidc/device", getPublicOrigin());
+  if (searchParams.user_code) {
+    base.searchParams.set("user_code", searchParams.user_code);
+  }
+  if (searchParams.client_id) {
+    base.searchParams.set("client_id", searchParams.client_id);
+  }
+  if (searchParams.iss) {
+    base.searchParams.set("iss", searchParams.iss);
+  }
+  if (searchParams.login_hint) {
+    base.searchParams.set("login_hint", searchParams.login_hint);
+  }
+  return base.href;
+}
+
+export function validateInitiateLoginUri(uri: string): void {
+  const u = new URL(uri);
+  if (u.hash) {
+    throw new Error("initiate_login_uri must not include a fragment");
+  }
+  if (u.protocol === "https:") {
+    return;
+  }
+  if (
+    process.env.NODE_ENV !== "production" &&
+    u.protocol === "http:" &&
+    isLocalhostHostname(u.hostname)
+  ) {
+    return;
+  }
+  throw new Error("initiate_login_uri must use HTTPS");
+}
+
+export function initiateLoginUriAcceptedByOidcProvider(uri: string): boolean {
+  try {
+    const u = new URL(uri);
+    if (u.hash) return false;
+    return u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function validateDeviceFlowTargetLinkUri(targetLinkUri: string): void {
+  const expectedOrigin = new URL(getPublicOrigin()).origin;
+  const u = new URL(targetLinkUri);
+  if (u.origin !== expectedOrigin) {
+    throw new Error("target_link_uri must use this site's origin");
+  }
+  if (u.pathname !== "/oidc/device") {
+    throw new Error("target_link_uri path must be /oidc/device");
+  }
+  if (u.hash) {
+    throw new Error("target_link_uri must not include a fragment");
+  }
+}
+
+export function buildInitiateLoginRedirectUrl(
+  initiateLoginUri: string,
+  args: {
+    iss: string;
+    target_link_uri: string;
+    login_hint?: string | null;
+  },
+): string {
+  validateInitiateLoginUri(initiateLoginUri);
+  validateDeviceFlowTargetLinkUri(args.target_link_uri);
+  const dest = new URL(initiateLoginUri);
+  dest.searchParams.set("iss", args.iss);
+  dest.searchParams.set("target_link_uri", args.target_link_uri);
+  if (args.login_hint && args.login_hint.trim()) {
+    dest.searchParams.set("login_hint", args.login_hint.trim());
+  }
+  return dest.toString();
+}
+
+export function userCodeFromDeviceTargetLinkUri(
+  targetLinkUri: string,
+): string | undefined {
+  try {
+    const raw = new URL(targetLinkUri).searchParams.get("user_code")?.trim();
+    return raw || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function thirdPartyInitiateSkipCookieName(
+  clientId: string,
+  userCode?: string | null,
+): string {
+  const normalized = userCode?.trim() ? normalizeUserCode(userCode) : "";
+  const h = createHash("sha256")
+    .update(`${clientId}\0${normalized}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `pmth_tp_skip_${h}`;
+}
+
+export function initiateSkipCookieOptions(): {
+  httpOnly: boolean;
+  sameSite: "lax";
+  path: string;
+  maxAge: number;
+  secure: boolean;
+} {
+  const secure =
+    process.env.NODE_ENV === "production" ||
+    (process.env.NEXTAUTH_URL ?? "").startsWith("https:");
+  return {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: INITIATE_SKIP_MAX_AGE_SEC,
+    secure,
+  };
+}

--- a/src/platform/ops/active-streams.ts
+++ b/src/platform/ops/active-streams.ts
@@ -1,0 +1,102 @@
+import { inArray, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import { streamSessions } from "@/db/schema";
+import type { StreamSession } from "@/db/schema";
+
+export const ACTIVE_STREAM_PAYMENT_WINDOW_MINUTES = 5;
+export const ACTIVE_STREAM_PAYMENT_WINDOW_LABEL = `paid in last ${ACTIVE_STREAM_PAYMENT_WINDOW_MINUTES} min`;
+
+type ActiveStreamIdRow = {
+  id: string;
+};
+
+type CountRow = {
+  count: number | string;
+};
+
+function isMissingRelationError(error: unknown): boolean {
+  const cause = (error as { cause?: { code?: string } })?.cause;
+  const direct = error as { code?: string };
+  return cause?.code === "42P01" || direct?.code === "42P01";
+}
+
+async function countActiveStreamsFallback(): Promise<number> {
+  const rows = await db.execute<CountRow>(sql`
+    SELECT COUNT(DISTINCT t.stream_session_id)::int AS count
+    FROM transactions t
+    WHERE t.type = 'usage'
+      AND t.status = 'confirmed'
+      AND t.stream_session_id IS NOT NULL
+      AND t.created_at::timestamptz > NOW() - INTERVAL '5 minutes'
+  `);
+  const count = rows[0]?.count ?? 0;
+  return typeof count === "number" ? count : Number(count);
+}
+
+export async function countActiveStreamsByRecentPayment(): Promise<number> {
+  try {
+    const rows = await db.execute<CountRow>(sql`
+      SELECT COUNT(*)::int AS count
+      FROM active_stream_ids_by_recent_payment
+    `);
+    const count = rows[0]?.count ?? 0;
+    return typeof count === "number" ? count : Number(count);
+  } catch (error) {
+    if (isMissingRelationError(error)) {
+      return countActiveStreamsFallback();
+    }
+    throw error;
+  }
+}
+
+export async function getActiveStreamSessionsByRecentPayment(
+  limit?: number,
+): Promise<StreamSession[]> {
+  const limitClause = typeof limit === "number" ? sql`LIMIT ${limit}` : sql``;
+  let idRows: ActiveStreamIdRow[];
+  try {
+    idRows = await db.execute<ActiveStreamIdRow>(sql`
+      SELECT grouped.stream_session_id AS id
+      FROM (
+        SELECT t.stream_session_id, MAX(t.created_at::timestamptz) AS last_payment_at
+        FROM transactions t
+        INNER JOIN active_stream_ids_by_recent_payment a ON a.id = t.stream_session_id
+        WHERE t.type = 'usage'
+          AND t.status = 'confirmed'
+          AND t.stream_session_id IS NOT NULL
+          AND t.created_at::timestamptz > NOW() - INTERVAL '5 minutes'
+        GROUP BY t.stream_session_id
+      ) grouped
+      ORDER BY grouped.last_payment_at DESC
+      ${limitClause}
+    `);
+  } catch (error) {
+    if (!isMissingRelationError(error)) throw error;
+    idRows = await db.execute<ActiveStreamIdRow>(sql`
+      SELECT grouped.stream_session_id AS id
+      FROM (
+        SELECT t.stream_session_id, MAX(t.created_at::timestamptz) AS last_payment_at
+        FROM transactions t
+        WHERE t.type = 'usage'
+          AND t.status = 'confirmed'
+          AND t.stream_session_id IS NOT NULL
+          AND t.created_at::timestamptz > NOW() - INTERVAL '5 minutes'
+        GROUP BY t.stream_session_id
+      ) grouped
+      ORDER BY grouped.last_payment_at DESC
+      ${limitClause}
+    `);
+  }
+  const ids = idRows.map((row) => row.id);
+  if (ids.length === 0) return [];
+
+  const sessions = await db
+    .select()
+    .from(streamSessions)
+    .where(inArray(streamSessions.id, ids));
+  const sessionById = new Map(sessions.map((session) => [session.id, session]));
+
+  return ids
+    .map((id) => sessionById.get(id))
+    .filter((session): session is StreamSession => !!session);
+}

--- a/src/platform/ops/billing-usage-dashboard-data.ts
+++ b/src/platform/ops/billing-usage-dashboard-data.ts
@@ -1,0 +1,406 @@
+import { getServerSession } from "next-auth";
+import { and, eq, gte, inArray, lte } from "drizzle-orm";
+import { db } from "@/db/index";
+import { appUsers, developerApps, usageBillingEvents, usageRecords, users } from "@/db/schema";
+import { getAuthorizedProviderApp } from "@/domains/developer-apps/runtime/provider-access";
+import { authOptions } from "@/platform/auth/next-auth-options";
+import { calendarMonthBoundsUtc, dateKeysInclusiveUtc } from "@/shared/utils/billing-utils";
+
+export type BillingAppRow = {
+  id: string;
+  name: string;
+  ownerId: string;
+  ownerName: string | null;
+  ownerEmail: string | null;
+};
+
+export type BillingUserUsageRow = {
+  endUserId: string;
+  externalUserId: string | null;
+  userType: "system_managed" | "oidc_authorized" | "unknown";
+  userLabel: string;
+  identifier: string;
+  requestCount: number;
+  totalFeeWei: string;
+  totalUnits: string;
+};
+
+export type BillingPipelineModelSummary = {
+  pipeline: string;
+  modelId: string;
+  requestCount: number;
+  networkFeeUsdMicros: string;
+  endUserBillableUsdMicros: string;
+};
+
+export type BillingAppUsageSummary = {
+  app: BillingAppRow;
+  requestCount: number;
+  totalFeeWei: string;
+  totalUnits: string;
+  networkFeeUsdMicros: string;
+  endUserBillableUsdMicros: string;
+  byUser: BillingUserUsageRow[];
+  byPipelineModel: BillingPipelineModelSummary[];
+};
+
+export function formatBillingWei(wei: string): string {
+  if (!wei || !/^\d+$/.test(wei)) return "0";
+  const value = BigInt(wei);
+  if (value === 0n) return "0";
+  const divisor = 10n ** 18n;
+  const whole = value / divisor;
+  const remainder = value % divisor;
+  if (whole === 0n && remainder > 0n) return `${value.toString()} wei`;
+  const fracStr = remainder.toString().padStart(18, "0").slice(0, 6);
+  return `${whole}.${fracStr} ETH`;
+}
+
+export function formatBillingPeriod(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function dateKeyFromIso(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function classifyUsageUser(endUserId: string, externalUserId: string | null): {
+  userType: "system_managed" | "oidc_authorized" | "unknown";
+  userLabel: string;
+  identifier: string;
+} {
+  if (externalUserId) {
+    return {
+      userType: "system_managed",
+      userLabel: externalUserId,
+      identifier: endUserId,
+    };
+  }
+  if (endUserId !== "unknown") {
+    return {
+      userType: "oidc_authorized",
+      userLabel: "OIDC user (not provisioned)",
+      identifier: endUserId,
+    };
+  }
+  return {
+    userType: "unknown",
+    userLabel: "Unknown / unscoped",
+    identifier: "unknown",
+  };
+}
+
+function sortAppsForViewer(apps: BillingAppRow[], userId: string, isAdmin: boolean): BillingAppRow[] {
+  const byName = (a: BillingAppRow, b: BillingAppRow) => a.name.localeCompare(b.name);
+  if (!isAdmin) {
+    return [...apps].sort(byName);
+  }
+  const owned = apps.filter((app) => app.ownerId === userId).sort(byName);
+  const rest = apps.filter((app) => app.ownerId !== userId).sort(byName);
+  return [...owned, ...rest];
+}
+
+function isTestUserOwner(app: BillingAppRow): boolean {
+  return app.ownerName?.trim() === "Test User";
+}
+
+function sortAppUsageByMostUsed(appUsage: BillingAppUsageSummary[]): BillingAppUsageSummary[] {
+  return [...appUsage].sort((a, b) => {
+    const tierA = isTestUserOwner(a.app) ? 1 : 0;
+    const tierB = isTestUserOwner(b.app) ? 1 : 0;
+    if (tierA !== tierB) {
+      return tierA - tierB;
+    }
+    if (b.requestCount !== a.requestCount) {
+      return b.requestCount - a.requestCount;
+    }
+    const unitsA = BigInt(a.totalUnits);
+    const unitsB = BigInt(b.totalUnits);
+    if (unitsA !== unitsB) {
+      return unitsB > unitsA ? 1 : -1;
+    }
+    const feeA = BigInt(a.totalFeeWei);
+    const feeB = BigInt(b.totalFeeWei);
+    if (feeA !== feeB) {
+      return feeB > feeA ? 1 : -1;
+    }
+    return a.app.name.localeCompare(b.app.name);
+  });
+}
+
+export type BillingUsageDashboardPayload = {
+  scope: "all" | "single";
+  userId: string;
+  role: string | undefined;
+  isAdmin: boolean;
+  cycle: { start: string; end: string };
+  orderedApps: BillingAppRow[];
+  appUsage: BillingAppUsageSummary[];
+  chartData: { date: string; value: number }[];
+  totalRequests: number;
+  totalFeeWei: bigint;
+  appsWithUsage: number;
+};
+
+export type BillingUsageDashboardResult =
+  | { ok: false; reason: "no_session" }
+  | { ok: false; reason: "forbidden" }
+  | { ok: true; data: BillingUsageDashboardPayload };
+
+export async function getBillingUsageDashboardData(
+  filterAppId?: string | null,
+): Promise<BillingUsageDashboardResult> {
+  const session = await getServerSession(authOptions);
+  const sessionUser = session?.user as Record<string, unknown> | undefined;
+  const userId = sessionUser?.id as string | undefined;
+  const role = sessionUser?.role as string | undefined;
+  const isAdmin = role === "admin";
+
+  if (!userId) {
+    return { ok: false, reason: "no_session" };
+  }
+
+  const appsQuery = db
+    .select({
+      id: developerApps.id,
+      name: developerApps.name,
+      ownerId: developerApps.ownerId,
+      ownerName: users.name,
+      ownerEmail: users.email,
+    })
+    .from(developerApps)
+    .leftJoin(users, eq(developerApps.ownerId, users.id));
+
+  let orderedApps: BillingAppRow[];
+  let scope: "all" | "single";
+
+  if (filterAppId) {
+    const auth = await getAuthorizedProviderApp(filterAppId);
+    if (!auth) {
+      return { ok: false, reason: "forbidden" };
+    }
+    const rows = await appsQuery.where(eq(developerApps.id, auth.app.id)).limit(1);
+    const row = rows[0];
+    if (!row) {
+      return { ok: false, reason: "forbidden" };
+    }
+    orderedApps = [row as BillingAppRow];
+    scope = "single";
+  } else {
+    const visibleApps = (isAdmin
+      ? await appsQuery
+      : await appsQuery.where(eq(developerApps.ownerId, userId))) as BillingAppRow[];
+    orderedApps = sortAppsForViewer(visibleApps, userId, isAdmin);
+    scope = "all";
+  }
+
+  const appIds = orderedApps.map((app) => app.id);
+  const cycleBounds = calendarMonthBoundsUtc(new Date());
+  const cycle = { start: cycleBounds.start, end: cycleBounds.end };
+
+  const usageRows =
+    appIds.length > 0
+      ? await db
+          .select()
+          .from(usageRecords)
+          .where(
+            and(
+              inArray(usageRecords.clientId, appIds),
+              gte(usageRecords.createdAt, cycleBounds.start),
+              lte(usageRecords.createdAt, cycleBounds.end),
+            ),
+          )
+      : [];
+
+  const appUserRows =
+    appIds.length > 0
+      ? await db
+          .select({
+            id: appUsers.id,
+            clientId: appUsers.clientId,
+            externalUserId: appUsers.externalUserId,
+          })
+          .from(appUsers)
+          .where(inArray(appUsers.clientId, appIds))
+      : [];
+
+  const usageRecordIds = usageRows.map((r) => r.id).filter(Boolean);
+  const billingEventRows =
+    usageRecordIds.length > 0
+      ? await db
+          .select()
+          .from(usageBillingEvents)
+          .where(inArray(usageBillingEvents.usageRecordId, usageRecordIds))
+      : [];
+
+  const eventByUsageRecord = new Map(billingEventRows.map((e) => [e.usageRecordId, e]));
+  const externalUserIdByAppUser = new Map(
+    appUserRows.map((row) => [`${row.clientId}:${row.id}`, row.externalUserId]),
+  );
+
+  const summaryByApp = new Map<
+    string,
+    {
+      requestCount: number;
+      totalFeeWei: bigint;
+      totalUnits: bigint;
+      networkFeeUsdMicros: bigint;
+      endUserBillableUsdMicros: bigint;
+      byUser: Map<string, { requestCount: number; totalFeeWei: bigint; totalUnits: bigint }>;
+      byPipelineModel: Map<
+        string,
+        {
+          pipeline: string;
+          modelId: string;
+          requestCount: number;
+          networkFeeUsdMicros: bigint;
+          endUserBillableUsdMicros: bigint;
+        }
+      >;
+    }
+  >();
+
+  for (const app of orderedApps) {
+    summaryByApp.set(app.id, {
+      requestCount: 0,
+      totalFeeWei: 0n,
+      totalUnits: 0n,
+      networkFeeUsdMicros: 0n,
+      endUserBillableUsdMicros: 0n,
+      byUser: new Map(),
+      byPipelineModel: new Map(),
+    });
+  }
+
+  for (const row of usageRows) {
+    const appSummary = summaryByApp.get(row.clientId);
+    if (!appSummary) continue;
+
+    appSummary.requestCount += 1;
+    appSummary.totalFeeWei += BigInt(row.fee || "0");
+    appSummary.totalUnits += BigInt(row.units || "0");
+
+    const billingEvent = eventByUsageRecord.get(row.id);
+    if (billingEvent) {
+      appSummary.networkFeeUsdMicros += BigInt(billingEvent.networkFeeUsdMicros);
+      appSummary.endUserBillableUsdMicros += BigInt(billingEvent.endUserBillableUsdMicros);
+
+      const pmKey = `${billingEvent.pipeline}|${billingEvent.modelId}`;
+      const existing = appSummary.byPipelineModel.get(pmKey) || {
+        pipeline: billingEvent.pipeline,
+        modelId: billingEvent.modelId,
+        requestCount: 0,
+        networkFeeUsdMicros: 0n,
+        endUserBillableUsdMicros: 0n,
+      };
+      existing.requestCount += 1;
+      existing.networkFeeUsdMicros += BigInt(billingEvent.networkFeeUsdMicros);
+      existing.endUserBillableUsdMicros += BigInt(billingEvent.endUserBillableUsdMicros);
+      appSummary.byPipelineModel.set(pmKey, existing);
+    }
+
+    const endUserId = row.userId || "unknown";
+    const userSummary = appSummary.byUser.get(endUserId) || {
+      requestCount: 0,
+      totalFeeWei: 0n,
+      totalUnits: 0n,
+    };
+    userSummary.requestCount += 1;
+    userSummary.totalFeeWei += BigInt(row.fee || "0");
+    userSummary.totalUnits += BigInt(row.units || "0");
+    appSummary.byUser.set(endUserId, userSummary);
+  }
+
+  const appUsage: BillingAppUsageSummary[] = sortAppUsageByMostUsed(
+    orderedApps.map((app) => {
+      const summary = summaryByApp.get(app.id)!;
+      const byUser: BillingUserUsageRow[] = [...summary.byUser.entries()]
+        .map(([endUserId, userSummary]) => {
+          const externalUserId =
+            endUserId === "unknown"
+              ? null
+              : externalUserIdByAppUser.get(`${app.id}:${endUserId}`) || null;
+          const identity = classifyUsageUser(endUserId, externalUserId);
+          return {
+            endUserId,
+            externalUserId,
+            userType: identity.userType,
+            userLabel: identity.userLabel,
+            identifier: identity.identifier,
+            requestCount: userSummary.requestCount,
+            totalFeeWei: userSummary.totalFeeWei.toString(),
+            totalUnits: userSummary.totalUnits.toString(),
+          };
+        })
+        .sort((a, b) => {
+          if (b.requestCount !== a.requestCount) {
+            return b.requestCount - a.requestCount;
+          }
+          const feeA = BigInt(a.totalFeeWei);
+          const feeB = BigInt(b.totalFeeWei);
+          if (feeA === feeB) return 0;
+          return feeB > feeA ? 1 : -1;
+        });
+
+      return {
+        app,
+        requestCount: summary.requestCount,
+        totalFeeWei: summary.totalFeeWei.toString(),
+        totalUnits: summary.totalUnits.toString(),
+        networkFeeUsdMicros: summary.networkFeeUsdMicros.toString(),
+        endUserBillableUsdMicros: summary.endUserBillableUsdMicros.toString(),
+        byUser,
+        byPipelineModel: [...summary.byPipelineModel.values()].map((pm) => ({
+          pipeline: pm.pipeline,
+          modelId: pm.modelId,
+          requestCount: pm.requestCount,
+          networkFeeUsdMicros: pm.networkFeeUsdMicros.toString(),
+          endUserBillableUsdMicros: pm.endUserBillableUsdMicros.toString(),
+        })),
+      };
+    }),
+  );
+
+  const totalRequests = appUsage.reduce((sum, row) => sum + row.requestCount, 0);
+  const totalFeeWei = appUsage.reduce(
+    (sum, row) => sum + BigInt(row.totalFeeWei || "0"),
+    0n,
+  );
+  const appsWithUsage = appUsage.filter((app) => app.requestCount > 0).length;
+  const requestsByDay = new Map<string, number>();
+  for (const row of usageRows) {
+    const day = dateKeyFromIso(row.createdAt);
+    requestsByDay.set(day, (requestsByDay.get(day) ?? 0) + 1);
+  }
+  const chartData: { date: string; value: number }[] = dateKeysInclusiveUtc(
+    cycleBounds.start,
+    cycleBounds.end,
+  ).map((date) => ({
+    date,
+    value: requestsByDay.get(date) ?? 0,
+  }));
+
+  return {
+    ok: true,
+    data: {
+      scope,
+      userId,
+      role,
+      isAdmin,
+      cycle: { start: cycle.start, end: cycle.end },
+      orderedApps,
+      appUsage,
+      chartData,
+      totalRequests,
+      totalFeeWei,
+      appsWithUsage,
+    },
+  };
+}

--- a/src/platform/ops/prices/eth-usd-oracle.ts
+++ b/src/platform/ops/prices/eth-usd-oracle.ts
@@ -1,0 +1,124 @@
+import { v4 as uuidv4 } from "uuid";
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { priceOracleSnapshots } from "@/db/schema";
+import { fetchEthUsdFromPublicExchanges } from "./public-exchange-spot";
+
+export interface EthUsdOracleResult {
+  priceUsd: number;
+  source: string;
+  observedAt: string;
+  isFallback: boolean;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const ETH_SYMBOL = "ETH";
+const DEFAULT_PRICE = 3000;
+
+async function getFreshCacheRow(): Promise<EthUsdOracleResult | null> {
+  const cutoff = new Date(Date.now() - CACHE_TTL_MS).toISOString();
+  const rows = await db
+    .select()
+    .from(priceOracleSnapshots)
+    .where(eq(priceOracleSnapshots.symbol, ETH_SYMBOL))
+    .orderBy(desc(priceOracleSnapshots.fetchedAt))
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  if (row.fetchedAt < cutoff) return null;
+  const price = parseFloat(row.priceUsd);
+  if (!Number.isFinite(price) || price <= 0) return null;
+  return {
+    priceUsd: price,
+    source: "cache",
+    observedAt: row.fetchedAt,
+    isFallback: false,
+  };
+}
+
+async function getStaleCacheRow(): Promise<EthUsdOracleResult | null> {
+  const rows = await db
+    .select()
+    .from(priceOracleSnapshots)
+    .where(eq(priceOracleSnapshots.symbol, ETH_SYMBOL))
+    .orderBy(desc(priceOracleSnapshots.fetchedAt))
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  const price = parseFloat(row.priceUsd);
+  if (!Number.isFinite(price) || price <= 0) return null;
+  return {
+    priceUsd: price,
+    source: "stale_cache",
+    observedAt: row.fetchedAt,
+    isFallback: true,
+  };
+}
+
+function persistPriceAsync(priceUsd: number, exchange: string, fetchedAt: string): void {
+  if (!Number.isFinite(priceUsd) || priceUsd <= 0) return;
+  const source = exchange === "binance" || exchange === "kraken" ? exchange : "public_exchange";
+  db.insert(priceOracleSnapshots)
+    .values({
+      id: uuidv4(),
+      symbol: ETH_SYMBOL,
+      priceUsd: priceUsd.toString(),
+      source,
+      fetchedAt,
+      createdAt: new Date().toISOString(),
+    })
+    .catch(() => {
+      // Background persistence — do not surface errors to the billing hot path.
+    });
+}
+
+export async function getEthUsdOracle(): Promise<EthUsdOracleResult> {
+  try {
+    const fresh = await getFreshCacheRow();
+    if (fresh) return fresh;
+  } catch {
+    // DB unavailable — continue to live fetch
+  }
+
+  try {
+    const spot = await fetchEthUsdFromPublicExchanges();
+    if (spot !== null) {
+      const now = new Date().toISOString();
+      persistPriceAsync(spot.priceUsd, spot.exchange, now);
+      return {
+        priceUsd: spot.priceUsd,
+        source: spot.exchange,
+        observedAt: now,
+        isFallback: false,
+      };
+    }
+  } catch {
+    // Live fetch failed — continue to stale cache
+  }
+
+  try {
+    const stale = await getStaleCacheRow();
+    if (stale) return stale;
+  } catch {
+    // DB unavailable — continue to env/default
+  }
+
+  const envPrice = process.env.ETH_USD_PRICE ? parseFloat(process.env.ETH_USD_PRICE) : NaN;
+  if (Number.isFinite(envPrice) && envPrice > 0) {
+    return {
+      priceUsd: envPrice,
+      source: "env",
+      observedAt: new Date().toISOString(),
+      isFallback: true,
+    };
+  }
+
+  return {
+    priceUsd: DEFAULT_PRICE,
+    source: "default",
+    observedAt: new Date().toISOString(),
+    isFallback: true,
+  };
+}

--- a/src/platform/ops/prices/public-exchange-spot.test.ts
+++ b/src/platform/ops/prices/public-exchange-spot.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test, mock } from "node:test";
+
+// We need to mock global fetch before importing the module under test.
+// Using node:test's mock.method to patch globalThis.fetch.
+
+test("fetchEthUsdFromPublicExchanges: returns Binance result on success", async () => {
+  const original = globalThis.fetch;
+  let callCount = 0;
+  globalThis.fetch = async (input: string | URL | Request) => {
+    callCount++;
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("binance")) {
+      return {
+        ok: true,
+        json: async () => ({ price: "2500.12" }),
+      } as Response;
+    }
+    throw new Error("unexpected url");
+  };
+
+  try {
+    const { fetchEthUsdFromPublicExchanges } = await import("@/platform/ops/prices/public-exchange-spot");
+    const result = await fetchEthUsdFromPublicExchanges();
+    assert.ok(result !== null);
+    assert.equal(result!.exchange, "binance");
+    assert.equal(result!.priceUsd, 2500.12);
+    assert.equal(callCount, 1);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("fetchEthUsdFromPublicExchanges: falls back to Kraken when Binance fails", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("binance")) {
+      return { ok: false, status: 503, json: async () => ({}) } as Response;
+    }
+    if (url.includes("kraken")) {
+      return {
+        ok: true,
+        json: async () => ({
+          result: { XETHZUSD: { c: ["1800.50", "1"] } },
+        }),
+      } as Response;
+    }
+    throw new Error("unexpected url");
+  };
+
+  try {
+    const { fetchEthUsdFromPublicExchanges } = await import("@/platform/ops/prices/public-exchange-spot");
+    const result = await fetchEthUsdFromPublicExchanges();
+    assert.ok(result !== null);
+    assert.equal(result!.exchange, "kraken");
+    assert.equal(result!.priceUsd, 1800.5);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("fetchEthUsdFromPublicExchanges: returns null when both fail", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => {
+    return { ok: false, status: 503, json: async () => ({}) } as Response;
+  };
+
+  try {
+    const { fetchEthUsdFromPublicExchanges } = await import("@/platform/ops/prices/public-exchange-spot");
+    const result = await fetchEthUsdFromPublicExchanges();
+    assert.equal(result, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("fetchEthUsdFromPublicExchanges: returns null when Binance returns non-positive price", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("binance")) {
+      return { ok: true, json: async () => ({ price: "0" }) } as Response;
+    }
+    return { ok: false, status: 503, json: async () => ({}) } as Response;
+  };
+
+  try {
+    const { fetchEthUsdFromPublicExchanges } = await import("@/platform/ops/prices/public-exchange-spot");
+    const result = await fetchEthUsdFromPublicExchanges();
+    // Binance returns 0 (invalid), should fall back to Kraken which also fails → null
+    assert.equal(result, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("fetchEthUsdFromPublicExchanges: returns null when Binance returns invalid JSON", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("binance")) {
+      return { ok: true, json: async () => { throw new SyntaxError("bad json"); } } as unknown as Response;
+    }
+    return { ok: false, status: 503, json: async () => ({}) } as Response;
+  };
+
+  try {
+    const { fetchEthUsdFromPublicExchanges } = await import("@/platform/ops/prices/public-exchange-spot");
+    const result = await fetchEthUsdFromPublicExchanges();
+    assert.equal(result, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/src/platform/ops/prices/public-exchange-spot.ts
+++ b/src/platform/ops/prices/public-exchange-spot.ts
@@ -1,0 +1,80 @@
+/**
+ * Fetch the ETH/USD spot price from public exchanges.
+ *
+ * Implements the same resolution pattern as livepeer/naap PR #283:
+ *  1. Binance public ticker (ETHUSDT — treated as USD for spot estimates)
+ *  2. Kraken public ticker (XETHZUSD)
+ *
+ * Never throws. Returns null when both sources are unavailable or return
+ * invalid data. Callers are responsible for fallback (stale cache / env / default).
+ */
+
+export interface SpotResult {
+  priceUsd: number;
+  /** "binance" | "kraken" */
+  exchange: string;
+}
+
+const TIMEOUT_MS = 3000;
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  return fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+}
+
+/** Parse and validate a price number: must be finite and positive. */
+function parsePositiveNumber(v: unknown): number | null {
+  const n = typeof v === "string" ? parseFloat(v) : typeof v === "number" ? v : NaN;
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function fetchBinance(): Promise<SpotResult | null> {
+  try {
+    const res = await fetchWithTimeout(
+      "https://api.binance.com/api/v3/ticker/price?symbol=ETHUSDT",
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as unknown;
+    if (typeof data !== "object" || data === null) return null;
+    const price = parsePositiveNumber((data as Record<string, unknown>).price);
+    return price !== null ? { priceUsd: price, exchange: "binance" } : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchKraken(): Promise<SpotResult | null> {
+  try {
+    const res = await fetchWithTimeout(
+      "https://api.kraken.com/0/public/Ticker?pair=XETHZUSD",
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as unknown;
+    if (typeof data !== "object" || data === null) return null;
+    const result = (data as Record<string, unknown>).result;
+    if (typeof result !== "object" || result === null) return null;
+    // Kraken returns the pair data under a key like "XETHZUSD" or "ETHUSD"
+    const pairs = Object.values(result as Record<string, unknown>);
+    if (pairs.length === 0) return null;
+    const pair = pairs[0] as Record<string, unknown> | null;
+    if (!pair) return null;
+    // "c" is the last trade closed: [price, lot volume]
+    const c = pair.c;
+    if (!Array.isArray(c) || c.length === 0) return null;
+    const price = parsePositiveNumber(c[0]);
+    return price !== null ? { priceUsd: price, exchange: "kraken" } : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Try Binance first, then Kraken. Returns the first successful result or null.
+ */
+export async function fetchEthUsdFromPublicExchanges(): Promise<SpotResult | null> {
+  const binance = await fetchBinance();
+  if (binance !== null) return binance;
+  return fetchKraken();
+}

--- a/src/platform/ops/repo/dashboard.ts
+++ b/src/platform/ops/repo/dashboard.ts
@@ -1,0 +1,25 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { endUsers, signerConfig, transactions } from "@/db/schema";
+
+export async function getDefaultSignerSnapshot() {
+  const rows = await db
+    .select()
+    .from(signerConfig)
+    .where(eq(signerConfig.id, "default"))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listTransactionFeeRows() {
+  return db
+    .select({
+      amountWei: transactions.amountWei,
+      platformCutWei: transactions.platformCutWei,
+    })
+    .from(transactions);
+}
+
+export async function listEndUsers() {
+  return db.select().from(endUsers);
+}

--- a/src/platform/ops/repo/end-users.ts
+++ b/src/platform/ops/repo/end-users.ts
@@ -1,0 +1,51 @@
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import { endUsers, sessions, streamSessions, transactions, users } from "@/db/schema";
+
+export async function listAdminUsers() {
+  return db.select().from(users);
+}
+
+export async function listEndUsers() {
+  return db.select().from(endUsers);
+}
+
+export async function getEndUserById(id: string) {
+  const rows = await db.select().from(endUsers).where(eq(endUsers.id, id)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listEndUserSessions(endUserId: string) {
+  return db.select().from(sessions).where(eq(sessions.endUserId, endUserId));
+}
+
+export async function listEndUserStreams(endUserId: string) {
+  return db.select().from(streamSessions).where(eq(streamSessions.endUserId, endUserId));
+}
+
+export async function countEndUserTransactions(endUserId: string) {
+  const [row] = await db
+    .select({
+      transactionCount: sql<number>`cast(count(${transactions.id}) as integer)`.mapWith(Number),
+    })
+    .from(transactions)
+    .where(eq(transactions.endUserId, endUserId));
+
+  return row?.transactionCount ?? 0;
+}
+
+export async function listEndUserTransactions(endUserId: string) {
+  return db
+    .select({
+      id: transactions.id,
+      type: transactions.type,
+      amountWei: transactions.amountWei,
+      platformCutPercent: transactions.platformCutPercent,
+      platformCutWei: transactions.platformCutWei,
+      txHash: transactions.txHash,
+      status: transactions.status,
+      createdAt: transactions.createdAt,
+    })
+    .from(transactions)
+    .where(eq(transactions.endUserId, endUserId));
+}

--- a/src/platform/ops/repo/home.ts
+++ b/src/platform/ops/repo/home.ts
@@ -1,0 +1,45 @@
+import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+export async function listPublishedHomeApps() {
+  return db
+    .select({
+      id: developerApps.id,
+      name: developerApps.name,
+      subtitle: developerApps.subtitle,
+      description: developerApps.description,
+      category: developerApps.category,
+      developerName: developerApps.developerName,
+      marketplaceFeatured: developerApps.marketplaceFeatured,
+      publishedAt: developerApps.publishedAt,
+    })
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(
+      and(
+        eq(developerApps.status, "approved"),
+        isNotNull(developerApps.publishedAt),
+      ),
+    )
+    .orderBy(desc(developerApps.publishedAt));
+}
+
+export async function listPopularPublishedHomeAppIds(limit: number) {
+  return db.execute<{ id: string }>(sql`
+    SELECT d.id
+    FROM developer_apps d
+    LEFT JOIN (
+      SELECT COALESCE(client_id, app_id) AS aid, COUNT(*)::bigint AS cnt
+      FROM transactions
+      WHERE type = 'usage'
+        AND status = 'confirmed'
+        AND COALESCE(client_id, app_id) IS NOT NULL
+      GROUP BY COALESCE(client_id, app_id)
+    ) u ON u.aid = d.id
+    WHERE d.status = 'approved'
+      AND d.published_at IS NOT NULL
+    ORDER BY COALESCE(u.cnt, 0) DESC, d.published_at::timestamptz DESC NULLS LAST
+    LIMIT ${limit}
+  `);
+}

--- a/src/platform/ops/repo/streams.ts
+++ b/src/platform/ops/repo/streams.ts
@@ -1,0 +1,6 @@
+import { db } from "@/db/index";
+import { streamSessions } from "@/db/schema";
+
+export async function listAllStreamSessions() {
+  return db.select().from(streamSessions);
+}

--- a/src/platform/ops/runtime/dashboard.ts
+++ b/src/platform/ops/runtime/dashboard.ts
@@ -1,0 +1,48 @@
+import {
+  ACTIVE_STREAM_PAYMENT_WINDOW_LABEL,
+  countActiveStreamsByRecentPayment,
+  getActiveStreamSessionsByRecentPayment,
+} from "../active-streams";
+import {
+  getDefaultSignerSnapshot,
+  listEndUsers,
+  listTransactionFeeRows,
+} from "../repo/dashboard";
+
+export { ACTIVE_STREAM_PAYMENT_WINDOW_LABEL };
+
+export function formatDashboardWei(wei: string): string {
+  if (wei === "0") return "0 ETH";
+  const value = BigInt(wei);
+  const eth = Number(value) / 1e18;
+  if (eth < 0.001) return `${wei} wei`;
+  return `${eth.toFixed(6)} ETH`;
+}
+
+export async function getAdminDashboardData() {
+  const [signer, activeStreamCount, recentActiveSessions, allTransactions, allEndUsers] =
+    await Promise.all([
+      getDefaultSignerSnapshot(),
+      countActiveStreamsByRecentPayment(),
+      getActiveStreamSessionsByRecentPayment(5),
+      listTransactionFeeRows(),
+      listEndUsers(),
+    ]);
+
+  let totalFeeWei = 0n;
+  let totalPlatformCutWei = 0n;
+  for (const txn of allTransactions) {
+    totalFeeWei += BigInt(txn.amountWei);
+    totalPlatformCutWei += BigInt(txn.platformCutWei || "0");
+  }
+
+  return {
+    signer,
+    activeStreamCount,
+    recentActiveSessions,
+    allTransactions,
+    allEndUsers,
+    totalFeeWei,
+    totalPlatformCutWei,
+  };
+}

--- a/src/platform/ops/runtime/end-users.ts
+++ b/src/platform/ops/runtime/end-users.ts
@@ -1,0 +1,68 @@
+import { confirmedUsageCountByStreamSessionId } from "../stream-session-stats";
+import {
+  countEndUserTransactions,
+  getEndUserById,
+  listAdminUsers,
+  listEndUserSessions,
+  listEndUserStreams,
+  listEndUserTransactions,
+  listEndUsers,
+} from "../repo/end-users";
+
+export async function getUsersPageData() {
+  const [adminUsers, allEndUsers] = await Promise.all([
+    listAdminUsers(),
+    listEndUsers(),
+  ]);
+
+  const enriched = await Promise.all(
+    allEndUsers.map(async (user) => {
+      const [userSessionRows, userStreams, transactionCount] = await Promise.all([
+        listEndUserSessions(user.id),
+        listEndUserStreams(user.id),
+        countEndUserTransactions(user.id),
+      ]);
+
+      return {
+        ...user,
+        tokenCount: userSessionRows.length,
+        streamCount: userStreams.length,
+        transactionCount,
+      };
+    }),
+  );
+
+  return {
+    adminUsers,
+    enrichedEndUsers: enriched,
+  };
+}
+
+export async function getUserDetailPageData(id: string) {
+  const user = await getEndUserById(id);
+  if (!user) {
+    return null;
+  }
+
+  const [userStreams, userTxns] = await Promise.all([
+    listEndUserStreams(id),
+    listEndUserTransactions(id),
+  ]);
+
+  const streamUsageCounts = await confirmedUsageCountByStreamSessionId(
+    userStreams.map((s) => s.id),
+  );
+
+  let totalUsage = 0n;
+  for (const txn of userTxns) {
+    if (txn.type === "usage") totalUsage += BigInt(txn.amountWei);
+  }
+
+  return {
+    user,
+    userStreams,
+    userTxns,
+    streamUsageCounts,
+    totalUsage,
+  };
+}

--- a/src/platform/ops/runtime/home.ts
+++ b/src/platform/ops/runtime/home.ts
@@ -1,0 +1,63 @@
+import type { HomeApp } from "@/components/AppCard";
+import {
+  listPopularPublishedHomeAppIds,
+  listPublishedHomeApps,
+} from "../repo/home";
+
+type PublishedAppRow = HomeApp & { featured: boolean };
+
+function toHomeApp(row: PublishedAppRow): HomeApp {
+  return {
+    id: row.id,
+    name: row.name,
+    subtitle: row.subtitle,
+    description: row.description,
+    category: row.category,
+    developerName: row.developerName,
+  };
+}
+
+export async function getHomeShowcaseData() {
+  const rows = await listPublishedHomeApps();
+  const mapped: PublishedAppRow[] = rows
+    .filter((r): r is typeof r & { id: string } => Boolean(r.id))
+    .map((r) => ({
+      id: r.id,
+      name: r.name,
+      subtitle: r.subtitle,
+      description: r.description,
+      category: r.category,
+      developerName: r.developerName,
+      featured: r.marketplaceFeatured === 1,
+    }));
+
+  const featuredApps = mapped.filter((a) => a.featured).slice(0, 4).map(toHomeApp);
+
+  if (featuredApps.length > 0) {
+    return {
+      showcaseApps: featuredApps,
+      showcaseTitle: "Featured apps",
+    };
+  }
+
+  if (mapped.length === 0) {
+    return {
+      showcaseApps: [] as HomeApp[],
+      showcaseTitle: "Featured apps",
+    };
+  }
+
+  const rankRows = await listPopularPublishedHomeAppIds(4);
+  const byId = new Map(mapped.map((m) => [m.id, toHomeApp(m)]));
+  let showcaseApps = rankRows
+    .map((r) => byId.get(r.id))
+    .filter((a): a is HomeApp => a !== undefined);
+  if (showcaseApps.length === 0) {
+    showcaseApps = mapped.slice(0, 4).map(toHomeApp);
+  }
+
+  return {
+    showcaseApps,
+    showcaseTitle: "Popular apps",
+  };
+}

--- a/src/platform/ops/runtime/streams.ts
+++ b/src/platform/ops/runtime/streams.ts
@@ -1,0 +1,35 @@
+import {
+  ACTIVE_STREAM_PAYMENT_WINDOW_LABEL,
+  getActiveStreamSessionsByRecentPayment,
+} from "../active-streams";
+import { confirmedUsageCountByStreamSessionId } from "../stream-session-stats";
+import { listAllStreamSessions } from "../repo/streams";
+
+export { ACTIVE_STREAM_PAYMENT_WINDOW_LABEL };
+
+function sessionRecencyMs(s: { lastPaymentAt: string | null; startedAt: string }) {
+  const t = s.lastPaymentAt ?? s.startedAt;
+  return new Date(t).getTime();
+}
+
+export async function getStreamsPageData() {
+  const activeSessions = await getActiveStreamSessionsByRecentPayment();
+  const activeSessionIds = new Set(activeSessions.map((session) => session.id));
+
+  const allSessions = await listAllStreamSessions();
+  const historicalSessions = allSessions
+    .filter((s) => !activeSessionIds.has(s.id))
+    .sort((a, b) => sessionRecencyMs(b) - sessionRecencyMs(a))
+    .slice(0, 100);
+
+  const usageCounts = await confirmedUsageCountByStreamSessionId([
+    ...activeSessions.map((s) => s.id),
+    ...historicalSessions.map((s) => s.id),
+  ]);
+
+  return {
+    activeSessions,
+    historicalSessions,
+    usageCounts,
+  };
+}

--- a/src/platform/ops/stream-session-stats.ts
+++ b/src/platform/ops/stream-session-stats.ts
@@ -1,0 +1,31 @@
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { db } from "@/db/index";
+import { transactions } from "@/db/schema";
+
+export async function confirmedUsageCountByStreamSessionId(
+  streamSessionIds: readonly string[],
+): Promise<Map<string, number>> {
+  if (streamSessionIds.length === 0) return new Map();
+  const uniq = [...new Set(streamSessionIds)];
+  const rows = await db
+    .select({
+      streamSessionId: transactions.streamSessionId,
+      n: sql<number>`count(*)::int`,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.type, "usage"),
+        eq(transactions.status, "confirmed"),
+        isNotNull(transactions.streamSessionId),
+        inArray(transactions.streamSessionId, uniq),
+      ),
+    )
+    .groupBy(transactions.streamSessionId);
+
+  const m = new Map<string, number>();
+  for (const r of rows) {
+    if (r.streamSessionId != null) m.set(r.streamSessionId, r.n);
+  }
+  return m;
+}

--- a/src/platform/ops/stream-session-ui.ts
+++ b/src/platform/ops/stream-session-ui.ts
@@ -1,0 +1,26 @@
+import type { StreamSession } from "@/db/schema";
+
+/** Shape expected by `StreamSessionTable` (client component). */
+export function streamSessionToTableRow(
+  s: StreamSession,
+  usageCountBySessionId?: Map<string, number>,
+) {
+  const fromTx = usageCountBySessionId?.get(s.id);
+  const signerPaymentCount =
+    fromTx !== undefined
+      ? Math.max(s.signerPaymentCount, fromTx)
+      : s.signerPaymentCount;
+  return {
+    id: s.id,
+    manifestId: s.manifestId,
+    orchestratorAddress: s.orchestratorAddress,
+    pricePerUnit: s.pricePerUnit,
+    pixelsPerUnit: s.pixelsPerUnit,
+    signerPaymentCount,
+    totalFeeWei: s.totalFeeWei,
+    status: s.status,
+    startedAt: s.startedAt,
+    lastPaymentAt: s.lastPaymentAt,
+    endedAt: s.endedAt,
+  };
+}

--- a/src/platform/signer/cli.ts
+++ b/src/platform/signer/cli.ts
@@ -1,0 +1,147 @@
+/**
+ * signer-cli.ts
+ *
+ * Client for go-livepeer’s CLI API (livepeer listens on 4935 inside the signer
+ * container; with DMZ, PymtHouse calls Apache’s /__signer_cli proxy).
+ * This is the same port that livepeer_cli connects to.
+ * Must only be called server-side; the port is bound to 127.0.0.1 on the host.
+ *
+ * When the signer sits behind the Apache DMZ, set SIGNER_CLI_URL to the CLI base
+ * URL — typically the DMZ origin plus `/__signer_cli` (e.g. http://localhost:8080/__signer_cli).
+ * Alternatively, a dedicated admin listener on a second port is supported. The server
+ * mints a short-lived JWT with admin scope for these requests.
+ */
+
+import { issueSignerDmzToken } from "@/platform/signer/dmz-token";
+
+export function getSignerCliUrl(): string {
+  if (process.env.SIGNER_CLI_URL) return process.env.SIGNER_CLI_URL;
+  return "http://127.0.0.1:8080/__signer_cli";
+}
+
+let cliDmzTokenCache: { token: string; expMs: number } | null = null;
+
+async function getCliDmzBearer(): Promise<string> {
+  if (process.env.SIGNER_DMZ_FORWARD_JWT === "false") {
+    return "";
+  }
+  const now = Date.now();
+  if (cliDmzTokenCache && cliDmzTokenCache.expMs > now + 15_000) {
+    return cliDmzTokenCache.token;
+  }
+  const token = await issueSignerDmzToken({
+    gate: "cli",
+    subject: "pymthouse-server",
+  });
+  cliDmzTokenCache = { token, expMs: now + 3.5 * 60 * 1000 };
+  return token;
+}
+
+export interface SenderInfo {
+  deposit: string;
+  withdrawRound: string;
+  reserve: {
+    fundsRemaining: string;
+    claimedInCurrentRound: string;
+  };
+}
+
+export interface SignerCliStatus {
+  reachable: boolean;
+  senderInfo: SenderInfo | null;
+  ethBalance: string | null;
+  tokenBalance: string | null;
+  fetchedAt: string;
+}
+
+async function cliGet<T>(path: string): Promise<T> {
+  const url = `${getSignerCliUrl()}${path}`;
+  const headers: Record<string, string> = {};
+  const bearer = await getCliDmzBearer();
+  if (bearer) {
+    headers.Authorization = `Bearer ${bearer}`;
+  }
+  const res = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(5000),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`CLI GET ${path} failed: ${res.status}`);
+  }
+  const text = await res.text();
+  if (!text) throw new Error(`CLI GET ${path} returned empty body`);
+  return JSON.parse(text) as T;
+}
+
+/**
+ * GET /senderInfo — returns deposit, reserve, and withdraw round.
+ * This is what livepeer_cli uses to show gateway payment state.
+ */
+export async function getSenderInfo(): Promise<SenderInfo | null> {
+  try {
+    const raw = await cliGet<Record<string, unknown>>("/senderInfo");
+    // Normalize: go-livepeer may return PascalCase or camelCase field names
+    const deposit = String(raw.deposit ?? raw.Deposit ?? "0");
+    const withdrawRound = String(raw.withdrawRound ?? raw.WithdrawRound ?? "0");
+    const reserve = (raw.reserve ?? raw.Reserve) as
+      | Record<string, unknown>
+      | undefined;
+    return {
+      deposit,
+      withdrawRound,
+      reserve: {
+        fundsRemaining: String(
+          reserve?.fundsRemaining ?? reserve?.FundsRemaining ?? "0"
+        ),
+        claimedInCurrentRound: String(
+          reserve?.claimedInCurrentRound ?? reserve?.ClaimedInCurrentRound ?? "0"
+        ),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GET /ethBalance — ETH balance of the signer account.
+ */
+export async function getEthBalance(): Promise<string | null> {
+  try {
+    const raw = await cliGet<unknown>("/ethBalance");
+    return String(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GET /tokenBalance — LPT token balance of the signer account.
+ */
+export async function getTokenBalance(): Promise<string | null> {
+  try {
+    const raw = await cliGet<unknown>("/tokenBalance");
+    return String(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch all live CLI state in parallel.
+ */
+export async function fetchSignerCliStatus(): Promise<SignerCliStatus> {
+  const [senderInfo, ethBalance, tokenBalance] = await Promise.all([
+    getSenderInfo(),
+    getEthBalance(),
+    getTokenBalance(),
+  ]);
+  return {
+    reachable: senderInfo !== null,
+    senderInfo,
+    ethBalance,
+    tokenBalance,
+    fetchedAt: new Date().toISOString(),
+  };
+}

--- a/src/platform/signer/dmz-host-port.ts
+++ b/src/platform/signer/dmz-host-port.ts
@@ -1,0 +1,16 @@
+/** Legacy go-livepeer HTTP port stored on older signer_config rows (bare signer). */
+const LEGACY_BARE_SIGNER_PORT = 8081;
+
+/** Host-published Apache DMZ listener (maps legacy 8081 rows to real DMZ port). */
+const DEFAULT_SIGNER_DMZ_HOST_PORT = 8080;
+
+/**
+ * Map persisted `signerPort` to the TCP port published on the host for Apache
+ * (signer-dmz). Matches docker compose env in signer control route.
+ */
+export function resolveDmzHostPort(signerPort: number | undefined): number {
+  if (!signerPort || signerPort === LEGACY_BARE_SIGNER_PORT) {
+    return DEFAULT_SIGNER_DMZ_HOST_PORT;
+  }
+  return signerPort;
+}

--- a/src/platform/signer/dmz-token.ts
+++ b/src/platform/signer/dmz-token.ts
@@ -1,0 +1,39 @@
+import { SignJWT } from "jose";
+import { ensureSigningKey } from "@/domains/oidc-platform/runtime/jwks";
+import { getIssuer } from "@/platform/oidc/issuer-urls";
+
+const DMZ_TOKEN_TTL_SECONDS = 4 * 60;
+
+export type SignerDmzGate = "http" | "cli";
+
+/**
+ * Short-lived RS256 JWT for the remote signer Apache DMZ. Minted only on the
+ * PymtHouse server after user/API auth; Apache validates signature + iss/aud + scope.
+ *
+ * - gate "http" → scope "sign:job" (go-livepeer HTTP API, port 8081)
+ * - gate "cli"   → scope "admin" (CLI API, port 4935, proxied under /__signer_cli)
+ */
+export async function issueSignerDmzToken(input: {
+  gate: SignerDmzGate;
+  subject: string;
+}): Promise<string> {
+  const issuer = getIssuer();
+  const keyPair = await ensureSigningKey();
+  const now = Math.floor(Date.now() / 1000);
+  const scope = input.gate === "http" ? "sign:job" : "admin";
+
+  return new SignJWT({
+    scope,
+    signer_proxy: true,
+    gate: input.gate,
+  })
+    .setProtectedHeader({ alg: "RS256", kid: keyPair.kid, typ: "JWT" })
+    .setIssuer(issuer)
+    .setAudience(issuer)
+    .setSubject(input.subject)
+    .setJti(`dmz_${input.gate}_${now}_${Math.random().toString(36).slice(2, 10)}`)
+    .setIssuedAt(now)
+    .setNotBefore(now)
+    .setExpirationTime(now + DMZ_TOKEN_TTL_SECONDS)
+    .sign(keyPair.privateKey);
+}

--- a/src/platform/signer/local-compose.ts
+++ b/src/platform/signer/local-compose.ts
@@ -1,0 +1,5 @@
+/**
+ * Name of the Docker Compose service in `infra/dev/docker-compose.local.yml`
+ * that runs the local signer (Apache DMZ + go-livepeer, same as production).
+ */
+export const DOCKER_COMPOSE_LOCAL_SIGNER_SERVICE = "signer-dmz" as const;

--- a/src/shared/discovery/discovery-plans.test.ts
+++ b/src/shared/discovery/discovery-plans.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mergeDiscoveryPolicies,
+  parseDiscoveryPolicyInput,
+} from "@/shared/discovery/discovery-plans";
+
+test("parseDiscoveryPolicyInput accepts valid policy", () => {
+  const r = parseDiscoveryPolicyInput(
+    {
+      topN: 10,
+      sortBy: "price",
+      slaMinScore: 0.5,
+      filters: { gpuRamGbMin: 8, gpuRamGbMax: 48, priceMax: 1.5 },
+    },
+    "discoveryPolicy",
+  );
+  assert.equal(r.ok, true);
+  assert.ok(r.ok && r.policy?.topN === 10);
+  assert.ok(r.ok && r.policy?.filters?.gpuRamGbMin === 8);
+});
+
+test("parseDiscoveryPolicyInput rejects invalid sortBy", () => {
+  const r = parseDiscoveryPolicyInput({ sortBy: "nope" }, "discoveryPolicy");
+  assert.equal(r.ok, false);
+});
+
+test("parseDiscoveryPolicyInput rejects gpuRamGbMin > gpuRamGbMax", () => {
+  const r = parseDiscoveryPolicyInput(
+    { filters: { gpuRamGbMin: 64, gpuRamGbMax: 16 } },
+    "discoveryPolicy",
+  );
+  assert.equal(r.ok, false);
+});
+
+test("mergeDiscoveryPolicies caps topN and intersects filters", () => {
+  const merged = mergeDiscoveryPolicies(
+    { topN: 10, filters: { priceMax: 100, gpuRamGbMin: 8 } },
+    { topN: 50, filters: { priceMax: 50, gpuRamGbMin: 16 } },
+  );
+  assert.equal(merged?.topN, 10);
+  assert.equal(merged?.filters?.priceMax, 50);
+  assert.equal(merged?.filters?.gpuRamGbMin, 16);
+});

--- a/src/shared/discovery/discovery-plans.ts
+++ b/src/shared/discovery/discovery-plans.ts
@@ -1,0 +1,261 @@
+/**
+ * App-scoped discovery policy stored on PymtHouse plans.
+ * Field names align with NaaP Orchestrator Leaderboard CreatePlanInput (for-ai.md).
+ */
+
+export type DiscoverySortBy = "slaScore" | "latency" | "price" | "swapRate" | "avail";
+
+export interface DiscoveryPolicyFilters {
+  gpuRamGbMin?: number;
+  gpuRamGbMax?: number;
+  priceMax?: number;
+  maxAvgLatencyMs?: number;
+  maxSwapRatio?: number;
+}
+
+export interface DiscoveryPolicy {
+  topN?: number;
+  sortBy?: DiscoverySortBy;
+  slaMinScore?: number;
+  slaWeights?: {
+    latency?: number;
+    swapRate?: number;
+    price?: number;
+  };
+  filters?: DiscoveryPolicyFilters;
+}
+
+const SORT_BY_VALUES: DiscoverySortBy[] = [
+  "slaScore",
+  "latency",
+  "price",
+  "swapRate",
+  "avail",
+];
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function parseWeight(raw: unknown, path: string): { ok: true; value: number } | { ok: false; error: string } {
+  if (raw === undefined) return { ok: true, value: 0 };
+  const n = typeof raw === "number" ? raw : Number(String(raw).trim());
+  if (!Number.isFinite(n) || n < 0 || n > 1) {
+    return { ok: false, error: `${path} must be a number between 0 and 1` };
+  }
+  return { ok: true, value: n };
+}
+
+function parseNonNegativeNumber(
+  raw: unknown,
+  path: string,
+): { ok: true; value: number } | { ok: false; error: string } {
+  const n = typeof raw === "number" ? raw : Number(String(raw).trim());
+  if (!Number.isFinite(n) || n < 0) {
+    return { ok: false, error: `${path} must be a non-negative number` };
+  }
+  return { ok: true, value: n };
+}
+
+function parseRatio(raw: unknown, path: string): { ok: true; value: number } | { ok: false; error: string } {
+  const n = typeof raw === "number" ? raw : Number(String(raw).trim());
+  if (!Number.isFinite(n) || n < 0 || n > 1) {
+    return { ok: false, error: `${path} must be a number between 0 and 1` };
+  }
+  return { ok: true, value: n };
+}
+
+function parseTopN(raw: unknown): { ok: true; value: number } | { ok: false; error: string } {
+  const n = typeof raw === "number" ? raw : Number(String(raw).trim());
+  if (!Number.isInteger(n) || n < 1 || n > 1000) {
+    return { ok: false, error: "topN must be an integer between 1 and 1000" };
+  }
+  return { ok: true, value: n };
+}
+
+/**
+ * Parse and validate a discovery policy object.
+ * `null` / `undefined` input → success with `policy: null` (clear / omit).
+ */
+export function parseDiscoveryPolicyInput(
+  raw: unknown,
+  pathPrefix: string,
+): { ok: true; policy: DiscoveryPolicy | null } | { ok: false; error: string } {
+  if (raw === undefined || raw === null) {
+    return { ok: true, policy: null };
+  }
+  if (!isPlainObject(raw)) {
+    return { ok: false, error: `${pathPrefix} must be an object or null` };
+  }
+
+  const out: DiscoveryPolicy = {};
+
+  if (raw.topN !== undefined) {
+    const t = parseTopN(raw.topN);
+    if (!t.ok) return { ok: false, error: `${pathPrefix}.topN: ${t.error}` };
+    out.topN = t.value;
+  }
+
+  if (raw.sortBy !== undefined) {
+    const s = String(raw.sortBy).trim() as DiscoverySortBy;
+    if (!SORT_BY_VALUES.includes(s)) {
+      return {
+        ok: false,
+        error: `${pathPrefix}.sortBy must be one of: ${SORT_BY_VALUES.join(", ")}`,
+      };
+    }
+    out.sortBy = s;
+  }
+
+  if (raw.slaMinScore !== undefined) {
+    const r = parseRatio(raw.slaMinScore, `${pathPrefix}.slaMinScore`);
+    if (!r.ok) return { ok: false, error: r.error };
+    out.slaMinScore = r.value;
+  }
+
+  if (raw.slaWeights !== undefined) {
+    if (!isPlainObject(raw.slaWeights)) {
+      return { ok: false, error: `${pathPrefix}.slaWeights must be an object` };
+    }
+    const sw: NonNullable<DiscoveryPolicy["slaWeights"]> = {};
+    for (const key of ["latency", "swapRate", "price"] as const) {
+      if (raw.slaWeights[key] !== undefined) {
+        const w = parseWeight(raw.slaWeights[key], `${pathPrefix}.slaWeights.${key}`);
+        if (!w.ok) return { ok: false, error: w.error };
+        if (w.value !== 0) sw[key] = w.value;
+      }
+    }
+    if (Object.keys(sw).length > 0) out.slaWeights = sw;
+  }
+
+  if (raw.filters !== undefined) {
+    if (!isPlainObject(raw.filters)) {
+      return { ok: false, error: `${pathPrefix}.filters must be an object` };
+    }
+    const f: DiscoveryPolicyFilters = {};
+    const fl = raw.filters;
+    if (fl.gpuRamGbMin !== undefined) {
+      const v = parseNonNegativeNumber(fl.gpuRamGbMin, `${pathPrefix}.filters.gpuRamGbMin`);
+      if (!v.ok) return { ok: false, error: v.error };
+      f.gpuRamGbMin = v.value;
+    }
+    if (fl.gpuRamGbMax !== undefined) {
+      const v = parseNonNegativeNumber(fl.gpuRamGbMax, `${pathPrefix}.filters.gpuRamGbMax`);
+      if (!v.ok) return { ok: false, error: v.error };
+      f.gpuRamGbMax = v.value;
+    }
+    if (fl.priceMax !== undefined) {
+      const v = parseNonNegativeNumber(fl.priceMax, `${pathPrefix}.filters.priceMax`);
+      if (!v.ok) return { ok: false, error: v.error };
+      f.priceMax = v.value;
+    }
+    if (fl.maxAvgLatencyMs !== undefined) {
+      const v = parseNonNegativeNumber(fl.maxAvgLatencyMs, `${pathPrefix}.filters.maxAvgLatencyMs`);
+      if (!v.ok) return { ok: false, error: v.error };
+      f.maxAvgLatencyMs = v.value;
+    }
+    if (fl.maxSwapRatio !== undefined) {
+      const v = parseRatio(fl.maxSwapRatio, `${pathPrefix}.filters.maxSwapRatio`);
+      if (!v.ok) return { ok: false, error: v.error };
+      f.maxSwapRatio = v.value;
+    }
+    if (
+      f.gpuRamGbMin !== undefined &&
+      f.gpuRamGbMax !== undefined &&
+      f.gpuRamGbMin > f.gpuRamGbMax
+    ) {
+      return {
+        ok: false,
+        error: `${pathPrefix}.filters: gpuRamGbMin must be <= gpuRamGbMax`,
+      };
+    }
+    if (Object.keys(f).length > 0) out.filters = f;
+  }
+
+  if (Object.keys(out).length === 0) {
+    return { ok: true, policy: null };
+  }
+  return { ok: true, policy: out };
+}
+
+/** Normalize DB JSON (unknown) to DiscoveryPolicy | null. */
+export function discoveryPolicyFromDb(raw: unknown): DiscoveryPolicy | null {
+  if (raw === null || raw === undefined) return null;
+  if (!isPlainObject(raw)) return null;
+  const parsed = parseDiscoveryPolicyInput(raw, "discoveryPolicy");
+  return parsed.ok ? parsed.policy : null;
+}
+
+/**
+ * Conservative merge: app policy is an upper bound; user refines within it.
+ * Used by integrators (e.g. NaaP) when combining app plan defaults with user preferences.
+ */
+export function mergeDiscoveryPolicies(
+  app: DiscoveryPolicy | null,
+  user: DiscoveryPolicy | null,
+): DiscoveryPolicy | null {
+  if (!app && !user) return null;
+  if (!app) return user ? { ...user } : null;
+  if (!user) return { ...app };
+
+  const out: DiscoveryPolicy = { ...app };
+
+  if (user.topN !== undefined) {
+    const cap = app.topN ?? user.topN;
+    out.topN = Math.min(cap, user.topN);
+  }
+
+  if (user.sortBy !== undefined) {
+    out.sortBy = user.sortBy;
+  }
+
+  if (user.slaMinScore !== undefined) {
+    out.slaMinScore = Math.max(app.slaMinScore ?? user.slaMinScore, user.slaMinScore);
+  }
+
+  const mergedWeights = { ...app.slaWeights, ...user.slaWeights };
+  if (Object.keys(mergedWeights).length > 0) {
+    out.slaWeights = mergedWeights;
+  } else {
+    delete out.slaWeights;
+  }
+
+  const af = app.filters;
+  const uf = user.filters;
+  if (af || uf) {
+    const f: DiscoveryPolicyFilters = {};
+    const gminA = af?.gpuRamGbMin;
+    const gminU = uf?.gpuRamGbMin;
+    if (gminA !== undefined || gminU !== undefined) {
+      f.gpuRamGbMin = Math.max(gminA ?? 0, gminU ?? 0);
+    }
+    const gmaxA = af?.gpuRamGbMax;
+    const gmaxU = uf?.gpuRamGbMax;
+    if (gmaxA !== undefined && gmaxU !== undefined) f.gpuRamGbMax = Math.min(gmaxA, gmaxU);
+    else if (gmaxU !== undefined) f.gpuRamGbMax = gmaxU;
+    else if (gmaxA !== undefined) f.gpuRamGbMax = gmaxA;
+
+    const pA = af?.priceMax;
+    const pU = uf?.priceMax;
+    if (pA !== undefined && pU !== undefined) f.priceMax = Math.min(pA, pU);
+    else if (pU !== undefined) f.priceMax = pU;
+    else if (pA !== undefined) f.priceMax = pA;
+
+    const lA = af?.maxAvgLatencyMs;
+    const lU = uf?.maxAvgLatencyMs;
+    if (lA !== undefined && lU !== undefined) f.maxAvgLatencyMs = Math.min(lA, lU);
+    else if (lU !== undefined) f.maxAvgLatencyMs = lU;
+    else if (lA !== undefined) f.maxAvgLatencyMs = lA;
+
+    const sA = af?.maxSwapRatio;
+    const sU = uf?.maxSwapRatio;
+    if (sA !== undefined && sU !== undefined) f.maxSwapRatio = Math.min(sA, sU);
+    else if (sU !== undefined) f.maxSwapRatio = sU;
+    else if (sA !== undefined) f.maxSwapRatio = sA;
+
+    if (Object.keys(f).length > 0) out.filters = f;
+    else delete out.filters;
+  }
+
+  return out;
+}

--- a/src/shared/utils/billing-utils.ts
+++ b/src/shared/utils/billing-utils.ts
@@ -1,0 +1,34 @@
+/** Calendar month bounds in UTC as ISO strings (matches billing cycle fallback). */
+export function calendarMonthBoundsUtc(now: Date): { start: string; end: string } {
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  const start = new Date(Date.UTC(y, m, 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(y, m + 1, 0, 23, 59, 59, 999));
+  return {
+    start: start.toISOString(),
+    end: end.toISOString(),
+  };
+}
+
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MAX_DATE_RANGE_DAYS = 365; // Safety limit for date range iteration
+
+/** YYYY-MM-DD keys from period bounds (inclusive of both calendar days). */
+export function dateKeysInclusiveUtc(periodStartIso: string, periodEndIso: string): string[] {
+  const startDay = new Date(`${periodStartIso.slice(0, 10)}T12:00:00.000Z`);
+  const endDay = new Date(`${periodEndIso.slice(0, 10)}T12:00:00.000Z`);
+  const keys: string[] = [];
+  let t = startDay.getTime();
+  const endT = endDay.getTime();
+  const dayDiff = Math.floor((endT - t) / MS_PER_DAY) + 1;
+  if (dayDiff > MAX_DATE_RANGE_DAYS) {
+    throw new Error(`dateKeysInclusiveUtc: Range exceeds maximum of ${MAX_DATE_RANGE_DAYS} days`);
+  }
+  while (t <= endT) {
+    const current = new Date(t);
+    keys.push(current.toISOString().slice(0, 10));
+    t += MS_PER_DAY;
+  }
+  return keys;
+}

--- a/src/shared/utils/domain-whitelist.ts
+++ b/src/shared/utils/domain-whitelist.ts
@@ -1,0 +1,160 @@
+/**
+ * Domain whitelist normalization per RFC 6454 origin format.
+ * 
+ * Rules:
+ * - Origin = scheme "://" host [":" port] (per RFC 6454 §7.1)
+ * - Paths, query strings, fragments are stripped (not part of origin)
+ * - Default scheme is https, unless host is localhost (then http allowed)
+ * - http is ONLY allowed for localhost, 127.0.0.1, and [::1]
+ * - Port is omitted if it matches the default for the scheme
+ * - Input is trimmed and lowercased
+ */
+
+export interface NormalizationResult {
+  success: true;
+  normalized: string;
+}
+
+export interface NormalizationError {
+  success: false;
+  error: string;
+}
+
+type NormalizeResult = NormalizationResult | NormalizationError;
+
+const DEFAULT_HTTP_PORT = 80;
+const DEFAULT_HTTPS_PORT = 443;
+
+// Cap attacker-controlled input length before any pattern matching to eliminate
+// ReDoS / polynomial-regex surface (OWASP ReDoS guidance, CWE-1333).
+// A legitimate origin is scheme (8) + host (max 253 per RFC 1035) + port (6) +
+// brackets/colons, so 512 is a generous upper bound.
+const MAX_INPUT_LENGTH = 512;
+const SLASH_CHAR_CODE = 47;
+
+function isLocalhost(host: string): boolean {
+  const h = host.toLowerCase();
+  return h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]";
+}
+
+function getDefaultPort(scheme: string): number {
+  return scheme === "http" ? DEFAULT_HTTP_PORT : DEFAULT_HTTPS_PORT;
+}
+
+export function normalizeDomainWhitelist(input: string): NormalizeResult {
+  if (typeof input !== "string") {
+    return { success: false, error: "Domain must be a string" };
+  }
+
+  let trimmed = input.trim();
+
+  // Reject oversize input before running any regex-based parsing so that
+  // attacker-controlled strings cannot trigger super-linear backtracking.
+  if (trimmed.length > MAX_INPUT_LENGTH) {
+    return { success: false, error: `Domain exceeds max length of ${MAX_INPUT_LENGTH} characters` };
+  }
+
+  if (!trimmed) {
+    return { success: false, error: "Domain cannot be empty" };
+  }
+
+  // Strip trailing slashes without a regex (e.g. "example.com///").
+  // Using a bounded index scan guarantees O(n) worst case and avoids the
+  // polynomial-regex ReDoS surface flagged by CodeQL (js/polynomial-redos).
+  let end = trimmed.length;
+  while (end > 0 && trimmed.charCodeAt(end - 1) === SLASH_CHAR_CODE) {
+    end--;
+  }
+  if (end !== trimmed.length) {
+    trimmed = trimmed.slice(0, end);
+  }
+
+  // Parse scheme and host:port
+  let scheme: string | null = null;
+  let hostPort: string;
+
+  const schemeMatch = trimmed.match(/^([a-z][a-z0-9+.-]*):\/\//i);
+  if (schemeMatch) {
+    scheme = schemeMatch[1].toLowerCase();
+    hostPort = trimmed.slice(schemeMatch[0].length);
+    // For full URLs, ignore path/query/fragment and keep only authority.
+    const authorityEnd = hostPort.search(/[/?#]/);
+    if (authorityEnd !== -1) {
+      hostPort = hostPort.slice(0, authorityEnd);
+    }
+  } else {
+    // No scheme provided - determine based on host
+    hostPort = trimmed;
+    // For host input without scheme, allow accidental path/query suffixes.
+    const hostEnd = hostPort.search(/[/?#]/);
+    if (hostEnd !== -1) {
+      hostPort = hostPort.slice(0, hostEnd);
+    }
+  }
+
+  // Parse host and port
+  let host: string;
+  let port: number | null = null;
+
+  // IPv6 addresses in URLs are wrapped in brackets like [::1]
+  const ipv6Match = hostPort.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (ipv6Match) {
+    host = `[${ipv6Match[1]}]`;
+    if (ipv6Match[2]) {
+      port = parseInt(ipv6Match[2], 10);
+    }
+  } else {
+    const lastColon = hostPort.lastIndexOf(":");
+    if (lastColon !== -1 && hostPort.indexOf(":") === lastColon) {
+      // Only one colon, likely host:port
+      const possiblePort = hostPort.slice(lastColon + 1);
+      if (/^\d+$/.test(possiblePort)) {
+        host = hostPort.slice(0, lastColon);
+        port = parseInt(possiblePort, 10);
+      } else {
+        host = hostPort;
+      }
+    } else {
+      host = hostPort;
+    }
+  }
+
+  if (!host) {
+    return { success: false, error: "Invalid domain: no host found" };
+  }
+
+  host = host.toLowerCase();
+
+  // Validate port
+  if (port !== null) {
+    if (port < 1 || port > 65535) {
+      return { success: false, error: `Invalid port: ${port} (must be 1-65535)` };
+    }
+  }
+
+  // Determine scheme if not provided
+  if (!scheme) {
+    scheme = isLocalhost(host.replace(/[\[\]]/g, "")) ? "http" : "https";
+  }
+
+  // Validate scheme
+  if (scheme !== "http" && scheme !== "https") {
+    return { success: false, error: `Unsupported scheme: ${scheme} (only http and https are allowed)` };
+  }
+
+  // http is only allowed for localhost
+  if (scheme === "http" && !isLocalhost(host.replace(/[\[\]]/g, ""))) {
+    return { success: false, error: "http scheme is only allowed for localhost, 127.0.0.1, and [::1]" };
+  }
+
+  // Normalize port: omit if it's the default for the scheme
+  const defaultPort = getDefaultPort(scheme);
+  if (port === defaultPort) {
+    port = null;
+  }
+
+  // Build canonical origin
+  const normalized = port !== null ? `${scheme}://${host}:${port}` : `${scheme}://${host}`;
+
+  return { success: true, normalized };
+}

--- a/src/shared/utils/format-usd-micros.ts
+++ b/src/shared/utils/format-usd-micros.ts
@@ -1,0 +1,29 @@
+/**
+ * Format integer USD micros strings (1 USD = 1_000_000 micros) without Number precision loss.
+ * Returns null for missing, invalid, or zero values.
+ */
+export function formatUsdMicrosString(
+  microsStr: string | undefined | null,
+  maxFractionDigits: number,
+): string | null {
+  if (microsStr == null || microsStr === "") return null;
+  const t = microsStr.trim();
+  if (!/^-?\d+$/.test(t)) return null;
+  try {
+    const negative = t.startsWith("-");
+    const abs = BigInt(negative ? t.slice(1) : t);
+    if (abs === 0n) return null;
+    const whole = abs / 1_000_000n;
+    const frac = abs % 1_000_000n;
+    const digits = Math.min(6, Math.max(0, Math.floor(maxFractionDigits)));
+    let fracStr = frac.toString().padStart(6, "0").slice(0, digits);
+    fracStr = fracStr.replace(/0+$/, "");
+    const sign = negative ? "-" : "";
+    if (fracStr.length === 0) {
+      return `${sign}$${whole.toString()}`;
+    }
+    return `${sign}$${whole.toString()}.${fracStr}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/shared/utils/format-wei.ts
+++ b/src/shared/utils/format-wei.ts
@@ -1,0 +1,81 @@
+const WEI_PER_GWEI = 10n ** 9n;
+const WEI_PER_ETH = 10n ** 18n;
+/** Values at or above this display as ETH (0.001 ETH). */
+const ETH_DISPLAY_THRESHOLD = WEI_PER_ETH / 1000n;
+
+function trimTrailingZeros(s: string): string {
+  return s.replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function formatEthFraction(rem: bigint, maxDigits: number): string {
+  if (rem === 0n) return "";
+  const frac = rem.toString().padStart(18, "0").slice(0, maxDigits);
+  return trimTrailingZeros(frac);
+}
+
+/** Integer string for the first `decimals` fractional gwei digits (floored). */
+function subGweiFractionalDigits(weiRem: bigint, decimals: number): string {
+  if (weiRem === 0n) return "";
+  const mult = 10n ** BigInt(decimals);
+  const q = (weiRem * mult) / WEI_PER_GWEI;
+  return trimTrailingZeros(q.toString().padStart(decimals, "0"));
+}
+
+/**
+ * Human-readable wei: gwei when below 0.001 ETH, otherwise ETH with trimmed
+ * fractional digits (no dependency — BigInt-safe).
+ */
+export function formatWeiHuman(weiStr: string | null | undefined): string {
+  const raw = (weiStr ?? "").trim() || "0";
+  let w: bigint;
+  try {
+    w = BigInt(raw);
+  } catch {
+    return raw;
+  }
+  if (w === 0n) return "0";
+
+  if (w >= ETH_DISPLAY_THRESHOLD) {
+    const whole = w / WEI_PER_ETH;
+    const rem = w % WEI_PER_ETH;
+    const frac = formatEthFraction(rem, 8);
+    return frac ? `${whole.toString()}.${frac}` : whole.toString();
+  }
+
+  const gWhole = w / WEI_PER_GWEI;
+  const gRem = w % WEI_PER_GWEI;
+  if (gRem === 0n) return gWhole.toString();
+  const frac = subGweiFractionalDigits(gRem, 6);
+  if (frac) return `${gWhole.toString()}.${frac}`;
+  // Remainder wei is nonzero but rounds to 0 at 6 fractional gwei digits; 9 digits
+  // resolve sub-gwei wei exactly (1 gwei = 1e9 wei).
+  const fracFine = subGweiFractionalDigits(gRem, 9);
+  if (fracFine) return `${gWhole.toString()}.${fracFine}`;
+  return "<0.000001 gwei";
+}
+
+/** Wei column label helper: value + unit suffix for table headers. */
+export function weiHumanWithUnit(weiStr: string | null | undefined): string {
+  const raw = (weiStr ?? "").trim() || "0";
+  let w: bigint;
+  try {
+    w = BigInt(raw);
+  } catch {
+    return raw;
+  }
+  if (w === 0n) return "0";
+  const n = formatWeiHuman(raw);
+  if (w >= ETH_DISPLAY_THRESHOLD) return `${n} ETH`;
+  return `${n} gwei`;
+}
+
+export function formatIntegerString(
+  s: string | null | undefined,
+): string | null {
+  if (s == null || s === "") return null;
+  try {
+    return BigInt(s).toLocaleString();
+  } catch {
+    return s;
+  }
+}

--- a/src/shared/utils/token-hash.ts
+++ b/src/shared/utils/token-hash.ts
@@ -1,0 +1,61 @@
+/**
+ * Deterministic PBKDF2-SHA256 hashing for high-entropy credential material
+ * (bearer tokens, API keys, OIDC refresh tokens, admin invite codes).
+ *
+ * Why deterministic PBKDF2 and not per-record random salt:
+ *   These values are 256-bit random secrets, not user passwords. The hash
+ *   column is used as an indexed equality-lookup key (`WHERE token_hash = $1`),
+ *   so the KDF must map one plaintext to exactly one digest. We achieve
+ *   constant-time verification at the database level via the unique index,
+ *   and CWE-916 ("insufficient computational effort") is satisfied by the
+ *   OWASP-recommended PBKDF2 iteration count.
+ *
+ * Why a server-side pepper:
+ *   A global, deployment-scoped secret salt makes offline brute-force of
+ *   a stolen `token_hash` dump require also compromising the application
+ *   secret — the standard pepper pattern.
+ *
+ * Compatibility: digest is 64 hex chars, same shape as the previous
+ * `createHash("sha256")` output, so existing column types and unique
+ * indexes require no migration. Existing row values must be rotated
+ * manually (hard cutover, no SHA-256 fallback).
+ */
+
+import { pbkdf2Sync } from "crypto";
+
+const TOKEN_HASH_ITERATIONS = 600_000;
+const TOKEN_HASH_KEYLEN = 32;
+const TOKEN_HASH_DIGEST = "sha256";
+const MIN_PEPPER_LENGTH = 32;
+
+let cachedPepper: string | null = null;
+
+function loadPepper(): string {
+  if (cachedPepper !== null) return cachedPepper;
+
+  const pepper = process.env.AUTH_TOKEN_PEPPER?.trim();
+  if (!pepper || pepper.length < MIN_PEPPER_LENGTH) {
+    throw new Error(
+      `AUTH_TOKEN_PEPPER is required (min ${MIN_PEPPER_LENGTH} chars). ` +
+        `Generate one with: openssl rand -base64 48`,
+    );
+  }
+
+  cachedPepper = pepper;
+  return pepper;
+}
+
+/**
+ * Deterministic PBKDF2-SHA256 hash of a credential value, keyed by the
+ * server-side pepper. Returns a 64-character lowercase hex string suitable
+ * for direct equality comparison in the database.
+ */
+export function hashToken(token: string): string {
+  return pbkdf2Sync(
+    token,
+    loadPepper(),
+    TOKEN_HASH_ITERATIONS,
+    TOKEN_HASH_KEYLEN,
+    TOKEN_HASH_DIGEST,
+  ).toString("hex");
+}


### PR DESCRIPTION
## Summary
- Splits the domain/platform/shared foundation out of #85.
- Adds the new `src/domains`, `src/platform`, and `src/shared` modules without yet deleting legacy `src/lib` routes.
- Prepares the runtime surface used by the route-thinning follow-up.

## Merge Order
- Base of the runtime stack.
- Merge before the route-thinning PR.

## Test plan
- `npm run lint` was run on the final split code stack.

Made with [Cursor](https://cursor.com)