### PR TITLE
Pin signer livepeer base image to 0.8.10-5c9ec54

### DIFF
--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -167,7 +167,7 @@ ENV SIGNER_DMZ_ENABLE_CLI_LISTENER=1
 EXPOSE 8080 8082
 
 # Production / Railway: livepeer from official Docker image (default final stage).
-FROM livepeer/go-livepeer:0.8.10-d909a4c3 AS livepeer-prod
+FROM eliteencoder/go-livepeer:0.8.10-5c9ec54 AS livepeer-prod
 
 FROM gateway AS signer-dmz
 

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -2,7 +2,7 @@
 # Copies livepeer + required CUDA NPP libs from the official image — do not wget
 # a bare binary into debian:slim; the binary links libnppig.so and other NPP libs.
 
-FROM livepeer/go-livepeer:0.8.10-d909a4c3 AS livepeer-src
+FROM eliteencoder/go-livepeer:0.8.10-5c9ec54 AS livepeer-src
 
 FROM debian:bookworm-slim
 

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -16,8 +16,8 @@ Everything needed to run the go-livepeer signer with an optional **Apache + mod_
 | Image | Dockerfile | go-livepeer source | Use |
 |-------|------------|--------------------|-----|
 | `pymthouse/signer-dmz:local` | `Dockerfile` → `signer-dmz-local` | `../go-livepeer` via `lpclearinghouse` | **Local dev** with PymtHouse (`docker-compose.yml`) |
-| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:0.8.10-d909a4c3` | **Production** (Railway / Render) and prod smoke tests |
-| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:0.8.10-d909a4c3` | **Livepeer only** (no Apache; not for public deploy) |
+| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `eliteencoder/go-livepeer:0.8.10-5c9ec54` | **Production** (Railway / Render) and prod smoke tests |
+| `pymthouse-signer:local` | `Dockerfile.signer` | `eliteencoder/go-livepeer:0.8.10-5c9ec54` | **Livepeer only** (no Apache; not for public deploy) |
 
 ### Force rebuild
 
@@ -33,7 +33,7 @@ docker build --pull --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthou
 # Verify version after rebuild
 docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse-signer:local -version
 docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse/signer-dmz:latest -version
-# expect: Livepeer Node Version: 0.8.10-d909a4c3
+# expect: Livepeer Node Version: 0.8.10-5c9ec54
 ```
 
 ### Local dev


### PR DESCRIPTION
## Summary
- Point production signer-dmz and `Dockerfile.signer` at `eliteencoder/go-livepeer:0.8.10-5c9ec54`
- Update signer-dmz README image table and version check note

## Test plan
- [ ] `docker build --pull -f docker/signer-dmz/Dockerfile -t pymthouse/signer-dmz:test .`
- [ ] `docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse/signer-dmz:test -version` → `0.8.10-5c9ec54`
- [ ] After merge, redeploy Railway signer: `bash scripts/railway-deploy-signer.sh pymthouse production`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the signer-dmz component's base dependency image to a newer version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->