### PR TITLE
fix(apps): make app list cards fully clickable

### DIFF
--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -297,11 +297,11 @@ export default function AppsPage() {
           {apps.map((app) => (
             <div
               key={app.id}
-              className="relative flex h-full min-h-0 flex-col rounded-xl border border-zinc-800 bg-zinc-900/30 transition-colors group hover:border-zinc-700"
+              className="relative flex h-full min-h-0 flex-col rounded-xl border border-zinc-800 bg-zinc-900/30 transition-colors group hover:border-zinc-700 hover:bg-zinc-900/60"
             >
               <Link
                 href={`/apps/${app.id}`}
-                className="absolute inset-0 z-0 rounded-xl outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500/60"
+                className="absolute inset-0 z-0 cursor-pointer rounded-xl outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500/60"
                 aria-label={`${app.name} — open app settings`}
               />
               <div className="relative z-10 flex h-full min-h-0 flex-col gap-3 p-5 pointer-events-none">
@@ -320,7 +320,7 @@ export default function AppsPage() {
                         </h3>
                       </div>
                       {app.clientId ? (
-                        <div className="mt-2 space-y-1 pointer-events-auto">
+                        <div className="mt-2 space-y-1">
                           <div className="text-[10px] font-medium uppercase tracking-wide text-zinc-500">
                             Public app id
                           </div>

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -200,6 +200,7 @@ export default function AppSettingsScreen({
           backendHelper: putJson.m2mOidcClient ?? null,
         }));
       }
+      setSavedGrantTypes([...formData.grantTypes]);
 
       const settingsRes = await fetch(`/api/v1/apps/${appId}/settings`, {
         method: "PUT",
@@ -218,7 +219,6 @@ export default function AppSettingsScreen({
         );
       }
 
-      setSavedGrantTypes([...formData.grantTypes]);
       setMessage("All settings saved.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
@@ -544,11 +544,15 @@ export default function AppSettingsScreen({
                 </p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+                <label
+                  htmlFor="postLogoutUriInput"
+                  className="block text-sm font-medium text-zinc-300 mb-1.5"
+                >
                   Post-logout redirect URIs
                 </label>
                 <div className="flex gap-2 mb-2">
                   <input
+                    id="postLogoutUriInput"
                     type="text"
                     value={newPostLogoutUri}
                     onChange={(e) => setNewPostLogoutUri(e.target.value)}

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -111,6 +111,9 @@ export default function AppSettingsScreen({
   const [integrationSection, setIntegrationSection] =
     useState<IntegrationSection>(() => resolveInitialTab(initialTab));
   const tabRefs = useRef<Partial<Record<IntegrationSection, HTMLButtonElement | null>>>({});
+  const [savedGrantTypes, setSavedGrantTypes] = useState<string[]>(
+    initialData.grantTypes ?? [...defaultAppFormData.grantTypes],
+  );
 
   const selectIntegrationSection = useCallback(
     (section: IntegrationSection, updateUrl = true) => {
@@ -215,6 +218,7 @@ export default function AppSettingsScreen({
         );
       }
 
+      setSavedGrantTypes([...formData.grantTypes]);
       setMessage("All settings saved.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
@@ -346,6 +350,7 @@ export default function AppSettingsScreen({
     typeof window !== "undefined"
       ? `${window.location.origin}/api/v1/oidc/token`
       : "";
+  const showPostLogoutRedirectUris = savedGrantTypes.includes("authorization_code");
 
   return (
     <div className="max-w-3xl">
@@ -456,64 +461,6 @@ export default function AppSettingsScreen({
             <AppInfoStep data={formData} onChange={updateFormData} readOnly={!canEdit} />
           </section>
 
-          <section className="space-y-4">
-            <div>
-              <h2 className="text-lg font-semibold text-zinc-100">Post-logout Redirects</h2>
-              <p className="text-sm text-zinc-500 mt-1">
-                URIs to redirect users to after sign-out. Saved with{" "}
-                <strong className="text-zinc-400">Save changes</strong> below.
-              </p>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-zinc-300 mb-1.5">
-                Post-logout redirect URIs
-              </label>
-              <div className="flex gap-2 mb-2">
-                <input
-                  type="text"
-                  value={newPostLogoutUri}
-                  onChange={(e) => setNewPostLogoutUri(e.target.value)}
-                  onKeyDown={(e) =>
-                    e.key === "Enter" && (e.preventDefault(), addPostLogoutUri())
-                  }
-                  placeholder="https://example.com/logout-complete"
-                  disabled={!canEdit}
-                  className="flex-1 px-3 py-1.5 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 focus:border-emerald-500/50 disabled:opacity-50 disabled:cursor-not-allowed"
-                />
-                <button
-                  type="button"
-                  onClick={addPostLogoutUri}
-                  disabled={!canEdit}
-                  className="px-4 py-1.5 rounded-md bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  Add
-                </button>
-              </div>
-              <div className="space-y-1.5">
-                {postLogoutRedirectUris.map((uri) => (
-                  <div
-                    key={uri}
-                    className="flex items-center justify-between rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2"
-                  >
-                    <code className="text-xs text-zinc-300">{uri}</code>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setPostLogoutRedirectUris((items) =>
-                          items.filter((item) => item !== uri),
-                        )
-                      }
-                      disabled={!canEdit}
-                      className="text-xs text-zinc-500 hover:text-red-400 disabled:opacity-40 disabled:cursor-not-allowed"
-                    >
-                      Remove
-                    </button>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </section>
-
           {canSubmitForReview && appState.status === "draft" && (
             <section className="space-y-3 pt-2 border-t border-zinc-800">
               <h2 className="text-sm font-semibold text-zinc-100">Delete draft app</h2>
@@ -586,6 +533,66 @@ export default function AppSettingsScreen({
               readOnly={!canEdit}
             />
           </section>
+
+          {showPostLogoutRedirectUris && (
+            <section className="space-y-4">
+              <div>
+                <h2 className="text-lg font-semibold text-zinc-100">Post-logout Redirects</h2>
+                <p className="text-sm text-zinc-500 mt-1">
+                  URIs to redirect users to after sign-out for browser-based auth flows. Saved with{" "}
+                  <strong className="text-zinc-400">Save changes</strong> below.
+                </p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+                  Post-logout redirect URIs
+                </label>
+                <div className="flex gap-2 mb-2">
+                  <input
+                    type="text"
+                    value={newPostLogoutUri}
+                    onChange={(e) => setNewPostLogoutUri(e.target.value)}
+                    onKeyDown={(e) =>
+                      e.key === "Enter" && (e.preventDefault(), addPostLogoutUri())
+                    }
+                    placeholder="https://example.com/logout-complete"
+                    disabled={!canEdit}
+                    className="flex-1 px-3 py-1.5 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 focus:border-emerald-500/50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  />
+                  <button
+                    type="button"
+                    onClick={addPostLogoutUri}
+                    disabled={!canEdit}
+                    className="px-4 py-1.5 rounded-md bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Add
+                  </button>
+                </div>
+                <div className="space-y-1.5">
+                  {postLogoutRedirectUris.map((uri) => (
+                    <div
+                      key={uri}
+                      className="flex items-center justify-between rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2"
+                    >
+                      <code className="text-xs text-zinc-300">{uri}</code>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setPostLogoutRedirectUris((items) =>
+                            items.filter((item) => item !== uri),
+                          )
+                        }
+                        disabled={!canEdit}
+                        className="text-xs text-zinc-500 hover:text-red-400 disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+          )}
 
           <ReferenceEndpointsSection
             clientId={appState.clientId || ""}

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -6,6 +6,7 @@ import { docsDeviceFlowUrl } from "@/lib/docs-base-url";
 import { DEFAULT_OIDC_SCOPES, OIDC_SCOPES } from "@/lib/oidc/scopes";
 
 const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+const AUTHORIZATION_CODE_GRANT = "authorization_code";
 
 const USERS_TOKEN_SCOPE = OIDC_SCOPES.find((s) => s.value === "users:token")!;
 
@@ -37,7 +38,7 @@ export interface AppState {
 }
 
 const DEFAULT_GRANT_TYPES_WITH_DEVICE = [
-  "authorization_code",
+  AUTHORIZATION_CODE_GRANT,
   "refresh_token",
   DEVICE_CODE_GRANT,
 ] as const;
@@ -154,6 +155,10 @@ export default function AppWizard({ initialData }: Props) {
     try {
       const payload: AppFormData = {
         ...formData,
+        grantTypes:
+          formData.redirectUris.length === 0
+            ? formData.grantTypes.filter((grantType) => grantType !== AUTHORIZATION_CODE_GRANT)
+            : formData.grantTypes,
       };
       const res = await fetch("/api/v1/apps", {
         method: "POST",

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -5,8 +5,9 @@ import { useRouter } from "next/navigation";
 import { docsDeviceFlowUrl } from "@/lib/docs-base-url";
 import { DEFAULT_OIDC_SCOPES, OIDC_SCOPES } from "@/lib/oidc/scopes";
 
-const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 const AUTHORIZATION_CODE_GRANT = "authorization_code";
+const REFRESH_TOKEN_GRANT = "refresh_token";
+const DEVICE_FLOW_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
 const USERS_TOKEN_SCOPE = OIDC_SCOPES.find((s) => s.value === "users:token")!;
 
@@ -39,8 +40,8 @@ export interface AppState {
 
 const DEFAULT_GRANT_TYPES_WITH_DEVICE = [
   AUTHORIZATION_CODE_GRANT,
-  "refresh_token",
-  DEVICE_CODE_GRANT,
+  REFRESH_TOKEN_GRANT,
+  DEVICE_FLOW_GRANT,
 ] as const;
 
 export const defaultAppFormData: AppFormData = {
@@ -91,7 +92,7 @@ export default function AppWizard({ initialData }: Props) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const hasDeviceCode = formData.grantTypes.includes(DEVICE_CODE_GRANT);
+  const hasDeviceCode = formData.grantTypes.includes(DEVICE_FLOW_GRANT);
   const scopesList = useMemo(() => parseScopes(formData.allowedScopes), [formData.allowedScopes]);
   const hasIssueUserTokens = scopesList.includes("users:token");
 
@@ -106,7 +107,7 @@ export default function AppWizard({ initialData }: Props) {
         return {
           ...prev,
           backendDeviceHelper: false,
-          grantTypes: prev.grantTypes.filter((g) => g !== DEVICE_CODE_GRANT),
+          grantTypes: prev.grantTypes.filter((g) => g !== DEVICE_FLOW_GRANT),
           allowedScopes: joinScopes(scopes),
           initiateLoginUri: "",
           deviceThirdPartyInitiateLogin: false,
@@ -128,14 +129,14 @@ export default function AppWizard({ initialData }: Props) {
   const toggleDeviceCode = () => {
     if (!formData.backendDeviceHelper) return;
     if (hasDeviceCode) {
-      set("grantTypes", formData.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT));
+      set("grantTypes", formData.grantTypes.filter((v) => v !== DEVICE_FLOW_GRANT));
       return;
     }
     setFormData((prev) => ({
       ...prev,
-      grantTypes: prev.grantTypes.includes(DEVICE_CODE_GRANT)
+      grantTypes: prev.grantTypes.includes(DEVICE_FLOW_GRANT)
         ? prev.grantTypes
-        : [...prev.grantTypes, DEVICE_CODE_GRANT],
+        : [...prev.grantTypes, DEVICE_FLOW_GRANT],
     }));
   };
 
@@ -153,12 +154,22 @@ export default function AppWizard({ initialData }: Props) {
     setSaving(true);
     setError(null);
     try {
+      const grantTypesWithoutRedirectlessAuthCode = formData.grantTypes.filter(
+        (grantType) =>
+          formData.redirectUris.length > 0 || grantType !== AUTHORIZATION_CODE_GRANT,
+      );
+      const hasRefreshTokenIssuingGrant = grantTypesWithoutRedirectlessAuthCode.some(
+        (grantType) =>
+          grantType === AUTHORIZATION_CODE_GRANT || grantType === DEVICE_FLOW_GRANT,
+      );
+      const grantTypes = hasRefreshTokenIssuingGrant
+        ? grantTypesWithoutRedirectlessAuthCode
+        : grantTypesWithoutRedirectlessAuthCode.filter(
+            (grantType) => grantType !== REFRESH_TOKEN_GRANT,
+          );
       const payload: AppFormData = {
         ...formData,
-        grantTypes:
-          formData.redirectUris.length === 0
-            ? formData.grantTypes.filter((grantType) => grantType !== AUTHORIZATION_CODE_GRANT)
-            : formData.grantTypes,
+        grantTypes,
       };
       const res = await fetch("/api/v1/apps", {
         method: "POST",

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { docsDeviceFlowUrl, docsInteractiveLoginUrl } from "@/lib/docs-base-url";
+import { docsDeviceFlowUrl } from "@/lib/docs-base-url";
 import { DEFAULT_OIDC_SCOPES, OIDC_SCOPES } from "@/lib/oidc/scopes";
 
 const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
@@ -87,10 +87,8 @@ export default function AppWizard({ initialData }: Props) {
         ? [...initialData.redirectUris]
         : [...defaultAppFormData.redirectUris],
   });
-  const [callbackUrl, setCallbackUrl] = useState(initialData?.redirectUris?.[0] ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const hasDeviceCode = formData.grantTypes.includes(DEVICE_CODE_GRANT);
   const scopesList = useMemo(() => parseScopes(formData.allowedScopes), [formData.allowedScopes]);
@@ -156,7 +154,6 @@ export default function AppWizard({ initialData }: Props) {
     try {
       const payload: AppFormData = {
         ...formData,
-        redirectUris: callbackUrl.trim() ? [callbackUrl.trim()] : [],
       };
       const res = await fetch("/api/v1/apps", {
         method: "POST",
@@ -213,10 +210,25 @@ export default function AppWizard({ initialData }: Props) {
             type="text"
             value={formData.name}
             onChange={(e) => set("name", e.target.value)}
+            autoFocus
             required
             className={fieldClass}
           />
           <p className="text-xs text-zinc-500 mt-1.5">Something users will recognize and trust.</p>
+        </div>
+
+        {/* Developer / organization name */}
+        <div>
+          <label className="block text-sm font-medium text-zinc-200 mb-1.5">
+            Developer / organization name
+          </label>
+          <input
+            type="text"
+            value={formData.developerName}
+            onChange={(e) => set("developerName", e.target.value)}
+            placeholder="Acme Inc."
+            className={fieldClass}
+          />
         </div>
 
         {/* Homepage URL (optional) */}
@@ -233,6 +245,23 @@ export default function AppWizard({ initialData }: Props) {
           />
           <p className="text-xs text-zinc-500 mt-1.5">
             Shown on consent and in marketplace listings when set.
+          </p>
+        </div>
+
+        {/* Description */}
+        <div>
+          <label className="block text-sm font-medium text-zinc-200 mb-1.5">
+            Application description
+          </label>
+          <textarea
+            value={formData.description}
+            onChange={(e) => set("description", e.target.value)}
+            rows={3}
+            placeholder="Application description is optional"
+            className={`${fieldClass} resize-none`}
+          />
+          <p className="text-xs text-zinc-500 mt-1.5">
+            This is displayed to all users of your application.
           </p>
         </div>
 
@@ -325,86 +354,6 @@ export default function AppWizard({ initialData }: Props) {
             and set <strong className="text-zinc-400">Initiate login URI</strong> so users complete
             sign-in on your site instead of the default PymtHouse device page.
           </div>
-        </div>
-
-        {/* Authorization callback URL */}
-        <div>
-          <label className="block text-sm font-medium text-zinc-200 mb-1.5">
-            Authorization callback URL
-          </label>
-          <input
-            type="url"
-            value={callbackUrl}
-            onChange={(e) => setCallbackUrl(e.target.value)}
-            placeholder="https://"
-            className={fieldClass}
-          />
-          <p className="text-xs text-zinc-500 mt-1.5">
-            Required for the browser authorization code flow. Optional if you only use device or
-            server flows for now; you can add this later in app settings. Read our{" "}
-            <a
-              href={docsInteractiveLoginUrl()}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-emerald-500 hover:underline"
-            >
-              OAuth documentation
-            </a>{" "}
-            for more information.
-          </p>
-        </div>
-
-        {/* Description */}
-        <div>
-          <label className="block text-sm font-medium text-zinc-200 mb-1.5">
-            Application description
-          </label>
-          <textarea
-            value={formData.description}
-            onChange={(e) => set("description", e.target.value)}
-            rows={3}
-            placeholder="Application description is optional"
-            className={`${fieldClass} resize-none`}
-          />
-          <p className="text-xs text-zinc-500 mt-1.5">
-            This is displayed to all users of your application.
-          </p>
-        </div>
-
-        {/* Advanced: developer name only */}
-        <div className="border-t border-zinc-800 pt-4">
-          <button
-            type="button"
-            onClick={() => setShowAdvanced((v) => !v)}
-            className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
-          >
-            <svg
-              className={`w-3.5 h-3.5 transition-transform ${showAdvanced ? "rotate-90" : ""}`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-            Advanced settings
-          </button>
-
-          {showAdvanced && (
-            <div className="mt-4 space-y-5 pl-[22px]">
-              <div>
-                <label className="block text-sm font-medium text-zinc-200 mb-1.5">
-                  Developer / organization name
-                </label>
-                <input
-                  type="text"
-                  value={formData.developerName}
-                  onChange={(e) => set("developerName", e.target.value)}
-                  placeholder="Acme Inc."
-                  className={fieldClass}
-                />
-              </div>
-            </div>
-          )}
         </div>
 
         {/* Actions */}

--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -730,6 +730,28 @@ function buildPlanPayload(
   return payload;
 }
 
+// ── Collapsed card hit area ───────────────────────────────────────────────────
+
+function CollapsedPlanCardHitArea({
+  enabled,
+  ariaLabel,
+  onActivate,
+}: {
+  enabled: boolean;
+  ariaLabel: string;
+  onActivate: () => void;
+}) {
+  if (!enabled) return null;
+  return (
+    <button
+      type="button"
+      onClick={onActivate}
+      className="absolute inset-0 z-0 cursor-pointer rounded-xl outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500/60"
+      aria-label={ariaLabel}
+    />
+  );
+}
+
 // ── Network Price card ────────────────────────────────────────────────────────
 
 function NetworkPricePlanCard({
@@ -880,9 +902,24 @@ function NetworkPricePlanCard({
     ? excludedDocumentFromPickerValues(catalogLite, pickerValues).length
     : null;
 
+  const collapsedEditable = canEdit && !expanded;
+
   return (
-    <article className="rounded-xl border border-emerald-500/25 bg-zinc-900/40 p-5 space-y-3">
-      <div className="flex items-start justify-between gap-4">
+    <article
+      className={`group relative rounded-xl border border-emerald-500/25 bg-zinc-900/40 p-5 space-y-3 transition-colors ${
+        collapsedEditable ? "hover:border-emerald-500/40 hover:bg-zinc-900/50" : ""
+      }`}
+    >
+      <CollapsedPlanCardHitArea
+        enabled={collapsedEditable}
+        ariaLabel="Edit network discovery"
+        onActivate={openEdit}
+      />
+      <div
+        className={`relative z-10 flex items-start justify-between gap-4 ${
+          collapsedEditable ? "pointer-events-none" : ""
+        }`}
+      >
         <div className="min-w-0 flex-1">
           <h3 className="text-base font-semibold text-zinc-100 flex flex-wrap items-center gap-2">
             {planDisplayName({ name: plan.name, isNetworkDefault: true })}
@@ -897,14 +934,10 @@ function NetworkPricePlanCard({
             <p className="text-sm text-zinc-300 mt-2">{discoverySummary}</p>
           )}
         </div>
-        {canEdit && !expanded && (
-          <button
-            type="button"
-            onClick={openEdit}
-            className="shrink-0 text-sm text-emerald-400 hover:text-emerald-300"
-          >
+        {collapsedEditable && (
+          <span className="shrink-0 text-sm font-medium text-emerald-400 group-hover:text-emerald-300">
             Edit discovery
-          </button>
+          </span>
         )}
       </div>
 
@@ -1065,9 +1098,24 @@ function CustomPlanCard({
     }
   };
 
+  const collapsedEditable = canEdit && !isEditing;
+
   return (
-    <article className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-5 space-y-3">
-      <div className="flex items-start justify-between gap-4">
+    <article
+      className={`relative rounded-xl border border-zinc-800 bg-zinc-900/30 p-5 space-y-3 transition-colors ${
+        collapsedEditable ? "hover:border-zinc-700 hover:bg-zinc-900/50" : ""
+      }`}
+    >
+      <CollapsedPlanCardHitArea
+        enabled={collapsedEditable}
+        ariaLabel={`Edit plan ${plan.name}`}
+        onActivate={onEdit}
+      />
+      <div
+        className={`relative z-10 flex items-start justify-between gap-4 ${
+          collapsedEditable ? "pointer-events-none" : ""
+        }`}
+      >
         <div className="min-w-0 flex-1">
           <h3 className="text-base font-semibold text-zinc-100 flex flex-wrap items-center gap-2">
             {plan.name}
@@ -1088,18 +1136,15 @@ function CustomPlanCard({
             <CapabilityChips capabilities={plan.capabilities} catalog={catalog} />
           )}
         </div>
-        {canEdit && !isEditing && (
-          <div className="flex shrink-0 gap-3">
+        {collapsedEditable && (
+          <div className="flex shrink-0 gap-3 pointer-events-auto">
+            <span className="text-sm font-medium text-emerald-400">Edit</span>
             <button
               type="button"
-              onClick={onEdit}
-              className="text-sm text-emerald-400 hover:text-emerald-300"
-            >
-              Edit
-            </button>
-            <button
-              type="button"
-              onClick={onDelete}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
               className="text-sm text-zinc-500 hover:text-red-400"
             >
               Delete
@@ -1202,16 +1247,28 @@ function AddPlanPanel({
 
   if (!canEdit) return null;
 
+  const openCreate = () => {
+    setError(null);
+    setExpanded(true);
+  };
+
   return (
-    <article className="rounded-xl border border-dashed border-zinc-700 bg-zinc-900/20 p-5">
+    <article
+      className={`relative rounded-xl border border-dashed border-zinc-700 bg-zinc-900/20 p-5 transition-colors ${
+        !expanded ? "hover:border-zinc-600 hover:bg-zinc-900/30" : ""
+      }`}
+    >
       {!expanded ? (
-        <button
-          type="button"
-          onClick={() => setExpanded(true)}
-          className="w-full text-left text-sm font-medium text-emerald-400 hover:text-emerald-300"
-        >
-          + Add custom plan
-        </button>
+        <>
+          <CollapsedPlanCardHitArea
+            enabled
+            ariaLabel="Add custom plan"
+            onActivate={openCreate}
+          />
+          <div className="relative z-10 flex items-center justify-end pointer-events-none">
+            <span className="text-sm font-medium text-emerald-400">+ Add custom plan</span>
+          </div>
+        </>
       ) : (
         <div className="space-y-4">
           <h3 className="text-base font-semibold text-zinc-100">New custom plan</h3>
@@ -1319,6 +1376,32 @@ export default function PlansTab({ appId, canEdit }: PlansTabProps) {
     void fetchPlans();
   }, [fetchPlans]);
 
+  const refreshCustomPlans = useCallback(async () => {
+    try {
+      const plansWrap = await fetch(`/api/v1/apps/${appId}/plans`).then(readFetchJson);
+      if (plansWrap.ok && Array.isArray(plansWrap.body.plans)) {
+        const nextPlans = plansWrap.body.plans as PlanRow[];
+        const nextCustomPlans = nextPlans.filter((p) => p.isNetworkDefault !== true);
+        setPlans((prevPlans) => {
+          const previousNetworkPlan = prevPlans.find((p) => p.isNetworkDefault === true);
+          if (!previousNetworkPlan) {
+            return nextPlans;
+          }
+          return [previousNetworkPlan, ...nextCustomPlans];
+        });
+        setPlanError(null);
+      } else {
+        const msg =
+          typeof plansWrap.body.error === "string"
+            ? plansWrap.body.error
+            : `Could not refresh plans (HTTP ${plansWrap.status})`;
+        setPlanError(msg);
+      }
+    } catch (err) {
+      setPlanError(err instanceof Error ? err.message : "Failed to refresh plans");
+    }
+  }, [appId]);
+
   useEffect(() => {
     void fetchPlans();
   }, [fetchPlans]);
@@ -1368,15 +1451,20 @@ export default function PlansTab({ appId, canEdit }: PlansTabProps) {
         return;
       }
       if (editingPlanId === planId) setEditingPlanId(null);
-      reloadPlans();
+      void refreshCustomPlans();
     } catch (err) {
       setPlanError(err instanceof Error ? err.message : "Failed to delete plan");
     }
   };
 
-  const handleSaved = () => {
+  const handleNetworkSaved = () => {
     setEditingPlanId(null);
     reloadPlans();
+  };
+
+  const handleCustomPlanSaved = () => {
+    setEditingPlanId(null);
+    void refreshCustomPlans();
   };
 
   return (
@@ -1411,7 +1499,7 @@ export default function PlansTab({ appId, canEdit }: PlansTabProps) {
               catalog={catalog}
               catalogError={catalogError}
               canEdit={canEdit}
-              onSaved={handleSaved}
+              onSaved={handleNetworkSaved}
             />
           ) : (
             <p className="text-sm text-amber-400">Network Price plan not found for this app.</p>
@@ -1429,7 +1517,7 @@ export default function PlansTab({ appId, canEdit }: PlansTabProps) {
               isEditing={editingPlanId === plan.id}
               onEdit={() => setEditingPlanId(plan.id)}
               onCancelEdit={() => setEditingPlanId(null)}
-              onSaved={handleSaved}
+              onSaved={handleCustomPlanSaved}
               onDelete={() => void deletePlan(plan.id)}
             />
           ))}
@@ -1440,7 +1528,7 @@ export default function PlansTab({ appId, canEdit }: PlansTabProps) {
             catalogError={catalogError}
             blockedConcreteKeys={blockedConcreteKeys}
             canEdit={canEdit}
-            onCreated={handleSaved}
+            onCreated={handleCustomPlanSaved}
           />
         </div>
       )}

--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -859,9 +859,9 @@ function NetworkPricePlanCard({
         );
         return;
       }
+      await onSaved();
       setExpanded(false);
       setSynced(false);
-      onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
     } finally {
@@ -888,9 +888,9 @@ function NetworkPricePlanCard({
         );
         return;
       }
+      await onSaved();
       setExpanded(false);
       setSynced(false);
-      onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to reset");
     } finally {

--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -767,7 +767,7 @@ function NetworkPricePlanCard({
   catalog: PipelineCatalogEntry[];
   catalogError: string | null;
   canEdit: boolean;
-  onSaved: () => void;
+  onSaved: () => void | Promise<void>;
 }) {
   const catalogLite = useMemo(() => catalogLiteFrom(catalog), [catalog]);
   const [expanded, setExpanded] = useState(false);
@@ -1057,7 +1057,7 @@ function CustomPlanCard({
   isEditing: boolean;
   onEdit: () => void;
   onCancelEdit: () => void;
-  onSaved: () => void;
+  onSaved: () => void | Promise<void>;
   onDelete: () => void;
 }) {
   const [draft, setDraft] = useState<PlanDraft>(() => planToDraft(plan));
@@ -1090,7 +1090,7 @@ function CustomPlanCard({
         );
         return;
       }
-      onSaved();
+      await onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
     } finally {
@@ -1209,7 +1209,7 @@ function AddPlanPanel({
   catalogError: string | null;
   blockedConcreteKeys: Set<string>;
   canEdit: boolean;
-  onCreated: () => void;
+  onCreated: () => void | Promise<void>;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [draft, setDraft] = useState<PlanDraft>(emptyDraft);
@@ -1237,7 +1237,7 @@ function AddPlanPanel({
       }
       setDraft(emptyDraft());
       setExpanded(false);
-      onCreated();
+      await onCreated();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create plan");
     } finally {
@@ -1451,7 +1451,7 @@ export default function PlansTab({ appId, canEdit }: PlansTabProps) {
         return;
       }
       if (editingPlanId === planId) setEditingPlanId(null);
-      void refreshCustomPlans();
+      await refreshCustomPlans();
     } catch (err) {
       setPlanError(err instanceof Error ? err.message : "Failed to delete plan");
     }
@@ -1462,9 +1462,9 @@ export default function PlansTab({ appId, canEdit }: PlansTabProps) {
     reloadPlans();
   };
 
-  const handleCustomPlanSaved = () => {
+  const handleCustomPlanSaved = async () => {
     setEditingPlanId(null);
-    void refreshCustomPlans();
+    await refreshCustomPlans();
   };
 
   return (


### PR DESCRIPTION
## Summary

- Fix app list cards so clicks on the title, public app id, and empty card area navigate to `/apps/{id}` (same target as Settings).
- Remove `pointer-events-auto` from the whole public app id block; only the copy button keeps direct pointer events so it no longer blocks the card overlay link.
- Add `cursor-pointer` on the overlay link and `hover:bg-zinc-900/60` on the card for clearer click affordance.

## Test plan

- [ ] Open `/apps` with at least one app that has a public app id.
- [ ] Click the app name — should open app settings (`/apps/{id}`).
- [ ] Click the public app id text — should open app settings.
- [ ] Click empty padding on the card — should open app settings.
- [ ] Click the copy button — should copy the app id without navigating.
- [ ] Click **Usage** — should go to `/apps/{id}/usage`.
- [ ] Click **Settings** — should go to `/apps/{id}`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved app card hover interactions with background highlight and cursor changes; refined pointer behavior in the public app id area.

* **New Features / UX**
  * Post-logout Redirects moved to credentials and shown only when relevant grant types are saved.
  * App creation wizard simplified: developer name visible, description added, autofocus on app name, advanced callback URL removed.

* **Usability**
  * Collapsed plan cards use a unified clickable hit area; plan refresh/save flows now preserve network-defaults and refresh custom plans independently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eliteprox/pymthouse/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->