### PR TITLE
feat(bpp): PYMT-3 — C0-conformant POST /auth/validate (additive, flag-gated) [stacked on #149]

### DIFF
--- a/src/app/api/v1/auth/validate/route.test.ts
+++ b/src/app/api/v1/auth/validate/route.test.ts
@@ -1,0 +1,145 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import { run } from "@/test-utils/db-guard";
+import { cleanupTestApp, seedDeveloperAppWithClient } from "@/test-utils/fixtures";
+import { db } from "@/db/index";
+import { apiKeys } from "@/db/schema";
+import { hashToken } from "@/lib/auth";
+
+/** Insert an active, subscription-less API key for `clientId`; returns the token. */
+async function seedActiveApiKey(clientId: string, userId: string): Promise<string> {
+  const token = `pmth_test_${randomUUID()}`;
+  await db.insert(apiKeys).values({
+    id: `key-${randomUUID()}`,
+    keyHash: hashToken(token),
+    clientId,
+    userId,
+    label: "PYMT-3 test key",
+    status: "active",
+  });
+  return token;
+}
+
+function withFlag<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+  const prior = process.env.BPP_VALIDATE_V2;
+  if (value === undefined) {
+    delete process.env.BPP_VALIDATE_V2;
+  } else {
+    process.env.BPP_VALIDATE_V2 = value;
+  }
+  return fn().finally(() => {
+    if (prior === undefined) {
+      delete process.env.BPP_VALIDATE_V2;
+    } else {
+      process.env.BPP_VALIDATE_V2 = prior;
+    }
+  });
+}
+
+// ---- flag gating (no DB required) ----------------------------------------
+
+test("POST validate is a no-op 404 when BPP_VALIDATE_V2 is OFF (zero regression)", async () => {
+  const { POST } = await import("./route");
+  await withFlag(undefined, async () => {
+    const res = await POST(
+      new Request("http://localhost/api/v1/auth/validate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ key: "pmth_whatever" }),
+      }) as never,
+    );
+    assert.equal(res.status, 404);
+  });
+});
+
+test("POST validate rejects a missing key with 400 when enabled", async () => {
+  const { POST } = await import("./route");
+  await withFlag("1", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/v1/auth/validate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }) as never,
+    );
+    assert.equal(res.status, 400);
+    assert.deepEqual(await res.json(), { valid: false });
+  });
+});
+
+// ---- DB-backed back-compat + C0 conformance ------------------------------
+
+run("legacy GET validate is unchanged (back-compat): client_id + allowedModels", async (t) => {
+  const { GET } = await import("./route");
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(app));
+  const token = await seedActiveApiKey(app.clientId, app.userId);
+
+  const res = await GET(
+    new Request("http://localhost/api/v1/auth/validate", {
+      headers: { Authorization: `Bearer ${token}` },
+    }) as never,
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Record<string, unknown>;
+  assert.equal(body.valid, true);
+  // Legacy neutral fields preserved verbatim for current consumers.
+  assert.equal(body.client_id, app.clientId);
+  assert.equal(body.plan, null);
+  assert.deepEqual(body.allowedModels, []);
+  // Legacy path does NOT expose the reshaped C0 fields.
+  assert.ok(!("user" in body));
+  assert.ok(!("billing_account" in body));
+});
+
+run("POST validate returns the C0-conformant reshaped body for a valid key", async (t) => {
+  const { POST } = await import("./route");
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(app));
+  const token = await seedActiveApiKey(app.clientId, app.userId);
+
+  await withFlag("1", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/v1/auth/validate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ key: token }),
+      }) as never,
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    assert.equal(body.valid, true);
+    assert.deepEqual(body.user, { sub: app.userId });
+    assert.deepEqual(body.billing_account, {
+      id: app.clientId,
+      providerSlug: "pymthouse",
+      billingMode: "delegated",
+    });
+    assert.deepEqual(body.capabilities, ["*"]); // delegated MVP — all
+    assert.equal(body.quota, null);
+
+    // The ⑨ forbidden public client_id (and the legacy shape) must be gone.
+    assert.ok(!("client_id" in body), "client_id must not leak");
+    assert.ok(!("allowedModels" in body), "allowedModels must be reshaped");
+    assert.ok(!("plan" in body), "plan is not part of the C0 ② contract");
+    assert.ok(!("openmeter_subscription_id" in body));
+  });
+});
+
+run("POST validate rejects an unknown key with 401", async () => {
+  const { POST } = await import("./route");
+  await withFlag("1", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/v1/auth/validate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ key: "pmth_does_not_exist" }),
+      }) as never,
+    );
+    assert.equal(res.status, 401);
+    assert.deepEqual(await res.json(), { valid: false });
+  });
+});

--- a/src/app/api/v1/auth/validate/route.ts
+++ b/src/app/api/v1/auth/validate/route.ts
@@ -1,12 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/db/index";
-import { apiKeys, planCapabilityBundles, plans } from "@/db/schema";
+import { apiKeys, planCapabilityBundles, plans, signerConfig } from "@/db/schema";
 import { hashToken } from "@/lib/auth";
 import { getHostedAdminClient, isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
 import { resolveApiKeyOpenMeterSubscription } from "@/lib/openmeter/api-key-subscription";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
 import { buildValidateResponseBody } from "@/lib/bpp/validate-response";
+import {
+  buildC0ValidateResponseBody,
+  toCapabilityIds,
+  CAPABILITY_WILDCARD,
+  type BillingMode,
+} from "@/lib/bpp/validate-response-c0";
+import { bppValidateV2Enabled } from "@/lib/billing/feature-flags";
+
+/** Stable provider slug for the pymthouse reference billing provider. */
+const PROVIDER_SLUG = "pymthouse";
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization") || "";
@@ -89,5 +99,143 @@ export async function GET(request: NextRequest) {
   // When OPENMETER_URL / the hosted admin client is unavailable (the branch above
   // is skipped), there is intentionally no Postgres-only fallback — reject the
   // key rather than honoring a legacy local subscription row.
+  return NextResponse.json({ valid: false }, { status: 401 });
+}
+
+// ---------------------------------------------------------------------------
+// PYMT-3 — additive, C0-conformant `validate` (POST {key})
+//
+// The legacy `GET` above is intentionally left untouched (deprecated, not
+// removed) for current consumers. `POST /api/v1/auth/validate` is the NEW
+// provider-neutral front door that conforms to the C0 `validate.schema.json`:
+//   { valid, user.sub, billing_account, capabilities[pipeline:model], quota,
+//     subscriptionRef?, signerSession? }
+//
+// It is gated behind `BPP_VALIDATE_V2` (default OFF). Flag-off → 404, so the
+// endpoint behaves as if absent and the legacy GET path is the only behavior
+// in production until the NaaP front door (NAAP-C) is ready (gated by D0).
+// ---------------------------------------------------------------------------
+
+type ApiKeyRow = typeof apiKeys.$inferSelect;
+
+/** Neutral, stable subject id for a resolved API key (never a metering id). */
+function resolveSubject(apiKey: ApiKeyRow): string {
+  return apiKey.appUserId || apiKey.userId || `app:${apiKey.clientId}`;
+}
+
+/** Resolve the singleton signer's billing posture (delegated by default). */
+async function resolveBillingMode(): Promise<BillingMode> {
+  const rows = await db.select({ billingMode: signerConfig.billingMode }).from(signerConfig).limit(1);
+  return rows[0]?.billingMode === "prepay" ? "prepay" : "delegated";
+}
+
+/** Read `{ key }` from a JSON body without throwing on malformed input. */
+async function readKeyFromBody(request: NextRequest): Promise<string | null> {
+  try {
+    const body = (await request.json()) as unknown;
+    if (body && typeof body === "object" && "key" in body) {
+      const key = (body as { key?: unknown }).key;
+      if (typeof key === "string" && key.length > 0) {
+        return key;
+      }
+    }
+  } catch {
+    // Malformed/empty body → treated as a missing key below.
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  if (!bppValidateV2Enabled()) {
+    // Endpoint not enabled — behave as if it does not exist (zero regression).
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const key = await readKeyFromBody(request);
+  if (!key) {
+    return NextResponse.json({ valid: false }, { status: 400 });
+  }
+
+  const keyHash = hashToken(key);
+  const apiKeyRows = await db
+    .select()
+    .from(apiKeys)
+    .where(eq(apiKeys.keyHash, keyHash))
+    .limit(1);
+  const apiKey = apiKeyRows[0];
+  if (!apiKey || apiKey.status !== "active") {
+    return NextResponse.json({ valid: false }, { status: 401 });
+  }
+
+  const billingMode = await resolveBillingMode();
+  const billingAccount = {
+    // Account of record = the developer app (per PR #149 coordination header:
+    // D2/PYMT-1 dropped — no separate billing-account entity). Neutral, app-facing.
+    id: apiKey.clientId,
+    providerSlug: PROVIDER_SLUG,
+    billingMode,
+  };
+
+  // No subscription on the key → delegated MVP: capabilities = all, quota = null.
+  if (!apiKey.subscriptionId && !apiKey.openmeterSubscriptionId) {
+    return NextResponse.json(
+      buildC0ValidateResponseBody({
+        sub: resolveSubject(apiKey),
+        billingAccount,
+        capabilities: [CAPABILITY_WILDCARD],
+        quota: null,
+      }),
+    );
+  }
+
+  if (requireOpenMeterForUsageReads() && isHostedAdminClientAvailable()) {
+    const resolved = await resolveApiKeyOpenMeterSubscription({
+      apiKey,
+      client: getHostedAdminClient(),
+    });
+    if (!resolved) {
+      return NextResponse.json({ valid: false }, { status: 401 });
+    }
+
+    // Subscription resolved but no local plan → delegated MVP: all capabilities.
+    if (!resolved.planId) {
+      return NextResponse.json(
+        buildC0ValidateResponseBody({
+          sub: resolveSubject(apiKey),
+          billingAccount,
+          capabilities: [CAPABILITY_WILDCARD],
+          quota: null,
+          openmeterSubscriptionId: resolved.openmeterSubscriptionId,
+        }),
+      );
+    }
+
+    const planRows = await db
+      .select()
+      .from(plans)
+      .where(eq(plans.id, resolved.planId))
+      .limit(1);
+    const plan = planRows[0];
+    if (!plan) {
+      return NextResponse.json({ valid: false }, { status: 401 });
+    }
+
+    const bundles = await db
+      .select()
+      .from(planCapabilityBundles)
+      .where(eq(planCapabilityBundles.planId, plan.id));
+
+    return NextResponse.json(
+      buildC0ValidateResponseBody({
+        sub: resolveSubject(apiKey),
+        billingAccount,
+        capabilities: toCapabilityIds(bundles),
+        quota: null,
+        openmeterSubscriptionId: resolved.openmeterSubscriptionId,
+      }),
+    );
+  }
+
+  // Hard cutover parity with GET: subscription-backed keys require OpenMeter.
   return NextResponse.json({ valid: false }, { status: 401 });
 }

--- a/src/lib/billing/feature-flags.ts
+++ b/src/lib/billing/feature-flags.ts
@@ -26,3 +26,19 @@ export function billingStableFeatureKeysEnabled(): boolean {
 export function usageIngestPushEnabled(): boolean {
   return envFlag("USAGE_INGEST_PUSH", false);
 }
+
+/**
+ * Gate the C0-conformant BPP ② `validate` shape (PYMT-3).
+ *
+ * The legacy `GET /api/v1/auth/validate` (client_id / plan / allowedModels) is
+ * UNCHANGED and always available for current consumers. This flag only controls
+ * the NEW, additive `POST /api/v1/auth/validate` which returns the fully reshaped
+ * C0 body (`user.sub` / `billing_account` / `capabilities` as `pipeline:model`).
+ *
+ * Default OFF: flag-off makes the new POST behave as if absent (404), so there is
+ * zero regression for the legacy GET path. Flip `BPP_VALIDATE_V2=1` only once the
+ * NaaP front door (NAAP-C) is ready to consume the C0 shape (gated by D0).
+ */
+export function bppValidateV2Enabled(): boolean {
+  return envFlag("BPP_VALIDATE_V2", false);
+}

--- a/src/lib/bpp/validate-response-c0.test.ts
+++ b/src/lib/bpp/validate-response-c0.test.ts
@@ -85,7 +85,7 @@ function assertConformsToC0(body: Record<string, unknown>): void {
 
   if ("signerSession" in body) {
     const s = body.signerSession as Record<string, unknown>;
-    assert.deepEqual(Object.keys(s).sort(), ["headers", "url"]);
+    assert.deepEqual(Object.keys(s).sort((a, b) => a.localeCompare(b)), ["headers", "url"]);
     assert.equal(typeof s.url, "string");
     assert.equal(typeof s.headers, "object");
   }

--- a/src/lib/bpp/validate-response-c0.test.ts
+++ b/src/lib/bpp/validate-response-c0.test.ts
@@ -1,0 +1,166 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildC0ValidateResponseBody,
+  toCapabilityIds,
+  CAPABILITY_WILDCARD,
+} from "./validate-response-c0";
+import { fromSubscriptionRef } from "./subscription-ref";
+import { findLeakedInternalFieldNames } from "./forbidden-fields";
+
+const OPENMETER_ULID = "01J8ZQ9X7K6M3N2P4R5S6T7U8V";
+
+/**
+ * Structural validator mirroring
+ * `contracts/billing-provider-protocol/validate.schema.json` (C0 ② response).
+ * Kept in-repo (like `forbidden-fields`) so pymthouse can assert conformance at
+ * the producing edge without depending on the cross-repo contract file or an
+ * external JSON-schema dependency.
+ */
+const C0_TOP_LEVEL_KEYS = new Set([
+  "valid",
+  "user",
+  "billing_account",
+  "capabilities",
+  "quota",
+  "subscriptionRef",
+  "signerSession",
+]);
+const C0_BILLING_ACCOUNT_KEYS = new Set(["id", "providerSlug", "billingMode"]);
+const C0_BILLING_MODES = new Set(["delegated", "prepay"]);
+const CAPABILITY_RE = /^(\*|[^:]+:[^:]+|tool:[^:]+)$/;
+
+function assertConformsToC0(body: Record<string, unknown>): void {
+  // required + additionalProperties:false
+  assert.equal(typeof body.valid, "boolean", "valid must be boolean");
+  for (const key of Object.keys(body)) {
+    assert.ok(C0_TOP_LEVEL_KEYS.has(key), `unexpected top-level key: ${key}`);
+  }
+
+  if ("user" in body) {
+    const user = body.user as Record<string, unknown>;
+    assert.deepEqual(Object.keys(user), ["sub"], "user must contain only `sub`");
+    assert.equal(typeof user.sub, "string");
+    assert.ok((user.sub as string).length >= 1, "user.sub must be non-empty");
+  }
+
+  if ("billing_account" in body) {
+    const acct = body.billing_account as Record<string, unknown>;
+    for (const key of Object.keys(acct)) {
+      assert.ok(C0_BILLING_ACCOUNT_KEYS.has(key), `unexpected billing_account key: ${key}`);
+    }
+    assert.equal(typeof acct.id, "string");
+    assert.ok((acct.id as string).length >= 1);
+    assert.equal(typeof acct.providerSlug, "string");
+    assert.ok((acct.providerSlug as string).length >= 1);
+    assert.ok(C0_BILLING_MODES.has(acct.billingMode as string), "billingMode enum");
+  }
+
+  if ("capabilities" in body) {
+    const caps = body.capabilities;
+    assert.ok(Array.isArray(caps), "capabilities must be an array");
+    for (const cap of caps as unknown[]) {
+      assert.equal(typeof cap, "string");
+      assert.ok((cap as string).length >= 1);
+      assert.match(cap as string, CAPABILITY_RE, `capability shape: ${String(cap)}`);
+    }
+  }
+
+  if ("quota" in body) {
+    const quota = body.quota;
+    if (quota !== null) {
+      const q = quota as Record<string, unknown>;
+      for (const key of Object.keys(q)) {
+        assert.ok(["remaining", "resetAt"].includes(key), `unexpected quota key: ${key}`);
+      }
+      assert.equal(typeof q.remaining, "number");
+    }
+  }
+
+  if ("subscriptionRef" in body) {
+    assert.equal(typeof body.subscriptionRef, "string");
+    assert.ok((body.subscriptionRef as string).length >= 1);
+  }
+
+  if ("signerSession" in body) {
+    const s = body.signerSession as Record<string, unknown>;
+    assert.deepEqual(Object.keys(s).sort(), ["headers", "url"]);
+    assert.equal(typeof s.url, "string");
+    assert.equal(typeof s.headers, "object");
+  }
+
+  // Seam isolation: no provider-internal field NAME anywhere in the response.
+  assert.deepEqual(findLeakedInternalFieldNames(body), []);
+}
+
+test("C0 validate body conforms to validate.schema.json (delegated MVP — wildcard, no quota)", () => {
+  const body = buildC0ValidateResponseBody({
+    sub: "user_abc",
+    billingAccount: { id: "app_123", providerSlug: "pymthouse", billingMode: "delegated" },
+    capabilities: [CAPABILITY_WILDCARD],
+    quota: null,
+  });
+  assertConformsToC0(body);
+  assert.equal(body.valid, true);
+  assert.deepEqual(body.user, { sub: "user_abc" });
+  assert.deepEqual(body.capabilities, ["*"]);
+  assert.equal(body.quota, null);
+});
+
+test("C0 validate body conforms with pipeline:model capabilities + subscriptionRef", () => {
+  const body = buildC0ValidateResponseBody({
+    sub: "user_abc",
+    billingAccount: { id: "app_123", providerSlug: "pymthouse", billingMode: "prepay" },
+    capabilities: ["text-to-image:sdxl", "text-to-video:ltx"],
+    quota: { remaining: 12345, resetAt: "2026-07-01T00:00:00.000Z" },
+    openmeterSubscriptionId: OPENMETER_ULID,
+  });
+  assertConformsToC0(body);
+  // subscriptionRef is opaque + provider-decodable, never the raw OM id.
+  const ref = body.subscriptionRef as string;
+  assert.match(ref, /^subref_/);
+  assert.ok(!ref.includes(OPENMETER_ULID));
+  assert.equal(fromSubscriptionRef(ref), OPENMETER_ULID);
+});
+
+test("C0 validate body NEVER leaks the forbidden public client_id / allowedModels / plan keys", () => {
+  const body = buildC0ValidateResponseBody({
+    sub: "user_abc",
+    billingAccount: { id: "app_123", providerSlug: "pymthouse", billingMode: "delegated" },
+    capabilities: ["text-to-image:sdxl"],
+    openmeterSubscriptionId: OPENMETER_ULID,
+  });
+  assert.ok(!("client_id" in body), "client_id must be removed (⑨ forbidden)");
+  assert.ok(!("allowedModels" in body), "allowedModels must be reshaped to capabilities");
+  assert.ok(!("plan" in body), "plan is not part of the C0 ② contract");
+  assert.ok(!("openmeter_subscription_id" in body));
+});
+
+test("C0 validate body includes an optional signerSession when provided", () => {
+  const body = buildC0ValidateResponseBody({
+    sub: "user_abc",
+    billingAccount: { id: "app_123", providerSlug: "pymthouse", billingMode: "delegated" },
+    capabilities: ["*"],
+    signerSession: {
+      url: "https://signer.example/session",
+      headers: { Authorization: "Bearer provider-token" },
+    },
+  });
+  assertConformsToC0(body);
+  assert.deepEqual(body.signerSession, {
+    url: "https://signer.example/session",
+    headers: { Authorization: "Bearer provider-token" },
+  });
+});
+
+test("toCapabilityIds maps pipeline+model rows to sorted, de-duplicated pipeline:model ids", () => {
+  const ids = toCapabilityIds([
+    { pipeline: "text-to-video", modelId: "ltx" },
+    { pipeline: "text-to-image", modelId: "sdxl" },
+    { pipeline: "text-to-image", modelId: "sdxl" }, // dup
+    { pipeline: "text-to-image", modelId: null }, // skipped
+    { pipeline: null, modelId: "sdxl" }, // skipped
+  ]);
+  assert.deepEqual(ids, ["text-to-image:sdxl", "text-to-video:ltx"]);
+});

--- a/src/lib/bpp/validate-response-c0.ts
+++ b/src/lib/bpp/validate-response-c0.ts
@@ -1,0 +1,126 @@
+/**
+ * BPP ② `validate` — C0-conformant response assembly (PYMT-3).
+ *
+ * This is the fully reshaped, provider-NEUTRAL `validate` body that conforms to
+ * `contracts/billing-provider-protocol/validate.schema.json`. It is the target
+ * shape for the NaaP front door (NAAP-C) and the C0 conformance suite.
+ *
+ * Differences vs the legacy `buildValidateResponseBody` (kept for back-compat):
+ *  - identity is surfaced as neutral `user.sub` + a `billing_account` ref instead
+ *    of the public, metering-coupled `client_id` (⑨ forbidden field name);
+ *  - capabilities are generic `"<pipeline>:<model>"` ids (or the `["*"]` wildcard)
+ *    instead of bare `allowedModels` model ids;
+ *  - the response carries ONLY C0-allowed top-level fields (`additionalProperties:
+ *    false` in the schema) — no `plan`, no `client_id`, no `allowedModels`.
+ *
+ * The provider-internal OpenMeter subscription id is NEVER returned directly — it
+ * is encoded into a neutral, opaque `subscriptionRef` (see `subscription-ref.ts`),
+ * exactly as in the legacy builder.
+ */
+
+import { toSubscriptionRef } from "./subscription-ref";
+import { assertNoLeakedInternalFieldNames } from "./forbidden-fields";
+
+/** Generic capability wildcard — grants all capabilities the plan allows. */
+export const CAPABILITY_WILDCARD = "*";
+
+export type BillingMode = "delegated" | "prepay";
+
+export interface C0BillingAccount {
+  /** Neutral, app-facing account-of-record id (NOT a provider-internal id). */
+  id: string;
+  /** Stable provider slug (e.g. `"pymthouse"`). */
+  providerSlug: string;
+  /** Billing posture for the account. */
+  billingMode: BillingMode;
+}
+
+export interface C0Quota {
+  /** Remaining metered units. */
+  remaining: number;
+  /** Optional ISO-8601 reset instant. */
+  resetAt?: string;
+}
+
+export interface C0SignerSession {
+  url: string;
+  headers: Record<string, string>;
+}
+
+export interface BuildC0ValidateResponseInput {
+  /** Stable, neutral subject identifier for the resolved user. */
+  sub: string;
+  /** Provider-neutral billing account of record. */
+  billingAccount: C0BillingAccount;
+  /**
+   * Generic capability ids in the form `"<pipeline>:<model>"` / `"tool:<name>"`,
+   * or the single-element wildcard `["*"]`. Empty array is allowed (no caps).
+   */
+  capabilities: string[];
+  /** Remaining quota, or `null`/omitted when not metered/unbounded. */
+  quota?: C0Quota | null;
+  /**
+   * Provider-internal OpenMeter subscription id, when resolved. Encoded to a
+   * neutral `subscriptionRef`; the raw id never appears in the response.
+   */
+  openmeterSubscriptionId?: string | null;
+  /** OPTIONAL provider-issued signer session (opaque-to-apps headers). */
+  signerSession?: C0SignerSession;
+}
+
+/**
+ * Build the C0-conformant `validate` success body. The returned object contains
+ * only schema-allowed top-level keys, and is asserted free of provider-internal
+ * field names before it is returned (defense in depth at the producing edge).
+ */
+export function buildC0ValidateResponseBody(
+  input: BuildC0ValidateResponseInput,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    valid: true,
+    user: { sub: input.sub },
+    billing_account: {
+      id: input.billingAccount.id,
+      providerSlug: input.billingAccount.providerSlug,
+      billingMode: input.billingAccount.billingMode,
+    },
+    capabilities: input.capabilities,
+    // C0 allows `null` for unmetered/unbounded; delegated MVP is unmetered.
+    quota: input.quota ?? null,
+  };
+
+  const subscriptionRef = toSubscriptionRef(input.openmeterSubscriptionId);
+  if (subscriptionRef) {
+    body.subscriptionRef = subscriptionRef;
+  }
+
+  if (input.signerSession) {
+    body.signerSession = {
+      url: input.signerSession.url,
+      headers: input.signerSession.headers,
+    };
+  }
+
+  // Defense in depth: the C0 ② seam must never carry a provider-internal field
+  // NAME (e.g. `client_id`, `openmeter_subscription_id`, `model_id`).
+  assertNoLeakedInternalFieldNames(body, "validate C0 response");
+  return body;
+}
+
+/**
+ * Map plan capability bundles to generic `"<pipeline>:<model>"` capability ids.
+ * Rows missing either part are skipped. Returns a de-duplicated, sorted list.
+ */
+export function toCapabilityIds(
+  bundles: Array<{ pipeline: string | null; modelId: string | null }>,
+): string[] {
+  const ids = new Set<string>();
+  for (const bundle of bundles) {
+    const pipeline = bundle.pipeline?.trim();
+    const modelId = bundle.modelId?.trim();
+    if (pipeline && modelId) {
+      ids.add(`${pipeline}:${modelId}`);
+    }
+  }
+  return [...ids].sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
> # 🚫 DO NOT MERGE — gated by D0
> This PR is **stacked on #149** (`feat/pymt-om-bpp-isolation`) and is **flag-OFF / additive**. It must not be merged until (a) **#149 lands first**, and (b) the C0 BPP contracts + the NaaP front door (**NAAP-C**) that consumes the reshaped ② body are ready and the coordination owner gives the go-ahead (**D0**). Merging early has **no functional effect** (the new POST is default OFF → 404) but should still wait for the gate.

## Coordination header
| | |
|---|---|
| **Plan item** | **PYMT-3** — Implement the full BPP ② `validate` reshape to the C0 contract (reference provider) |
| **Stacked on** | **#149** (PYMT-OM seam hardening) — **base branch = `feat/pymt-om-bpp-isolation`** |
| **Decisions** | D2 (OpenMeter = chosen backend); **D2/PYMT-1 dropped** per #149 (OpenMeter customer/subscription *is* the billing account of record — no separate billing-account entity) |
| **Conforms to** | `contracts/billing-provider-protocol/validate.schema.json` (C0 ②) |
| **Feature flag** | `BPP_VALIDATE_V2` (default **OFF**) |
| **Migrations** | none (code-only; expand-only) |
| **Depends on** | #149; C0 BPP contracts; NaaP **NAAP-C** front door (the ② consumer) |

## Summary
PYMT-OM (#149) intentionally deferred the **full ② reshape** to PYMT-3 to preserve zero-regression. This PR implements it as a **new, additive, flag-gated** endpoint and **leaves the legacy `GET` untouched**.

### New: `POST /api/v1/auth/validate` ({ "key": "<opaque>" }) → C0 body
Returns only C0-allowed top-level fields (`additionalProperties:false`):
```jsonc
{
  "valid": true,
  "user": { "sub": "<neutral subject>" },
  "billing_account": { "id": "<account>", "providerSlug": "pymthouse", "billingMode": "delegated"|"prepay" },
  "capabilities": ["*"] | ["text-to-image:sdxl", "text-to-video:ltx"],
  "quota": null,
  "subscriptionRef": "subref_<base64url>",   // optional, opaque (from #149)
  "signerSession": { "url": "…", "headers": { … } }  // optional (omitted in MVP — see below)
}
```

### What changed vs the legacy shape (the PYMT-3 reshape)
- **`client_id` → neutral identity.** The ⑨ forbidden public `client_id` is **removed** from the BPP response. Identity is surfaced as `user.sub` (stable subject) + a provider-neutral `billing_account` ref. Account of record = the developer app (per #149's D2/PYMT-1 drop).
- **`allowedModels` → neutral `capabilities`.** Plan capability bundles are mapped to generic `"<pipeline>:<model>"` ids (sorted, de-duplicated); the delegated MVP / no-plan case returns the wildcard `["*"]` (capabilities = all). No bare model-id list, no `plan` object.
- **GET → POST.** New `POST /api/v1/auth/validate` per the BPP ③ contract (`{ key }` in the body).
- **Opaque `subscriptionRef` kept** from #149 — the raw `openmeter_subscription_id` never crosses the seam.

## Zero-regression (how the legacy path stays back-compat)
- **The legacy `GET /api/v1/auth/validate` is byte-for-byte unchanged** — same `buildValidateResponseBody` (`valid` / `client_id` / `plan` / `allowedModels` / `subscriptionRef`), same auth (Bearer), same valid/invalid decision branches. Current consumers are unaffected (deprecate, don't remove).
- The reshape is delivered as a **separate HTTP method (POST)** on the same route — purely additive; `GET` callers never hit the new code.
- The new POST is **gated behind `BPP_VALIDATE_V2` (default OFF)**. Flag-OFF → **404**, i.e. the endpoint behaves as if absent. Flip ON only once NAAP-C is ready (D0).
- **No migrations** — derived entirely from existing columns (expand-only).

## Security / seam isolation
- Producing-edge guard (`assertNoLeakedInternalFieldNames`) asserts the C0 body carries **no provider-internal field NAME** (`client_id`, `openmeter_subscription_id`, `model_id`, …) before it is returned — defense in depth, mirroring the C0 `provider-internal-openmeter` forbidden list.
- `subscriptionRef` is opaque (NaaP can't infer the metering backend) yet provider-decodable; carries no secret.
- **`signerSession` is intentionally omitted in this PR**: handing out the shared signer session/credential is a security-sensitive concern that belongs with signer-session minting (NAAP-B / `mintSignerSession`). The field is optional in C0, so omitting it is conformant; the builder supports it for when minting lands.
- Malformed body / missing key → `400`; unknown/inactive key → `401`; structured, PII-free responses.

## Test plan
- [x] `npm run lint` — 0 errors (2 pre-existing warnings, unrelated)
- [x] `npm test` — 205 pass, 0 fail, 20 DB-skipped
- [x] `npm run build` — compiles + typechecks
- [x] C0 schema-shape conformance of the new POST body (structural validator mirroring `validate.schema.json`)
- [x] No forbidden-field leak (`client_id` / `allowedModels` / `plan` / `openmeter_*` absent)
- [x] `capabilities` mapping (`pipeline:model`, sorted/deduped) + wildcard for delegated MVP
- [x] `subscriptionRef` opacity round-trip (no raw OM id)
- [x] **Back-compat:** legacy `GET` still returns `client_id`/`plan`/`allowedModels` and no C0 fields (DB-backed)
- [x] Flag-OFF → 404 (zero regression); missing key → 400; unknown key → 401
- [ ] Integration vs the NaaP front door (NAAP-C) once it lands (gated by D0)

> [!NOTE]
> DB-backed route tests skip without `DATABASE_URL` (repo convention — same as #149's "DB-skipped" set). C0 conformance of the exact serialized body is verified at the builder level, which the route returns verbatim.

Made with [Cursor](https://cursor.com)