### PR TITLE
fix(oidc): repair public clients missing openid in production

### DIFF
--- a/src/app/api/v1/apps/[id]/route.ts
+++ b/src/app/api/v1/apps/[id]/route.ts
@@ -15,6 +15,7 @@ import {
   ensureM2mBackendClient,
   loadM2mOidcClientSummary,
   removeM2mBackendClient,
+  normalizePublicAllowedScopes,
   syncBackendM2mAllowedScopesFromPublicApp,
   updateClientConfig,
 } from "@/lib/oidc/clients";
@@ -93,7 +94,10 @@ export async function GET(
       clientInfo = {
         clientId: client.clientId,
         redirectUris: JSON.parse(client.redirectUris) as string[],
-        allowedScopes: client.allowedScopes,
+        allowedScopes: normalizePublicAllowedScopes(
+          client.allowedScopes,
+          client.clientId,
+        ),
         grantTypes: client.grantTypes,
         tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
         // Public app_ row must never report a secret when a confidential m2m_ sibling exists.
@@ -281,12 +285,17 @@ export async function PUT(
       if (body.tokenEndpointAuthMethod)
         clientUpdates.tokenEndpointAuthMethod = body.tokenEndpointAuthMethod;
       if (body.allowedScopes) {
-        const validScopeValues = new Set(OIDC_SCOPES.map((s) => s.value));
+        const validScopeValues = new Set(
+          OIDC_SCOPES.filter((s) => !s.hiddenInAppConfig).map((s) => s.value),
+        );
         const filtered = String(body.allowedScopes)
           .split(/[,\s]+/)
           .filter((s) => s && validScopeValues.has(s))
           .join(" ");
-        clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
+        clientUpdates.allowedScopes = normalizePublicAllowedScopes(
+          filtered || DEFAULT_OIDC_SCOPES,
+          client.clientId,
+        );
       }
       if (body.grantTypes) clientUpdates.grantTypes = body.grantTypes;
 

--- a/src/app/api/v1/apps/route.ts
+++ b/src/app/api/v1/apps/route.ts
@@ -7,6 +7,7 @@ import { eq, inArray } from "drizzle-orm";
 import {
   createAppClient,
   ensureM2mBackendClient,
+  normalizePublicAllowedScopes,
   updateClientConfig,
 } from "@/lib/oidc/clients";
 import { resetProvider } from "@/lib/oidc/provider";
@@ -124,12 +125,17 @@ export async function POST(request: NextRequest) {
     clientUpdates.tokenEndpointAuthMethod = body.tokenEndpointAuthMethod;
   }
   if (typeof body.allowedScopes === "string" && body.allowedScopes.trim()) {
-    const validScopeValues = new Set(OIDC_SCOPES.map((s) => s.value));
+    const validScopeValues = new Set(
+      OIDC_SCOPES.filter((s) => !s.hiddenInAppConfig).map((s) => s.value),
+    );
     const filtered = body.allowedScopes
       .split(/[,\s]+/)
       .filter((s: string) => s && validScopeValues.has(s))
       .join(" ");
-    clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
+    clientUpdates.allowedScopes = normalizePublicAllowedScopes(
+      filtered || DEFAULT_OIDC_SCOPES,
+      clientId,
+    );
   }
   if (Array.isArray(body.grantTypes) && body.grantTypes.length > 0) {
     const grantTypes = body.grantTypes.filter(

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -48,6 +48,30 @@ export function normalizePublicAllowedScopes(
   return ensureOpenIdScope(allowedScopes);
 }
 
+/**
+ * Persist `openid` on every public OIDC client row (legacy apps saved before #112).
+ * Returns how many rows were updated.
+ */
+export async function repairPublicOidcClientScopesInDatabase(): Promise<number> {
+  const rows = await db.select().from(oidcClients);
+  let fixed = 0;
+  for (const row of rows) {
+    if (isM2mClientId(row.clientId)) {
+      continue;
+    }
+    const normalized = normalizePublicAllowedScopes(row.allowedScopes, row.clientId);
+    if (normalized === row.allowedScopes) {
+      continue;
+    }
+    await db
+      .update(oidcClients)
+      .set({ allowedScopes: normalized })
+      .where(eq(oidcClients.clientId, row.clientId));
+    fixed += 1;
+  }
+  return fixed;
+}
+
 export async function registerClient(config: OidcClientConfig): Promise<void> {
   const existingRows = await db
     .select()

--- a/src/lib/oidc/provider.ts
+++ b/src/lib/oidc/provider.ts
@@ -9,7 +9,11 @@ import type { Configuration, ClientMetadata, KoaContextWithOIDC } from "oidc-pro
 import { PostgresOidcAdapter } from "./adapter";
 import { findAccount } from "./account";
 import { getIssuer } from "./issuer-urls";
-import { hashClientSecret, normalizePublicAllowedScopes } from "./clients";
+import {
+  hashClientSecret,
+  normalizePublicAllowedScopes,
+  repairPublicOidcClientScopesInDatabase,
+} from "./clients";
 import { normalizePublicGrantTypes, parseGrantTypes } from "./grants";
 import { getTrustedLoginHosts, normalizeDomain } from "./custom-domains";
 import { ensureSigningKey } from "./jwks";
@@ -277,6 +281,12 @@ export async function getProvider(): Promise<Provider> {
 
   const issuer = getIssuer();
   const jwks = await loadJWKS();
+  const repaired = await repairPublicOidcClientScopesInDatabase();
+  if (repaired > 0) {
+    console.info(
+      `[OIDC] Repaired allowed_scopes (added openid) on ${repaired} public client(s)`,
+    );
+  }
   const clients = await loadClients();
 
   const configuration: Configuration = {

--- a/src/lib/oidc/scopes.test.ts
+++ b/src/lib/oidc/scopes.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { ensureOpenIdScope } from "./scopes";
+
+describe("ensureOpenIdScope", () => {
+  it("adds openid when missing", () => {
+    expect(ensureOpenIdScope("sign:job users:token")).toBe(
+      "openid sign:job users:token",
+    );
+  });
+
+  it("does not duplicate openid", () => {
+    expect(ensureOpenIdScope("openid sign:job")).toBe("openid sign:job");
+  });
+});


### PR DESCRIPTION
## Summary
- [#112](https://github.com/pymthouse/pymthouse/pull/112) added runtime `normalizePublicAllowedScopes` in `loadClients`, but **production** still returns `invalid_scope` for `openid` on `app_22e4b79f3a3d38609ec3fae0` while `sign:job` works — consistent with pre-#112 provider behavior and/or DB rows saved without `openid`.
- Adds `repairPublicOidcClientScopesInDatabase()` on first `getProvider()` to persist `openid` on legacy public clients.
- Apps API GET/PUT always surface and save normalized scopes; UI hidden `openid` row stays cosmetic.

## Deploy note
Merge and confirm **Vercel production** deploys this commit (native Git on `main`). Warm instances only pick up the repair after redeploy.

## Test plan
- [ ] After deploy: `curl -X POST https://pymthouse.com/api/v1/oidc/device/auth -d 'client_id=app_22e4b79f3a3d38609ec3fae0&scope=openid sign:job&resource=https://pymthouse.com/api/v1/oidc'` returns device_code (not invalid_scope).
- [ ] Device flow from livepeer-python-gateway `write_frames` launch config succeeds.

Made with [Cursor](https://cursor.com)