### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymthouse",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pymthouse",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymthouse",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "engines": {
     "node": ">=20.18.1"


### PR DESCRIPTION
## Summary
- Bump `pymthouse` package version from `0.2.2` to `0.2.3` in `package.json` and `package-lock.json`
- Prepares for the `v0.2.3` release tag and production deploy

## Test plan
- [ ] Verify `package.json` and `package-lock.json` both report `0.2.3`
- [ ] After merge, tag `v0.2.3` and push to trigger release deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->