### PR TITLE
fix(ci): retry Railway CLI on GraphQL timeouts

### DIFF
--- a/.github/workflows/deploy-railway-production.yml
+++ b/.github/workflows/deploy-railway-production.yml
@@ -41,7 +41,6 @@ jobs:
     timeout-minutes: 45
     env:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_ENVIRONMENT: production
       RAILWAY_PROJECT_ID: dab233aa-dd5f-429d-8cc4-9042e8735e2b
       OPENMETER_POSTGRES_PASSWORD: ${{ secrets.OPENMETER_POSTGRES_PASSWORD }}

--- a/scripts/lib/railway-auth.sh
+++ b/scripts/lib/railway-auth.sh
@@ -47,3 +47,43 @@ railway_export_auth() {
 railway_pe_flags() {
   echo "-p $(railway_default_project_id) -e $1"
 }
+
+# True when stderr looks like a transient network / API failure (retryable).
+railway_retryable_failure() {
+  local err_file="$1"
+  grep -qiE \
+    'timed out|timeout|Failed to fetch|error sending request|connection reset|connection refused|temporarily unavailable|\b502\b|\b503\b|\b429\b' \
+    "$err_file"
+}
+
+# Run a Railway CLI command with exponential backoff on transient failures.
+# Usage: railway_retry railway variable set KEY=val ...
+railway_retry() {
+  local max_attempts="${RAILWAY_CLI_MAX_ATTEMPTS:-5}"
+  local delay="${RAILWAY_CLI_RETRY_DELAY_SEC:-5}"
+  local attempt=1
+  local rc err_file
+
+  err_file="$(mktemp)"
+
+  while true; do
+    : >"$err_file"
+    if "$@" 2>"$err_file"; then
+      rm -f "$err_file"
+      return 0
+    fi
+    rc=$?
+    cat "$err_file" >&2
+    if [[ $attempt -ge $max_attempts ]] || ! railway_retryable_failure "$err_file"; then
+      rm -f "$err_file"
+      return "$rc"
+    fi
+    echo "Railway CLI attempt $attempt/$max_attempts failed (transient); retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+    if [[ $delay -gt 60 ]]; then
+      delay=60
+    fi
+  done
+}

--- a/scripts/railway-apply-stack-env.sh
+++ b/scripts/railway-apply-stack-env.sh
@@ -34,11 +34,16 @@ set_kv() {
   local service="$1"
   shift
   # shellcheck disable=SC2086
-  railway variable set "$@" --service "$service" $PE_FLAGS --skip-deploys >/dev/null
+  railway_retry railway variable set "$@" --service "$service" $PE_FLAGS --skip-deploys >/dev/null
   echo "  $service: set $# variable(s)"
 }
 
 echo "Applying stack env to Railway environment: $ENV (project $PROJECT_ID)"
+
+# Warm up API connectivity before bulk writes (CI runners sometimes hit a slow first request).
+# shellcheck disable=SC2086
+railway_retry railway variables --service pymthouse $PE_FLAGS >/dev/null
+echo "Railway API reachable."
 
 # Postgres
 set_kv openmeter-postgres \
@@ -108,15 +113,15 @@ if [[ -n "$NEXTAUTH_URL" ]]; then
     "JWKS_URI=${JWKS_URI}"
   if [[ -n "${DATABASE_URL:-}" ]]; then
     # shellcheck disable=SC2086
-    railway variable set "DATABASE_URL=${DATABASE_URL}" --service pymthouse $PE_FLAGS --skip-deploys >/dev/null
+    railway_retry railway variable set "DATABASE_URL=${DATABASE_URL}" --service pymthouse $PE_FLAGS --skip-deploys >/dev/null
   fi
   if [[ -n "${AUTH_TOKEN_PEPPER:-}" ]]; then
     # shellcheck disable=SC2086
-    railway variable set "AUTH_TOKEN_PEPPER=${AUTH_TOKEN_PEPPER}" --service pymthouse $PE_FLAGS --skip-deploys >/dev/null
+    railway_retry railway variable set "AUTH_TOKEN_PEPPER=${AUTH_TOKEN_PEPPER}" --service pymthouse $PE_FLAGS --skip-deploys >/dev/null
   fi
   if [[ -n "${NEXTAUTH_SECRET:-}" ]]; then
     # shellcheck disable=SC2086
-    railway variable set "NEXTAUTH_SECRET=${NEXTAUTH_SECRET}" --service pymthouse $PE_FLAGS --skip-deploys >/dev/null
+    railway_retry railway variable set "NEXTAUTH_SECRET=${NEXTAUTH_SECRET}" --service pymthouse $PE_FLAGS --skip-deploys >/dev/null
   fi
   echo "  pymthouse: NEXTAUTH_URL=${NEXTAUTH_URL} OIDC_ISSUER=${ISSUER} (+ optional DB/OIDC secrets)"
 fi

--- a/scripts/railway-deploy-openmeter.sh
+++ b/scripts/railway-deploy-openmeter.sh
@@ -78,6 +78,6 @@ trap restore_manifest EXIT
 cp "$TMP_MANIFEST" "$ROOT/railway.json"
 
 # shellcheck disable=SC2086
-railway up -s "$SERVICE" $PE_FLAGS -d -m "openmeter $CMD"
+railway_retry railway up -s "$SERVICE" $PE_FLAGS -d -m "openmeter $CMD"
 
 echo "Deployed $CMD to service $SERVICE in $ENV"

--- a/scripts/railway-deploy-signer.sh
+++ b/scripts/railway-deploy-signer.sh
@@ -45,6 +45,6 @@ trap restore_manifest EXIT
 cp "$TMP_MANIFEST" "$ROOT/railway.json"
 
 # shellcheck disable=SC2086
-railway up -s "$SERVICE" $PE_FLAGS -d -m "signer DMZ deploy ($ENV)"
+railway_retry railway up -s "$SERVICE" $PE_FLAGS -d -m "signer DMZ deploy ($ENV)"
 
 echo "Deployed signer DMZ to $SERVICE in $ENV"

--- a/scripts/railway-deploy-stack.sh
+++ b/scripts/railway-deploy-stack.sh
@@ -32,7 +32,7 @@ echo "=== Railway stack deploy: $ENV ==="
 for svc in openmeter-postgres openmeter-redis openmeter-kafka openmeter-clickhouse; do
   echo "Deploying $svc from source ..."
   # shellcheck disable=SC2086
-  railway redeploy --service "$svc" $PE_FLAGS --from-source --yes
+  railway_retry railway redeploy --service "$svc" $PE_FLAGS --from-source --yes
 done
 
 # OpenMeter images from repo


### PR DESCRIPTION
## Summary
- After #116 fixed auth, run [26860557781](https://github.com/pymthouse/pymthouse/actions/runs/26860557781) failed on the **first** `railway variable set` with `operation timed out` (~30s) to `backboard.railway.com/graphql/v2` — transient from GitHub Actions, not a token issue.
- Adds `railway_retry` (up to 5 attempts, exponential backoff) for timeouts / connection errors across apply + deploy scripts.
- Preflight `railway variables` before bulk writes so a slow first request retries instead of failing the job.
- Removes `RAILWAY_TOKEN` from workflow `env` (empty secret was redundant after #116).

## Test plan
- [ ] Merge and confirm production deploy workflow completes *Apply production environment variables*.
- [ ] If it still flakes, re-run workflow (retries should handle brief Railway outages).

Made with [Cursor](https://cursor.com)