### PR TITLE
feat(signer-dmz): dedicated CLI port and optional no-auth mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 # Local signer: full signer-dmz (Apache + mod_authnz_jwt + go-livepeer in one
 # image), same as production (railway.json / render.yaml). Exposes the DMZ on
 # 127.0.0.1:8080 by default (see SIGNER_DMZ_HOST_PORT). The app should use
-# SIGNER_INTERNAL_URL=http://127.0.0.1:8080 and SIGNER_CLI_URL=http://127.0.0.1:8080/__signer_cli
+# SIGNER_INTERNAL_URL=http://127.0.0.1:8080
+# SIGNER_CLI_URL=http://127.0.0.1:8082 (livepeer-cli paths at /) or http://127.0.0.1:8080/__signer_cli
 #
 # Build the image first (go-livepeer from ../go-livepeer via lpclearinghouse):
 #   ./scripts/build-local-signer.sh
@@ -26,6 +27,9 @@ services:
     ports:
       - target: 8080
         published: ${SIGNER_DMZ_HOST_PORT:-8080}
+        host_ip: ${SIGNER_DMZ_BIND_HOST:-127.0.0.1}
+      - target: 8082
+        published: ${SIGNER_CLI_HOST_PORT:-8082}
         host_ip: ${SIGNER_DMZ_BIND_HOST:-127.0.0.1}
     volumes:
       - ${SIGNER_DATA_DIR:-./data}:/data

--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -79,7 +79,9 @@ RUN ldconfig && \
 COPY docker/signer-dmz/scripts/jwks_to_pem.py /opt/pymthouse/scripts/jwks_to_pem.py
 COPY docker/signer-dmz/apache/ports.conf.in /etc/apache2/templates/ports.conf.in
 COPY docker/signer-dmz/apache/signer-dmz.conf.in /etc/apache2/templates/signer-dmz.conf.in
+COPY docker/signer-dmz/apache/signer-dmz-noauth.conf.in /etc/apache2/templates/signer-dmz-noauth.conf.in
 COPY docker/signer-dmz/apache/signer-dmz-cli-vhost.conf.in /etc/apache2/templates/signer-dmz-cli-vhost.conf.in
+COPY docker/signer-dmz/apache/signer-dmz-cli-vhost-noauth.conf.in /etc/apache2/templates/signer-dmz-cli-vhost-noauth.conf.in
 COPY docker/signer-dmz/entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh /opt/pymthouse/scripts/jwks_to_pem.py
@@ -177,10 +179,10 @@ ENV ETH_RPC_URL=https://arb1.arbitrum.io/rpc
 ENV SIGNER_ETH_ADDR=""
 ENV SIGNER_REMOTE_DISCOVERY=0
 
-# Apache listens on $PORT (Railway sets this, default 8080). CLI is path-mounted at /__signer_cli.
-# go-livepeer binds loopback :8081 / :4935 only — they must not be the public edge port.
-ENV SIGNER_DMZ_ENABLE_CLI_LISTENER=0
-EXPOSE 8080
+# Apache: $PORT = signing API; $CLI_PORT (8082) = livepeer-cli routes at / (no /__signer_cli prefix).
+# /__signer_cli on $PORT remains for single-port hosts (Railway). Loopback :8081 / :4935 are not public.
+ENV SIGNER_DMZ_ENABLE_CLI_LISTENER=1
+EXPOSE 8080 8082
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
   CMD sh -c 'curl -sf "http://127.0.0.1:${PORT:-8080}/healthz" || exit 1'

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -72,6 +72,35 @@ docker exec signer-dmz-smoke /usr/local/bin/livepeer -version
 
 On Railway, the image is built from the same Dockerfile; no local tag is required.
 
+## Dedicated CLI port (8082)
+
+Local compose publishes **`CLI_PORT`** (default **8082**) so `livepeer_cli -http 8082` uses the same paths as a bare node (`/ethAddr`, `/contractAddresses`, …) without the `/__signer_cli` prefix.
+
+Set **`SIGNER_CLI_URL=http://127.0.0.1:8082`** in PymtHouse, or keep **`http://127.0.0.1:8080/__signer_cli`** on the main port.
+
+On Railway, set **`SIGNER_DMZ_ENABLE_CLI_LISTENER=0`** for single-port hosts; CLI stays at **`/__signer_cli`** on **`$PORT`**.
+
+## Local dev without JWT (`SIGNER_DMZ_DISABLE_AUTH=1`)
+
+Skip JWKS sync and Apache JWT verification on signing and CLI routes. **Local development only — never enable on Railway or any public host.**
+
+```bash
+docker run -d --name signer-dmz-noauth \
+  -e SIGNER_DMZ_DISABLE_AUTH=1 \
+  -p 127.0.0.1:8080:8080 \
+  -p 127.0.0.1:8082:8082 \
+  -v "$(pwd)/data/signer-dmz:/data" \
+  pymthouse/signer-dmz:latest
+
+curl -sf http://127.0.0.1:8080/healthz
+curl -sf -X POST http://127.0.0.1:8080/sign-orchestrator-info \
+  -H 'Content-Type: application/json' -d '{}'
+curl -sf http://127.0.0.1:8082/contractAddresses
+livepeer_cli -http 8082
+```
+
+`NEXTAUTH_URL` / `JWKS_URI` are not required when auth is disabled. Startup logs include `SIGNER_DMZ_DISABLE_AUTH=1` and `JWT_VERIFICATION=disabled`.
+
 ### Legacy: two-container stack (gateway + signer)
 
 Apache DMZ and go-livepeer run as separate containers (`gateway` target + `Dockerfile.signer`):
@@ -111,7 +140,8 @@ The image listens on **`$PORT`** (Apache HTTP + `/__signer_cli`, `/healthz`, pro
    Point the primary Railway hostname at **Apache’s port**, i.e. whatever **`PORT`** is at runtime (Railway usually sets **`PORT=8080`**). Do **not** set the edge to **8081** or **4935**; that produces **502**s because nothing listens on all interfaces there.
 
 2. **CLI from the internet**  
-   You can use **one** public URL on **`PORT`** only: Apache already proxies **`/__signer_cli/`** on that same listener (see `apache/signer-dmz.conf.in`). Alternatively, expose **`CLI_PORT` (8082)** with a second hostname if you want the dedicated CLI vhost.
+   **Local / livepeer-cli:** publish **`CLI_PORT` (8082)** — Apache proxies livepeer-cli routes at **`/`** (`/contractAddresses`, `/ethAddr`, …) with no `/__signer_cli` prefix. Run `livepeer_cli -http 8082`.  
+   **Single-port (Railway):** use **`/__signer_cli/`** on **`PORT`** (see `apache/signer-dmz.conf.in`), or expose **`CLI_PORT`** on a second hostname.
 
 3. **`/__signer_cli` and PymtHouse — not automatic**  
    Apache serves **`https://<your-dmz-host>/__signer_cli`** on the **same** port as **`SIGNER_INTERNAL_URL`** (no extra path needed in `SIGNER_INTERNAL_URL`). The Next app **does not** infer that URL: **`getSignerCliUrl()`** uses **`SIGNER_CLI_URL`** if set, otherwise defaults to **`http://127.0.0.1:8080/__signer_cli`** (local compose’s single published port). For Railway single-port DMZ, set explicitly, for example:  
@@ -125,7 +155,7 @@ The image listens on **`$PORT`** (Apache HTTP + `/__signer_cli`, `/healthz`, pro
 5. **Health check**  
    Use **`GET /healthz`** (200, body `OK`) from the public URL.
 
-The production image **`EXPOSE`s only `8080`** (Apache). Local **`signer-dmz-local`** may also expose **`8082`** when `SIGNER_DMZ_ENABLE_CLI_LISTENER=1`. Railway health checks use **`GET /healthz`** on **`$PORT`** (see root `railway.json`).
+The image **`EXPOSE`s `8080`** (signing) and **`8082`** (CLI). Set **`SIGNER_DMZ_ENABLE_CLI_LISTENER=0`** to disable the CLI listener (Railway single-port only). Railway health checks use **`GET /healthz`** on **`$PORT`** (see root `railway.json`).
 
 ## Troubleshooting DMZ `401` (HTML body from PymtHouse `/api/signer/*`)
 

--- a/docker/signer-dmz/apache/signer-dmz-cli-vhost-noauth.conf.in
+++ b/docker/signer-dmz/apache/signer-dmz-cli-vhost-noauth.conf.in
@@ -1,0 +1,22 @@
+# Dedicated CLI listener (CLI_PORT). Root paths → livepeer -cliAddr (no /__signer_cli prefix).
+
+<VirtualHost *:${CLI_PORT}>
+	ServerName localhost
+	ProxyPreserveHost On
+	ProxyRequests Off
+
+	ProxyPass /healthz !
+	Alias /healthz /var/www/static/healthz
+	<Location "/healthz">
+		AuthType None
+		Require all granted
+	</Location>
+
+	ProxyPass / ${SIGNER_CLI_HTTP_ADDR}/
+	ProxyPassReverse / ${SIGNER_CLI_HTTP_ADDR}/
+
+	<LocationMatch "^/(?!healthz(?:/|$))">
+		AuthType None
+		Require all granted
+	</LocationMatch>
+</VirtualHost>

--- a/docker/signer-dmz/apache/signer-dmz-cli-vhost.conf.in
+++ b/docker/signer-dmz/apache/signer-dmz-cli-vhost.conf.in
@@ -1,5 +1,6 @@
-# Optional second listener (CLI_PORT). Included only when SIGNER_DMZ_ENABLE_CLI_LISTENER=1.
-# Prefer /__signer_cli on the main PORT listener for single-port hosts (Railway).
+# Dedicated CLI listener (CLI_PORT, default 8082). Proxies livepeer -cliAddr routes at /
+# (/contractAddresses, /ethAddr, /status, …) — same paths livepeer-cli uses on a bare node.
+# Single-port Railway hosts use /__signer_cli on PORT instead; publish CLI_PORT locally.
 
 <VirtualHost *:${CLI_PORT}>
 	ServerName localhost

--- a/docker/signer-dmz/apache/signer-dmz-noauth.conf.in
+++ b/docker/signer-dmz/apache/signer-dmz-noauth.conf.in
@@ -1,0 +1,54 @@
+# Templated with envsubst: PORT, SIGNER_HTTP_ADDR, SIGNER_CLI_HTTP_ADDR
+# Used when SIGNER_DMZ_DISABLE_AUTH=1 (local dev only — no JWT verification).
+
+ServerName localhost
+ServerTokens Prod
+ServerSignature Off
+
+ErrorLog /dev/stderr
+LogLevel warn
+
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" signer_combined
+CustomLog /dev/stdout signer_combined
+
+<VirtualHost *:${PORT}>
+	ProxyPreserveHost On
+	ProxyRequests Off
+
+	ProxyPass /healthz !
+	Alias /healthz /var/www/static/healthz
+	<Directory "/var/www/static">
+		Options -Indexes
+		Require all granted
+	</Directory>
+
+	RedirectMatch permanent ^/__signer_cli$ /__signer_cli/
+	ProxyPass /__signer_cli/ ${SIGNER_CLI_HTTP_ADDR}/
+	ProxyPassReverse /__signer_cli/ ${SIGNER_CLI_HTTP_ADDR}/
+
+	ProxyPass /status ${SIGNER_HTTP_ADDR}/status
+	ProxyPassReverse /status ${SIGNER_HTTP_ADDR}/status
+
+	ProxyPass / ${SIGNER_HTTP_ADDR}/
+	ProxyPassReverse / ${SIGNER_HTTP_ADDR}/
+
+	<Location "/healthz">
+		AuthType None
+		Require all granted
+	</Location>
+
+	<Location "/status">
+		AuthType None
+		Require all granted
+	</Location>
+
+	<LocationMatch "^/__signer_cli(?:/|$)">
+		AuthType None
+		Require all granted
+	</LocationMatch>
+
+	<LocationMatch "^/(?!(?:healthz|status|__signer_cli)(?:/|$))">
+		AuthType None
+		Require all granted
+	</LocationMatch>
+</VirtualHost>

--- a/docker/signer-dmz/entrypoint.sh
+++ b/docker/signer-dmz/entrypoint.sh
@@ -44,6 +44,7 @@ _disable_auth_raw="${SIGNER_DMZ_DISABLE_AUTH:-0}"
 SIGNER_DMZ_DISABLE_AUTH=0
 case "$_disable_auth_raw" in
   1 | true | TRUE | yes | YES) SIGNER_DMZ_DISABLE_AUTH=1 ;;
+  *) SIGNER_DMZ_DISABLE_AUTH=0 ;;
 esac
 export SIGNER_DMZ_DISABLE_AUTH
 if [ "$SIGNER_DMZ_DISABLE_AUTH" = "1" ]; then

--- a/docker/signer-dmz/entrypoint.sh
+++ b/docker/signer-dmz/entrypoint.sh
@@ -40,6 +40,16 @@ print(urlunparse(u))
 fi
 export JWT_PEM_PATH="${JWT_PEM_PATH:-/run/jwt/jwks.pem}"
 
+_disable_auth_raw="${SIGNER_DMZ_DISABLE_AUTH:-0}"
+SIGNER_DMZ_DISABLE_AUTH=0
+case "$_disable_auth_raw" in
+  1 | true | TRUE | yes | YES) SIGNER_DMZ_DISABLE_AUTH=1 ;;
+esac
+export SIGNER_DMZ_DISABLE_AUTH
+if [ "$SIGNER_DMZ_DISABLE_AUTH" = "1" ]; then
+  echo "entrypoint: WARNING SIGNER_DMZ_DISABLE_AUTH=1 — Apache JWT verification disabled; local dev only" >&2
+fi
+
 if [ -n "${SIGNER_UPSTREAM:-}" ]; then
   export SIGNER_HTTP_ADDR="${SIGNER_UPSTREAM}"
   # Derive the CLI address from SIGNER_UPSTREAM when not explicitly set, preserving scheme+host.
@@ -70,25 +80,27 @@ else
   export SIGNER_CLI_HTTP_ADDR="${SIGNER_CLI_HTTP_ADDR:-http://127.0.0.1:4935}"
 fi
 
-mkdir -p /run/jwt
-if ! python3 /opt/pymthouse/scripts/jwks_to_pem.py --url "$JWKS_URI" --out "$JWT_PEM_PATH"; then
-  echo "entrypoint: JWKS sync failed" >&2
-  exit 1
-fi
+if [ "$SIGNER_DMZ_DISABLE_AUTH" != "1" ]; then
+  mkdir -p /run/jwt
+  if ! python3 /opt/pymthouse/scripts/jwks_to_pem.py --url "$JWKS_URI" --out "$JWT_PEM_PATH"; then
+    echo "entrypoint: JWKS sync failed" >&2
+    exit 1
+  fi
 
-(
-  while true; do
-    sleep "${JWKS_REFRESH_SECONDS:-900}"
-    if python3 /opt/pymthouse/scripts/jwks_to_pem.py --url "$JWKS_URI" --out "${JWT_PEM_PATH}.next" 2>/dev/null; then
-      if ! cmp -s "$JWT_PEM_PATH" "${JWT_PEM_PATH}.next"; then
-        mv "${JWT_PEM_PATH}.next" "$JWT_PEM_PATH"
-        apache2ctl graceful 2>/dev/null || true
-      else
-        rm -f "${JWT_PEM_PATH}.next"
+  (
+    while true; do
+      sleep "${JWKS_REFRESH_SECONDS:-900}"
+      if python3 /opt/pymthouse/scripts/jwks_to_pem.py --url "$JWKS_URI" --out "${JWT_PEM_PATH}.next" 2>/dev/null; then
+        if ! cmp -s "$JWT_PEM_PATH" "${JWT_PEM_PATH}.next"; then
+          mv "${JWT_PEM_PATH}.next" "$JWT_PEM_PATH"
+          apache2ctl graceful 2>/dev/null || true
+        else
+          rm -f "${JWT_PEM_PATH}.next"
+        fi
       fi
-    fi
-  done
-) &
+    done
+  ) &
+fi
 
 if [ -z "${SIGNER_UPSTREAM:-}" ] && [ -x /usr/local/bin/livepeer ]; then
   if [ ! -f /data/.eth-password ]; then
@@ -145,39 +157,56 @@ mkdir -p "$APACHE_LOG_DIR"
 # the DMZ integration stabilises; set APACHE_AUTH_JWT_LOG_LEVEL=warn in prod.
 export APACHE_AUTH_JWT_LOG_LEVEL="${APACHE_AUTH_JWT_LOG_LEVEL:-info}"
 
-# Dump the resolved DMZ auth context so 401s can be diagnosed by comparing this
-# to the claims on a minted token. Emitted on stderr (visible via `docker logs`).
-{
-  _pem_kids="(missing)"
-  if [ -r "$JWT_PEM_PATH" ]; then
-    _pem_kids="$(grep -c 'BEGIN PUBLIC KEY' "$JWT_PEM_PATH" 2>/dev/null || echo 0)"
-  fi
-  printf 'signer-dmz: auth config:\n'
-  printf '  OIDC_ISSUER=%s\n' "$OIDC_ISSUER"
-  printf '  OIDC_AUDIENCE=%s\n' "$OIDC_AUDIENCE"
-  printf '  JWKS_URI=%s\n' "$JWKS_URI"
-  printf '  JWT_PEM_PATH=%s (public keys: %s)\n' "$JWT_PEM_PATH" "$_pem_kids"
-  printf '  SIGNER_HTTP_ADDR=%s\n' "$SIGNER_HTTP_ADDR"
-  printf '  SIGNER_CLI_HTTP_ADDR=%s\n' "$SIGNER_CLI_HTTP_ADDR"
-  printf '  APACHE_PUBLIC_BIND=0.0.0.0:%s\n' "$PORT"
-  printf '  APACHE_AUTH_JWT_LOG_LEVEL=%s\n' "$APACHE_AUTH_JWT_LOG_LEVEL"
-} >&2
-
-_envsubst_apache='${PORT} ${CLI_PORT} ${SIGNER_HTTP_ADDR} ${SIGNER_CLI_HTTP_ADDR} ${OIDC_ISSUER} ${OIDC_AUDIENCE} ${JWT_PEM_PATH} ${APACHE_AUTH_JWT_LOG_LEVEL}'
-
-envsubst "$_envsubst_apache" < /etc/apache2/templates/ports.conf.in >/etc/apache2/ports.conf
 _enable_cli_listener="${SIGNER_DMZ_ENABLE_CLI_LISTENER:-1}"
 case "$_enable_cli_listener" in
   0 | false | FALSE | no | NO) _enable_cli_listener=0 ;;
   *) _enable_cli_listener=1 ;;
 esac
+
+# Dump the resolved DMZ auth context so 401s can be diagnosed by comparing this
+# to the claims on a minted token. Emitted on stderr (visible via `docker logs`).
+{
+  printf 'signer-dmz: auth config:\n'
+  printf '  SIGNER_DMZ_DISABLE_AUTH=%s\n' "$SIGNER_DMZ_DISABLE_AUTH"
+  if [ "$SIGNER_DMZ_DISABLE_AUTH" = "1" ]; then
+    printf '  JWT_VERIFICATION=disabled\n'
+  else
+    _pem_kids="(missing)"
+    if [ -r "$JWT_PEM_PATH" ]; then
+      _pem_kids="$(grep -c 'BEGIN PUBLIC KEY' "$JWT_PEM_PATH" 2>/dev/null || echo 0)"
+    fi
+    printf '  OIDC_ISSUER=%s\n' "$OIDC_ISSUER"
+    printf '  OIDC_AUDIENCE=%s\n' "$OIDC_AUDIENCE"
+    printf '  JWKS_URI=%s\n' "$JWKS_URI"
+    printf '  JWT_PEM_PATH=%s (public keys: %s)\n' "$JWT_PEM_PATH" "$_pem_kids"
+    printf '  APACHE_AUTH_JWT_LOG_LEVEL=%s\n' "$APACHE_AUTH_JWT_LOG_LEVEL"
+  fi
+  printf '  SIGNER_HTTP_ADDR=%s\n' "$SIGNER_HTTP_ADDR"
+  printf '  SIGNER_CLI_HTTP_ADDR=%s\n' "$SIGNER_CLI_HTTP_ADDR"
+  printf '  APACHE_PUBLIC_BIND=0.0.0.0:%s\n' "$PORT"
+  if [ "$_enable_cli_listener" = "1" ]; then
+    printf '  APACHE_CLI_BIND=0.0.0.0:%s (livepeer-cli: -http %s)\n' "$CLI_PORT" "$CLI_PORT"
+  fi
+} >&2
+
+if [ "$SIGNER_DMZ_DISABLE_AUTH" = "1" ]; then
+  _envsubst_apache='${PORT} ${CLI_PORT} ${SIGNER_HTTP_ADDR} ${SIGNER_CLI_HTTP_ADDR}'
+  _apache_main_tmpl=/etc/apache2/templates/signer-dmz-noauth.conf.in
+  _apache_cli_tmpl=/etc/apache2/templates/signer-dmz-cli-vhost-noauth.conf.in
+else
+  _envsubst_apache='${PORT} ${CLI_PORT} ${SIGNER_HTTP_ADDR} ${SIGNER_CLI_HTTP_ADDR} ${OIDC_ISSUER} ${OIDC_AUDIENCE} ${JWT_PEM_PATH} ${APACHE_AUTH_JWT_LOG_LEVEL}'
+  _apache_main_tmpl=/etc/apache2/templates/signer-dmz.conf.in
+  _apache_cli_tmpl=/etc/apache2/templates/signer-dmz-cli-vhost.conf.in
+fi
+
+envsubst "$_envsubst_apache" < /etc/apache2/templates/ports.conf.in >/etc/apache2/ports.conf
 if [ "$_enable_cli_listener" = "1" ]; then
   printf 'Listen 0.0.0.0:%s\n' "$CLI_PORT" >>/etc/apache2/ports.conf
 fi
 
-envsubst "$_envsubst_apache" < /etc/apache2/templates/signer-dmz.conf.in >/etc/apache2/sites-available/signer-dmz.conf
+envsubst "$_envsubst_apache" < "$_apache_main_tmpl" >/etc/apache2/sites-available/signer-dmz.conf
 if [ "$_enable_cli_listener" = "1" ]; then
-  envsubst "$_envsubst_apache" < /etc/apache2/templates/signer-dmz-cli-vhost.conf.in >>/etc/apache2/sites-available/signer-dmz.conf
+  envsubst "$_envsubst_apache" < "$_apache_cli_tmpl" >>/etc/apache2/sites-available/signer-dmz.conf
 fi
 
 # Do not use a2ensite/a2dissite as non-root: they touch /var/lib/apache2/site/enabled_by_admin/


### PR DESCRIPTION
## Summary

- Publish **CLI_PORT (8082)** in local compose so `livepeer_cli -http 8082` hits livepeer-cli routes at `/` (no `/__signer_cli` prefix).
- Add **`SIGNER_DMZ_DISABLE_AUTH=1`** for local development without JWKS sync or Apache JWT verification (noauth Apache templates).
- **`SIGNER_DMZ_ENABLE_CLI_LISTENER=0`** disables the dedicated CLI listener on single-port hosts (Railway).

Split from draft #126 (PR 2 of 6). No Turnkey bootstrap or Railway deploy changes.

## Test plan

- [ ] `docker compose up signer-dmz` — ports 8080 + 8082 published
- [ ] `curl http://127.0.0.1:8082/contractAddresses` returns JSON (with signer running)
- [ ] `SIGNER_DMZ_DISABLE_AUTH=1` — startup skips JWKS, `sign-orchestrator-info` works without bearer token
- [ ] Default path (auth enabled) — JWKS sync still required, JWT-protected routes return 401 without token
- [ ] Build image: `docker build -f docker/signer-dmz/Dockerfile -t pymthouse/signer-dmz:latest .`


Made with [Cursor](https://cursor.com)