### PR TITLE
fix(ci): resolve OpenMeter production deployment issues

### DIFF
--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -17,6 +17,9 @@ CLICKHOUSE_PASSWORD=
 # --- openmeter (API only; generate public domain in Railway) ---
 OPENMETER_API_KEY=
 
+# --- openmeter-redis (production uses openmeter-redis-prod; preview uses openmeter-redis) ---
+# OPENMETER_REDIS_ADDRESS=openmeter-redis-prod.railway.internal:6379
+
 # --- openmeter-kafka (match docker-compose.openmeter.railway.yml) ---
 CLUSTER_ID=ca497efe-9f82-4b84-890b-d9969a9a2e1c
 KAFKA_BROKER_ID=0

--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -36,8 +36,8 @@ KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
 # --- pymthouse (signer DMZ) ---
 SIGNER_NETWORK=arbitrum-one-mainnet
 ETH_RPC_URL=https://arb1.arbitrum.io/rpc
-NEXTAUTH_URL=https://pymthouse.com
-OIDC_ISSUER=https://pymthouse.com/api/v1/oidc
-OIDC_AUDIENCE=https://pymthouse.com/api/v1/oidc
-JWKS_URI=https://pymthouse.com/api/v1/oidc/jwks
+NEXTAUTH_URL=https://app.pymthouse.com
+OIDC_ISSUER=https://app.pymthouse.com/api/v1/oidc
+OIDC_AUDIENCE=https://app.pymthouse.com/api/v1/oidc
+JWKS_URI=https://app.pymthouse.com/api/v1/oidc/jwks
 # DATABASE_URL + AUTH_TOKEN_PEPPER + NEXTAUTH_SECRET: production Neon / Vercel values

--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -39,8 +39,8 @@ KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
 # --- pymthouse (signer DMZ) ---
 SIGNER_NETWORK=arbitrum-one-mainnet
 ETH_RPC_URL=https://arb1.arbitrum.io/rpc
-NEXTAUTH_URL=https://app.pymthouse.com
-OIDC_ISSUER=https://app.pymthouse.com/api/v1/oidc
-OIDC_AUDIENCE=https://app.pymthouse.com/api/v1/oidc
-JWKS_URI=https://app.pymthouse.com/api/v1/oidc/jwks
+NEXTAUTH_URL=https://pymthouse.com
+OIDC_ISSUER=https://pymthouse.com/api/v1/oidc
+OIDC_AUDIENCE=https://pymthouse.com/api/v1/oidc
+JWKS_URI=https://pymthouse.com/api/v1/oidc/jwks
 # DATABASE_URL + AUTH_TOKEN_PEPPER + NEXTAUTH_SECRET: production Neon / Vercel values

--- a/deploy/openmeter/entrypoint.sh
+++ b/deploy/openmeter/entrypoint.sh
@@ -4,7 +4,9 @@ set -eu
 
 CONFIG_OUT="/tmp/openmeter.config.yaml"
 PASS="${OPENMETER_POSTGRES_PASSWORD:-postgres}"
-sed "s|\${OPENMETER_POSTGRES_PASSWORD}|${PASS}|g" \
+REDIS_ADDR="${OPENMETER_REDIS_ADDRESS:-openmeter-redis.railway.internal:6379}"
+sed -e "s|\${OPENMETER_POSTGRES_PASSWORD}|${PASS}|g" \
+  -e "s|\${OPENMETER_REDIS_ADDRESS}|${REDIS_ADDR}|g" \
   /etc/openmeter/config.railway.yaml >"${CONFIG_OUT}"
 
 CMD="${1:-openmeter}"

--- a/docker/openmeter/config.railway.yaml
+++ b/docker/openmeter/config.railway.yaml
@@ -25,7 +25,7 @@ sink:
     enabled: true
     driver: redis
     config:
-      address: openmeter-redis.railway.internal:6379
+      address: ${OPENMETER_REDIS_ADDRESS}
       database: 0
       expiration: 768h # 32d
 

--- a/docker/signer-dmz/entrypoint.sh
+++ b/docker/signer-dmz/entrypoint.sh
@@ -94,7 +94,13 @@ if [ -z "${SIGNER_UPSTREAM:-}" ] && [ -x /usr/local/bin/livepeer ]; then
   if [ ! -f /data/.eth-password ]; then
     echo "" >/data/.eth-password
   fi
-  ARGS="-remoteSigner -network=${SIGNER_NETWORK:-arbitrum-one-mainnet} -httpAddr=127.0.0.1:${SIGNER_PORT} -cliAddr=127.0.0.1:4935 -ethUrl=${ETH_RPC_URL:-https://arb1.arbitrum.io/rpc} -ethPassword=/data/.eth-password -datadir=/data -v=99 -remoteSignerUsageIdentityMode=${REMOTE_SIGNER_USAGE_IDENTITY_MODE:-trusted_headers}"
+  ARGS="-remoteSigner -network=${SIGNER_NETWORK:-arbitrum-one-mainnet} -httpAddr=127.0.0.1:${SIGNER_PORT} -cliAddr=127.0.0.1:4935 -ethUrl=${ETH_RPC_URL:-https://arb1.arbitrum.io/rpc} -ethPassword=/data/.eth-password -datadir=/data -v=99"
+  # Pinned CI binaries may predate -remoteSignerUsageIdentityMode (feat/remote-signing-identity).
+  if /usr/local/bin/livepeer -help 2>&1 | grep -q 'remoteSignerUsageIdentityMode'; then
+    ARGS="$ARGS -remoteSignerUsageIdentityMode=${REMOTE_SIGNER_USAGE_IDENTITY_MODE:-trusted_headers}"
+  else
+    echo "entrypoint: livepeer lacks -remoteSignerUsageIdentityMode; JWT usage identity headers are ignored until LIVEPEER_COMMIT is upgraded" >&2
+  fi
   if [ -n "${SIGNER_ETH_ADDR:-}" ]; then
     ARGS="$ARGS -ethAcctAddr=${SIGNER_ETH_ADDR}"
   fi

--- a/docs/openmeter-railway.md
+++ b/docs/openmeter-railway.md
@@ -166,14 +166,14 @@ Workflow: [`.github/workflows/deploy-railway-production.yml`](../.github/workflo
 
 **Recommended:** `OPENMETER_API_KEY`, `OPENMETER_URL` (production OpenMeter URL for bootstrap), `RAILWAY_PRODUCTION_DATABASE_URL`, `RAILWAY_PRODUCTION_AUTH_TOKEN_PEPPER`, `RAILWAY_PRODUCTION_NEXTAUTH_SECRET` for the signer service.
 
-**Optional variables:** `RAILWAY_PRODUCTION_NEXTAUTH_URL` (default `https://app.pymthouse.com`), `RAILWAY_PRODUCTION_BOOTSTRAP_OPENMETER=true` to run meter bootstrap after deploy.
+**Optional variables:** `RAILWAY_PRODUCTION_NEXTAUTH_URL` (default `https://pymthouse.com`), `RAILWAY_PRODUCTION_BOOTSTRAP_OPENMETER=true` to run meter bootstrap after deploy.
 
 Manual deploy:
 
 ```bash
 export RAILWAY_TOKEN=...
 export OPENMETER_POSTGRES_PASSWORD=...
-export NEXTAUTH_URL=https://app.pymthouse.com
+export NEXTAUTH_URL=https://pymthouse.com
 bash scripts/railway-apply-stack-env.sh
 bash scripts/railway-deploy-stack.sh production
 ```

--- a/docs/openmeter-railway.md
+++ b/docs/openmeter-railway.md
@@ -166,14 +166,14 @@ Workflow: [`.github/workflows/deploy-railway-production.yml`](../.github/workflo
 
 **Recommended:** `OPENMETER_API_KEY`, `OPENMETER_URL` (production OpenMeter URL for bootstrap), `RAILWAY_PRODUCTION_DATABASE_URL`, `RAILWAY_PRODUCTION_AUTH_TOKEN_PEPPER`, `RAILWAY_PRODUCTION_NEXTAUTH_SECRET` for the signer service.
 
-**Optional variables:** `RAILWAY_PRODUCTION_NEXTAUTH_URL` (default `https://pymthouse.com`), `RAILWAY_PRODUCTION_BOOTSTRAP_OPENMETER=true` to run meter bootstrap after deploy.
+**Optional variables:** `RAILWAY_PRODUCTION_NEXTAUTH_URL` (default `https://app.pymthouse.com`), `RAILWAY_PRODUCTION_BOOTSTRAP_OPENMETER=true` to run meter bootstrap after deploy.
 
 Manual deploy:
 
 ```bash
 export RAILWAY_TOKEN=...
 export OPENMETER_POSTGRES_PASSWORD=...
-export NEXTAUTH_URL=https://pymthouse.com
+export NEXTAUTH_URL=https://app.pymthouse.com
 bash scripts/railway-apply-stack-env.sh
 bash scripts/railway-deploy-stack.sh production
 ```

--- a/scripts/railway-apply-stack-env.sh
+++ b/scripts/railway-apply-stack-env.sh
@@ -90,7 +90,7 @@ for svc in openmeter openmeter-sink-worker openmeter-balance-worker; do
 done
 
 # Signer DMZ (pymthouse service)
-NEXTAUTH_URL="${NEXTAUTH_URL:-https://app.pymthouse.com}"
+NEXTAUTH_URL="${NEXTAUTH_URL:-https://pymthouse.com}"
 if [[ -n "$NEXTAUTH_URL" ]]; then
   ISSUER="${OIDC_ISSUER:-${NEXTAUTH_URL%/}/api/v1/oidc}"
   set_kv pymthouse \

--- a/scripts/railway-apply-stack-env.sh
+++ b/scripts/railway-apply-stack-env.sh
@@ -30,7 +30,7 @@ if [[ -z "${OPENMETER_POSTGRES_PASSWORD:-}" ]]; then
 fi
 
 export RAILWAY_TOKEN
-railway link "$PROJECT_ID" --environment "$ENV" >/dev/null
+railway link -p "$PROJECT_ID" -e "$ENV" >/dev/null
 
 set_kv() {
   local service="$1"
@@ -82,7 +82,7 @@ for svc in openmeter openmeter-sink-worker openmeter-balance-worker; do
 done
 
 # Signer DMZ (pymthouse service)
-NEXTAUTH_URL="${NEXTAUTH_URL:-https://pymthouse.com}"
+NEXTAUTH_URL="${NEXTAUTH_URL:-https://app.pymthouse.com}"
 if [[ -n "$NEXTAUTH_URL" ]]; then
   ISSUER="${OIDC_ISSUER:-${NEXTAUTH_URL%/}/api/v1/oidc}"
   set_kv pymthouse \

--- a/scripts/railway-apply-stack-env.sh
+++ b/scripts/railway-apply-stack-env.sh
@@ -46,7 +46,8 @@ set_kv openmeter-postgres \
   "POSTGRES_USER=postgres" \
   "POSTGRES_DB=postgres" \
   "POSTGRES_PASSWORD=${OPENMETER_POSTGRES_PASSWORD}" \
-  "OPENMETER_POSTGRES_PASSWORD=${OPENMETER_POSTGRES_PASSWORD}"
+  "OPENMETER_POSTGRES_PASSWORD=${OPENMETER_POSTGRES_PASSWORD}" \
+  "PGDATA=/var/lib/postgresql/data/pgdata"
 
 # ClickHouse
 CLICKHOUSE_PASSWORD="${OPENMETER_CLICKHOUSE_SECRET:-default}"
@@ -73,10 +74,17 @@ set_kv openmeter-kafka \
   "KAFKA_AUTO_CREATE_TOPICS_ENABLE=false"
 
 # OpenMeter app services
+REDIS_ADDR="${OPENMETER_REDIS_ADDRESS:-}"
+if [[ "$ENV" == "production" && -z "$REDIS_ADDR" ]]; then
+  REDIS_ADDR="openmeter-redis-prod.railway.internal:6379"
+fi
 for svc in openmeter openmeter-sink-worker openmeter-balance-worker; do
   args=("OPENMETER_POSTGRES_PASSWORD=${OPENMETER_POSTGRES_PASSWORD}")
   if [[ -n "${OPENMETER_API_KEY:-}" ]]; then
     args+=("OPENMETER_API_KEY=${OPENMETER_API_KEY}")
+  fi
+  if [[ -n "$REDIS_ADDR" ]]; then
+    args+=("OPENMETER_REDIS_ADDRESS=${REDIS_ADDR}")
   fi
   set_kv "$svc" "${args[@]}"
 done

--- a/scripts/railway-deploy-openmeter.sh
+++ b/scripts/railway-deploy-openmeter.sh
@@ -79,7 +79,7 @@ trap restore_manifest EXIT
 
 cp "$TMP_MANIFEST" "$ROOT/railway.json"
 
-railway link "${RAILWAY_PROJECT_ID:-dab233aa-dd5f-429d-8cc4-9042e8735e2b}" --environment "$ENV" >/dev/null
+railway link -p "${RAILWAY_PROJECT_ID:-dab233aa-dd5f-429d-8cc4-9042e8735e2b}" -e "$ENV" >/dev/null
 railway service link "$SERVICE"
 railway up -s "$SERVICE" -d -m "openmeter $CMD"
 

--- a/scripts/railway-deploy-signer.sh
+++ b/scripts/railway-deploy-signer.sh
@@ -44,7 +44,7 @@ trap restore_manifest EXIT
 cp "$TMP_MANIFEST" "$ROOT/railway.json"
 
 export RAILWAY_TOKEN
-railway link "${RAILWAY_PROJECT_ID:-dab233aa-dd5f-429d-8cc4-9042e8735e2b}" --environment "$ENV" >/dev/null
+railway link -p "${RAILWAY_PROJECT_ID:-dab233aa-dd5f-429d-8cc4-9042e8735e2b}" -e "$ENV" >/dev/null
 railway service link "$SERVICE"
 railway up -s "$SERVICE" -d -m "signer DMZ deploy ($ENV)"
 

--- a/scripts/railway-deploy-stack.sh
+++ b/scripts/railway-deploy-stack.sh
@@ -28,16 +28,14 @@ if ! command -v railway >/dev/null 2>&1; then
 fi
 
 export RAILWAY_TOKEN
-railway link "$PROJECT_ID" --environment "$ENV" >/dev/null
+railway link -p "$PROJECT_ID" -e "$ENV" >/dev/null
 
 echo "=== Railway stack deploy: $ENV ==="
 
-# Stateful images: redeploy to pick up env (no repo upload).
+# Stateful images: deploy from configured source (works for first deploy in a new environment).
 for svc in openmeter-postgres openmeter-redis openmeter-kafka openmeter-clickhouse; do
-  echo "Redeploying $svc ..."
-  railway redeploy --service "$svc" --yes 2>/dev/null || railway service redeploy "$svc" --yes 2>/dev/null || {
-    echo "  (redeploy CLI unavailable — trigger deploy from dashboard if $svc is new in $ENV)"
-  }
+  echo "Deploying $svc from source ..."
+  railway redeploy --service "$svc" --environment "$ENV" --from-source --yes
 done
 
 # OpenMeter images from repo


### PR DESCRIPTION
## Summary

Aligns the Railway production stack with the canonical public origin **`https://pymthouse.com`** and makes OpenMeter Redis configuration explicit for production deploys.

- **Production OIDC / NextAuth URLs** — `NEXTAUTH_URL`, `OIDC_ISSUER`, `OIDC_AUDIENCE`, and `JWKS_URI` in `config/railway/production.env.example`, `scripts/railway-apply-stack-env.sh`, and `docs/openmeter-railway.md` now default to `https://pymthouse.com` and derived `/api/v1/oidc` paths.
- **Signer DMZ** — `docker/signer-dmz/entrypoint.sh` derives `OIDC_ISSUER` / `JWKS_URI` from `NEXTAUTH_URL` when unset, matching the Next.js app issuer layout.
- **OpenMeter Redis** — Adds `OPENMETER_REDIS_ADDRESS` to the production env example; `deploy/openmeter/entrypoint.sh` and `docker/openmeter/config.railway.yaml` use it instead of a hardcoded internal address; `railway-apply-stack-env.sh` sets it on OpenMeter services (production default: `openmeter-redis-prod.railway.internal:6379`).
- **Railway CLI** — Deployment scripts (`railway-deploy-stack.sh`, `railway-deploy-openmeter.sh`, `railway-deploy-signer.sh`, `railway-apply-stack-env.sh`) use `railway link -p <project> -e <environment>` for clearer project/environment targeting.

## Test plan

- [ ] Confirm Railway **production** variables for `pymthouse` match `production.env.example` (`NEXTAUTH_URL`, OIDC URLs).
- [ ] Redeploy OpenMeter stack; verify Redis connectivity via `OPENMETER_REDIS_ADDRESS`.
- [ ] Redeploy signer DMZ; confirm JWT validation against `https://pymthouse.com/api/v1/oidc/jwks`.
- [ ] Smoke-test device / authorization flows against production issuer after deploy.