### PR TITLE
chore: sync package.json version to 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymthouse",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pymthouse",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymthouse",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

- Syncs `package.json` / `package-lock.json` from `0.2.1` → `0.2.2` to match the already-released `v0.2.2` tag.
- The manual release attempt left `package.json` behind while prod deployed successfully on the hand-pushed tag.

## Why

`release.yml` bumps from `package.json`. Without this sync, the next **Release → patch** would try to create `v0.2.2` again and fail on the existing tag.

## Test plan

- [ ] Merge — no deploy impact (prod workflows are tag-triggered only).
- [ ] After merge, **Release → patch** should produce `v0.2.3` cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->