### PR TITLE
fix(manifest): use app ID for network plan ETag lookup

### DIFF
--- a/src/app/api/v1/apps/[id]/manifest/route.ts
+++ b/src/app/api/v1/apps/[id]/manifest/route.ts
@@ -68,7 +68,7 @@ export async function GET(
 
   const body = await buildAppManifestForApp(app.id);
   publishCachedManifestPolicy(clientId, body, "manifest_get");
-  const networkPlan = await selectNetworkDefaultPlan(clientId, db);
+  const networkPlan = await selectNetworkDefaultPlan(app.id, db);
   const etag = buildManifestEtagFromPlanUpdatedAt(networkPlan?.updatedAt);
   if (requestMatchesIfNoneMatch(request, etag)) {
     return new NextResponse(null, {
@@ -89,7 +89,7 @@ export async function HEAD(
     return new NextResponse(null, { status: 404 });
   }
 
-  const networkPlan = await selectNetworkDefaultPlan(clientId, db);
+  const networkPlan = await selectNetworkDefaultPlan(app.id, db);
   const etag = buildManifestEtagFromPlanUpdatedAt(networkPlan?.updatedAt);
   if (requestMatchesIfNoneMatch(request, etag)) {
     return new NextResponse(null, {


### PR DESCRIPTION
## Summary
- Fix manifest `GET` and `HEAD` handlers to pass the provider app internal ID (`app.id`) into `selectNetworkDefaultPlan` instead of the OAuth client ID from the URL.
- Aligns ETag / conditional `304` behavior with `buildAppManifestForApp`, which already resolves the network default plan by internal app ID.

## Context
The `plans.clientId` column stores the provider app internal ID, not the public OAuth client ID. Using the URL client ID for plan lookup could miss the network default plan and produce incorrect or stale `ETag` values on manifest responses.

## Test plan
- [ ] `GET /api/v1/apps/{clientId}/manifest` returns `ETag` that changes when network default plan exclusions are updated
- [ ] `HEAD` with matching `If-None-Match` returns `304`
- [ ] Manifest body still matches prior behavior (unchanged `buildAppManifestForApp` path)
- [ ] Run manifest route tests: `npm test -- src/app/api/v1/apps/[id]/manifest/route.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache validation for the app manifest endpoint to correctly identify when manifest updates occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eliteprox/pymthouse/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->