### PR TITLE
feat(ci): Vercel production deploy on push to main

### DIFF
--- a/.github/workflows/deploy-production-vercel.yml
+++ b/.github/workflows/deploy-production-vercel.yml
@@ -1,28 +1,34 @@
-name: Deploy staging (Vercel)
+name: Deploy production (Vercel)
 
-# Non-main branches deploy to the pymthouse-staging Vercel project as Production.
-# The pymthouse production project (main) deploys via deploy-production-vercel.yml.
-# Env vars are configured in the Vercel dashboard — not in this workflow.
-# Requires repo secret VERCEL_TOKEN and variable VERCEL_STAGING_AUTO_DEPLOY=true.
+# Deploys the pymthouse Vercel project (pymthouse.com) on every push to main.
+# Env vars live in the Vercel dashboard — not in this workflow.
+#
+# Enable with repository variable:
+#   VERCEL_PRODUCTION_AUTO_DEPLOY=true
+#
+# Required secret:
+#   VERCEL_TOKEN
+#
+# Recommended: disable native Git auto-builds on the pymthouse Vercel project
+# (Settings → Git → Ignored Build Step: exit 1) so only this workflow deploys prod.
 
 on:
   push:
-    branches-ignore:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: deploy-staging-vercel-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy-production-vercel
+  cancel-in-progress: false
 
 jobs:
   deploy:
-    if: vars.VERCEL_STAGING_AUTO_DEPLOY == 'true'
+    if: vars.VERCEL_PRODUCTION_AUTO_DEPLOY == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       VERCEL_ORG_ID: team_JoeNhmK7pgiuSeOwgQASAUFl
-      VERCEL_PROJECT_ID: prj_wzb1ad2UlUxia7bHdwFCopBScP9Z
+      VERCEL_PROJECT_ID: prj_oldvnmdXcGDc7Db5ohPCOUGBZOaG
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
     steps:
@@ -48,5 +54,5 @@ jobs:
       - name: Build
         run: vercel build --prod --token="$VERCEL_TOKEN"
 
-      - name: Deploy to pymthouse-staging production
+      - name: Deploy to pymthouse production
         run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -138,10 +138,10 @@ Deploy with: `fly deploy`
 
 PymtHouse uses **two separate Vercel projects**, not preview URLs on one project:
 
-| Vercel project | URL | Git trigger |
-|----------------|-----|-------------|
-| `pymthouse` | `https://pymthouse.vercel.app` | `main` → Production (native Git integration) |
-| `pymthouse-staging` | `https://pymthouse-staging.vercel.app` | Non-`main` branches → Production via [deploy-staging-vercel.yml](../.github/workflows/deploy-staging-vercel.yml) or [scripts/deploy-staging-vercel.sh](../scripts/deploy-staging-vercel.sh) |
+| Vercel project | URL | Deploy trigger |
+|----------------|-----|----------------|
+| `pymthouse` | `https://pymthouse.com` | `main` → [deploy-production-vercel.yml](../.github/workflows/deploy-production-vercel.yml) when `VERCEL_PRODUCTION_AUTO_DEPLOY=true` (or [scripts/deploy-production-vercel.sh](../scripts/deploy-production-vercel.sh)) |
+| `pymthouse-staging` | `https://pymthouse-staging.vercel.app` | Non-`main` branches → [deploy-staging-vercel.yml](../.github/workflows/deploy-staging-vercel.yml) when `VERCEL_STAGING_AUTO_DEPLOY=true` |
 
 Railway (signer, OpenMeter) uses the **PymtHouse** project with two environments:
 
@@ -162,7 +162,18 @@ Point each Vercel project’s `OPENMETER_URL` and `SIGNER_INTERNAL_URL` at the m
 
 **GitHub secret required for CI deploy:** `VERCEL_TOKEN` (same token used for CLI deploys).
 
-**Enable the deploy workflow:** set repository variable `VERCEL_STAGING_AUTO_DEPLOY=true` after `VERCEL_TOKEN` is configured. Until then the deploy job is skipped so PR checks stay green.
+**Enable deploy workflows** (after `VERCEL_TOKEN` is configured):
+
+| Variable | Workflow |
+|----------|----------|
+| `VERCEL_PRODUCTION_AUTO_DEPLOY=true` | [deploy-production-vercel.yml](../.github/workflows/deploy-production-vercel.yml) on push to `main` |
+| `VERCEL_STAGING_AUTO_DEPLOY=true` | [deploy-staging-vercel.yml](../.github/workflows/deploy-staging-vercel.yml) on non-`main` pushes |
+
+```bash
+bash scripts/set-github-production-vercel-vars.sh
+```
+
+**Avoid double deploys on production:** In the **pymthouse** Vercel project → Settings → Git → **Ignored Build Step**, set `exit 1` so native Git integration does not also build on push (CI owns production deploys).
 
 **Manual staging deploy:**
 

--- a/scripts/deploy-production-vercel.sh
+++ b/scripts/deploy-production-vercel.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Deploy main to the pymthouse Vercel project (pymthouse.com production).
+#
+# Environment variables are read from the pymthouse Vercel project dashboard.
+#
+# Prerequisites: vercel CLI logged in (`vercel login`) or VERCEL_TOKEN set.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export VERCEL_ORG_ID="${VERCEL_ORG_ID:-team_JoeNhmK7pgiuSeOwgQASAUFl}"
+export VERCEL_PROJECT_ID="${VERCEL_PROJECT_ID:-prj_oldvnmdXcGDc7Db5ohPCOUGBZOaG}"
+
+if [[ -z "${VERCEL_TOKEN:-}" ]] && ! vercel whoami >/dev/null 2>&1; then
+  echo "Set VERCEL_TOKEN or run: vercel login" >&2
+  exit 1
+fi
+
+vercel pull --yes --environment=production ${VERCEL_TOKEN:+--token="$VERCEL_TOKEN"}
+vercel build --prod ${VERCEL_TOKEN:+--token="$VERCEL_TOKEN"}
+vercel deploy --prebuilt --prod ${VERCEL_TOKEN:+--token="$VERCEL_TOKEN"}
+
+echo "Deployed to pymthouse production (https://pymthouse.com)."

--- a/scripts/set-github-production-vercel-vars.sh
+++ b/scripts/set-github-production-vercel-vars.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Enable deploy-production-vercel.yml on push to main.
+# Requires: gh auth login, VERCEL_TOKEN secret, write access to pymthouse/pymthouse
+#
+#   bash scripts/set-github-production-vercel-vars.sh
+#   bash scripts/set-github-production-vercel-vars.sh --dry-run
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-pymthouse/pymthouse}"
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+set_var() {
+  local name="$1"
+  local value="$2"
+  if $DRY_RUN; then
+    echo "gh variable set $name --body '$value' -R $REPO"
+  else
+    gh variable set "$name" --body "$value" -R "$REPO"
+    echo "set $name"
+  fi
+}
+
+set_var VERCEL_PRODUCTION_AUTO_DEPLOY "true"
+
+echo "Done. Requires GitHub secret VERCEL_TOKEN (same as staging deploy)."
+echo ""
+echo "Optional: on Vercel → pymthouse project → Settings → Git → Ignored Build Step:"
+echo "  exit 1"
+echo "so native Git pushes do not double-deploy with this workflow."


### PR DESCRIPTION
## Summary
- Adds **Deploy production (Vercel)** workflow: `vercel pull` → `vercel build --prod` → `vercel deploy --prebuilt --prod` for project `pymthouse` (`prj_oldvnmdXcGDc7Db5ohPCOUGBZOaG`) on push to `main`.
- Gated by repo variable `VERCEL_PRODUCTION_AUTO_DEPLOY=true` (helper: `scripts/set-github-production-vercel-vars.sh`).
- Uses existing `VERCEL_TOKEN` secret (same as staging).

## Why
Production was relying on Vercel native Git integration, which did not reliably pick up `main` after merges (e.g. OIDC scope fixes). CI deploy matches the Railway production pattern.

## After merge
1. `bash scripts/set-github-production-vercel-vars.sh` (or `gh variable set VERCEL_PRODUCTION_AUTO_DEPLOY --body true`)
2. Confirm `VERCEL_TOKEN` is set in GitHub secrets
3. Optional: Vercel → pymthouse → Git → Ignored Build Step: `exit 1` to avoid double deploys

## Test plan
- [ ] Merge to `main`, workflow runs and Vercel production deployment succeeds
- [ ] `curl` device auth with `openid` scope against pymthouse.com succeeds after deploy

Made with [Cursor](https://cursor.com)