### PR TITLE
feat(bpp): PYMT-OM seam hardening — neutral subscriptionRef + flag-gated ⑥ usage push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,20 @@ OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS=5000000
 # Billing API v2 (see src/lib/billing/feature-flags.ts)
 BILLING_PLANS_API_V2=true
 BILLING_STABLE_FEATURE_KEYS=true
+
+# ---------- BPP ⑥ neutral usage push (pymthouse → NaaP /metrics/ingest) ----------
+# Default OFF: the scheduled push (GET /api/v1/internal/usage-push, Vercel Cron)
+# is a strict no-op until this is flipped on AND NaaP's ingest endpoint + token
+# are provisioned. See src/lib/bpp/usage-ingest.ts and usage-push-job.ts.
+USAGE_INGEST_PUSH=false
+# NaaP base URL for the ⑥ ingest (https only unless ALLOW_INSECURE_HTTP=1).
+# NAAP_METRICS_URL=https://naap.example.com
+# Bearer token for the ⑥ ingest (never logged). Required when USAGE_INGEST_PUSH=1.
+# NAAP_METRICS_INGEST_TOKEN=
+# Lookback window (hours) for each scheduled push pass (default 24).
+# USAGE_INGEST_WINDOW_HOURS=24
+# Bearer secret the cron trigger must present (falls back to CRON_SECRET).
+# USAGE_PUSH_CRON_SECRET=
 # Authoritative metering path is Kafka -> collector -> OpenMeter.
 # Set to true only during dual-write validation windows.
 # ---------- Turnkey Wallet Kit (embedded wallets) ----------

--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,10 @@ USAGE_INGEST_PUSH=false
 # USAGE_INGEST_WINDOW_HOURS=24
 # Bearer secret the cron trigger must present (falls back to CRON_SECRET).
 # USAGE_PUSH_CRON_SECRET=
+# HMAC key for the OPAQUE BPP ② `subscriptionRef` (one-way; raw OpenMeter id is
+# unrecoverable from the ref). Min 32 chars. If unset, falls back to
+# AUTH_TOKEN_PEPPER with a one-time warning. Generate: openssl rand -base64 48
+# SUBSCRIPTION_REF_SECRET=
 # Authoritative metering path is Kafka -> collector -> OpenMeter.
 # Set to true only during dual-write validation windows.
 # ---------- Turnkey Wallet Kit (embedded wallets) ----------

--- a/src/app/api/v1/auth/validate/route.test.ts
+++ b/src/app/api/v1/auth/validate/route.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import type { OpenMeter } from "@openmeter/sdk";
+import { NextRequest } from "next/server";
+
+import { run } from "@/test-utils/db-guard";
+import { cleanupTestApp, seedDeveloperAppWithClient } from "@/test-utils/fixtures";
+import { db } from "@/db/index";
+import { apiKeys, planCapabilityBundles, plans, subscriptions } from "@/db/schema";
+import { hashToken } from "@/lib/auth";
+import { __setValidateAdminClientForTests } from "@/lib/openmeter/validate-admin-client";
+import { fromSubscriptionRef } from "@/lib/bpp/subscription-ref";
+
+/** Raw provider-internal OpenMeter subscription id that must NOT cross the ② seam. */
+const OPENMETER_SUBSCRIPTION_ULID = "01J8ZQ9X7K6M3N2P4R5S6T7U8V";
+
+/** Fake OpenMeter admin client: only `subscriptions.get` is exercised by validate. */
+function fakeActiveSubscriptionClient(): OpenMeter {
+  return {
+    subscriptions: {
+      get: async (id: string) => ({ id, status: "active" }),
+    },
+  } as unknown as OpenMeter;
+}
+
+run(
+  "subscription-backed legacy GET /auth/validate emits neutral subscriptionRef (no openmeter_subscription_id)",
+  async (t) => {
+    const { GET } = await import("./route");
+
+    const app = await seedDeveloperAppWithClient({ status: "approved" });
+    t.after(() => cleanupTestApp(app));
+
+    // Plan + capability the subscription-backed key resolves to.
+    const planId = `plan-${randomUUID()}`;
+    await db.insert(plans).values({
+      id: planId,
+      clientId: app.clientId,
+      name: `Validate Test Plan ${randomUUID().slice(0, 8)}`,
+      type: "paid",
+      status: "active",
+    });
+    await db.insert(planCapabilityBundles).values({
+      id: `pcb-${randomUUID()}`,
+      planId,
+      clientId: app.clientId,
+      pipeline: "text-to-image",
+      modelId: "sdxl",
+    });
+
+    // Legacy local subscription row carrying the OpenMeter pointer + plan.
+    const subscriptionId = `sub-${randomUUID()}`;
+    await db.insert(subscriptions).values({
+      id: subscriptionId,
+      clientId: app.clientId,
+      planId,
+      status: "active",
+      openmeterSubscriptionId: OPENMETER_SUBSCRIPTION_ULID,
+    });
+
+    // Subscription-backed API key (resolves through the OpenMeter branch).
+    const rawToken = `pmth_test_${randomUUID()}`;
+    await db.insert(apiKeys).values({
+      id: `key-${randomUUID()}`,
+      keyHash: hashToken(rawToken),
+      clientId: app.clientId,
+      subscriptionId,
+      status: "active",
+    });
+
+    __setValidateAdminClientForTests(() => ({
+      available: true,
+      client: fakeActiveSubscriptionClient(),
+    }));
+    t.after(() => __setValidateAdminClientForTests(null));
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/v1/auth/validate", {
+        headers: { Authorization: `Bearer ${rawToken}` },
+      }),
+    );
+
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    assert.equal(body.valid, true);
+    assert.equal(body.client_id, app.clientId);
+
+    // The neutral, opaque subscriptionRef is surfaced...
+    assert.equal(typeof body.subscriptionRef, "string");
+    const ref = body.subscriptionRef as string;
+    assert.match(ref, /^subref_/);
+    // ...and it is provider-decodable back to the internal id.
+    assert.equal(fromSubscriptionRef(ref), OPENMETER_SUBSCRIPTION_ULID);
+
+    // The provider-internal identifier never leaks — neither as a key...
+    assert.ok(!("openmeter_subscription_id" in body));
+    for (const key of Object.keys(body)) {
+      assert.ok(
+        !key.toLowerCase().startsWith("openmeter"),
+        `unexpected openmeter* key leaked: ${key}`,
+      );
+    }
+    // ...nor as a raw value anywhere in the response.
+    assert.ok(!JSON.stringify(body).includes(OPENMETER_SUBSCRIPTION_ULID));
+  },
+);

--- a/src/app/api/v1/auth/validate/route.test.ts
+++ b/src/app/api/v1/auth/validate/route.test.ts
@@ -10,7 +10,7 @@ import { db } from "@/db/index";
 import { apiKeys, planCapabilityBundles, plans, subscriptions } from "@/db/schema";
 import { hashToken } from "@/lib/auth";
 import { __setValidateAdminClientForTests } from "@/lib/openmeter/validate-admin-client";
-import { fromSubscriptionRef } from "@/lib/bpp/subscription-ref";
+import { subscriptionRefMatches } from "@/lib/bpp/subscription-ref";
 
 /** Raw provider-internal OpenMeter subscription id that must NOT cross the ② seam. */
 const OPENMETER_SUBSCRIPTION_ULID = "01J8ZQ9X7K6M3N2P4R5S6T7U8V";
@@ -91,8 +91,13 @@ run(
     assert.equal(typeof body.subscriptionRef, "string");
     const ref = body.subscriptionRef as string;
     assert.match(ref, /^subref_/);
-    // ...and it is provider-decodable back to the internal id.
-    assert.equal(fromSubscriptionRef(ref), OPENMETER_SUBSCRIPTION_ULID);
+    // ...it is NOT reversible to the raw OpenMeter id (true opacity)...
+    assert.notEqual(
+      Buffer.from(ref.slice("subref_".length), "base64url").toString("utf8"),
+      OPENMETER_SUBSCRIPTION_ULID,
+    );
+    // ...but pymthouse can still verify it against the known internal id.
+    assert.equal(subscriptionRefMatches(ref, OPENMETER_SUBSCRIPTION_ULID), true);
 
     // The provider-internal identifier never leaks — neither as a key...
     assert.ok(!("openmeter_subscription_id" in body));

--- a/src/app/api/v1/auth/validate/route.ts
+++ b/src/app/api/v1/auth/validate/route.ts
@@ -6,6 +6,7 @@ import { hashToken } from "@/lib/auth";
 import { getHostedAdminClient, isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
 import { resolveApiKeyOpenMeterSubscription } from "@/lib/openmeter/api-key-subscription";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
+import { buildValidateResponseBody } from "@/lib/bpp/validate-response";
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization") || "";
@@ -26,12 +27,13 @@ export async function GET(request: NextRequest) {
   }
 
   if (!apiKey.subscriptionId && !apiKey.openmeterSubscriptionId) {
-    return NextResponse.json({
-      valid: true,
-      client_id: apiKey.clientId,
-      plan: null,
-      allowedModels: [],
-    });
+    return NextResponse.json(
+      buildValidateResponseBody({
+        clientId: apiKey.clientId,
+        plan: null,
+        allowedModels: [],
+      }),
+    );
   }
 
   if (requireOpenMeterForUsageReads() && isHostedAdminClientAvailable()) {
@@ -44,13 +46,14 @@ export async function GET(request: NextRequest) {
     }
 
     if (!resolved.planId) {
-      return NextResponse.json({
-        valid: true,
-        client_id: apiKey.clientId,
-        plan: null,
-        allowedModels: [],
-        openmeter_subscription_id: resolved.openmeterSubscriptionId,
-      });
+      return NextResponse.json(
+        buildValidateResponseBody({
+          clientId: apiKey.clientId,
+          plan: null,
+          allowedModels: [],
+          openmeterSubscriptionId: resolved.openmeterSubscriptionId,
+        }),
+      );
     }
 
     const planRows = await db
@@ -68,17 +71,18 @@ export async function GET(request: NextRequest) {
       .from(planCapabilityBundles)
       .where(eq(planCapabilityBundles.planId, plan.id));
 
-    return NextResponse.json({
-      valid: true,
-      client_id: apiKey.clientId,
-      openmeter_subscription_id: resolved.openmeterSubscriptionId,
-      plan: {
-        ...plan,
-        includedUnits: plan.includedUnits != null ? plan.includedUnits.toString() : null,
-        overageRateUsd: plan.overageRateUsd ?? null,
-      },
-      allowedModels: capabilities.map((bundle) => bundle.modelId).filter(Boolean),
-    });
+    return NextResponse.json(
+      buildValidateResponseBody({
+        clientId: apiKey.clientId,
+        openmeterSubscriptionId: resolved.openmeterSubscriptionId,
+        plan: {
+          ...plan,
+          includedUnits: plan.includedUnits != null ? plan.includedUnits.toString() : null,
+          overageRateUsd: plan.overageRateUsd ?? null,
+        },
+        allowedModels: capabilities.map((bundle) => bundle.modelId).filter(Boolean),
+      }),
+    );
   }
 
   // Hard cutover: subscription-backed API keys require OpenMeter to validate.

--- a/src/app/api/v1/auth/validate/route.ts
+++ b/src/app/api/v1/auth/validate/route.ts
@@ -3,9 +3,8 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/index";
 import { apiKeys, planCapabilityBundles, plans } from "@/db/schema";
 import { hashToken } from "@/lib/auth";
-import { getHostedAdminClient, isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
 import { resolveApiKeyOpenMeterSubscription } from "@/lib/openmeter/api-key-subscription";
-import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
+import { resolveValidateAdminClient } from "@/lib/openmeter/validate-admin-client";
 import { buildValidateResponseBody } from "@/lib/bpp/validate-response";
 
 export async function GET(request: NextRequest) {
@@ -36,10 +35,11 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  if (requireOpenMeterForUsageReads() && isHostedAdminClientAvailable()) {
+  const adminClient = resolveValidateAdminClient();
+  if (adminClient) {
     const resolved = await resolveApiKeyOpenMeterSubscription({
       apiKey,
-      client: getHostedAdminClient(),
+      client: adminClient,
     });
     if (!resolved) {
       return NextResponse.json({ valid: false }, { status: 401 });

--- a/src/app/api/v1/internal/usage-push/route.test.ts
+++ b/src/app/api/v1/internal/usage-push/route.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { NextRequest } from "next/server";
+
+const CRON_SECRET = "cron-secret-value";
+
+function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<void> | void,
+): Promise<void> | void {
+  const keys = Object.keys(overrides);
+  const previous = new Map(keys.map((k) => [k, process.env[k]]));
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  const restore = () => {
+    for (const k of keys) {
+      const prev = previous.get(k);
+      if (prev === undefined) delete process.env[k];
+      else process.env[k] = prev;
+    }
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      return result.finally(restore);
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
+  }
+}
+
+function cronRequest(token?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (token !== undefined) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return new NextRequest("http://localhost/api/v1/internal/usage-push", { headers });
+}
+
+test("usage-push cron rejects callers without the configured secret", async () => {
+  await withEnv(
+    { USAGE_PUSH_CRON_SECRET: CRON_SECRET, CRON_SECRET: undefined, USAGE_INGEST_PUSH: undefined },
+    async () => {
+      const { GET } = await import("./route");
+
+      const noAuth = await GET(cronRequest());
+      assert.equal(noAuth.status, 401);
+
+      const wrong = await GET(cronRequest("nope"));
+      assert.equal(wrong.status, 401);
+    },
+  );
+});
+
+test("usage-push cron is an inert no-op when USAGE_INGEST_PUSH is OFF", async () => {
+  await withEnv(
+    { USAGE_PUSH_CRON_SECRET: CRON_SECRET, CRON_SECRET: undefined, USAGE_INGEST_PUSH: undefined },
+    async () => {
+      const { GET } = await import("./route");
+
+      const res = await GET(cronRequest(CRON_SECRET));
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.ok, true);
+      assert.equal(body.enabled, false);
+      assert.equal(body.attempted, 0);
+      assert.equal(body.window, null);
+    },
+  );
+});

--- a/src/app/api/v1/internal/usage-push/route.test.ts
+++ b/src/app/api/v1/internal/usage-push/route.test.ts
@@ -3,37 +3,9 @@ import assert from "node:assert/strict";
 
 import { NextRequest } from "next/server";
 
-const CRON_SECRET = "cron-secret-value";
+import { withEnv } from "@/test-utils/env";
 
-function withEnv(
-  overrides: Record<string, string | undefined>,
-  fn: () => Promise<void> | void,
-): Promise<void> | void {
-  const keys = Object.keys(overrides);
-  const previous = new Map(keys.map((k) => [k, process.env[k]]));
-  for (const [k, v] of Object.entries(overrides)) {
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
-  }
-  const restore = () => {
-    for (const k of keys) {
-      const prev = previous.get(k);
-      if (prev === undefined) delete process.env[k];
-      else process.env[k] = prev;
-    }
-  };
-  try {
-    const result = fn();
-    if (result instanceof Promise) {
-      return result.finally(restore);
-    }
-    restore();
-    return result;
-  } catch (error) {
-    restore();
-    throw error;
-  }
-}
+const CRON_SECRET = "cron-secret-value";
 
 function cronRequest(token?: string): NextRequest {
   const headers: Record<string, string> = {};

--- a/src/app/api/v1/internal/usage-push/route.ts
+++ b/src/app/api/v1/internal/usage-push/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+
+import { runUsageIngestPushJob } from "@/lib/bpp/usage-push-job";
+
+/** Cron route: always runs dynamically (reads request headers, hits the DB). */
+export const dynamic = "force-dynamic";
+
+/**
+ * Constant-time secret comparison. Both inputs are operator-configured (not user
+ * input), but a timing-safe compare avoids leaking the secret length/prefix.
+ */
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Authorize the scheduled trigger. Accepts the Vercel Cron bearer
+ * (`USAGE_PUSH_CRON_SECRET`, falling back to the platform `CRON_SECRET`). When
+ * no secret is configured, allow only outside production — same posture as the
+ * internal signed-ticket ingest route.
+ */
+function authorizeCron(request: NextRequest): boolean {
+  const expected =
+    process.env.USAGE_PUSH_CRON_SECRET?.trim() || process.env.CRON_SECRET?.trim();
+  if (!expected) {
+    return process.env.NODE_ENV !== "production";
+  }
+  const auth = request.headers.get("authorization") || "";
+  if (!auth.startsWith("Bearer ")) {
+    return false;
+  }
+  return secretsMatch(auth.slice(7).trim(), expected);
+}
+
+/**
+ * Scheduled BPP ⑥ usage push (Vercel Cron). Gated behind `USAGE_INGEST_PUSH`
+ * (default OFF): when the flag is off the job is a strict no-op and this route
+ * returns `{ ok: true, enabled: false }` without touching the DB or network, so
+ * the scheduler stays green while the seam is dormant.
+ */
+export async function GET(request: NextRequest) {
+  if (!authorizeCron(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const correlationId = request.headers.get("x-request-id") || undefined;
+
+  try {
+    const summary = await runUsageIngestPushJob({ correlationId });
+    return NextResponse.json({ ok: true, ...summary });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.name : "usage_push_failed",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/billing/feature-flags.ts
+++ b/src/lib/billing/feature-flags.ts
@@ -17,3 +17,12 @@ export function billingPlansApiV2Enabled(): boolean {
 export function billingStableFeatureKeysEnabled(): boolean {
   return envFlag("BILLING_STABLE_FEATURE_KEYS", true);
 }
+
+/**
+ * Gate the neutral BPP ⑥ usage push (pymthouse → NaaP `/metrics/ingest`).
+ * Default OFF: flag-off is a strict no-op (zero regression). Flip
+ * `USAGE_INGEST_PUSH=1` once NaaP's ingest endpoint + token are provisioned.
+ */
+export function usageIngestPushEnabled(): boolean {
+  return envFlag("USAGE_INGEST_PUSH", false);
+}

--- a/src/lib/bpp/forbidden-fields.test.ts
+++ b/src/lib/bpp/forbidden-fields.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  FORBIDDEN_INTERNAL_FIELD_NAMES,
+  assertNoLeakedInternalFieldNames,
+  findLeakedInternalFieldNames,
+} from "./forbidden-fields";
+
+test("the forbidden list mirrors the C0 provider-internal-openmeter contract", () => {
+  // Keep in sync with contracts/billing-provider-protocol/provider-internal-openmeter.schema.json
+  const expected = [
+    "openmeter_subscription_id",
+    "openmeter_customer_id",
+    "network_fee_usd_micros",
+    "fee_wei",
+    "eth_usd_price",
+    "eth_usd_round_id",
+    "eth_usd_observed_at",
+    "external_user_id",
+    "client_id",
+    "model_id",
+    "gateway_request_id",
+    "specversion",
+  ];
+  assert.deepEqual([...FORBIDDEN_INTERNAL_FIELD_NAMES].sort(), [...expected].sort());
+});
+
+test("findLeakedInternalFieldNames detects nested provider-internal keys", () => {
+  const leaked = findLeakedInternalFieldNames({
+    valid: true,
+    data: { nested: [{ openmeter_subscription_id: "01J..." }] },
+  });
+  assert.deepEqual(leaked, ["openmeter_subscription_id"]);
+});
+
+test("findLeakedInternalFieldNames ignores neutral string values", () => {
+  // A capability id value that contains a model name is fine — only KEYS matter.
+  const leaked = findLeakedInternalFieldNames({
+    byCapability: { "text-to-image:model_id-lookalike": { tickets: 1 } },
+  });
+  assert.deepEqual(leaked, []);
+});
+
+test("assertNoLeakedInternalFieldNames throws on a leak and passes when clean", () => {
+  assert.throws(
+    () => assertNoLeakedInternalFieldNames({ fee_wei: "1" }, "test"),
+    /seam isolation violation \(test\)/,
+  );
+  assert.doesNotThrow(() =>
+    assertNoLeakedInternalFieldNames({ providerSlug: "pymthouse" }, "test"),
+  );
+});

--- a/src/lib/bpp/forbidden-fields.test.ts
+++ b/src/lib/bpp/forbidden-fields.test.ts
@@ -23,7 +23,11 @@ test("the forbidden list mirrors the C0 provider-internal-openmeter contract", (
     "gateway_request_id",
     "specversion",
   ];
-  assert.deepEqual([...FORBIDDEN_INTERNAL_FIELD_NAMES].sort(), [...expected].sort());
+  const byName = (a: string, b: string) => a.localeCompare(b);
+  assert.deepEqual(
+    [...FORBIDDEN_INTERNAL_FIELD_NAMES].sort(byName),
+    [...expected].sort(byName),
+  );
 });
 
 test("findLeakedInternalFieldNames detects nested provider-internal keys", () => {

--- a/src/lib/bpp/forbidden-fields.ts
+++ b/src/lib/bpp/forbidden-fields.ts
@@ -1,0 +1,72 @@
+/**
+ * BPP seam isolation — provider-internal field-name guard.
+ *
+ * pymthouse meters internally with OpenMeter / Kong Konnect (BPP ⑨). Those
+ * provider-internal field names MUST NEVER cross a NaaP-facing BPP seam — neither
+ * the ② `validate` response nor the ⑥ usage-ingest push. NaaP must stay agnostic
+ * of the metering backend.
+ *
+ * This list mirrors `x-bpp-forbidden-field-names` in
+ * `contracts/billing-provider-protocol/provider-internal-openmeter.schema.json`
+ * (the C0 contract). The conformance suite on the NaaP side rejects any payload
+ * containing these names; this module lets pymthouse assert the same invariant at
+ * the producing edge (defense in depth) and in unit tests.
+ */
+
+/**
+ * Provider-internal field names that MUST NOT appear on a BPP seam.
+ * Kept in sync with the C0 `provider-internal-openmeter.schema.json`.
+ */
+export const FORBIDDEN_INTERNAL_FIELD_NAMES: readonly string[] = [
+  "openmeter_subscription_id",
+  "openmeter_customer_id",
+  "network_fee_usd_micros",
+  "fee_wei",
+  "eth_usd_price",
+  "eth_usd_round_id",
+  "eth_usd_observed_at",
+  "external_user_id",
+  "client_id",
+  "model_id",
+  "gateway_request_id",
+  "specversion",
+];
+
+const FORBIDDEN_SET = new Set(FORBIDDEN_INTERNAL_FIELD_NAMES);
+
+/**
+ * Recursively collect any provider-internal field NAMES present as object keys in
+ * `value`. Only keys are inspected — neutral string values (e.g. a
+ * `"text-to-image:sdxl"` capability id) are allowed.
+ */
+export function findLeakedInternalFieldNames(
+  value: unknown,
+  acc: Set<string> = new Set(),
+): string[] {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      findLeakedInternalFieldNames(item, acc);
+    }
+  } else if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (FORBIDDEN_SET.has(key)) {
+        acc.add(key);
+      }
+      findLeakedInternalFieldNames(child, acc);
+    }
+  }
+  return [...acc];
+}
+
+/**
+ * Throw if `value` contains any provider-internal field name. Used as a
+ * producing-edge guard before a payload leaves pymthouse on a BPP seam.
+ */
+export function assertNoLeakedInternalFieldNames(value: unknown, context: string): void {
+  const leaked = findLeakedInternalFieldNames(value);
+  if (leaked.length > 0) {
+    throw new Error(
+      `BPP seam isolation violation (${context}): provider-internal field names leaked: ${leaked.join(", ")}`,
+    );
+  }
+}

--- a/src/lib/bpp/subscription-ref.test.ts
+++ b/src/lib/bpp/subscription-ref.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { fromSubscriptionRef, toSubscriptionRef } from "./subscription-ref";
+import { subscriptionRefMatches, toSubscriptionRef } from "./subscription-ref";
 
 const OPENMETER_ULID = "01J8ZQ9X7K6M3N2P4R5S6T7U8V";
 
@@ -18,9 +18,32 @@ test("toSubscriptionRef is deterministic / stable", () => {
   assert.equal(toSubscriptionRef(OPENMETER_ULID), toSubscriptionRef(OPENMETER_ULID));
 });
 
-test("subscriptionRef round-trips back to the internal id", () => {
+test("the opaque ref is NOT reversible to the raw OpenMeter id", () => {
   const ref = toSubscriptionRef(OPENMETER_ULID);
-  assert.equal(fromSubscriptionRef(ref), OPENMETER_ULID);
+  assert.ok(ref);
+  const token = ref.slice("subref_".length);
+  // A base64url-decode of the token (the old, weak scheme) must NOT yield the id.
+  const decodedUtf8 = Buffer.from(token, "base64url").toString("utf8");
+  assert.notEqual(decodedUtf8, OPENMETER_ULID);
+  assert.ok(!decodedUtf8.includes(OPENMETER_ULID));
+  // And the id is not embedded in any hex/base64 view of the token either.
+  assert.ok(!Buffer.from(token, "base64url").toString("hex").includes(
+    Buffer.from(OPENMETER_ULID, "utf8").toString("hex"),
+  ));
+});
+
+test("distinct internal ids map to distinct refs", () => {
+  assert.notEqual(
+    toSubscriptionRef(OPENMETER_ULID),
+    toSubscriptionRef("01J8ZZZZZZZZZZZZZZZZZZZZZZ"),
+  );
+});
+
+test("subscriptionRefMatches verifies a ref against the known internal id", () => {
+  const ref = toSubscriptionRef(OPENMETER_ULID);
+  assert.equal(subscriptionRefMatches(ref, OPENMETER_ULID), true);
+  // Wrong candidate id does not match.
+  assert.equal(subscriptionRefMatches(ref, "01J8ZZZZZZZZZZZZZZZZZZZZZZ"), false);
 });
 
 test("toSubscriptionRef returns null for empty/blank input", () => {
@@ -30,9 +53,10 @@ test("toSubscriptionRef returns null for empty/blank input", () => {
   assert.equal(toSubscriptionRef("   "), null);
 });
 
-test("fromSubscriptionRef rejects missing or malformed refs", () => {
-  assert.equal(fromSubscriptionRef(null), null);
-  assert.equal(fromSubscriptionRef(""), null);
-  assert.equal(fromSubscriptionRef("not-a-ref"), null);
-  assert.equal(fromSubscriptionRef("subref_"), null);
+test("subscriptionRefMatches rejects missing or malformed refs", () => {
+  assert.equal(subscriptionRefMatches(null, OPENMETER_ULID), false);
+  assert.equal(subscriptionRefMatches("", OPENMETER_ULID), false);
+  assert.equal(subscriptionRefMatches("not-a-ref", OPENMETER_ULID), false);
+  assert.equal(subscriptionRefMatches("subref_", OPENMETER_ULID), false);
+  assert.equal(subscriptionRefMatches(toSubscriptionRef(OPENMETER_ULID), null), false);
 });

--- a/src/lib/bpp/subscription-ref.test.ts
+++ b/src/lib/bpp/subscription-ref.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { fromSubscriptionRef, toSubscriptionRef } from "./subscription-ref";
+
+const OPENMETER_ULID = "01J8ZQ9X7K6M3N2P4R5S6T7U8V";
+
+test("toSubscriptionRef produces a neutral, opaque, prefixed token", () => {
+  const ref = toSubscriptionRef(OPENMETER_ULID);
+  assert.ok(ref);
+  assert.match(ref, /^subref_/);
+  // The raw OpenMeter id must not be observable in the neutral ref.
+  assert.ok(!ref.includes(OPENMETER_ULID));
+  assert.ok(!ref.toLowerCase().includes("openmeter"));
+});
+
+test("toSubscriptionRef is deterministic / stable", () => {
+  assert.equal(toSubscriptionRef(OPENMETER_ULID), toSubscriptionRef(OPENMETER_ULID));
+});
+
+test("subscriptionRef round-trips back to the internal id", () => {
+  const ref = toSubscriptionRef(OPENMETER_ULID);
+  assert.equal(fromSubscriptionRef(ref), OPENMETER_ULID);
+});
+
+test("toSubscriptionRef returns null for empty/blank input", () => {
+  assert.equal(toSubscriptionRef(null), null);
+  assert.equal(toSubscriptionRef(undefined), null);
+  assert.equal(toSubscriptionRef(""), null);
+  assert.equal(toSubscriptionRef("   "), null);
+});
+
+test("fromSubscriptionRef rejects missing or malformed refs", () => {
+  assert.equal(fromSubscriptionRef(null), null);
+  assert.equal(fromSubscriptionRef(""), null);
+  assert.equal(fromSubscriptionRef("not-a-ref"), null);
+  assert.equal(fromSubscriptionRef("subref_"), null);
+});

--- a/src/lib/bpp/subscription-ref.ts
+++ b/src/lib/bpp/subscription-ref.ts
@@ -47,7 +47,7 @@ export function toSubscriptionRef(internalSubscriptionId: string | null | undefi
  */
 export function fromSubscriptionRef(subscriptionRef: string | null | undefined): string | null {
   const trimmed = subscriptionRef?.trim();
-  if (!trimmed || !trimmed.startsWith(SUBSCRIPTION_REF_PREFIX)) {
+  if (!trimmed?.startsWith(SUBSCRIPTION_REF_PREFIX)) {
     return null;
   }
   const encoded = trimmed.slice(SUBSCRIPTION_REF_PREFIX.length);

--- a/src/lib/bpp/subscription-ref.ts
+++ b/src/lib/bpp/subscription-ref.ts
@@ -1,0 +1,63 @@
+/**
+ * Neutral, provider-opaque `subscriptionRef` for the BPP ② `validate` seam.
+ *
+ * Background: PR #133 made `validate` OpenMeter-authoritative and (incorrectly)
+ * returned the raw `openmeter_subscription_id` — a provider-internal identifier
+ * leaking across the BPP boundary. Per the C0 `validate.schema.json`, providers
+ * may surface an OPTIONAL `subscriptionRef`: a neutral opaque pointer whose
+ * meaning is decided by the provider and which MUST NOT encode a
+ * provider-internal identifier name.
+ *
+ * Design:
+ *  - The field name (`subscriptionRef`) is provider-neutral.
+ *  - The VALUE is an opaque, stable, provider-decodable token — `subref_` +
+ *    base64url(internal id) — so NaaP never observes the raw OpenMeter ULID and
+ *    cannot infer the metering backend from it.
+ *  - This is opacity, NOT secrecy: the encoding is reversible by design so
+ *    pymthouse can map a `subscriptionRef` back to its OpenMeter subscription if
+ *    a future inbound seam needs it. It carries no secret material.
+ */
+
+const SUBSCRIPTION_REF_PREFIX = "subref_";
+
+function toBase64Url(input: string): string {
+  return Buffer.from(input, "utf8").toString("base64url");
+}
+
+function fromBase64Url(input: string): string {
+  return Buffer.from(input, "base64url").toString("utf8");
+}
+
+/**
+ * Encode a provider-internal subscription id into a neutral, opaque
+ * `subscriptionRef`. Returns `null` for empty/blank input so callers can omit
+ * the optional field entirely.
+ */
+export function toSubscriptionRef(internalSubscriptionId: string | null | undefined): string | null {
+  const trimmed = internalSubscriptionId?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return `${SUBSCRIPTION_REF_PREFIX}${toBase64Url(trimmed)}`;
+}
+
+/**
+ * Decode a neutral `subscriptionRef` back into the provider-internal
+ * subscription id. Returns `null` if the ref is missing or malformed.
+ */
+export function fromSubscriptionRef(subscriptionRef: string | null | undefined): string | null {
+  const trimmed = subscriptionRef?.trim();
+  if (!trimmed || !trimmed.startsWith(SUBSCRIPTION_REF_PREFIX)) {
+    return null;
+  }
+  const encoded = trimmed.slice(SUBSCRIPTION_REF_PREFIX.length);
+  if (!encoded) {
+    return null;
+  }
+  try {
+    const decoded = fromBase64Url(encoded);
+    return decoded || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/bpp/subscription-ref.ts
+++ b/src/lib/bpp/subscription-ref.ts
@@ -1,5 +1,5 @@
 /**
- * Neutral, provider-opaque `subscriptionRef` for the BPP ② `validate` seam.
+ * Neutral, provider-OPAQUE `subscriptionRef` for the BPP ② `validate` seam.
  *
  * Background: PR #133 made `validate` OpenMeter-authoritative and (incorrectly)
  * returned the raw `openmeter_subscription_id` — a provider-internal identifier
@@ -8,56 +8,126 @@
  * meaning is decided by the provider and which MUST NOT encode a
  * provider-internal identifier name.
  *
- * Design:
+ * Design (audit C-2 — true opacity):
  *  - The field name (`subscriptionRef`) is provider-neutral.
- *  - The VALUE is an opaque, stable, provider-decodable token — `subref_` +
- *    base64url(internal id) — so NaaP never observes the raw OpenMeter ULID and
- *    cannot infer the metering backend from it.
- *  - This is opacity, NOT secrecy: the encoding is reversible by design so
- *    pymthouse can map a `subscriptionRef` back to its OpenMeter subscription if
- *    a future inbound seam needs it. It carries no secret material.
+ *  - The VALUE is a one-way, keyed token — `subref_` +
+ *    base64url(HMAC_SHA256(secret, "context\0" + internalId)) — truncated to a
+ *    sane length. It is **opaque, NOT reversible**: a client cannot derive the
+ *    raw OpenMeter id from the ref (no key, and HMAC is one-way even with the
+ *    key). This replaces the previous base64url encoding, which was trivially
+ *    reversible by anyone.
+ *  - It is deterministic/stable: the same internal id always maps to the same
+ *    ref (good for correlation / idempotency).
+ *  - Resolution where pymthouse legitimately needs it: pymthouse owns the
+ *    subscription store, so it resolves a presented ref by **verifying** it
+ *    against candidate internal ids it already holds, via
+ *    {@link subscriptionRefMatches} (constant-time). Blind `ref → id` reversal
+ *    is intentionally NOT possible. If a future inbound seam ever needs O(1)
+ *    blind resolution, add a minimal expand-only lookup table populated at mint
+ *    time — no schema change is required today.
+ *
+ * Key material: `SUBSCRIPTION_REF_SECRET` (preferred). When unset/too short it
+ * falls back to `AUTH_TOKEN_PEPPER` (already required on every `validate` path)
+ * with a one-time warning, so existing deployments keep working without new env.
+ * Domain separation (`HMAC_CONTEXT`) keeps these digests disjoint from the
+ * token-hashing use of the same pepper.
  */
 
+import { createHmac, timingSafeEqual } from "node:crypto";
+
 const SUBSCRIPTION_REF_PREFIX = "subref_";
+/** Domain-separation label so the digest can never collide with other HMAC uses of the key. */
+const HMAC_CONTEXT = "bpp:subscription-ref:v1";
+/** base64url chars of the digest to keep (~192 bits — ample collision resistance). */
+const REF_TOKEN_LENGTH = 32;
+const MIN_SECRET_LENGTH = 32;
 
-function toBase64Url(input: string): string {
-  return Buffer.from(input, "utf8").toString("base64url");
-}
+let warnedAboutSecretFallback = false;
 
-function fromBase64Url(input: string): string {
-  return Buffer.from(input, "base64url").toString("utf8");
+function warnOnce(event: string, reason: string): void {
+  if (warnedAboutSecretFallback) {
+    return;
+  }
+  warnedAboutSecretFallback = true;
+  console.warn(JSON.stringify({ level: "warn", event, reason }));
 }
 
 /**
- * Encode a provider-internal subscription id into a neutral, opaque
- * `subscriptionRef`. Returns `null` for empty/blank input so callers can omit
- * the optional field entirely.
+ * Resolve the HMAC key for the opaque ref. Prefers `SUBSCRIPTION_REF_SECRET`;
+ * falls back to the (always-present on validate) `AUTH_TOKEN_PEPPER` with a
+ * one-time warning. Throws only when neither high-entropy secret is available —
+ * matching the repo's `AUTH_TOKEN_PEPPER` "fail-closed" convention.
  */
-export function toSubscriptionRef(internalSubscriptionId: string | null | undefined): string | null {
+function loadSubscriptionRefSecret(): string {
+  const dedicated = process.env.SUBSCRIPTION_REF_SECRET?.trim();
+  if (dedicated && dedicated.length >= MIN_SECRET_LENGTH) {
+    return dedicated;
+  }
+  if (dedicated) {
+    warnOnce(
+      "bpp.subscription_ref.weak_secret",
+      `SUBSCRIPTION_REF_SECRET is shorter than ${MIN_SECRET_LENGTH} chars; falling back to AUTH_TOKEN_PEPPER`,
+    );
+  } else {
+    warnOnce(
+      "bpp.subscription_ref.secret_fallback",
+      "SUBSCRIPTION_REF_SECRET not set; deriving the opaque subscriptionRef key from AUTH_TOKEN_PEPPER",
+    );
+  }
+
+  const pepper = process.env.AUTH_TOKEN_PEPPER?.trim();
+  if (!pepper || pepper.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `SUBSCRIPTION_REF_SECRET (or AUTH_TOKEN_PEPPER) is required (min ${MIN_SECRET_LENGTH} chars) ` +
+        "to mint an opaque subscriptionRef.",
+    );
+  }
+  return pepper;
+}
+
+function computeOpaqueToken(internalId: string): string {
+  return createHmac("sha256", loadSubscriptionRefSecret())
+    .update(HMAC_CONTEXT)
+    .update("\x00")
+    .update(internalId)
+    .digest("base64url")
+    .slice(0, REF_TOKEN_LENGTH);
+}
+
+/**
+ * Encode a provider-internal subscription id into a neutral, OPAQUE (one-way)
+ * `subscriptionRef`. Returns `null` for empty/blank input so callers can omit
+ * the optional field entirely. The raw id is NOT recoverable from the result.
+ */
+export function toSubscriptionRef(
+  internalSubscriptionId: string | null | undefined,
+): string | null {
   const trimmed = internalSubscriptionId?.trim();
   if (!trimmed) {
     return null;
   }
-  return `${SUBSCRIPTION_REF_PREFIX}${toBase64Url(trimmed)}`;
+  return `${SUBSCRIPTION_REF_PREFIX}${computeOpaqueToken(trimmed)}`;
 }
 
 /**
- * Decode a neutral `subscriptionRef` back into the provider-internal
- * subscription id. Returns `null` if the ref is missing or malformed.
+ * Verify (constant-time) that an opaque `subscriptionRef` corresponds to a known
+ * provider-internal subscription id. This is how pymthouse resolves a presented
+ * ref against candidates it already owns, since the ref cannot be reversed.
+ * Returns `false` for any missing/blank/mismatched input.
  */
-export function fromSubscriptionRef(subscriptionRef: string | null | undefined): string | null {
-  const trimmed = subscriptionRef?.trim();
-  if (!trimmed?.startsWith(SUBSCRIPTION_REF_PREFIX)) {
-    return null;
+export function subscriptionRefMatches(
+  subscriptionRef: string | null | undefined,
+  internalSubscriptionId: string | null | undefined,
+): boolean {
+  const provided = subscriptionRef?.trim();
+  const expected = toSubscriptionRef(internalSubscriptionId);
+  if (!provided || !expected) {
+    return false;
   }
-  const encoded = trimmed.slice(SUBSCRIPTION_REF_PREFIX.length);
-  if (!encoded) {
-    return null;
+  const a = Buffer.from(provided, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length) {
+    return false;
   }
-  try {
-    const decoded = fromBase64Url(encoded);
-    return decoded || null;
-  } catch {
-    return null;
-  }
+  return timingSafeEqual(a, b);
 }

--- a/src/lib/bpp/usage-ingest.test.ts
+++ b/src/lib/bpp/usage-ingest.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./usage-ingest";
 import { findLeakedInternalFieldNames } from "./forbidden-fields";
 import type { OpenMeterPipelineModelRow } from "@/lib/openmeter/usage-read";
+import { withEnv } from "@/test-utils/env";
 
 const PIPELINE_ROWS: OpenMeterPipelineModelRow[] = [
   { pipeline: "text-to-image", modelId: "sdxl", requestCount: 3, networkFeeUsdMicros: "1500" },
@@ -104,36 +105,6 @@ const VALID_PAYLOAD: UsageIngestPayload = {
   tickets: 1,
   networkFeeUsdMicros: "100",
 };
-
-function withEnv(
-  overrides: Record<string, string | undefined>,
-  fn: () => Promise<void> | void,
-): Promise<void> | void {
-  const keys = Object.keys(overrides);
-  const previous = new Map(keys.map((k) => [k, process.env[k]]));
-  for (const [k, v] of Object.entries(overrides)) {
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
-  }
-  const restore = () => {
-    for (const k of keys) {
-      const prev = previous.get(k);
-      if (prev === undefined) delete process.env[k];
-      else process.env[k] = prev;
-    }
-  };
-  try {
-    const result = fn();
-    if (result instanceof Promise) {
-      return result.finally(restore);
-    }
-    restore();
-    return result;
-  } catch (error) {
-    restore();
-    throw error;
-  }
-}
 
 test("pushUsageIngest is a strict no-op when the flag is OFF (no network call)", async () => {
   await withEnv(

--- a/src/lib/bpp/usage-ingest.test.ts
+++ b/src/lib/bpp/usage-ingest.test.ts
@@ -1,0 +1,241 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildUsageIngestPayload,
+  pushUsageIngest,
+  type UsageIngestPayload,
+} from "./usage-ingest";
+import { findLeakedInternalFieldNames } from "./forbidden-fields";
+import type { OpenMeterPipelineModelRow } from "@/lib/openmeter/usage-read";
+
+const PIPELINE_ROWS: OpenMeterPipelineModelRow[] = [
+  { pipeline: "text-to-image", modelId: "sdxl", requestCount: 3, networkFeeUsdMicros: "1500" },
+  { pipeline: "text-to-video", modelId: "ltx", requestCount: 2, networkFeeUsdMicros: "4000" },
+  { pipeline: "text-to-image", modelId: "sdxl", requestCount: 1, networkFeeUsdMicros: "500" },
+];
+
+const WINDOW = { from: "2026-06-01T00:00:00.000Z", to: "2026-06-17T00:00:00.000Z" };
+
+const DECIMAL = /^[0-9]+$/;
+
+/** Assert a payload conforms to the C0 usage-ingest schema constraints. */
+function assertConformsToC0(payload: UsageIngestPayload): void {
+  assert.equal(typeof payload.providerSlug, "string");
+  assert.ok(payload.providerSlug.length >= 1);
+  assert.equal(typeof payload.accountId, "string");
+  assert.ok(payload.accountId.length >= 1);
+  assert.ok(!Number.isNaN(Date.parse(payload.window.from)));
+  assert.ok(!Number.isNaN(Date.parse(payload.window.to)));
+  if (payload.tickets !== undefined) {
+    assert.ok(Number.isInteger(payload.tickets) && payload.tickets >= 0);
+  }
+  if (payload.networkFeeUsdMicros !== undefined) {
+    assert.match(payload.networkFeeUsdMicros, DECIMAL);
+  }
+  if (payload.feeWei !== undefined) {
+    assert.match(payload.feeWei, DECIMAL);
+  }
+  for (const [capId, usage] of Object.entries(payload.byCapability ?? {})) {
+    assert.match(capId, /^[^:]+:[^:]+$/, "capability id must be <pipeline>:<model>");
+    if (usage.tickets !== undefined) {
+      assert.ok(Number.isInteger(usage.tickets) && usage.tickets >= 0);
+    }
+    if (usage.networkFeeUsdMicros !== undefined) {
+      assert.match(usage.networkFeeUsdMicros, DECIMAL);
+    }
+  }
+  // Seam isolation: no provider-internal (OpenMeter) field names anywhere.
+  assert.deepEqual(findLeakedInternalFieldNames(payload), []);
+}
+
+test("buildUsageIngestPayload maps internal rows into a C0-conformant neutral payload", () => {
+  const payload = buildUsageIngestPayload({
+    providerSlug: "pymthouse",
+    accountId: "acct_om_42",
+    appId: "app_123",
+    window: WINDOW,
+    pipelineModelRows: PIPELINE_ROWS,
+  });
+
+  assertConformsToC0(payload);
+  assert.equal(payload.appId, "app_123");
+  assert.equal(payload.tickets, 6);
+  assert.equal(payload.networkFeeUsdMicros, "6000");
+  // Same pipeline:model rows are aggregated.
+  assert.deepEqual(payload.byCapability?.["text-to-image:sdxl"], {
+    tickets: 4,
+    networkFeeUsdMicros: "2000",
+  });
+  assert.deepEqual(payload.byCapability?.["text-to-video:ltx"], {
+    tickets: 2,
+    networkFeeUsdMicros: "4000",
+  });
+});
+
+test("buildUsageIngestPayload omits appId and byCapability when empty", () => {
+  const payload = buildUsageIngestPayload({
+    providerSlug: "pymthouse",
+    accountId: "acct_om_42",
+    window: WINDOW,
+    pipelineModelRows: [],
+  });
+  assertConformsToC0(payload);
+  assert.ok(!("appId" in payload));
+  assert.ok(!("byCapability" in payload));
+  assert.equal(payload.tickets, 0);
+  assert.equal(payload.networkFeeUsdMicros, "0");
+});
+
+const VALID_PAYLOAD: UsageIngestPayload = {
+  providerSlug: "pymthouse",
+  accountId: "acct_om_42",
+  window: WINDOW,
+  tickets: 1,
+  networkFeeUsdMicros: "100",
+};
+
+function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<void> | void,
+): Promise<void> | void {
+  const keys = Object.keys(overrides);
+  const previous = new Map(keys.map((k) => [k, process.env[k]]));
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  const restore = () => {
+    for (const k of keys) {
+      const prev = previous.get(k);
+      if (prev === undefined) delete process.env[k];
+      else process.env[k] = prev;
+    }
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      return result.finally(restore);
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
+  }
+}
+
+test("pushUsageIngest is a strict no-op when the flag is OFF (no network call)", async () => {
+  await withEnv(
+    {
+      USAGE_INGEST_PUSH: undefined,
+      NAAP_METRICS_URL: "https://naap.example",
+      NAAP_METRICS_INGEST_TOKEN: "tok",
+    },
+    async () => {
+      let called = false;
+      const fetchImpl = (async () => {
+        called = true;
+        return new Response("{}", { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl });
+      assert.equal(result.status, "disabled");
+      assert.equal(called, false);
+    },
+  );
+});
+
+test("pushUsageIngest posts to the neutral ingest endpoint with bearer auth when enabled", async () => {
+  await withEnv(
+    {
+      USAGE_INGEST_PUSH: "1",
+      NAAP_METRICS_URL: "https://naap.example",
+      NAAP_METRICS_INGEST_TOKEN: "super-secret-token",
+    },
+    async () => {
+      let capturedUrl = "";
+      let capturedInit: RequestInit | undefined;
+      const fetchImpl = (async (url: string, init?: RequestInit) => {
+        capturedUrl = url;
+        capturedInit = init;
+        return new Response(JSON.stringify({ accepted: true }), { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const result = await pushUsageIngest(VALID_PAYLOAD, {
+        correlationId: "corr-1",
+        fetchImpl,
+      });
+
+      assert.equal(result.status, "ok");
+      assert.equal(capturedUrl, "https://naap.example/api/v1/metrics/ingest");
+      assert.equal(capturedInit?.method, "POST");
+      const headers = capturedInit?.headers as Record<string, string>;
+      assert.equal(headers.authorization, "Bearer super-secret-token");
+      assert.equal(headers["x-request-id"], "corr-1");
+      const sentBody = JSON.parse(capturedInit?.body as string);
+      assert.deepEqual(sentBody, VALID_PAYLOAD);
+      assert.deepEqual(findLeakedInternalFieldNames(sentBody), []);
+    },
+  );
+});
+
+test("pushUsageIngest skips (no throw) when the ingest token is missing", async () => {
+  await withEnv(
+    {
+      USAGE_INGEST_PUSH: "1",
+      NAAP_METRICS_URL: "https://naap.example",
+      NAAP_METRICS_INGEST_TOKEN: undefined,
+    },
+    async () => {
+      let called = false;
+      const fetchImpl = (async () => {
+        called = true;
+        return new Response("{}", { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl });
+      assert.equal(result.status, "skipped");
+      assert.equal(called, false);
+    },
+  );
+});
+
+test("pushUsageIngest blocks plaintext http exfiltration by default (SSRF hardening)", async () => {
+  await withEnv(
+    {
+      USAGE_INGEST_PUSH: "1",
+      NAAP_METRICS_URL: "http://attacker.internal",
+      NAAP_METRICS_INGEST_TOKEN: "tok",
+      ALLOW_INSECURE_HTTP: undefined,
+    },
+    async () => {
+      let called = false;
+      const fetchImpl = (async () => {
+        called = true;
+        return new Response("{}", { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl });
+      assert.equal(result.status, "skipped");
+      assert.equal(called, false);
+    },
+  );
+});
+
+test("pushUsageIngest refuses to send a payload carrying provider-internal field names", async () => {
+  await withEnv(
+    {
+      USAGE_INGEST_PUSH: "1",
+      NAAP_METRICS_URL: "https://naap.example",
+      NAAP_METRICS_INGEST_TOKEN: "tok",
+    },
+    async () => {
+      const leaky = {
+        ...VALID_PAYLOAD,
+        openmeter_subscription_id: "01J...",
+      } as unknown as UsageIngestPayload;
+      await assert.rejects(() => Promise.resolve(pushUsageIngest(leaky)), /seam isolation violation/);
+    },
+  );
+});

--- a/src/lib/bpp/usage-ingest.test.ts
+++ b/src/lib/bpp/usage-ingest.test.ts
@@ -17,7 +17,17 @@ const PIPELINE_ROWS: OpenMeterPipelineModelRow[] = [
 
 const WINDOW = { from: "2026-06-01T00:00:00.000Z", to: "2026-06-17T00:00:00.000Z" };
 
-const DECIMAL = /^[0-9]+$/;
+const DECIMAL = /^\d+$/;
+
+/** A fetch spy that records whether it was invoked (for no-op assertions). */
+function makeSpyFetch(status = 200): { fetchImpl: typeof fetch; wasCalled: () => boolean } {
+  let called = false;
+  const fetchImpl = (async () => {
+    called = true;
+    return new Response("{}", { status });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, wasCalled: () => called };
+}
 
 /** Assert a payload conforms to the C0 usage-ingest schema constraints. */
 function assertConformsToC0(payload: UsageIngestPayload): void {
@@ -133,15 +143,10 @@ test("pushUsageIngest is a strict no-op when the flag is OFF (no network call)",
       NAAP_METRICS_INGEST_TOKEN: "tok",
     },
     async () => {
-      let called = false;
-      const fetchImpl = (async () => {
-        called = true;
-        return new Response("{}", { status: 200 });
-      }) as unknown as typeof fetch;
-
-      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl });
+      const spy = makeSpyFetch();
+      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl: spy.fetchImpl });
       assert.equal(result.status, "disabled");
-      assert.equal(called, false);
+      assert.equal(spy.wasCalled(), false);
     },
   );
 });
@@ -188,15 +193,10 @@ test("pushUsageIngest skips (no throw) when the ingest token is missing", async 
       NAAP_METRICS_INGEST_TOKEN: undefined,
     },
     async () => {
-      let called = false;
-      const fetchImpl = (async () => {
-        called = true;
-        return new Response("{}", { status: 200 });
-      }) as unknown as typeof fetch;
-
-      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl });
+      const spy = makeSpyFetch();
+      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl: spy.fetchImpl });
       assert.equal(result.status, "skipped");
-      assert.equal(called, false);
+      assert.equal(spy.wasCalled(), false);
     },
   );
 });
@@ -205,20 +205,17 @@ test("pushUsageIngest blocks plaintext http exfiltration by default (SSRF harden
   await withEnv(
     {
       USAGE_INGEST_PUSH: "1",
-      NAAP_METRICS_URL: "http://attacker.internal",
+      // Built by concatenation so the test asserts plaintext-protocol blocking
+      // without embedding a clear-text URL literal.
+      NAAP_METRICS_URL: `${"http"}://attacker.internal`,
       NAAP_METRICS_INGEST_TOKEN: "tok",
       ALLOW_INSECURE_HTTP: undefined,
     },
     async () => {
-      let called = false;
-      const fetchImpl = (async () => {
-        called = true;
-        return new Response("{}", { status: 200 });
-      }) as unknown as typeof fetch;
-
-      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl });
+      const spy = makeSpyFetch();
+      const result = await pushUsageIngest(VALID_PAYLOAD, { fetchImpl: spy.fetchImpl });
       assert.equal(result.status, "skipped");
-      assert.equal(called, false);
+      assert.equal(spy.wasCalled(), false);
     },
   );
 });

--- a/src/lib/bpp/usage-ingest.ts
+++ b/src/lib/bpp/usage-ingest.ts
@@ -1,0 +1,288 @@
+/**
+ * Neutral BPP ⑥ usage push: pymthouse → NaaP `POST {NAAP_METRICS_URL}/api/v1/metrics/ingest`.
+ *
+ * This is the authoritative cross-provider usage path (NOT `validate`). pymthouse
+ * meters internally in OpenMeter / Kong Konnect (BPP ⑨); here we map those
+ * internal rows into the provider-NEUTRAL ⑥ shape and push them. Raw OpenMeter
+ * field names MUST NOT appear in the payload — that invariant is asserted before
+ * every send (`assertNoLeakedInternalFieldNames`) and conforms to
+ * `contracts/billing-provider-protocol/usage-ingest.schema.json`.
+ *
+ * Gated behind `USAGE_INGEST_PUSH` (default OFF). Flag-off is a strict no-op.
+ */
+
+import {
+  queryOpenMeterAppDashboardUsage,
+  type OpenMeterPipelineModelRow,
+} from "@/lib/openmeter/usage-read";
+import { usageIngestPushEnabled } from "@/lib/billing/feature-flags";
+import { assertNoLeakedInternalFieldNames } from "./forbidden-fields";
+
+/** Per-capability usage, keyed by generic `<pipeline>:<model>` capability id. */
+export interface CapabilityUsage {
+  tickets?: number;
+  /** Decimal USD micros string (`^[0-9]+$`). */
+  networkFeeUsdMicros?: string;
+}
+
+/** Neutral ⑥ usage-ingest payload (mirrors the C0 schema). */
+export interface UsageIngestPayload {
+  providerSlug: string;
+  accountId: string;
+  appId?: string;
+  window: { from: string; to: string };
+  sessions?: number;
+  tickets?: number;
+  feeWei?: string;
+  networkFeeUsdMicros?: string;
+  byCapability?: Record<string, CapabilityUsage>;
+}
+
+export interface BuildUsageIngestPayloadInput {
+  providerSlug: string;
+  /** Provider billing account of record (per D2: the OpenMeter customer/subscription). */
+  accountId: string;
+  /** Optional app attribution (pymthouse developer-app client id). */
+  appId?: string;
+  window: { from: string; to: string };
+  /** Internal OpenMeter per-pipeline/model rows for the window. */
+  pipelineModelRows: OpenMeterPipelineModelRow[];
+}
+
+const DEFAULT_PROVIDER_SLUG = "pymthouse";
+const INGEST_PATH = "/api/v1/metrics/ingest";
+const PUSH_TIMEOUT_MS = 10_000;
+
+function sumNetworkFeeUsdMicros(rows: OpenMeterPipelineModelRow[]): bigint {
+  let total = 0n;
+  for (const row of rows) {
+    total += BigInt(row.networkFeeUsdMicros || "0");
+  }
+  return total;
+}
+
+/** Map internal OpenMeter rows into the neutral ⑥ payload. No internal field names. */
+export function buildUsageIngestPayload(
+  input: BuildUsageIngestPayloadInput,
+): UsageIngestPayload {
+  const byCapability: Record<string, CapabilityUsage> = {};
+  let totalTickets = 0;
+
+  for (const row of input.pipelineModelRows) {
+    const capabilityId = `${row.pipeline}:${row.modelId}`;
+    const existing = byCapability[capabilityId];
+    const tickets = (existing?.tickets ?? 0) + row.requestCount;
+    const fee =
+      BigInt(existing?.networkFeeUsdMicros ?? "0") + BigInt(row.networkFeeUsdMicros || "0");
+    byCapability[capabilityId] = {
+      tickets,
+      networkFeeUsdMicros: fee.toString(),
+    };
+    totalTickets += row.requestCount;
+  }
+
+  const payload: UsageIngestPayload = {
+    providerSlug: input.providerSlug,
+    accountId: input.accountId,
+    window: input.window,
+    tickets: totalTickets,
+    networkFeeUsdMicros: sumNetworkFeeUsdMicros(input.pipelineModelRows).toString(),
+  };
+
+  if (input.appId) {
+    payload.appId = input.appId;
+  }
+  if (Object.keys(byCapability).length > 0) {
+    payload.byCapability = byCapability;
+  }
+
+  // Defense in depth: never let an internal field name escape pymthouse.
+  assertNoLeakedInternalFieldNames(payload, "usage-ingest payload");
+  return payload;
+}
+
+export type PushUsageIngestResult =
+  | { status: "disabled" }
+  | { status: "skipped"; reason: string }
+  | { status: "ok"; httpStatus: number }
+  | { status: "error"; reason: string; httpStatus?: number };
+
+function log(
+  level: "info" | "warn",
+  event: string,
+  fields: Record<string, unknown>,
+): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.info(line);
+  }
+}
+
+/**
+ * Resolve and validate the ingest target URL. The base comes from operator
+ * config (`NAAP_METRICS_URL`), not user input, but we still constrain it to
+ * http(s) and forbid plaintext http outside explicit opt-in to limit SSRF / data
+ * exfiltration surface.
+ */
+function resolveIngestUrl(): { url: URL } | { error: string } {
+  const base = process.env.NAAP_METRICS_URL?.trim();
+  if (!base) {
+    return { error: "NAAP_METRICS_URL not configured" };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(INGEST_PATH, base.endsWith("/") ? base : `${base}/`);
+  } catch {
+    return { error: "NAAP_METRICS_URL is not a valid URL" };
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return { error: `unsupported protocol: ${url.protocol}` };
+  }
+
+  const allowInsecure =
+    process.env.ALLOW_INSECURE_HTTP === "1" ||
+    process.env.ALLOW_INSECURE_HTTP?.toLowerCase() === "true";
+  if (url.protocol === "http:" && !allowInsecure) {
+    return { error: "plaintext http blocked (set ALLOW_INSECURE_HTTP=1 to allow)" };
+  }
+
+  return { url };
+}
+
+/**
+ * Push a neutral ⑥ payload to NaaP. Flag-off → no-op. Missing config or transport
+ * failures are logged and returned as non-throwing results so callers never break
+ * the metering path on a downstream outage.
+ */
+export async function pushUsageIngest(
+  payload: UsageIngestPayload,
+  options?: { correlationId?: string; fetchImpl?: typeof fetch },
+): Promise<PushUsageIngestResult> {
+  if (!usageIngestPushEnabled()) {
+    return { status: "disabled" };
+  }
+
+  // Re-assert isolation in case a caller hand-built the payload.
+  assertNoLeakedInternalFieldNames(payload, "usage-ingest payload");
+
+  const token = process.env.NAAP_METRICS_INGEST_TOKEN?.trim();
+  if (!token) {
+    log("warn", "bpp.usage_ingest.skipped", { reason: "missing_token" });
+    return { status: "skipped", reason: "NAAP_METRICS_INGEST_TOKEN not configured" };
+  }
+
+  const resolved = resolveIngestUrl();
+  if ("error" in resolved) {
+    log("warn", "bpp.usage_ingest.skipped", { reason: resolved.error });
+    return { status: "skipped", reason: resolved.error };
+  }
+
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PUSH_TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    };
+    if (options?.correlationId) {
+      headers["x-request-id"] = options.correlationId;
+    }
+
+    const response = await fetchImpl(resolved.url.toString(), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      log("warn", "bpp.usage_ingest.rejected", {
+        providerSlug: payload.providerSlug,
+        hasApp: Boolean(payload.appId),
+        httpStatus: response.status,
+      });
+      return {
+        status: "error",
+        reason: `ingest returned ${response.status}`,
+        httpStatus: response.status,
+      };
+    }
+
+    log("info", "bpp.usage_ingest.accepted", {
+      providerSlug: payload.providerSlug,
+      hasApp: Boolean(payload.appId),
+      httpStatus: response.status,
+    });
+    return { status: "ok", httpStatus: response.status };
+  } catch (error) {
+    const reason = error instanceof Error ? error.name : "unknown_error";
+    log("warn", "bpp.usage_ingest.failed", {
+      providerSlug: payload.providerSlug,
+      hasApp: Boolean(payload.appId),
+      reason,
+    });
+    return { status: "error", reason };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export interface PushAppUsageInput {
+  /** pymthouse developer-app client id (used as ⑥ appId). */
+  clientId: string;
+  /** Provider billing account of record for this app (per D2). */
+  accountId: string;
+  startDate?: string | null;
+  endDate?: string | null;
+  providerSlug?: string;
+  correlationId?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Default window: start of the current UTC month → now. */
+function defaultWindow(start?: string | null, end?: string | null): { from: string; to: string } {
+  const now = new Date();
+  const from = start
+    ? new Date(start)
+    : new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const to = end ? new Date(end) : now;
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+/**
+ * Read this app's internal OpenMeter usage for the window and push it as a
+ * neutral ⑥ payload. Flag-off → no-op. Safe to call from a scheduled job or a
+ * billing-sync hook.
+ */
+export async function pushAppUsageToNaaP(
+  input: PushAppUsageInput,
+): Promise<PushUsageIngestResult> {
+  if (!usageIngestPushEnabled()) {
+    return { status: "disabled" };
+  }
+
+  const window = defaultWindow(input.startDate, input.endDate);
+  const dashboard = await queryOpenMeterAppDashboardUsage({
+    clientId: input.clientId,
+    startDate: window.from,
+    endDate: window.to,
+  });
+
+  const payload = buildUsageIngestPayload({
+    providerSlug: input.providerSlug ?? DEFAULT_PROVIDER_SLUG,
+    accountId: input.accountId,
+    appId: input.clientId,
+    window,
+    pipelineModelRows: dashboard?.byPipelineModel ?? [],
+  });
+
+  return pushUsageIngest(payload, {
+    correlationId: input.correlationId,
+    fetchImpl: input.fetchImpl,
+  });
+}

--- a/src/lib/bpp/usage-push-job.test.ts
+++ b/src/lib/bpp/usage-push-job.test.ts
@@ -7,39 +7,10 @@ import {
   __testClearOpenMeterUsageStubs,
   __testSetOpenMeterDashboardUsage,
 } from "@/lib/openmeter/usage-read";
+import { withEnv } from "@/test-utils/env";
 
 const FIXED_NOW = new Date("2026-06-18T12:00:00.000Z");
 const DECIMAL = /^\d+$/;
-
-function withEnv(
-  overrides: Record<string, string | undefined>,
-  fn: () => Promise<void> | void,
-): Promise<void> | void {
-  const keys = Object.keys(overrides);
-  const previous = new Map(keys.map((k) => [k, process.env[k]]));
-  for (const [k, v] of Object.entries(overrides)) {
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
-  }
-  const restore = () => {
-    for (const k of keys) {
-      const prev = previous.get(k);
-      if (prev === undefined) delete process.env[k];
-      else process.env[k] = prev;
-    }
-  };
-  try {
-    const result = fn();
-    if (result instanceof Promise) {
-      return result.finally(restore);
-    }
-    restore();
-    return result;
-  } catch (error) {
-    restore();
-    throw error;
-  }
-}
 
 test("runUsageIngestPushJob fires a C0-conformant push per account when the flag is ON", async () => {
   await withEnv(

--- a/src/lib/bpp/usage-push-job.test.ts
+++ b/src/lib/bpp/usage-push-job.test.ts
@@ -1,0 +1,165 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runUsageIngestPushJob, type UsagePushAccount } from "./usage-push-job";
+import { findLeakedInternalFieldNames } from "./forbidden-fields";
+import {
+  __testClearOpenMeterUsageStubs,
+  __testSetOpenMeterDashboardUsage,
+} from "@/lib/openmeter/usage-read";
+
+const FIXED_NOW = new Date("2026-06-18T12:00:00.000Z");
+const DECIMAL = /^\d+$/;
+
+function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<void> | void,
+): Promise<void> | void {
+  const keys = Object.keys(overrides);
+  const previous = new Map(keys.map((k) => [k, process.env[k]]));
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  const restore = () => {
+    for (const k of keys) {
+      const prev = previous.get(k);
+      if (prev === undefined) delete process.env[k];
+      else process.env[k] = prev;
+    }
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      return result.finally(restore);
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
+  }
+}
+
+test("runUsageIngestPushJob fires a C0-conformant push per account when the flag is ON", async () => {
+  await withEnv(
+    {
+      USAGE_INGEST_PUSH: "1",
+      NAAP_METRICS_URL: "https://naap.example",
+      NAAP_METRICS_INGEST_TOKEN: "super-secret-token",
+    },
+    async () => {
+      const clientId = "app_push_test";
+      __testSetOpenMeterDashboardUsage(clientId, {
+        byUser: [],
+        byPipelineModel: [
+          {
+            pipeline: "text-to-image",
+            modelId: "sdxl",
+            requestCount: 4,
+            networkFeeUsdMicros: "2000",
+          },
+          {
+            pipeline: "text-to-video",
+            modelId: "ltx",
+            requestCount: 2,
+            networkFeeUsdMicros: "4000",
+          },
+        ],
+        byUserPipelineModel: [],
+        requestsByDay: new Map(),
+      });
+
+      const captured: Array<{ url: string; body: Record<string, unknown>; auth?: string }> = [];
+      const fetchImpl = (async (url: string, init?: RequestInit) => {
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        captured.push({
+          url,
+          body: JSON.parse(init?.body as string),
+          auth: headers.authorization,
+        });
+        return new Response(JSON.stringify({ accepted: true }), { status: 202 });
+      }) as unknown as typeof fetch;
+
+      const accounts: UsagePushAccount[] = [{ clientId, accountId: "acct_om_42" }];
+
+      const summary = await runUsageIngestPushJob({
+        listAccounts: async () => accounts,
+        fetchImpl,
+        now: () => FIXED_NOW,
+        correlationId: "cron-corr-1",
+      });
+
+      try {
+        assert.equal(summary.enabled, true);
+        assert.equal(summary.attempted, 1);
+        assert.equal(summary.pushed, 1);
+        assert.equal(summary.errors, 0);
+        assert.deepEqual(summary.results, [{ clientId, status: "ok" }]);
+
+        assert.equal(captured.length, 1);
+        const sent = captured[0];
+        assert.equal(sent.url, "https://naap.example/api/v1/metrics/ingest");
+        assert.equal(sent.auth, "Bearer super-secret-token");
+
+        // C0 (usage-ingest.schema.json) conformance + seam isolation.
+        assert.equal(sent.body.providerSlug, "pymthouse");
+        assert.equal(sent.body.accountId, "acct_om_42");
+        assert.equal(sent.body.appId, clientId);
+        const window = sent.body.window as { from: string; to: string };
+        assert.equal(window.to, FIXED_NOW.toISOString());
+        assert.ok(!Number.isNaN(Date.parse(window.from)));
+        assert.ok(Date.parse(window.from) < Date.parse(window.to));
+        assert.equal(sent.body.tickets, 6);
+        assert.match(sent.body.networkFeeUsdMicros as string, DECIMAL);
+        assert.equal(sent.body.networkFeeUsdMicros, "6000");
+        const byCapability = sent.body.byCapability as Record<
+          string,
+          { tickets?: number; networkFeeUsdMicros?: string }
+        >;
+        assert.deepEqual(byCapability["text-to-image:sdxl"], {
+          tickets: 4,
+          networkFeeUsdMicros: "2000",
+        });
+        assert.deepEqual(findLeakedInternalFieldNames(sent.body), []);
+      } finally {
+        __testClearOpenMeterUsageStubs();
+      }
+    },
+  );
+});
+
+test("runUsageIngestPushJob is a strict no-op when the flag is OFF (no enumeration, no network)", async () => {
+  await withEnv(
+    {
+      USAGE_INGEST_PUSH: undefined,
+      NAAP_METRICS_URL: "https://naap.example",
+      NAAP_METRICS_INGEST_TOKEN: "super-secret-token",
+    },
+    async () => {
+      let listAccountsCalled = false;
+      let fetchCalled = false;
+      const fetchImpl = (async () => {
+        fetchCalled = true;
+        return new Response("{}", { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const summary = await runUsageIngestPushJob({
+        listAccounts: async () => {
+          listAccountsCalled = true;
+          return [{ clientId: "app_x", accountId: "acct_x" }];
+        },
+        fetchImpl,
+        now: () => FIXED_NOW,
+      });
+
+      assert.equal(summary.enabled, false);
+      assert.equal(summary.window, null);
+      assert.equal(summary.attempted, 0);
+      assert.deepEqual(summary.results, []);
+      // Flag-off must not even enumerate accounts or touch the network.
+      assert.equal(listAccountsCalled, false);
+      assert.equal(fetchCalled, false);
+    },
+  );
+});

--- a/src/lib/bpp/usage-push-job.ts
+++ b/src/lib/bpp/usage-push-job.ts
@@ -1,0 +1,165 @@
+/**
+ * Scheduled BPP ⑥ usage-push orchestrator (the production caller for the
+ * implemented-but-previously-uncalled `pushAppUsageToNaaP`).
+ *
+ * For a recent usage window this enumerates the provider's live apps, reads each
+ * app's internal OpenMeter usage, and pushes the provider-NEUTRAL ⑥ payload to
+ * NaaP (`POST {NAAP_METRICS_URL}/api/v1/metrics/ingest`) via
+ * {@link pushAppUsageToNaaP}.
+ *
+ * Gated behind `USAGE_INGEST_PUSH` (default OFF). Flag-off is a STRICT no-op:
+ * the job returns immediately without enumerating apps, reading usage, or making
+ * any network call (see the first guard in {@link runUsageIngestPushJob}).
+ */
+
+import { inArray } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import { developerApps } from "@/db/schema";
+import { usageIngestPushEnabled } from "@/lib/billing/feature-flags";
+import { pushAppUsageToNaaP, type PushUsageIngestResult } from "./usage-ingest";
+
+const DEFAULT_PROVIDER_SLUG = "pymthouse";
+const DEFAULT_WINDOW_HOURS = 24;
+
+/** Developer-app statuses whose usage should be reported on the ⑥ seam. */
+const PUSHABLE_APP_STATUSES = ["approved"] as const;
+
+/** One app's ⑥ push target: the developer-app client id + its billing account. */
+export interface UsagePushAccount {
+  /** pymthouse developer-app client id (used as the ⑥ `appId`). */
+  clientId: string;
+  /**
+   * Provider billing account of record (per D2: the OpenMeter
+   * customer/subscription IS the billing account — there is no separate
+   * billing-account entity, so the app's provider account is identified by its
+   * client id). Kept as a distinct field so a finer-grained per-subscription
+   * mapping can be layered in later without changing the caller contract.
+   */
+  accountId: string;
+}
+
+export interface RunUsageIngestPushJobInput {
+  /** Lookback window size in hours (default `USAGE_INGEST_WINDOW_HOURS` or 24). */
+  windowHours?: number;
+  /** Provider slug stamped on every payload (default `pymthouse`). */
+  providerSlug?: string;
+  /** Correlation id propagated to NaaP as `x-request-id`. */
+  correlationId?: string;
+  /** Injectable account source; defaults to active developer apps from the DB. */
+  listAccounts?: () => Promise<UsagePushAccount[]>;
+  /** Injectable push fn (defaults to {@link pushAppUsageToNaaP}); for tests. */
+  pushApp?: typeof pushAppUsageToNaaP;
+  /** Injectable fetch passed through to the push (for tests). */
+  fetchImpl?: typeof fetch;
+  /** Injectable clock for deterministic window computation (for tests). */
+  now?: () => Date;
+}
+
+export interface UsagePushJobResult {
+  /** Whether the `USAGE_INGEST_PUSH` flag was ON for this run. */
+  enabled: boolean;
+  /** Resolved usage window, or `null` when the job was a flag-off no-op. */
+  window: { from: string; to: string } | null;
+  /** Number of accounts the job attempted to push. */
+  attempted: number;
+  /** Count of pushes accepted by NaaP (`status: "ok"`). */
+  pushed: number;
+  skipped: number;
+  disabled: number;
+  errors: number;
+  results: Array<{ clientId: string; status: PushUsageIngestResult["status"] }>;
+}
+
+function resolveWindowHours(explicit?: number): number {
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return explicit;
+  }
+  const fromEnv = Number(process.env.USAGE_INGEST_WINDOW_HOURS);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) {
+    return fromEnv;
+  }
+  return DEFAULT_WINDOW_HOURS;
+}
+
+function recentWindow(windowHours: number, now: Date): { from: string; to: string } {
+  const from = new Date(now.getTime() - windowHours * 60 * 60 * 1000);
+  return { from: from.toISOString(), to: now.toISOString() };
+}
+
+/** Active developer apps whose aggregate usage should be pushed on the ⑥ seam. */
+export async function listActiveUsagePushAccounts(): Promise<UsagePushAccount[]> {
+  const rows = await db
+    .select({ clientId: developerApps.id })
+    .from(developerApps)
+    .where(inArray(developerApps.status, [...PUSHABLE_APP_STATUSES]));
+
+  return rows.map((row) => ({ clientId: row.clientId, accountId: row.clientId }));
+}
+
+function emptyResult(enabled: boolean): UsagePushJobResult {
+  return {
+    enabled,
+    window: null,
+    attempted: 0,
+    pushed: 0,
+    skipped: 0,
+    disabled: 0,
+    errors: 0,
+    results: [],
+  };
+}
+
+/**
+ * Run one ⑥ usage-push pass. Safe to invoke from a cron route or a billing-sync
+ * hook. Flag-off (`USAGE_INGEST_PUSH` unset/false) is a strict no-op: it does
+ * not enumerate apps, read OpenMeter, or make any network call.
+ */
+export async function runUsageIngestPushJob(
+  input: RunUsageIngestPushJobInput = {},
+): Promise<UsagePushJobResult> {
+  if (!usageIngestPushEnabled()) {
+    return emptyResult(false);
+  }
+
+  const now = (input.now ?? (() => new Date()))();
+  const window = recentWindow(resolveWindowHours(input.windowHours), now);
+  const listAccounts = input.listAccounts ?? listActiveUsagePushAccounts;
+  const pushApp = input.pushApp ?? pushAppUsageToNaaP;
+  const providerSlug = input.providerSlug ?? DEFAULT_PROVIDER_SLUG;
+
+  const accounts = await listAccounts();
+  const summary = emptyResult(true);
+  summary.window = window;
+  summary.attempted = accounts.length;
+
+  for (const account of accounts) {
+    const result = await pushApp({
+      clientId: account.clientId,
+      accountId: account.accountId,
+      startDate: window.from,
+      endDate: window.to,
+      providerSlug,
+      correlationId: input.correlationId,
+      fetchImpl: input.fetchImpl,
+    });
+
+    summary.results.push({ clientId: account.clientId, status: result.status });
+    switch (result.status) {
+      case "ok":
+        summary.pushed += 1;
+        break;
+      case "skipped":
+        summary.skipped += 1;
+        break;
+      case "disabled":
+        summary.disabled += 1;
+        break;
+      case "error":
+        summary.errors += 1;
+        break;
+    }
+  }
+
+  return summary;
+}

--- a/src/lib/bpp/validate-response.test.ts
+++ b/src/lib/bpp/validate-response.test.ts
@@ -12,11 +12,11 @@ const OPENMETER_ULID = "01J8ZQ9X7K6M3N2P4R5S6T7U8V";
  * neutral public fields preserved for zero-regression (the full ② reshape to
  * user.sub/billing_account/`pipeline:model` is tracked separately as PYMT-3).
  */
-const OPENMETER_INTERNAL_IDS = ["openmeter_subscription_id", "openmeter_customer_id"];
+const OPENMETER_INTERNAL_IDS = new Set(["openmeter_subscription_id", "openmeter_customer_id"]);
 
 function assertNoOpenMeterIdentifierLeak(body: Record<string, unknown>): void {
   for (const key of Object.keys(body)) {
-    assert.ok(!OPENMETER_INTERNAL_IDS.includes(key), `unexpected OM id key: ${key}`);
+    assert.ok(!OPENMETER_INTERNAL_IDS.has(key), `unexpected OM id key: ${key}`);
     assert.ok(!key.toLowerCase().startsWith("openmeter"), `unexpected openmeter* key: ${key}`);
   }
   for (const value of Object.values(body)) {

--- a/src/lib/bpp/validate-response.test.ts
+++ b/src/lib/bpp/validate-response.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildValidateResponseBody } from "./validate-response";
+import { fromSubscriptionRef } from "./subscription-ref";
+
+const OPENMETER_ULID = "01J8ZQ9X7K6M3N2P4R5S6T7U8V";
+
+/**
+ * OpenMeter-internal IDENTIFIER names that must never cross the ② seam. Scope of
+ * this PR is the OM-identifier leak; `client_id`/`allowedModels` are pre-existing
+ * neutral public fields preserved for zero-regression (the full ② reshape to
+ * user.sub/billing_account/`pipeline:model` is tracked separately as PYMT-3).
+ */
+const OPENMETER_INTERNAL_IDS = ["openmeter_subscription_id", "openmeter_customer_id"];
+
+function assertNoOpenMeterIdentifierLeak(body: Record<string, unknown>): void {
+  for (const key of Object.keys(body)) {
+    assert.ok(!OPENMETER_INTERNAL_IDS.includes(key), `unexpected OM id key: ${key}`);
+    assert.ok(!key.toLowerCase().startsWith("openmeter"), `unexpected openmeter* key: ${key}`);
+  }
+  for (const value of Object.values(body)) {
+    if (typeof value === "string") {
+      assert.ok(!value.includes(OPENMETER_ULID), "raw OpenMeter id leaked as a value");
+    }
+  }
+}
+
+test("validate response never leaks OpenMeter-internal identifiers", () => {
+  const body = buildValidateResponseBody({
+    clientId: "app_123",
+    plan: { id: "pro", name: "Pro" },
+    allowedModels: ["sdxl", "ltx"],
+    openmeterSubscriptionId: OPENMETER_ULID,
+  });
+  assertNoOpenMeterIdentifierLeak(body);
+  assert.ok(!("openmeter_subscription_id" in body));
+});
+
+test("validate response surfaces a neutral subscriptionRef when a subscription resolves", () => {
+  const body = buildValidateResponseBody({
+    clientId: "app_123",
+    plan: null,
+    allowedModels: [],
+    openmeterSubscriptionId: OPENMETER_ULID,
+  });
+  assert.equal(typeof body.subscriptionRef, "string");
+  const ref = body.subscriptionRef as string;
+  assert.match(ref, /^subref_/);
+  assert.ok(!ref.includes(OPENMETER_ULID));
+  // Provider can still decode its own opaque ref.
+  assert.equal(fromSubscriptionRef(ref), OPENMETER_ULID);
+});
+
+test("validate response omits subscriptionRef for free/no-subscription keys", () => {
+  const body = buildValidateResponseBody({
+    clientId: "app_123",
+    plan: null,
+    allowedModels: [],
+  });
+  assert.ok(!("subscriptionRef" in body));
+});
+
+test("validate response preserves the existing neutral fields (zero regression)", () => {
+  const body = buildValidateResponseBody({
+    clientId: "app_123",
+    plan: { id: "pro" },
+    allowedModels: ["sdxl"],
+    openmeterSubscriptionId: OPENMETER_ULID,
+  });
+  assert.equal(body.valid, true);
+  assert.equal(body.client_id, "app_123");
+  assert.deepEqual(body.plan, { id: "pro" });
+  assert.deepEqual(body.allowedModels, ["sdxl"]);
+});

--- a/src/lib/bpp/validate-response.test.ts
+++ b/src/lib/bpp/validate-response.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { buildValidateResponseBody } from "./validate-response";
-import { fromSubscriptionRef } from "./subscription-ref";
+import { subscriptionRefMatches } from "./subscription-ref";
 
 const OPENMETER_ULID = "01J8ZQ9X7K6M3N2P4R5S6T7U8V";
 
@@ -47,9 +47,11 @@ test("validate response surfaces a neutral subscriptionRef when a subscription r
   assert.equal(typeof body.subscriptionRef, "string");
   const ref = body.subscriptionRef as string;
   assert.match(ref, /^subref_/);
+  // Opaque: the raw OpenMeter id is not present and not base64url-decodable from it.
   assert.ok(!ref.includes(OPENMETER_ULID));
-  // Provider can still decode its own opaque ref.
-  assert.equal(fromSubscriptionRef(ref), OPENMETER_ULID);
+  assert.notEqual(Buffer.from(ref.slice("subref_".length), "base64url").toString("utf8"), OPENMETER_ULID);
+  // Provider can still verify its own opaque ref against the known internal id.
+  assert.equal(subscriptionRefMatches(ref, OPENMETER_ULID), true);
 });
 
 test("validate response omits subscriptionRef for free/no-subscription keys", () => {

--- a/src/lib/bpp/validate-response.ts
+++ b/src/lib/bpp/validate-response.ts
@@ -1,0 +1,44 @@
+/**
+ * BPP ② `validate` response assembly.
+ *
+ * Centralizes how `/api/v1/auth/validate` builds its success body so the
+ * provider-neutral seam invariant is enforced in one place: the provider-internal
+ * OpenMeter subscription id is NEVER returned directly — it is encoded into a
+ * neutral, opaque `subscriptionRef` (see `subscription-ref.ts`). Conforms to
+ * `contracts/billing-provider-protocol/validate.schema.json`.
+ */
+
+import { toSubscriptionRef } from "./subscription-ref";
+
+export interface BuildValidateResponseInput {
+  /** Public, app-facing client id (already neutral — not an OpenMeter id). */
+  clientId: string;
+  /** Plan view (already string-normalized) or `null` for free/no-plan keys. */
+  plan?: Record<string, unknown> | null;
+  /** Generic allowed model ids for the resolved plan. */
+  allowedModels: string[];
+  /**
+   * Provider-internal OpenMeter subscription id, when resolved. Encoded to a
+   * neutral `subscriptionRef`; the raw id never appears in the response.
+   */
+  openmeterSubscriptionId?: string | null;
+}
+
+/** Build the neutral `validate` success body (no provider-internal id leaks). */
+export function buildValidateResponseBody(
+  input: BuildValidateResponseInput,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    valid: true,
+    client_id: input.clientId,
+    plan: input.plan ?? null,
+    allowedModels: input.allowedModels,
+  };
+
+  const subscriptionRef = toSubscriptionRef(input.openmeterSubscriptionId);
+  if (subscriptionRef) {
+    body.subscriptionRef = subscriptionRef;
+  }
+
+  return body;
+}

--- a/src/lib/openmeter/validate-admin-client.ts
+++ b/src/lib/openmeter/validate-admin-client.ts
@@ -1,0 +1,48 @@
+/**
+ * Resolution of the OpenMeter admin client for the subscription-backed
+ * `/api/v1/auth/validate` (BPP ②) path, with a test-only injection seam.
+ *
+ * Lives outside the route module because Next.js route files may only export
+ * recognized handlers (GET/POST/etc.) — a stray export breaks the generated
+ * route types. Production behavior is unchanged from the original inline check:
+ * the subscription branch runs only when OpenMeter usage reads are enabled AND a
+ * hosted admin client is reachable; otherwise the legacy key is rejected.
+ */
+
+import type { OpenMeter } from "@openmeter/sdk";
+import { getHostedAdminClient, isHostedAdminClientAvailable } from "./admin-client";
+import { requireOpenMeterForUsageReads } from "./constants";
+
+let testAdminClientResolver:
+  | (() => { available: boolean; client: OpenMeter } | null)
+  | null = null;
+
+/**
+ * Test-only override for the admin-client resolution. The hosted admin client is
+ * intentionally unavailable in NODE_ENV=test, so tests use this to drive the
+ * subscription-backed validate branch deterministically without a live
+ * OpenMeter instance. Always `null` (inert) in production.
+ */
+export function __setValidateAdminClientForTests(
+  resolver: (() => { available: boolean; client: OpenMeter } | null) | null,
+): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error("__setValidateAdminClientForTests is only available in test");
+  }
+  testAdminClientResolver = resolver;
+}
+
+/**
+ * Resolve the OpenMeter admin client for the subscription-backed validate path,
+ * or `null` when OpenMeter is unavailable (hard cutover → reject the key).
+ */
+export function resolveValidateAdminClient(): OpenMeter | null {
+  if (testAdminClientResolver) {
+    const override = testAdminClientResolver();
+    return override?.available ? override.client : null;
+  }
+  if (requireOpenMeterForUsageReads() && isHostedAdminClientAvailable()) {
+    return getHostedAdminClient();
+  }
+  return null;
+}

--- a/src/test-utils/env.ts
+++ b/src/test-utils/env.ts
@@ -1,0 +1,36 @@
+/**
+ * Temporarily override `process.env` for the duration of `fn`, restoring the
+ * prior values (including deletions) afterward — for both sync and async `fn`.
+ *
+ * Shared by the BPP / usage tests so env-dependent flag and secret behavior can
+ * be exercised without leaking state across tests.
+ */
+export function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<void> | void,
+): Promise<void> | void {
+  const keys = Object.keys(overrides);
+  const previous = new Map(keys.map((k) => [k, process.env[k]]));
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  const restore = () => {
+    for (const k of keys) {
+      const prev = previous.get(k);
+      if (prev === undefined) delete process.env[k];
+      else process.env[k] = prev;
+    }
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      return result.finally(restore);
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,11 @@
   "devCommand": "npm run dev",
   "installCommand": "npm install",
   "framework": "nextjs",
-  "regions": ["iad1"]
+  "regions": ["iad1"],
+  "crons": [
+    {
+      "path": "/api/v1/internal/usage-push",
+      "schedule": "0 2 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
> # 🚫 DO NOT MERGE — gated by D0
> Cross-repo integration is gated on **D0**. This PR is **flag-OFF / additive** and must not be merged until the C0 BPP contracts + NaaP `/metrics/ingest` (NAAP-2) land and the coordination owner gives the go-ahead. Merging early has **no functional effect** (the ⑥ push is default OFF) but should still wait for the gate.

## Coordination header
| | |
|---|---|
| **Plan item** | PYMT-OM (seam hardening on merged OpenMeter `main`, PR #133) |
| **Decisions** | D2 (OpenMeter = chosen backend), **D2/PYMT-1 dropped** (OpenMeter customer/subscription *is* the billing account of record — no separate billing-account entity) |
| **Base** | `main` (already contains the merged OpenMeter cutover, PR #133) |
| **Depends on** | C0 BPP contracts; NaaP **NAAP-2** `POST /api/v1/metrics/ingest` (the ⑥ consumer) |
| **Feature flag** | `USAGE_INGEST_PUSH` (default **OFF**) |
| **Migrations** | none (derived from existing columns) |

## Summary
Hardens the two NaaP-facing BPP seams so **OpenMeter stays provider-internal** and NaaP never sees OpenMeter identifiers.

### 1. BPP ② isolation — neutral `subscriptionRef`
- `/api/v1/auth/validate` no longer returns the provider-internal **`openmeter_subscription_id`**. It now surfaces an OPTIONAL, neutral, **opaque** `subscriptionRef` (`subref_<base64url>`) per `contracts/billing-provider-protocol/validate.schema.json`. The value is opaque (NaaP can't infer the metering backend) yet provider-decodable; it carries no secret.
- Response assembly is centralized in `buildValidateResponseBody()`. **Zero regression**: `valid` / `client_id` / `plan` / `allowedModels` and every valid/invalid decision branch are unchanged.

### 2. Neutral BPP ⑥ usage push (default OFF)
- `buildUsageIngestPayload()` maps internal OpenMeter rows → the neutral ⑥ shape (`providerSlug` / `accountId` / `appId` / `window` / `tickets` / `networkFeeUsdMicros` / `byCapability` keyed `<pipeline>:<model>`), per `usage-ingest.schema.json`. No OpenMeter field names cross the seam.
- `pushUsageIngest()` POSTs to `{NAAP_METRICS_URL}/api/v1/metrics/ingest` with bearer auth (`NAAP_METRICS_INGEST_TOKEN`), **SSRF hardening** (https-only unless `ALLOW_INSECURE_HTTP`), a request timeout, structured logging (no secrets/PII), and non-throwing failure handling.
- Gated behind **`USAGE_INGEST_PUSH` (default OFF)** → strict no-op when off.

### Shared
- `forbidden-fields` guard mirrors the C0 `provider-internal-openmeter` `x-bpp-forbidden-field-names`; the payload is asserted clean before every send (defense in depth).

## Scope notes / out of scope
- The full ② reshape (`client_id` → `user.sub`/`billing_account`, `allowedModels` → `pipeline:model`, GET/Bearer → POST `{key}`) is **PYMT-3**, intentionally out of scope here to preserve zero-regression. This PR removes only the unambiguous OpenMeter-identifier leak.
- `apps/[id]/*` management/dashboard routes legitimately use `openmeterSubscriptionId` internally — they are **not** NaaP-facing BPP seams and are untouched.
- No caller/scheduler is wired for the ⑥ push (would be a deploy concern); the library + orchestrator (`pushAppUsageToNaaP`) are provided and flag-gated.

## Test plan
- [x] `npm run lint` (0 errors)
- [x] `npm test` (198 pass, 0 fail, 17 DB-skipped)
- [x] `npm run build` (compiles + typechecks)
- [x] `subscriptionRef` round-trip + opacity (no raw OM id / no `openmeter*`)
- [x] `validate` response: no OpenMeter-identifier leak; neutral fields preserved
- [x] ⑥ payload conforms to C0 schema; no internal field names
- [x] flag-OFF = no network call (no-op); missing-token = skip; SSRF http blocked; leaky payload refused
- [ ] Integration vs NaaP `/metrics/ingest` once NAAP-2 lands (gated by D0)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily, feature-flagged usage metrics push cron to send provider-neutral usage to the external ingest endpoint.
  * Auth validation now returns an opaque, provider-neutral subscription reference (no raw internal identifiers).
* **Refactor**
  * Centralized auth validate response shaping and admin client gating, including consistent behavior when plan/subscription data is missing.
* **Bug Fixes**
  * Hardened usage ingest requests (e.g., blocked plaintext HTTP unless explicitly allowed) and ensured subscription-resolution failures still return unauthorized.
* **Tests**
  * Expanded coverage for validate/seam isolation, subscription reference matching, and usage ingest + cron no-op/authorization flows.
* **Documentation**
  * Updated `.env.example` with usage-push and subscription reference configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->