### PR TITLE
fix(db): lazy DB init for Vercel/CI build without DATABASE_URL

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,8 @@
 import postgres from "postgres";
-import { drizzle } from "drizzle-orm/postgres-js";
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import * as schema from "./schema";
+
+export type Db = PostgresJsDatabase<typeof schema>;
 
 function requireDatabaseUrl(): string {
   const url = process.env.DATABASE_URL;
@@ -14,13 +16,46 @@ function requireDatabaseUrl(): string {
 
 const globalForDb = globalThis as unknown as {
   pymthousePostgres?: ReturnType<typeof postgres>;
+  pymthouseDb?: Db;
 };
 
-function createClient() {
-  return postgres(requireDatabaseUrl(), { max: 10 });
+function getPostgresClient() {
+  if (!globalForDb.pymthousePostgres) {
+    globalForDb.pymthousePostgres = postgres(requireDatabaseUrl(), { max: 10 });
+  }
+  return globalForDb.pymthousePostgres;
 }
 
-export const postgresClient =
-  globalForDb.pymthousePostgres ??= createClient();
+function getDb(): Db {
+  if (!globalForDb.pymthouseDb) {
+    globalForDb.pymthouseDb = drizzle(getPostgresClient(), { schema });
+  }
+  return globalForDb.pymthouseDb;
+}
 
-export const db = drizzle(postgresClient, { schema });
+/**
+ * Lazy Drizzle client — does not connect until first query.
+ * Avoids requiring DATABASE_URL during `next build` (page-data collection).
+ */
+export const db: Db = new Proxy({} as Db, {
+  get(_target, prop, receiver) {
+    const instance = getDb();
+    const value = Reflect.get(instance as object, prop, receiver);
+    if (typeof value === "function") {
+      return (value as (...args: unknown[]) => unknown).bind(instance);
+    }
+    return value;
+  },
+});
+
+/** @deprecated Prefer `db`; lazy-initialized on first use. */
+export const postgresClient = new Proxy({} as ReturnType<typeof postgres>, {
+  get(_target, prop, receiver) {
+    const instance = getPostgresClient();
+    const value = Reflect.get(instance as object, prop, receiver);
+    if (typeof value === "function") {
+      return (value as (...args: unknown[]) => unknown).bind(instance);
+    }
+    return value;
+  },
+});


### PR DESCRIPTION
## Summary
- `src/db/index.ts` no longer calls `postgres()` at import time.
- `next build` can complete when `DATABASE_URL` is runtime-only on Vercel (or unset during build).
- First API request at runtime still requires `DATABASE_URL` in Vercel Production env.

## Test plan
- [x] `unset DATABASE_URL && npm run build` succeeds locally
- [ ] Vercel production deploy workflow build step passes

Made with [Cursor](https://cursor.com)