### PR TITLE
fix(ci): unset empty RAILWAY_TOKEN so Railway CLI uses RAILWAY_API_TOKEN

### DIFF
--- a/scripts/lib/railway-auth.sh
+++ b/scripts/lib/railway-auth.sh
@@ -12,14 +12,24 @@ railway_default_project_id() {
 }
 
 railway_export_auth() {
+  # The Railway CLI treats RAILWAY_TOKEN as a project token whenever it is
+  # PRESENT — even as an empty string (e.g. `RAILWAY_TOKEN: ${{ secrets.X }}`
+  # in CI when the secret is unset). An empty project token => Unauthorized,
+  # even when RAILWAY_API_TOKEN is valid. So always unset the token we are not
+  # using before invoking the CLI.
   if [[ -n "${RAILWAY_API_TOKEN:-}" ]]; then
+    unset RAILWAY_TOKEN
     export RAILWAY_API_TOKEN
     return 0
   fi
   if [[ -n "${RAILWAY_TOKEN:-}" ]]; then
+    unset RAILWAY_API_TOKEN
     export RAILWAY_TOKEN
     return 0
   fi
+  # Neither token has a value: drop any empty vars so the CLI falls back to a
+  # local `railway login` session instead of failing on an empty token.
+  unset RAILWAY_API_TOKEN RAILWAY_TOKEN
   if railway whoami >/dev/null 2>&1; then
     return 0
   fi


### PR DESCRIPTION
## Summary
- Fixes the failed **Deploy Railway production stack** run ([26860386336](https://github.com/pymthouse/pymthouse/actions/runs/26860386336/job/79212522064)) which errored at *Apply production environment variables* with `Unauthorized`.
- Root cause: the workflow exports both `RAILWAY_API_TOKEN` and `RAILWAY_TOKEN`. The `RAILWAY_TOKEN` secret is unset, so it resolves to an empty string. The Railway CLI treats an empty `RAILWAY_TOKEN` as a (project) token and rejects it, ignoring the valid account token in `RAILWAY_API_TOKEN`.
- `railway_export_auth` now `unset`s whichever token it isn't using, so the CLI authenticates with the account token.

## Verification
Reproduced against the live project (`dab233aa` / PymtHouse, `production`):

- `RAILWAY_API_TOKEN=<valid> RAILWAY_TOKEN="" railway variables ...` → `Unauthorized`
- `RAILWAY_API_TOKEN=<valid>` with `RAILWAY_TOKEN` unset → succeeds (read + idempotent `variable set`)
- Confirmed the account token is valid, is a workspace token, and has access to the project and all 8 production services.

## Test plan
- [ ] Merge to `main`, confirm the production deploy workflow gets past *Apply production environment variables*.

Made with [Cursor](https://cursor.com)