### PR TITLE
feat(auth): integrate server session handling and enhance app settings

### DIFF
--- a/src/app/api/v1/apps/[id]/route.ts
+++ b/src/app/api/v1/apps/[id]/route.ts
@@ -13,6 +13,8 @@ import { v4 as uuidv4 } from "uuid";
 import {
   demotePublicClientWhenM2mSiblingExists,
   ensureM2mBackendClient,
+  loadM2mOidcClientSummary,
+  removeM2mBackendClient,
   syncBackendM2mAllowedScopesFromPublicApp,
   updateClientConfig,
 } from "@/lib/oidc/clients";
@@ -319,42 +321,28 @@ export async function PUT(
     }
   }
 
-  let m2mAfter: { clientId: string; hasSecret: boolean } | null = null;
-  if (body.backendDeviceHelper === true) {
+  if (body.backendDeviceHelper === false) {
+    if (await removeM2mBackendClient(app.id)) {
+      resetProvider();
+    }
+  } else if (body.backendDeviceHelper === true) {
     await ensureM2mBackendClient({
       appInternalId: app.id,
-      appDisplayName: typeof body.name === "string" && body.name.trim()
-        ? body.name.trim()
-        : app.name,
+      appDisplayName:
+        typeof body.name === "string" && body.name.trim()
+          ? body.name.trim()
+          : app.name,
     });
     if (await demotePublicClientWhenM2mSiblingExists(app.id)) {
       resetProvider();
-    }
-    const refreshed = await db
-      .select({ m2mOidcClientId: developerApps.m2mOidcClientId })
-      .from(developerApps)
-      .where(eq(developerApps.id, app.id))
-      .limit(1);
-    const m2mPk = refreshed[0]?.m2mOidcClientId;
-    if (m2mPk) {
-      const m2mRows = await db
-        .select()
-        .from(oidcClients)
-        .where(eq(oidcClients.id, m2mPk))
-        .limit(1);
-      const m2m = m2mRows[0];
-      if (m2m) {
-        m2mAfter = {
-          clientId: m2m.clientId,
-          hasSecret: !!m2m.clientSecretHash,
-        };
-      }
     }
   }
 
   if (await syncBackendM2mAllowedScopesFromPublicApp(app.id)) {
     resetProvider();
   }
+
+  const m2mAfter = await loadM2mOidcClientSummary(app.id);
 
   return NextResponse.json({ success: true, m2mOidcClient: m2mAfter });
 }

--- a/src/app/apps/[id]/page.tsx
+++ b/src/app/apps/[id]/page.tsx
@@ -5,7 +5,11 @@ import { useParams, useSearchParams } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import AppSettingsScreen from "@/components/apps/AppSettingsScreen";
 import type { AppFormData, AppState } from "@/components/apps/AppWizard";
-import { DEFAULT_OIDC_SCOPES } from "@/lib/oidc/scopes";
+import {
+  DEFAULT_PUBLIC_GRANT_TYPES,
+  ensureAuthorizationCodeGrant,
+} from "@/lib/oidc/grants";
+import { DEFAULT_OIDC_SCOPES, ensureOpenIdScope } from "@/lib/oidc/scopes";
 
 const STATUS_LABELS: Record<string, { label: string; color: string }> = {
   draft: { label: "Draft", color: "bg-zinc-700 text-zinc-300" },
@@ -51,11 +55,14 @@ export default function AppDetailPage() {
             developerName: data.developerName || "",
             websiteUrl: data.websiteUrl || "",
             redirectUris: data.oidcClient?.redirectUris || [],
-            allowedScopes: data.oidcClient?.allowedScopes || DEFAULT_OIDC_SCOPES,
-            grantTypes: data.oidcClient?.grantTypes?.split(",").filter(Boolean) || [
-              "authorization_code",
-              "refresh_token",
-            ],
+            allowedScopes: ensureOpenIdScope(
+              data.oidcClient?.allowedScopes || DEFAULT_OIDC_SCOPES,
+            ),
+            grantTypes: ensureAuthorizationCodeGrant(
+              data.oidcClient?.grantTypes?.split(",").filter(Boolean) || [
+                ...DEFAULT_PUBLIC_GRANT_TYPES,
+              ],
+            ),
             tokenEndpointAuthMethod:
               data.oidcClient?.tokenEndpointAuthMethod || "none",
             backendDeviceHelper: Boolean(data.m2mOidcClient),

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import DashboardLayout from "@/components/DashboardLayout";
+
+export default function DashboardRouteLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <DashboardLayout>{children}</DashboardLayout>;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,7 +6,6 @@ import { redirect } from "next/navigation";
 import { db } from "@/db/index";
 import { signerConfig, transactions, endUsers } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import DashboardLayout from "@/components/DashboardLayout";
 import Link from "next/link";
 import {
   ACTIVE_STREAM_PAYMENT_WINDOW_LABEL,
@@ -108,7 +107,7 @@ async function AdminDashboard() {
   ];
 
   return (
-    <DashboardLayout>
+    <>
       <div className="mb-8">
         <h2 className="text-2xl font-bold tracking-tight">Dashboard</h2>
         <p className="text-zinc-500 mt-1">Platform overview</p>
@@ -189,7 +188,7 @@ async function AdminDashboard() {
           )}
         </div>
       </div>
-    </DashboardLayout>
+    </>
   );
 }
 
@@ -225,7 +224,7 @@ function FreeUsageBanner() {
 
 function DeveloperDashboard() {
   return (
-    <DashboardLayout>
+    <>
       <div className="mb-8">
         <h2 className="text-2xl font-bold tracking-tight">Dashboard</h2>
         <p className="text-zinc-500 mt-1">Developer overview</p>
@@ -259,6 +258,6 @@ function DeveloperDashboard() {
           </div>
         </div>
       </div>
-    </DashboardLayout>
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
+import { getServerSession } from "next-auth";
 import "@turnkey/react-wallet-kit/styles.css";
 import "./globals.css";
 import Providers from "@/components/Providers";
+import { authOptions } from "@/lib/next-auth-options";
 
 export const metadata: Metadata = {
   title: "pymthouse - Identity & Payment Infrastructure",
@@ -9,15 +11,17 @@ export const metadata: Metadata = {
     "Whitelabel identity and payment infrastructure for Livepeer orchestrators",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const session = await getServerSession(authOptions);
+
   return (
     <html lang="en" className="dark">
       <body className="antialiased bg-zinc-950 text-zinc-100">
-        <Providers>{children}</Providers>
+        <Providers session={session}>{children}</Providers>
       </body>
     </html>
   );

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import type { Session } from "next-auth";
 import TurnkeyProviderWrapper from "./TurnkeyProvider";
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+export default function Providers({
+  children,
+  session,
+}: {
+  children: React.ReactNode;
+  session: Session | null;
+}) {
   return (
-    <SessionProvider>
+    <SessionProvider session={session}>
       <TurnkeyProviderWrapper>{children}</TurnkeyProviderWrapper>
     </SessionProvider>
   );

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -179,6 +179,34 @@ export default function AppSettingsScreen({
     [],
   );
 
+  const syncCredentialsFromServer = useCallback(async () => {
+    const res = await fetch(`/api/v1/apps/${appId}`);
+    if (!res.ok) {
+      return;
+    }
+    const data = (await res.json()) as {
+      m2mOidcClient?: { clientId: string; hasSecret: boolean } | null;
+      oidcClient?: { hasSecret?: boolean; clientId?: string } | null;
+    };
+    setAppState((s) => ({
+      ...s,
+      backendHelper: data.m2mOidcClient ?? null,
+      hasSecret: data.oidcClient?.hasSecret ?? s.hasSecret,
+      clientId: data.oidcClient?.clientId ?? s.clientId,
+    }));
+    setFormData((prev) => ({
+      ...prev,
+      backendDeviceHelper: Boolean(data.m2mOidcClient),
+    }));
+  }, [appId]);
+
+  useEffect(() => {
+    if (integrationSection !== "credentials") {
+      return;
+    }
+    void syncCredentialsFromServer();
+  }, [integrationSection, syncCredentialsFromServer]);
+
   const saveChanges = useCallback(async () => {
     if (!canEdit) return;
     setSaving(true);
@@ -199,12 +227,14 @@ export default function AppSettingsScreen({
         throw new Error(putJson.error || `Failed to save (${res.status})`);
       }
 
-      if (putJson.m2mOidcClient) {
-        setAppState((s) => ({
-          ...s,
-          backendHelper: putJson.m2mOidcClient ?? null,
-        }));
-      }
+      setAppState((s) => ({
+        ...s,
+        backendHelper: putJson.m2mOidcClient ?? null,
+      }));
+      setFormData((prev) => ({
+        ...prev,
+        backendDeviceHelper: Boolean(putJson.m2mOidcClient),
+      }));
       setSavedGrantTypes([...formData.grantTypes]);
 
       const settingsRes = await fetch(`/api/v1/apps/${appId}/settings`, {

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -3,11 +3,16 @@
 import { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { docsDeviceFlowUrl } from "@/lib/docs-base-url";
-import { DEFAULT_OIDC_SCOPES, OIDC_SCOPES } from "@/lib/oidc/scopes";
+import {
+  AUTHORIZATION_CODE_GRANT,
+  DEFAULT_PUBLIC_GRANT_TYPES,
+  DEVICE_CODE_GRANT,
+  ensureAuthorizationCodeGrant,
+  REFRESH_TOKEN_GRANT,
+} from "@/lib/oidc/grants";
+import { DEFAULT_OIDC_SCOPES, ensureOpenIdScope, OIDC_SCOPES } from "@/lib/oidc/scopes";
 
-const AUTHORIZATION_CODE_GRANT = "authorization_code";
-const REFRESH_TOKEN_GRANT = "refresh_token";
-const DEVICE_FLOW_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+const DEVICE_FLOW_GRANT = DEVICE_CODE_GRANT;
 
 const USERS_TOKEN_SCOPE = OIDC_SCOPES.find((s) => s.value === "users:token")!;
 
@@ -39,8 +44,7 @@ export interface AppState {
 }
 
 const DEFAULT_GRANT_TYPES_WITH_DEVICE = [
-  AUTHORIZATION_CODE_GRANT,
-  REFRESH_TOKEN_GRANT,
+  ...DEFAULT_PUBLIC_GRANT_TYPES,
   DEVICE_FLOW_GRANT,
 ] as const;
 
@@ -108,7 +112,7 @@ export default function AppWizard({ initialData }: Props) {
           ...prev,
           backendDeviceHelper: false,
           grantTypes: prev.grantTypes.filter((g) => g !== DEVICE_FLOW_GRANT),
-          allowedScopes: joinScopes(scopes),
+          allowedScopes: ensureOpenIdScope(joinScopes(scopes)),
           initiateLoginUri: "",
           deviceThirdPartyInitiateLogin: false,
         };
@@ -121,7 +125,7 @@ export default function AppWizard({ initialData }: Props) {
       return {
         ...prev,
         backendDeviceHelper: true,
-        allowedScopes: joinScopes(nextScopes),
+        allowedScopes: ensureOpenIdScope(joinScopes(nextScopes)),
       };
     });
   };
@@ -146,7 +150,7 @@ export default function AppWizard({ initialData }: Props) {
     const next = hasIssueUserTokens
       ? scopes.filter((s) => s !== "users:token")
       : [...scopes, "users:token"];
-    set("allowedScopes", joinScopes(next));
+    set("allowedScopes", ensureOpenIdScope(joinScopes(next)));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -169,7 +173,8 @@ export default function AppWizard({ initialData }: Props) {
           );
       const payload: AppFormData = {
         ...formData,
-        grantTypes,
+        grantTypes: ensureAuthorizationCodeGrant(grantTypes),
+        allowedScopes: ensureOpenIdScope(formData.allowedScopes),
       };
       const res = await fetch("/api/v1/apps", {
         method: "POST",

--- a/src/components/apps/steps/AppModeStep.tsx
+++ b/src/components/apps/steps/AppModeStep.tsx
@@ -2,10 +2,13 @@
 
 import { useEffect } from "react";
 import type { AppFormData } from "../AppWizard";
-import { OIDC_SCOPES } from "@/lib/oidc/scopes";
+import {
+  AUTHORIZATION_CODE_GRANT,
+  DEVICE_CODE_GRANT,
+  ensureAuthorizationCodeGrant,
+} from "@/lib/oidc/grants";
+import { ensureOpenIdScope, OIDC_SCOPES } from "@/lib/oidc/scopes";
 import { validateInitiateLoginUri } from "@/lib/oidc/third-party-initiate-login";
-
-const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
 function isValidInitiateLoginUri(uri: string): boolean {
   const t = uri.trim();
@@ -35,44 +38,66 @@ export default function AppModeStep({
     hasDeviceCode && data.deviceThirdPartyInitiateLogin && isValidInitiateLoginUri(data.initiateLoginUri);
   const hasIssueUserTokens = scopes.includes("users:token");
 
-  // openid (required) + sign:job always visible; users:token only when helper is on
-  const baseScopes = OIDC_SCOPES.filter((s) => ["openid", "sign:job"].includes(s.value));
+  // sign:job always visible; openid is implicit; users:token only when helper is on
+  const baseScopes = OIDC_SCOPES.filter(
+    (s) => s.value === "sign:job" && !s.hiddenInAppConfig,
+  );
   const helperScopes = OIDC_SCOPES.filter((s) => s.value === "users:token");
 
+  const setAllowedScopes = (next: string) => {
+    onChange({ allowedScopes: ensureOpenIdScope(next) });
+  };
+
+  useEffect(() => {
+    if (scopes.includes("openid")) return;
+    setAllowedScopes(data.allowedScopes);
+  }, [data.allowedScopes, scopes, onChange]);
+
+  useEffect(() => {
+    if (data.grantTypes.includes(AUTHORIZATION_CODE_GRANT)) return;
+    onChange({ grantTypes: ensureAuthorizationCodeGrant(data.grantTypes) });
+  }, [data.grantTypes, onChange]);
+
+  const setGrantTypes = (next: string[]) => {
+    onChange({ grantTypes: ensureAuthorizationCodeGrant(next) });
+  };
+
   const toggleScope = (scope: string) => {
-    if (readOnly || scope === "openid") return;
+    if (readOnly) return;
     if (scope === "users:token" && requiresIssueUserTokens) return;
     const next = scopes.includes(scope)
       ? scopes.filter((v) => v !== scope)
       : [...scopes, scope];
-    onChange({ allowedScopes: next.join(" ") });
+    setAllowedScopes(next.join(" "));
   };
 
   useEffect(() => {
     if (!requiresIssueUserTokens || hasIssueUserTokens) return;
-    onChange({ allowedScopes: [...scopes, "users:token"].join(" ") });
-  }, [hasIssueUserTokens, onChange, requiresIssueUserTokens, scopes]);
+    setAllowedScopes([...scopes, "users:token"].join(" "));
+  }, [hasIssueUserTokens, requiresIssueUserTokens, scopes]);
 
   const toggleRefreshToken = () => {
     if (readOnly) return;
     const has = data.grantTypes.includes("refresh_token");
-    onChange({
-      grantTypes: has
+    setGrantTypes(
+      has
         ? data.grantTypes.filter((v) => v !== "refresh_token")
         : [...data.grantTypes, "refresh_token"],
-    });
+    );
   };
 
   const toggleDeviceCode = () => {
     if (readOnly || !data.backendDeviceHelper) return;
     if (hasDeviceCode) {
       onChange({
-        grantTypes: data.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT),
+        grantTypes: ensureAuthorizationCodeGrant(
+          data.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT),
+        ),
         initiateLoginUri: "",
         deviceThirdPartyInitiateLogin: false,
       });
     } else {
-      onChange({ grantTypes: [...data.grantTypes, DEVICE_CODE_GRANT] });
+      setGrantTypes([...data.grantTypes, DEVICE_CODE_GRANT]);
     }
   };
 
@@ -80,14 +105,21 @@ export default function AppModeStep({
     if (readOnly) return;
     if (checked) {
       const nextScopes = scopes.includes("users:token") ? scopes : [...scopes, "users:token"];
-      onChange({ backendDeviceHelper: true, allowedScopes: nextScopes.join(" ") });
+      onChange({
+        backendDeviceHelper: true,
+        allowedScopes: ensureOpenIdScope(nextScopes.join(" ")),
+      });
     } else {
       onChange({
         backendDeviceHelper: false,
-        grantTypes: data.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT),
+        grantTypes: ensureAuthorizationCodeGrant(
+          data.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT),
+        ),
         initiateLoginUri: "",
         deviceThirdPartyInitiateLogin: false,
-        allowedScopes: scopes.filter((s) => s !== "users:token").join(" "),
+        allowedScopes: ensureOpenIdScope(
+          scopes.filter((s) => s !== "users:token").join(" "),
+        ),
       });
     }
   };
@@ -227,7 +259,7 @@ export default function AppModeStep({
           )}
         </div>
 
-        {/* ── Grant Types (auth_code always required; refresh_token optional) ── */}
+        {/* ── Grant Types (authorization_code implicit; refresh_token optional) ── */}
         <div className="space-y-3">
           <div>
             <label className="block text-sm font-medium text-zinc-300">Grant Types</label>
@@ -236,29 +268,6 @@ export default function AppModeStep({
             </p>
           </div>
           <div className="space-y-2">
-            <div className="rounded-lg border border-zinc-800 bg-zinc-800/20 overflow-hidden">
-              <label className="flex items-center gap-3 p-3 opacity-70 cursor-not-allowed">
-                <input
-                  type="checkbox"
-                  checked
-                  readOnly
-                  disabled
-                  className="w-4 h-4 rounded border-zinc-600 bg-zinc-800 text-emerald-500 shrink-0"
-                />
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-zinc-200">
-                    Authorization Code + PKCE
-                    <span className="ml-1.5 text-[10px] font-normal text-zinc-500 uppercase tracking-wide">
-                      (required)
-                    </span>
-                  </p>
-                  <p className="text-xs text-zinc-500">
-                    Browser redirect flow — the foundation of interactive sign-in. Always required for
-                    this app type.
-                  </p>
-                </div>
-              </label>
-            </div>
             <label
               className={`flex items-start gap-3 p-3 rounded-lg border transition-colors cursor-pointer ${
                 data.grantTypes.includes("refresh_token")

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -562,13 +562,9 @@ export default function TestingStep({
       )}
 
       {/*
-        Backend helper (confidential m2m_) section.
-        Shown whenever a backend helper exists in the DB, independent of the
-        `backendDeviceHelper` form toggle (which lives on the Auth & Scopes
-        tab). Hints below cover the not-yet-provisioned and off states for
-        interactive apps; M2M-only apps treat the m2m_ as optional, so we
-        skip the hints there to avoid confusion (their primary app_* client
-        is already confidential).
+        Backend helper (confidential m2m_) — driven by server state
+        (`backendHelper` / `backendDeviceHelper`), refreshed when the
+        Credentials tab loads and after save.
       */}
       {backendHelper ? (
         <div className="mt-6 p-4 rounded-xl border border-cyan-500/20 bg-cyan-500/5 space-y-3">

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -1,12 +1,20 @@
 import { db } from "@/db/index";
-import { developerApps, oidcClients } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { developerApps, oidcClients, oidcPayloads } from "@/db/schema";
+import { eq, or, sql } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { randomBytes } from "crypto";
 import {
   computeBackendM2mAllowedScopes,
 } from "@/lib/oidc/backend-m2m-scopes";
-import { DEFAULT_OIDC_SCOPES, OIDC_SCOPES } from "@/lib/oidc/scopes";
+import {
+  DEFAULT_PUBLIC_GRANT_TYPES,
+  normalizePublicGrantTypes,
+} from "@/lib/oidc/grants";
+import {
+  DEFAULT_OIDC_SCOPES,
+  ensureOpenIdScope,
+  OIDC_SCOPES,
+} from "@/lib/oidc/scopes";
 
 export { computeBackendM2mAllowedScopes };
 import { hashToken } from "@/lib/token-hash";
@@ -25,6 +33,21 @@ export function hashClientSecret(secret: string): string {
   return hashToken(secret);
 }
 
+function isM2mClientId(clientId: string): boolean {
+  return clientId.startsWith("m2m_");
+}
+
+/** Public OIDC clients always carry `openid`; M2M helper clients keep computed scopes as-is. */
+export function normalizePublicAllowedScopes(
+  allowedScopes: string,
+  clientId: string,
+): string {
+  if (isM2mClientId(clientId)) {
+    return allowedScopes;
+  }
+  return ensureOpenIdScope(allowedScopes);
+}
+
 export async function registerClient(config: OidcClientConfig): Promise<void> {
   const existingRows = await db
     .select()
@@ -39,9 +62,13 @@ export async function registerClient(config: OidcClientConfig): Promise<void> {
       .set({
         displayName: config.displayName,
         redirectUris: JSON.stringify(config.redirectUris),
-        allowedScopes: config.allowedScopes || DEFAULT_OIDC_SCOPES,
-        grantTypes: (config.grantTypes || ["authorization_code", "refresh_token"]).join(
-          ",",
+        allowedScopes: normalizePublicAllowedScopes(
+          config.allowedScopes || DEFAULT_OIDC_SCOPES,
+          config.clientId,
+        ),
+        grantTypes: normalizePublicGrantTypes(
+          (config.grantTypes || [...DEFAULT_PUBLIC_GRANT_TYPES]).join(","),
+          config.clientId,
         ),
         tokenEndpointAuthMethod: config.tokenEndpointAuthMethod || "none",
         clientSecretHash: config.clientSecret
@@ -60,8 +87,14 @@ export async function registerClient(config: OidcClientConfig): Promise<void> {
       : null,
     displayName: config.displayName,
     redirectUris: JSON.stringify(config.redirectUris),
-    allowedScopes: config.allowedScopes || DEFAULT_OIDC_SCOPES,
-    grantTypes: (config.grantTypes || ["authorization_code", "refresh_token"]).join(","),
+    allowedScopes: normalizePublicAllowedScopes(
+      config.allowedScopes || DEFAULT_OIDC_SCOPES,
+      config.clientId,
+    ),
+    grantTypes: normalizePublicGrantTypes(
+      (config.grantTypes || [...DEFAULT_PUBLIC_GRANT_TYPES]).join(","),
+      config.clientId,
+    ),
     tokenEndpointAuthMethod: config.tokenEndpointAuthMethod || "none",
   });
 }
@@ -459,6 +492,84 @@ export async function ensureM2mBackendClient(params: {
   return { id, clientId };
 }
 
+async function deleteOidcPayloadsForClientId(oauthClientId: string): Promise<void> {
+  await db.delete(oidcPayloads).where(
+    or(
+      sql`(${oidcPayloads.payload})::jsonb->>'clientId' = ${oauthClientId}`,
+      sql`(${oidcPayloads.payload})::jsonb->>'client_id' = ${oauthClientId}`,
+    ),
+  );
+}
+
+/**
+ * Removes the confidential backend helper (m2m_) for an interactive app.
+ * Clears `developer_apps.m2m_oidc_client_id` and deletes the OIDC client row.
+ */
+export async function removeM2mBackendClient(
+  appInternalId: string,
+): Promise<boolean> {
+  const appRows = await db
+    .select({ m2mOidcClientId: developerApps.m2mOidcClientId })
+    .from(developerApps)
+    .where(eq(developerApps.id, appInternalId))
+    .limit(1);
+  const m2mPk = appRows[0]?.m2mOidcClientId;
+  if (!m2mPk) {
+    return false;
+  }
+
+  const m2mRows = await db
+    .select({ clientId: oidcClients.clientId })
+    .from(oidcClients)
+    .where(eq(oidcClients.id, m2mPk))
+    .limit(1);
+  const oauthClientId = m2mRows[0]?.clientId;
+
+  await db
+    .update(developerApps)
+    .set({ m2mOidcClientId: null })
+    .where(eq(developerApps.id, appInternalId));
+
+  if (oauthClientId) {
+    await deleteOidcPayloadsForClientId(oauthClientId);
+  }
+  await db.delete(oidcClients).where(eq(oidcClients.id, m2mPk));
+
+  return true;
+}
+
+export async function loadM2mOidcClientSummary(
+  appInternalId: string,
+): Promise<{ clientId: string; hasSecret: boolean } | null> {
+  const appRows = await db
+    .select({ m2mOidcClientId: developerApps.m2mOidcClientId })
+    .from(developerApps)
+    .where(eq(developerApps.id, appInternalId))
+    .limit(1);
+  const m2mPk = appRows[0]?.m2mOidcClientId;
+  if (!m2mPk) {
+    return null;
+  }
+
+  const m2mRows = await db
+    .select({
+      clientId: oidcClients.clientId,
+      clientSecretHash: oidcClients.clientSecretHash,
+    })
+    .from(oidcClients)
+    .where(eq(oidcClients.id, m2mPk))
+    .limit(1);
+  const m2m = m2mRows[0];
+  if (!m2m) {
+    return null;
+  }
+
+  return {
+    clientId: m2m.clientId,
+    hasSecret: !!m2m.clientSecretHash,
+  };
+}
+
 export async function updateClientConfig(
   clientId: string,
   config: {
@@ -488,8 +599,18 @@ export async function updateClientConfig(
   const updates: Record<string, unknown> = {};
   if (config.displayName !== undefined) updates.displayName = config.displayName;
   if (config.redirectUris !== undefined) updates.redirectUris = JSON.stringify(config.redirectUris);
-  if (config.allowedScopes !== undefined) updates.allowedScopes = config.allowedScopes;
-  if (config.grantTypes !== undefined) updates.grantTypes = config.grantTypes.join(",");
+  if (config.allowedScopes !== undefined) {
+    updates.allowedScopes = normalizePublicAllowedScopes(
+      config.allowedScopes,
+      clientId,
+    );
+  }
+  if (config.grantTypes !== undefined) {
+    updates.grantTypes = normalizePublicGrantTypes(
+      config.grantTypes.join(","),
+      clientId,
+    );
+  }
   if (config.tokenEndpointAuthMethod !== undefined) {
     updates.tokenEndpointAuthMethod = config.tokenEndpointAuthMethod;
   }

--- a/src/lib/oidc/grants.ts
+++ b/src/lib/oidc/grants.ts
@@ -1,0 +1,51 @@
+/** Interactive public apps always use authorization code + PKCE (hidden in app config UI). */
+export const AUTHORIZATION_CODE_GRANT = "authorization_code";
+
+export const REFRESH_TOKEN_GRANT = "refresh_token";
+
+export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+
+export const CLIENT_CREDENTIALS_GRANT = "client_credentials";
+
+export const DEFAULT_PUBLIC_GRANT_TYPES = [
+  AUTHORIZATION_CODE_GRANT,
+  REFRESH_TOKEN_GRANT,
+] as const;
+
+function isM2mClientId(clientId: string): boolean {
+  return clientId.startsWith("m2m_");
+}
+
+export function parseGrantTypes(grantTypes: string): string[] {
+  return grantTypes
+    .split(/[,\s]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+/** Public OIDC clients always allow authorization code; omit from app config UI. */
+export function ensureAuthorizationCodeGrant(grantTypes: string[]): string[] {
+  if (grantTypes.includes(AUTHORIZATION_CODE_GRANT)) {
+    return grantTypes;
+  }
+  return [AUTHORIZATION_CODE_GRANT, ...grantTypes];
+}
+
+export function normalizePublicGrantTypesList(
+  grantTypes: string[],
+  clientId: string,
+): string[] {
+  if (isM2mClientId(clientId)) {
+    return grantTypes;
+  }
+  return ensureAuthorizationCodeGrant(grantTypes);
+}
+
+export function normalizePublicGrantTypes(
+  grantTypes: string,
+  clientId: string,
+): string {
+  return normalizePublicGrantTypesList(parseGrantTypes(grantTypes), clientId).join(
+    ",",
+  );
+}

--- a/src/lib/oidc/provider.ts
+++ b/src/lib/oidc/provider.ts
@@ -9,7 +9,8 @@ import type { Configuration, ClientMetadata, KoaContextWithOIDC } from "oidc-pro
 import { PostgresOidcAdapter } from "./adapter";
 import { findAccount } from "./account";
 import { getIssuer } from "./issuer-urls";
-import { hashClientSecret } from "./clients";
+import { hashClientSecret, normalizePublicAllowedScopes } from "./clients";
+import { normalizePublicGrantTypes, parseGrantTypes } from "./grants";
 import { getTrustedLoginHosts, normalizeDomain } from "./custom-domains";
 import { ensureSigningKey } from "./jwks";
 import { initiateLoginUriAcceptedByOidcProvider } from "./third-party-initiate-login";
@@ -82,7 +83,9 @@ async function loadClients(): Promise<ClientMetadata[]> {
         return expanded;
       });
 
-    const grantTypes = row.grantTypes.split(",").filter(Boolean);
+    const grantTypes = parseGrantTypes(
+      normalizePublicGrantTypes(row.grantTypes, row.clientId),
+    );
 
     // node-oidc-provider requires at least one redirect_uri for all clients.
     // For device-flow-only clients that may have none configured, use a
@@ -98,7 +101,7 @@ async function loadClients(): Promise<ClientMetadata[]> {
       redirect_uris: effectiveRedirectUris,
       grant_types: grantTypes,
       token_endpoint_auth_method: row.tokenEndpointAuthMethod as "none" | "client_secret_post" | "client_secret_basic",
-      scope: row.allowedScopes,
+      scope: normalizePublicAllowedScopes(row.allowedScopes, row.clientId),
     };
     meta.response_types = grantTypes.includes("authorization_code") ? ["code"] : [];
 

--- a/src/lib/oidc/scopes.ts
+++ b/src/lib/oidc/scopes.ts
@@ -9,16 +9,33 @@ export interface ScopeDefinition {
   /** Short description shown on the consent screen and in app settings. */
   description: string;
   required?: boolean;
+  /** Omitted from provider app Auth & Scopes UI; applied automatically on every public client. */
+  hiddenInAppConfig?: boolean;
 }
+
+export const OPENID_SCOPE = "openid";
 
 export const DEFAULT_OIDC_SCOPES = "openid sign:job";
 
+/** Public app clients always include `openid`; callers must not rely on the UI to add it. */
+export function ensureOpenIdScope(allowedScopes: string): string {
+  const tokens = allowedScopes
+    .split(/[,\s]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+  if (tokens.includes(OPENID_SCOPE)) {
+    return tokens.join(" ");
+  }
+  return [OPENID_SCOPE, ...tokens].join(" ");
+}
+
 export const OIDC_SCOPES: ScopeDefinition[] = [
   {
-    value: "openid",
+    value: OPENID_SCOPE,
     label: "OpenID",
     description: "Confirm which PymtHouse account you are signed in with",
     required: true,
+    hiddenInAppConfig: true,
   },
   {
     value: "sign:mint_user_token",


### PR DESCRIPTION
- Updated the RootLayout component to fetch the server session using `getServerSession` and pass it to the Providers component.
- Refactored the app settings to ensure proper handling of allowed scopes and grant types, utilizing new utility functions for authorization code and OpenID scope management.
- Introduced a new DashboardRouteLayout component for consistent dashboard layout rendering.
- Enhanced API routes to manage M2M backend client logic, including loading and removing clients based on app settings.
- Improved UI interactions in the AppSettingsScreen and AppWizard components to reflect changes in backend device helper states and grant type management.