### PR TITLE
Bump signer to livepeer/go-livepeer:0.8.10-d909a4c3

### DIFF
--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -1,7 +1,7 @@
 # Apache + mod_authnz_jwt in front of go-livepeer (DMZ). Targets:
 #   gateway         — Apache only; set SIGNER_UPSTREAM (e.g. http://signer:8081) for docker compose.
 #   signer-dmz-local — local dev; livepeer copied from go-livepeer-remote-signer:local (see scripts/build-local-signer.sh).
-#   signer-dmz      — production; pinned CI binary from build.livepeer.live (Railway single service).
+#   signer-dmz      — production; livepeer from livepeer/go-livepeer Docker image (Railway single service).
 
 FROM debian:bookworm-slim AS build-mod
 
@@ -149,26 +149,25 @@ ENV SIGNER_DMZ_ENABLE_CLI_LISTENER=1
 
 EXPOSE 8080 8082
 
-# Production / Railway: pinned CI binary from build.livepeer.live (default final stage).
+# Production / Railway: livepeer from official Docker image (default final stage).
+FROM livepeer/go-livepeer:0.8.10-d909a4c3 AS livepeer-prod
+
 FROM gateway AS signer-dmz
 
 USER root
-# Source artifact: https://github.com/livepeer/go-livepeer/actions/runs/25226599716/artifacts/6796975695
-# Node reports: Livepeer Node Version 0.8.10-0a1919e0
-ARG LIVEPEER_COMMIT=0a1919e0c58986375df158433445563a45a04df8
-ARG LIVEPEER_SHA256=0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget && \
-    wget -q "https://build.livepeer.live/go-livepeer/${LIVEPEER_COMMIT}/livepeer-linux-amd64.tar.gz" -O livepeer-linux-amd64.tar.gz && \
-    echo "${LIVEPEER_SHA256}  livepeer-linux-amd64.tar.gz" | sha256sum -c - && \
-    tar -xzf livepeer-linux-amd64.tar.gz && \
-    mv livepeer-linux-amd64/livepeer /usr/local/bin/livepeer && \
-    chmod +x /usr/local/bin/livepeer && \
-    rm -rf livepeer-linux-amd64.tar.gz livepeer-linux-amd64 && \
-    apt-get purge -y --auto-remove wget && \
-    rm -rf /var/lib/apt/lists/*
+# go-livepeer links against CUDA NPP (libnppig, libnppicc, libnppc).
+RUN mkdir -p /usr/local/cuda/targets/x86_64-linux/lib
 
-# /data was created in the gateway stage and already chown'd; nothing more to do here.
+COPY --from=livepeer-prod /usr/local/bin/livepeer /usr/local/bin/livepeer
+COPY --from=livepeer-prod /usr/local/lib/ /usr/local/lib/
+COPY --from=livepeer-prod /usr/local/cuda/targets/x86_64-linux/lib/libnppc.so* /usr/local/cuda/targets/x86_64-linux/lib/
+COPY --from=livepeer-prod /usr/local/cuda/targets/x86_64-linux/lib/libnppig.so* /usr/local/cuda/targets/x86_64-linux/lib/
+COPY --from=livepeer-prod /usr/local/cuda/targets/x86_64-linux/lib/libnppicc.so* /usr/local/cuda/targets/x86_64-linux/lib/
+
+ENV LD_LIBRARY_PATH=/usr/local/cuda/targets/x86_64-linux/lib:/usr/local/lib
+
+RUN chmod +x /usr/local/bin/livepeer && ldconfig
 
 USER pymthouse
 

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -1,42 +1,35 @@
-# Dockerfile for deploying go-livepeer signer separately
-# This downloads the binary release instead of using the full Docker image
-# Smaller, faster, and more platform-compatible!
+# go-livepeer remote signer only (no Apache DMZ).
+# Copies livepeer + required CUDA NPP libs from the official image — do not wget
+# a bare binary into debian:slim; the binary links libnppig.so and other NPP libs.
+
+FROM livepeer/go-livepeer:0.8.10-d909a4c3 AS livepeer-src
 
 FROM debian:bookworm-slim
 
-# Install wget and ca-certificates for downloading the binary
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    wget \
-    ca-certificates && \
+    apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# CI build (0.8.10-0a1919e0); mirrored from the same upload pipeline as GitHub Actions artifacts.
-ARG LIVEPEER_COMMIT=0a1919e0c58986375df158433445563a45a04df8
-ARG LIVEPEER_SHA256=0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade
+RUN mkdir -p /data /usr/local/cuda/targets/x86_64-linux/lib
 
-# Download and extract livepeer binary
-RUN wget -q "https://build.livepeer.live/go-livepeer/${LIVEPEER_COMMIT}/livepeer-linux-amd64.tar.gz" -O livepeer-linux-amd64.tar.gz && \
-    echo "${LIVEPEER_SHA256}  livepeer-linux-amd64.tar.gz" | sha256sum -c - && \
-    tar -xzf livepeer-linux-amd64.tar.gz && \
-    mv livepeer-linux-amd64/livepeer /usr/local/bin/livepeer && \
-    chmod +x /usr/local/bin/livepeer && \
-    rm -rf livepeer-linux-amd64.tar.gz livepeer-linux-amd64
+COPY --from=livepeer-src /usr/local/bin/livepeer /usr/local/bin/livepeer
+COPY --from=livepeer-src /usr/local/lib/ /usr/local/lib/
+COPY --from=livepeer-src /usr/local/cuda/targets/x86_64-linux/lib/libnppc.so* /usr/local/cuda/targets/x86_64-linux/lib/
+COPY --from=livepeer-src /usr/local/cuda/targets/x86_64-linux/lib/libnppig.so* /usr/local/cuda/targets/x86_64-linux/lib/
+COPY --from=livepeer-src /usr/local/cuda/targets/x86_64-linux/lib/libnppicc.so* /usr/local/cuda/targets/x86_64-linux/lib/
 
-# Create data directory
-RUN mkdir -p /data
+ENV LD_LIBRARY_PATH=/usr/local/cuda/targets/x86_64-linux/lib:/usr/local/lib
 
-# Environment variables (can be overridden at runtime)
+RUN chmod +x /usr/local/bin/livepeer && ldconfig
+
 ENV SIGNER_NETWORK=arbitrum-one-mainnet
 ENV SIGNER_PORT=8081
 ENV ETH_RPC_URL=https://arb1.arbitrum.io/rpc
 ENV SIGNER_ETH_ADDR=""
 ENV SIGNER_REMOTE_DISCOVERY=0
 
-# Expose ports
 EXPOSE 8081 4935
 
-# Create password file and start livepeer
 CMD /bin/sh -c ' \
   if [ ! -f /data/.eth-password ]; then \
     echo "" > /data/.eth-password; \

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -8,9 +8,8 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /data /usr/local/cuda/targets/x86_64-linux/lib
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /data /usr/local/cuda/targets/x86_64-linux/lib
 
 COPY --from=livepeer-src /usr/local/bin/livepeer /usr/local/bin/livepeer
 COPY --from=livepeer-src /usr/local/lib/ /usr/local/lib/

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -4,32 +4,92 @@ Everything needed to run the go-livepeer signer with an optional **Apache + mod_
 
 | File / directory | Purpose |
 |------------------|---------|
-| `Dockerfile.signer` | Minimal Debian image that downloads go-livepeer (Railway/Render-style single-service signer). |
-| `Dockerfile` | Multi-stage build: Apache gateway (`gateway` target) and combined Apache + livepeer (`signer-dmz` target). |
+| `Dockerfile.signer` | go-livepeer only, no Apache DMZ (legacy two-container stack; not for public deploy). |
+| `Dockerfile` | Multi-stage: `gateway` (Apache only), `signer-dmz-local` (local dev), `signer-dmz` (production). |
 | `docker-compose.yml` | Local two-container stack: signer + gateway (JWT DMZ). |
 | `apache/` | `envsubst` templates for Apache (`ports.conf`, `signer-dmz` vhost). |
 | `entrypoint.sh` | JWKS → PEM sync, optional livepeer spawn, Apache foreground. |
 | `scripts/jwks_to_pem.py` | Fetches OIDC JWKS and writes one RSA public key as PEM for `mod_authnz_jwt`. |
 
-**Compose (from repo root):**
+## Build commands (from repo root)
+
+| Image | Dockerfile | go-livepeer source | Use |
+|-------|------------|--------------------|-----|
+| `pymthouse/signer-dmz:local` | `Dockerfile` → `signer-dmz-local` | `../go-livepeer` via `lpclearinghouse` | **Local dev** with PymtHouse (`docker-compose.yml`) |
+| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:0.8.10-d909a4c3` | **Production** (Railway / Render) and prod smoke tests |
+| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:0.8.10-d909a4c3` | **Livepeer only** (no Apache; not for public deploy) |
+
+### Force rebuild
+
+Use `--pull --no-cache` when bumping the pinned `livepeer/go-livepeer` tag or Docker is serving a stale cached layer:
 
 ```bash
-# Builds go-livepeer from ../go-livepeer (lpclearinghouse build-remote-signer.sh), then signer-dmz.
-./scripts/build-local-signer.sh
+# Production DMZ (Apache + livepeer)
+docker build --pull --no-cache -f docker/signer-dmz/Dockerfile -t pymthouse/signer-dmz:latest .
+
+# Livepeer only (no Apache)
+docker build --pull --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthouse-signer:local .
+
+# Verify version after rebuild
+docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse-signer:local -version
+docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse/signer-dmz:latest -version
+# expect: Livepeer Node Version: 0.8.10-d909a4c3
+```
+
+### Local dev
+
+Builds go-livepeer from your `../go-livepeer` checkout, layers it into the Apache DMZ image, then starts the stack:
+
+```bash
+./scripts/build-local-signer.sh          # → pymthouse/signer-dmz:local
 docker compose up -d signer-dmz
+curl -sf http://127.0.0.1:8080/healthz  # expect: OK
 ```
 
-**Production / Railway** uses the default `signer-dmz` target (pinned CI binary from build.livepeer.live).
+`build-local-signer.sh` sets `SIGNER_DMZ_IMAGE` (default `pymthouse/signer-dmz:local`). Override with `SIGNER_DMZ_IMAGE=…` if needed.
 
-**Compose (legacy two-container stack):**
+Requires the Next app running so JWKS sync works (`NEXTAUTH_URL` in `docker-compose.yml`, default `http://localhost:3001`).
 
-**Build the standalone signer image (from repo root):**
+### Production build (smoke test)
+
+Same Dockerfile Railway uses (`railway.json`, `render.yaml`). Default final stage is `signer-dmz`:
 
 ```bash
-docker build -f docker/signer-dmz/Dockerfile.signer -t pymthouse-signer .
+docker build -f docker/signer-dmz/Dockerfile -t pymthouse/signer-dmz:latest .
+
+docker rm -f signer-dmz-smoke 2>/dev/null
+docker run -d --name signer-dmz-smoke \
+  -p 127.0.0.1:8080:8080 \
+  -e PORT=8080 \
+  -e NEXTAUTH_URL=http://localhost:3001 \
+  -v "$(pwd)/data/signer-dmz:/data" \
+  --add-host=host.docker.internal:host-gateway \
+  pymthouse/signer-dmz:latest
+
+curl -sf http://127.0.0.1:8080/healthz   # expect: OK (Next app must be up for JWKS)
+docker exec signer-dmz-smoke /usr/local/bin/livepeer -version
 ```
 
-Platform config (`railway.json`, `render.yaml`) builds `docker/signer-dmz/Dockerfile` (final image: Apache JWT DMZ + livepeer). For **livepeer only** (no Apache), use `Dockerfile.signer` instead. See [docs/DEPLOYMENT.md](../../docs/DEPLOYMENT.md) and [docs/signer-deployment-options.md](../../docs/signer-deployment-options.md).
+On Railway, the image is built from the same Dockerfile; no local tag is required.
+
+### Legacy: two-container stack (gateway + signer)
+
+Apache DMZ and go-livepeer run as separate containers (`gateway` target + `Dockerfile.signer`):
+
+```bash
+docker compose -f docker/signer-dmz/docker-compose.yml up --build
+```
+
+### Not for production: livepeer only (no Apache JWT gate)
+
+`Dockerfile.signer` is a minimal go-livepeer image **without** the DMZ. Do not expose it publicly.
+
+```bash
+docker build --pull --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthouse-signer:local .
+docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse-signer:local -version
+```
+
+See [docs/DEPLOYMENT.md](../../docs/DEPLOYMENT.md) and [docs/signer-deployment-options.md](../../docs/signer-deployment-options.md).
 
 ## Host publish (local compose)
 


### PR DESCRIPTION
## Summary
- Pin production and standalone signer Docker builds to `livepeer/go-livepeer:0.8.10-d909a4c3` instead of wget'ing the old `0.8.10-0a1919e0` CI tarball
- Copy livepeer binary plus required CUDA NPP libs into the Debian-based images (fixes missing `libnppig`/`libnppicc`/`libnppc` when using a bare binary)
- Document local dev vs production image names, smoke-test commands, and `--pull --no-cache` force rebuild steps in `docker/signer-dmz/README.md`

## Test plan
- [x] `docker build --pull --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthouse-signer:local .`
- [x] `docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse-signer:local -version` → `0.8.10-d909a4c3`
- [ ] `docker build --pull --no-cache -f docker/signer-dmz/Dockerfile -t pymthouse/signer-dmz:latest .`
- [ ] Smoke test DMZ container: `curl http://127.0.0.1:8080/healthz` with Next app running for JWKS


Made with [Cursor](https://cursor.com)