### PR TITLE
Pin signer livepeer base image to livepeer/go-livepeer:feat-add-model-id-signer-kafka

### DIFF
--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -167,7 +167,7 @@ ENV SIGNER_DMZ_ENABLE_CLI_LISTENER=1
 EXPOSE 8080 8082
 
 # Production / Railway: livepeer from official Docker image (default final stage).
-FROM eliteencoder/go-livepeer:0.8.10-5c9ec54 AS livepeer-prod
+FROM livepeer/go-livepeer:feat-add-model-id-signer-kafka AS livepeer-prod
 
 FROM gateway AS signer-dmz
 

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -2,7 +2,7 @@
 # Copies livepeer + required CUDA NPP libs from the official image — do not wget
 # a bare binary into debian:slim; the binary links libnppig.so and other NPP libs.
 
-FROM eliteencoder/go-livepeer:0.8.10-5c9ec54 AS livepeer-src
+FROM livepeer/go-livepeer:feat-add-model-id-signer-kafka AS livepeer-src
 
 FROM debian:bookworm-slim
 

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -16,8 +16,8 @@ Everything needed to run the go-livepeer signer with an optional **Apache + mod_
 | Image | Dockerfile | go-livepeer source | Use |
 |-------|------------|--------------------|-----|
 | `pymthouse/signer-dmz:local` | `Dockerfile` → `signer-dmz-local` | `../go-livepeer` via `lpclearinghouse` | **Local dev** with PymtHouse (`docker-compose.yml`) |
-| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `eliteencoder/go-livepeer:0.8.10-5c9ec54` | **Production** (Railway / Render) and prod smoke tests |
-| `pymthouse-signer:local` | `Dockerfile.signer` | `eliteencoder/go-livepeer:0.8.10-5c9ec54` | **Livepeer only** (no Apache; not for public deploy) |
+| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:feat-add-model-id-signer-kafka` | **Production** (Railway / Render) and prod smoke tests |
+| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:feat-add-model-id-signer-kafka` | **Livepeer only** (no Apache; not for public deploy) |
 
 ### Force rebuild
 
@@ -33,7 +33,7 @@ docker build --pull --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthou
 # Verify version after rebuild
 docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse-signer:local -version
 docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse/signer-dmz:latest -version
-# expect: Livepeer Node Version: 0.8.10-5c9ec54
+# expect: Livepeer Node Version: 0.8.10-e1e784f0
 ```
 
 ### Local dev


### PR DESCRIPTION
## Summary

- Switch production signer-dmz builds from `eliteencoder/go-livepeer:0.8.10-5c9ec54` back to `livepeer/go-livepeer:feat-add-model-id-signer-kafka`
- Updates `Dockerfile`, `Dockerfile.signer`, and `README.md` (mirrors #157 in reverse)

## Test plan

- [ ] `docker build --pull --no-cache -f docker/signer-dmz/Dockerfile -t pymthouse/signer-dmz:latest .`
- [ ] `docker build --pull --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthouse-signer:local .`
- [ ] `docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse/signer-dmz:latest -version` → expect `0.8.10-e1e784f0`
- [ ] `docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse-signer:local -version` → expect `0.8.10-e1e784f0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base image used for building the signer-dmz Docker container.

* **Documentation**
  * Updated build documentation and expected version output for the signer-dmz image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->