### PR TITLE
fix(oidc): sync authorization_code with redirect URIs

### DIFF
--- a/scripts/repair-client-grants.ts
+++ b/scripts/repair-client-grants.ts
@@ -1,0 +1,94 @@
+/**
+ * Repair grant_types for all public (app_*) OIDC clients to enforce the
+ * authorization_code ↔ redirect_uris invariant.
+ *
+ * Rule:
+ *   - Client has redirect URIs  → authorization_code MUST be in grant_types
+ *   - Client has no redirect URIs → authorization_code MUST NOT be in grant_types
+ *
+ * M2M clients (m2m_*) are left untouched.
+ *
+ * Usage:
+ *   DATABASE_URL=... npx tsx scripts/repair-client-grants.ts
+ *   or:
+ *   npx tsx scripts/repair-client-grants.ts  (loads from .env.local via load-env-first)
+ */
+import "./load-env-first";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { eq } from "drizzle-orm";
+import * as schema from "../src/db/schema";
+
+const AUTHORIZATION_CODE = "authorization_code";
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    console.error("[repair-client-grants] DATABASE_URL is not set.");
+    process.exit(1);
+  }
+
+  const client = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(client, { schema });
+
+  const rows = await db.select().from(schema.oidcClients);
+
+  let fixed = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    // Skip M2M clients — they never use redirect URIs or authorization_code.
+    if (row.clientId.startsWith("m2m_")) {
+      skipped++;
+      continue;
+    }
+
+    const redirectUris: string[] = JSON.parse(row.redirectUris ?? "[]");
+    const grants = row.grantTypes
+      .split(",")
+      .map((g) => g.trim())
+      .filter(Boolean);
+
+    const hasRedirects = redirectUris.length > 0;
+    const hasAuthCode = grants.includes(AUTHORIZATION_CODE);
+
+    const needsAdd = hasRedirects && !hasAuthCode;
+    const needsRemove = !hasRedirects && hasAuthCode;
+
+    if (!needsAdd && !needsRemove) {
+      skipped++;
+      continue;
+    }
+
+    let nextGrants: string[];
+    if (needsAdd) {
+      nextGrants = [AUTHORIZATION_CODE, ...grants];
+      console.log(
+        `[add]    ${row.clientId}  redirects=${redirectUris.length}  grants: ${grants.join(",")} → ${nextGrants.join(",")}`,
+      );
+    } else {
+      nextGrants = grants.filter((g) => g !== AUTHORIZATION_CODE);
+      console.log(
+        `[remove] ${row.clientId}  no redirects  grants: ${grants.join(",")} → ${nextGrants.join(",")}`,
+      );
+    }
+
+    await db
+      .update(schema.oidcClients)
+      .set({ grantTypes: nextGrants.join(",") })
+      .where(eq(schema.oidcClients.clientId, row.clientId));
+
+    fixed++;
+  }
+
+  console.log(
+    `\n[repair-client-grants] Done. Fixed: ${fixed}, Skipped: ${skipped}, Total: ${rows.length}`,
+  );
+
+  await client.end({ timeout: 5 });
+}
+
+main().catch((err) => {
+  console.error("[repair-client-grants] Fatal error:", err);
+  process.exit(1);
+});

--- a/src/app/api/v1/apps/[id]/route.ts
+++ b/src/app/api/v1/apps/[id]/route.ts
@@ -26,6 +26,7 @@ import {
   getProviderApp,
   appEditForbiddenResponse,
 } from "@/lib/provider-apps";
+import { syncPublicClientGrantTypes } from "@/lib/oidc/grants";
 import { deleteDeveloperAppAndRelatedData } from "@/lib/delete-developer-app";
 import { billingPatternFromAllowedScopesString } from "@/lib/allowed-scopes";
 import { authenticateAppClient } from "@/lib/auth";
@@ -290,9 +291,20 @@ export async function PUT(
       }
       if (body.grantTypes) clientUpdates.grantTypes = body.grantTypes;
 
-      const nextGrantTypes = (
-        clientUpdates.grantTypes ?? client.grantTypes.split(",").filter(Boolean)
+      // Resolve the final redirect URIs (updated or unchanged) and enforce the
+      // authorization_code ↔ redirect_uris invariant on every write.
+      const finalRedirectUris =
+        clientUpdates.redirectUris ??
+        (JSON.parse(client.redirectUris) as string[]);
+      const baseGrants =
+        clientUpdates.grantTypes ?? client.grantTypes.split(",").filter(Boolean);
+      clientUpdates.grantTypes = syncPublicClientGrantTypes(
+        baseGrants,
+        finalRedirectUris,
+        client.clientId,
       );
+
+      const nextGrantTypes = clientUpdates.grantTypes;
       const nextInitiateLoginUri = client.initiateLoginUri?.trim();
       const nextDeviceThirdPartyInitiateLogin = client.deviceThirdPartyInitiateLogin === 1;
       if (

--- a/src/app/api/v1/apps/route.ts
+++ b/src/app/api/v1/apps/route.ts
@@ -9,6 +9,7 @@ import {
   ensureM2mBackendClient,
   updateClientConfig,
 } from "@/lib/oidc/clients";
+import { syncPublicClientGrantTypes } from "@/lib/oidc/grants";
 import { resetProvider } from "@/lib/oidc/provider";
 import { DEFAULT_OIDC_SCOPES, OIDC_SCOPES } from "@/lib/oidc/scopes";
 import { ensureProviderAdminMembership } from "@/lib/provider-apps";
@@ -131,19 +132,32 @@ export async function POST(request: NextRequest) {
       .join(" ");
     clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
   }
+  // Resolve final redirect URIs early so we can sync authorization_code grant.
+  const finalRedirectUris = clientUpdates.redirectUris ?? [];
+
   if (Array.isArray(body.grantTypes) && body.grantTypes.length > 0) {
     const grantTypes = body.grantTypes.filter(
       (v: unknown): v is string => typeof v === "string" && v.trim().length > 0,
     );
     if (grantTypes.length > 0) {
-      clientUpdates.grantTypes = grantTypes;
+      clientUpdates.grantTypes = syncPublicClientGrantTypes(grantTypes, finalRedirectUris, clientId);
     }
   }
+
+  // Always ensure the grant list is consistent with redirect URIs.
+  if (clientUpdates.grantTypes) {
+    clientUpdates.grantTypes = syncPublicClientGrantTypes(
+      clientUpdates.grantTypes,
+      finalRedirectUris,
+      clientId,
+    );
+  }
+
   if (
     body.deviceThirdPartyInitiateLogin === true &&
     typeof body.initiateLoginUri === "string" &&
     body.initiateLoginUri.trim() &&
-    (clientUpdates.grantTypes ?? ["authorization_code", "refresh_token"]).includes(DEVICE_CODE_GRANT)
+    (clientUpdates.grantTypes ?? ["refresh_token"]).includes(DEVICE_CODE_GRANT)
   ) {
     const allowedScopes = (clientUpdates.allowedScopes ?? DEFAULT_OIDC_SCOPES)
       .split(/[,\s]+/)

--- a/src/app/apps/[id]/page.tsx
+++ b/src/app/apps/[id]/page.tsx
@@ -5,10 +5,7 @@ import { useParams, useSearchParams } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import AppSettingsScreen from "@/components/apps/AppSettingsScreen";
 import type { AppFormData, AppState } from "@/components/apps/AppWizard";
-import {
-  DEFAULT_PUBLIC_GRANT_TYPES,
-  ensureAuthorizationCodeGrant,
-} from "@/lib/oidc/grants";
+import { DEFAULT_PUBLIC_GRANT_TYPES } from "@/lib/oidc/grants";
 import { DEFAULT_OIDC_SCOPES, ensureOpenIdScope } from "@/lib/oidc/scopes";
 
 const STATUS_LABELS: Record<string, { label: string; color: string }> = {
@@ -58,11 +55,9 @@ export default function AppDetailPage() {
             allowedScopes: ensureOpenIdScope(
               data.oidcClient?.allowedScopes || DEFAULT_OIDC_SCOPES,
             ),
-            grantTypes: ensureAuthorizationCodeGrant(
-              data.oidcClient?.grantTypes?.split(",").filter(Boolean) || [
-                ...DEFAULT_PUBLIC_GRANT_TYPES,
-              ],
-            ),
+            grantTypes:
+              data.oidcClient?.grantTypes?.split(",").filter(Boolean) ??
+              [...DEFAULT_PUBLIC_GRANT_TYPES],
             tokenEndpointAuthMethod:
               data.oidcClient?.tokenEndpointAuthMethod || "none",
             backendDeviceHelper: Boolean(data.m2mOidcClient),

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -4,6 +4,7 @@ import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState }
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppInfoStep from "./steps/AppInfoStep";
 import AppModeStep from "./steps/AppModeStep";
+import AuthorizationCodeRedirectBlock from "./steps/AuthorizationCodeRedirectBlock";
 import TestingStep from "./steps/TestingStep";
 import PlansTab from "./PlansTab";
 import PaymentsTab from "./PaymentsTab";
@@ -521,13 +522,32 @@ export default function AppSettingsScreen({
           id="panel-auth"
           role="tabpanel"
           aria-labelledby="tab-auth"
-          className="pb-6"
+          className="space-y-10 pb-6"
         >
           <AppModeStep
             data={formData}
             onChange={updateFormData}
             readOnly={!canEdit}
           />
+
+          <div className="border-t border-zinc-800 pt-8 space-y-3">
+            <div>
+              <h2 className="text-base font-semibold text-zinc-100">Browser sign-in</h2>
+              <p className="text-sm text-zinc-500 mt-1">
+                Authorization Code + PKCE (browser-based login) is enabled automatically
+                when at least one redirect URI is registered. Device flow (CLI/SDK) works
+                without one.
+              </p>
+            </div>
+            <AuthorizationCodeRedirectBlock
+              appId={appState.id}
+              redirectUris={formData.redirectUris}
+              onRedirectUrisChange={(uris) => updateFormData({ redirectUris: uris })}
+              domains={domains}
+              onDomainsChange={setDomains}
+              readOnly={!canEdit}
+            />
+          </div>
         </section>
       )}
 
@@ -567,6 +587,7 @@ export default function AppSettingsScreen({
                 }));
               }}
               readOnly={!canEdit}
+              hideRedirectUriEditor
             />
           </section>
 

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -4,11 +4,8 @@ import { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { docsDeviceFlowUrl } from "@/lib/docs-base-url";
 import {
-  AUTHORIZATION_CODE_GRANT,
   DEFAULT_PUBLIC_GRANT_TYPES,
   DEVICE_CODE_GRANT,
-  ensureAuthorizationCodeGrant,
-  REFRESH_TOKEN_GRANT,
 } from "@/lib/oidc/grants";
 import { DEFAULT_OIDC_SCOPES, ensureOpenIdScope, OIDC_SCOPES } from "@/lib/oidc/scopes";
 
@@ -158,22 +155,11 @@ export default function AppWizard({ initialData }: Props) {
     setSaving(true);
     setError(null);
     try {
-      const grantTypesWithoutRedirectlessAuthCode = formData.grantTypes.filter(
-        (grantType) =>
-          formData.redirectUris.length > 0 || grantType !== AUTHORIZATION_CODE_GRANT,
-      );
-      const hasRefreshTokenIssuingGrant = grantTypesWithoutRedirectlessAuthCode.some(
-        (grantType) =>
-          grantType === AUTHORIZATION_CODE_GRANT || grantType === DEVICE_FLOW_GRANT,
-      );
-      const grantTypes = hasRefreshTokenIssuingGrant
-        ? grantTypesWithoutRedirectlessAuthCode
-        : grantTypesWithoutRedirectlessAuthCode.filter(
-            (grantType) => grantType !== REFRESH_TOKEN_GRANT,
-          );
+      // Let the server enforce the authorization_code ↔ redirect_uris coupling.
+      // We submit the grant list as-is; syncPublicClientGrantTypes on the server
+      // will add/remove authorization_code based on whether redirectUris is non-empty.
       const payload: AppFormData = {
         ...formData,
-        grantTypes: ensureAuthorizationCodeGrant(grantTypes),
         allowedScopes: ensureOpenIdScope(formData.allowedScopes),
       };
       const res = await fetch("/api/v1/apps", {

--- a/src/components/apps/steps/AppModeStep.tsx
+++ b/src/components/apps/steps/AppModeStep.tsx
@@ -2,11 +2,7 @@
 
 import { useEffect } from "react";
 import type { AppFormData } from "../AppWizard";
-import {
-  AUTHORIZATION_CODE_GRANT,
-  DEVICE_CODE_GRANT,
-  ensureAuthorizationCodeGrant,
-} from "@/lib/oidc/grants";
+import { DEVICE_CODE_GRANT } from "@/lib/oidc/grants";
 import { ensureOpenIdScope, OIDC_SCOPES } from "@/lib/oidc/scopes";
 import { validateInitiateLoginUri } from "@/lib/oidc/third-party-initiate-login";
 
@@ -53,13 +49,8 @@ export default function AppModeStep({
     setAllowedScopes(data.allowedScopes);
   }, [data.allowedScopes, scopes, onChange]);
 
-  useEffect(() => {
-    if (data.grantTypes.includes(AUTHORIZATION_CODE_GRANT)) return;
-    onChange({ grantTypes: ensureAuthorizationCodeGrant(data.grantTypes) });
-  }, [data.grantTypes, onChange]);
-
   const setGrantTypes = (next: string[]) => {
-    onChange({ grantTypes: ensureAuthorizationCodeGrant(next) });
+    onChange({ grantTypes: next });
   };
 
   const toggleScope = (scope: string) => {
@@ -90,9 +81,7 @@ export default function AppModeStep({
     if (readOnly || !data.backendDeviceHelper) return;
     if (hasDeviceCode) {
       onChange({
-        grantTypes: ensureAuthorizationCodeGrant(
-          data.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT),
-        ),
+        grantTypes: data.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT),
         initiateLoginUri: "",
         deviceThirdPartyInitiateLogin: false,
       });
@@ -112,9 +101,7 @@ export default function AppModeStep({
     } else {
       onChange({
         backendDeviceHelper: false,
-        grantTypes: ensureAuthorizationCodeGrant(
-          data.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT),
-        ),
+        grantTypes: data.grantTypes.filter((v) => v !== DEVICE_CODE_GRANT),
         initiateLoginUri: "",
         deviceThirdPartyInitiateLogin: false,
         allowedScopes: ensureOpenIdScope(

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -30,6 +30,8 @@ interface Props {
   onSecretGenerated: () => void;
   onBackendSecretGenerated?: () => void;
   readOnly?: boolean;
+  /** When true, the redirect URI / domain editor is omitted (managed from Auth & Scopes tab). */
+  hideRedirectUriEditor?: boolean;
 }
 
 function getDefaultRedirectUri(redirectUris: string[]) {
@@ -65,6 +67,7 @@ export default function TestingStep({
   onSecretGenerated,
   onBackendSecretGenerated,
   readOnly = false,
+  hideRedirectUriEditor = false,
 }: Props) {
   const [secret, setSecret] = useState<string | null>(null);
   const [backendSecret, setBackendSecret] = useState<string | null>(null);
@@ -286,7 +289,7 @@ export default function TestingStep({
 
       {hasAuthCodeFlow && (
         <div className="space-y-5 p-5 rounded-xl border border-zinc-800 bg-zinc-900/30">
-          {redirectUris.length === 0 && (
+          {!hideRedirectUriEditor && redirectUris.length === 0 && (
             <div
               className="flex gap-3 rounded-lg border border-blue-500/25 bg-blue-500/5 px-3 py-3"
               role="status"
@@ -315,21 +318,25 @@ export default function TestingStep({
             </div>
           )}
 
-          <div>
-            <h3 className="text-sm font-semibold text-zinc-200">Redirect &amp; login URLs</h3>
-            <p className="text-xs text-zinc-500 mt-1">
-              Callback URLs for authorization and sign-out. Domains are auto-suggested from redirect
-              origins.
-            </p>
-          </div>
-          <AuthorizationCodeRedirectBlock
-            appId={appId}
-            redirectUris={redirectUris}
-            onRedirectUrisChange={(uris) => onChange({ redirectUris: uris })}
-            domains={domains}
-            onDomainsChange={onDomainsChange}
-            readOnly={readOnly}
-          />
+          {!hideRedirectUriEditor && (
+            <>
+              <div>
+                <h3 className="text-sm font-semibold text-zinc-200">Redirect &amp; login URLs</h3>
+                <p className="text-xs text-zinc-500 mt-1">
+                  Callback URLs for authorization and sign-out. Domains are auto-suggested from
+                  redirect origins.
+                </p>
+              </div>
+              <AuthorizationCodeRedirectBlock
+                appId={appId}
+                redirectUris={redirectUris}
+                onRedirectUrisChange={(uris) => onChange({ redirectUris: uris })}
+                domains={domains}
+                onDomainsChange={onDomainsChange}
+                readOnly={readOnly}
+              />
+            </>
+          )}
 
           {testUrl && (
             <div className="space-y-3 border-t border-zinc-800 pt-5">

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -6,10 +6,7 @@ import { randomBytes } from "crypto";
 import {
   computeBackendM2mAllowedScopes,
 } from "@/lib/oidc/backend-m2m-scopes";
-import {
-  DEFAULT_PUBLIC_GRANT_TYPES,
-  normalizePublicGrantTypes,
-} from "@/lib/oidc/grants";
+import { DEFAULT_PUBLIC_GRANT_TYPES } from "@/lib/oidc/grants";
 import {
   DEFAULT_OIDC_SCOPES,
   ensureOpenIdScope,
@@ -66,10 +63,7 @@ export async function registerClient(config: OidcClientConfig): Promise<void> {
           config.allowedScopes || DEFAULT_OIDC_SCOPES,
           config.clientId,
         ),
-        grantTypes: normalizePublicGrantTypes(
-          (config.grantTypes || [...DEFAULT_PUBLIC_GRANT_TYPES]).join(","),
-          config.clientId,
-        ),
+        grantTypes: (config.grantTypes || [...DEFAULT_PUBLIC_GRANT_TYPES]).join(","),
         tokenEndpointAuthMethod: config.tokenEndpointAuthMethod || "none",
         clientSecretHash: config.clientSecret
           ? hashClientSecret(config.clientSecret)
@@ -91,10 +85,7 @@ export async function registerClient(config: OidcClientConfig): Promise<void> {
       config.allowedScopes || DEFAULT_OIDC_SCOPES,
       config.clientId,
     ),
-    grantTypes: normalizePublicGrantTypes(
-      (config.grantTypes || [...DEFAULT_PUBLIC_GRANT_TYPES]).join(","),
-      config.clientId,
-    ),
+    grantTypes: (config.grantTypes || [...DEFAULT_PUBLIC_GRANT_TYPES]).join(","),
     tokenEndpointAuthMethod: config.tokenEndpointAuthMethod || "none",
   });
 }
@@ -282,6 +273,8 @@ export async function createAppClient(displayName: string): Promise<{
   const id = uuidv4();
   const clientId = generateClientId();
 
+  // New apps start with no redirect URIs, so authorization_code is absent.
+  // It will be added by syncAuthorizationCodeGrant when the first redirect URI is registered.
   await db.insert(oidcClients).values({
     id,
     clientId,
@@ -289,7 +282,7 @@ export async function createAppClient(displayName: string): Promise<{
     displayName,
     redirectUris: JSON.stringify([]),
     allowedScopes: DEFAULT_OIDC_SCOPES,
-    grantTypes: "authorization_code,refresh_token",
+    grantTypes: "refresh_token",
     tokenEndpointAuthMethod: "none",
   });
 
@@ -606,10 +599,7 @@ export async function updateClientConfig(
     );
   }
   if (config.grantTypes !== undefined) {
-    updates.grantTypes = normalizePublicGrantTypes(
-      config.grantTypes.join(","),
-      clientId,
-    );
+    updates.grantTypes = config.grantTypes.join(",");
   }
   if (config.tokenEndpointAuthMethod !== undefined) {
     updates.tokenEndpointAuthMethod = config.tokenEndpointAuthMethod;

--- a/src/lib/oidc/grants.ts
+++ b/src/lib/oidc/grants.ts
@@ -1,4 +1,3 @@
-/** Interactive public apps always use authorization code + PKCE (hidden in app config UI). */
 export const AUTHORIZATION_CODE_GRANT = "authorization_code";
 
 export const REFRESH_TOKEN_GRANT = "refresh_token";
@@ -7,8 +6,12 @@ export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
 export const CLIENT_CREDENTIALS_GRANT = "client_credentials";
 
+/**
+ * Default grant types for a newly created public app with no redirect URIs.
+ * `authorization_code` is intentionally absent — it is added automatically
+ * by {@link syncAuthorizationCodeGrant} once a redirect URI is registered.
+ */
 export const DEFAULT_PUBLIC_GRANT_TYPES = [
-  AUTHORIZATION_CODE_GRANT,
   REFRESH_TOKEN_GRANT,
 ] as const;
 
@@ -23,29 +26,31 @@ export function parseGrantTypes(grantTypes: string): string[] {
     .filter(Boolean);
 }
 
-/** Public OIDC clients always allow authorization code; omit from app config UI. */
-export function ensureAuthorizationCodeGrant(grantTypes: string[]): string[] {
-  if (grantTypes.includes(AUTHORIZATION_CODE_GRANT)) {
-    return grantTypes;
-  }
-  return [AUTHORIZATION_CODE_GRANT, ...grantTypes];
+/**
+ * Enforce the RFC 6749 invariant: `authorization_code` belongs in grants if
+ * and only if the client has at least one registered redirect URI.
+ *
+ * - `hasRedirectUris` true  → ensures `authorization_code` is present (prepended)
+ * - `hasRedirectUris` false → removes `authorization_code` from the list
+ *
+ * All other grants are preserved as-is. Safe to call on M2M clients — pass
+ * `false` for `hasRedirectUris` and they are left untouched.
+ */
+export function syncAuthorizationCodeGrant(
+  grants: string[],
+  hasRedirectUris: boolean,
+): string[] {
+  const without = grants.filter((g) => g !== AUTHORIZATION_CODE_GRANT);
+  if (!hasRedirectUris) return without;
+  return [AUTHORIZATION_CODE_GRANT, ...without];
 }
 
-export function normalizePublicGrantTypesList(
-  grantTypes: string[],
+/** Pass-through for M2M clients; apply {@link syncAuthorizationCodeGrant} for public ones. */
+export function syncPublicClientGrantTypes(
+  grants: string[],
+  redirectUris: string[],
   clientId: string,
 ): string[] {
-  if (isM2mClientId(clientId)) {
-    return grantTypes;
-  }
-  return ensureAuthorizationCodeGrant(grantTypes);
-}
-
-export function normalizePublicGrantTypes(
-  grantTypes: string,
-  clientId: string,
-): string {
-  return normalizePublicGrantTypesList(parseGrantTypes(grantTypes), clientId).join(
-    ",",
-  );
+  if (isM2mClientId(clientId)) return grants;
+  return syncAuthorizationCodeGrant(grants, redirectUris.length > 0);
 }

--- a/src/lib/oidc/provider.ts
+++ b/src/lib/oidc/provider.ts
@@ -10,7 +10,7 @@ import { PostgresOidcAdapter } from "./adapter";
 import { findAccount } from "./account";
 import { getIssuer } from "./issuer-urls";
 import { hashClientSecret, normalizePublicAllowedScopes } from "./clients";
-import { normalizePublicGrantTypes, parseGrantTypes } from "./grants";
+import { parseGrantTypes } from "./grants";
 import { getTrustedLoginHosts, normalizeDomain } from "./custom-domains";
 import { ensureSigningKey } from "./jwks";
 import { initiateLoginUriAcceptedByOidcProvider } from "./third-party-initiate-login";
@@ -83,22 +83,12 @@ async function loadClients(): Promise<ClientMetadata[]> {
         return expanded;
       });
 
-    const grantTypes = parseGrantTypes(
-      normalizePublicGrantTypes(row.grantTypes, row.clientId),
-    );
-
-    // node-oidc-provider requires at least one redirect_uri for all clients.
-    // For device-flow-only clients that may have none configured, use a
-    // placeholder so the client can still be registered with the provider.
-    const effectiveRedirectUris =
-      redirectUris.length > 0
-        ? redirectUris
-        : [`${getIssuer()}/cb`];
+    const grantTypes = parseGrantTypes(row.grantTypes);
 
     const meta: ClientMetadata = {
       client_id: row.clientId,
       client_name: row.displayName,
-      redirect_uris: effectiveRedirectUris,
+      redirect_uris: redirectUris,
       grant_types: grantTypes,
       token_endpoint_auth_method: row.tokenEndpointAuthMethod as "none" | "client_secret_post" | "client_secret_basic",
       scope: normalizePublicAllowedScopes(row.allowedScopes, row.clientId),


### PR DESCRIPTION
## Summary

- Enforces the RFC 6749 invariant: `authorization_code` is present in `grant_types` **if and only if** the client has at least one redirect URI.
- New public apps default to device-flow grants only (`refresh_token`); `authorization_code` is added when the first redirect URI is registered.
- Removes the `${issuer}/cb` placeholder redirect from `loadClients()` — device-flow-only clients no longer need a fake redirect.
- Adds `scripts/repair-client-grants.ts` to fix existing `app_*` rows in the database.

Split from draft [#126](https://github.com/pymthouse/pymthouse/pull/126) (Turnkey signer work continues there).

## Test plan

- [ ] Create a new app with **no** redirect URIs → OIDC client has `refresh_token` (+ device flow scopes), no `authorization_code`; device flow still works.
- [ ] Add a redirect URI → `authorization_code` appears in grant types; browser/PKCE flow works.
- [ ] Remove all redirect URIs → `authorization_code` is removed again.
- [ ] Run `DATABASE_URL=... npx tsx scripts/repair-client-grants.ts` against staging and confirm only mismatched rows are updated.
- [ ] `npm run build` passes.


Made with [Cursor](https://cursor.com)