### PR TITLE
chore: sync package.json version to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymthouse",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pymthouse",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymthouse",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

`package.json` has been stuck at `0.1.0` while releases were tagged manually — both `v0.2.0` and `v0.2.1` still carry `0.1.0` in their `package.json`. Since `release.yml` bumps the version from `package.json` (`npm version <bump>`), running it now would produce `v0.1.1`, which is **behind** the latest release `v0.2.1` and an out-of-order tag.

This syncs `package.json` (and `package-lock.json`) to the current released version `0.2.1` so the next `release.yml` run produces a correct forward version (`patch` → `v0.2.2`).

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->