### PR TITLE
fix(ci): release.yml pushes tag via RELEASE_PAT to trigger prod deploys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
 name: Release (bump + tag + deploy prod)
 
-# Bumps package.json version, commits to main, creates a v* tag and GitHub Release,
-# then deploys production (Railway + Vercel) via reusable workflow_call jobs.
+# Bumps package.json version, commits to main, creates a v* tag and GitHub Release.
+# Production then deploys automatically: the tag is pushed with RELEASE_PAT (not the
+# default GITHUB_TOKEN, whose pushes do NOT re-trigger workflows), so the `on: push:
+# tags: ['v*']` triggers on deploy-production-vercel.yml and deploy-railway-production.yml
+# fire on their own — each running in its own environment context so env-scoped secrets
+# resolve. No reusable workflow_call (which can't pass env secrets cleanly).
 #
-# Tags pushed by GITHUB_TOKEN do not re-trigger tag-listening workflows, so prod
-# deploys are invoked directly — no PAT needed.
+# Required secret: RELEASE_PAT — a fine-grained PAT with `contents: write` and
+# `workflows: write` on this repo (and allowed to push to main if it is protected).
 
 on:
   workflow_dispatch:
@@ -27,14 +31,16 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.bump.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          # Use the PAT so the tag push below is attributed to a user and the
+          # production deploy workflows' `on: push: tags` triggers fire.
+          token: ${{ secrets.RELEASE_PAT }}
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -59,15 +65,3 @@ jobs:
         run: gh release create "${{ steps.bump.outputs.tag }}" --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy-railway:
-    needs: release
-    uses: ./.github/workflows/deploy-railway-production.yml
-    with:
-      ref: ${{ needs.release.outputs.tag }}
-
-  deploy-vercel:
-    needs: release
-    uses: ./.github/workflows/deploy-production-vercel.yml
-    with:
-      ref: ${{ needs.release.outputs.tag }}

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -166,7 +166,9 @@ Point each Vercel tier’s `OPENMETER_URL` and `SIGNER_INTERNAL_URL` at the matc
 
 **CI `vercel build` and sensitive vars:** Vercel marks Preview/Production secrets as *sensitive* and does not export them via `vercel pull` for local or GitHub Actions builds ([Vercel docs](https://vercel.com/docs/environment-variables/sensitive-environment-variables)). Non-sensitive vars (`NEXTAUTH_URL`, signer URLs, etc.) appear in the pull; `NEXTAUTH_SECRET` and `AUTH_TOKEN_PEPPER` must also exist as GitHub environment secrets on `vercel / preview` and `vercel / production` so `validate:env` passes during CI. Runtime on deployed previews/production still resolves secrets from Vercel.
 
-**GitHub secret required for CI deploy:** `VERCEL_TOKEN` (same token used for CLI deploys).
+**GitHub secrets required for CI deploy:**
+- `VERCEL_TOKEN` (same token used for CLI deploys).
+- `RELEASE_PAT` (for [release.yml](../.github/workflows/release.yml)) — a fine-grained PAT with `contents: write` + `workflows: write` on this repo, allowed to push to `main`. `release.yml` pushes the version tag with this PAT so the production deploy workflows' `on: push: tags` triggers fire (tags pushed by the default `GITHUB_TOKEN` do **not** re-trigger workflows).
 
 **Enable deploy workflows** (after `VERCEL_TOKEN` is configured):
 
@@ -198,7 +200,9 @@ if [ "$VERCEL_GIT_COMMIT_REF" = "main" ]; then exit 0; else exit 1; fi
 # GitHub Actions → Release (bump + tag + deploy prod) → choose patch/minor/major
 ```
 
-Or push a tag manually: `git tag v0.1.1 && git push origin v0.1.1`
+`release.yml` bumps `package.json`, tags `v*`, and pushes the tag with `RELEASE_PAT`; the tag push then fires [deploy-production-vercel.yml](../.github/workflows/deploy-production-vercel.yml) and [deploy-railway-production.yml](../.github/workflows/deploy-railway-production.yml) via their `on: push: tags` triggers (each runs in its own environment so env-scoped secrets resolve).
+
+Or push a tag manually (any user push, not GITHUB_TOKEN, fires the deploys): `git tag v0.2.2 && git push origin v0.2.2`
 
 **Manual staging deploy** (paired Railway + Vercel):
 


### PR DESCRIPTION
## Summary

`release.yml`'s reusable `workflow_call` deploy jobs caused a **`startup_failure`** (confirmed on two dispatch attempts). GitHub rejects a called reusable workflow that references secrets which aren't declared in its `on.workflow_call.secrets` unless the caller uses `secrets: inherit` — and the production secrets are **environment-scoped** (`railway / production`, `vercel / production`), so explicit secret-passing couldn't resolve them through a reusable call anyway.

Rather than `secrets: inherit` (which trips the SonarCloud hotspot), this switches to the **PAT tag-trigger** pattern:

- `release.yml` checks out with `RELEASE_PAT` and pushes the version tag with it. Because the push is attributed to a real identity (not the default `GITHUB_TOKEN`, whose pushes don't re-trigger workflows), the existing `on: push: tags: ['v*']` triggers on `deploy-production-vercel.yml` and `deploy-railway-production.yml` fire on their own — each in its own environment context, so env-scoped secrets resolve natively.
- Drops the broken `deploy-railway` / `deploy-vercel` reusable jobs.

## Required before running

A new repo secret **`RELEASE_PAT`** — a fine-grained PAT with `contents: write` + `workflows: write` on this repo, allowed to push to `main` (if `main` is protected, the PAT identity must be permitted to push).

## Notes

- Merging this PR does **not** deploy anything: production workflows are `push: { tags: ['v*'] }` (tag-only), and `release.yml` is `workflow_dispatch`-only.
- `package.json` is already synced to `0.2.1` (#144), so `Release → patch` will produce `v0.2.2`.

## Test plan

- [ ] Add `RELEASE_PAT` secret.
- [ ] Run **Release → patch** → confirms `v0.2.2` tag + GitHub Release created.
- [ ] Confirm the tag push auto-triggers `deploy-production-vercel.yml` and `deploy-railway-production.yml`, both succeed, and `https://pymthouse.com` serves the new deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment workflow configuration and documentation to improve release automation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->