### PR TITLE
Always emit issued_token_type on signer-JWT token exchange (RFC 8693 §2.2.1)

### DIFF
--- a/src/lib/oidc/signer-jwt-token-exchange.test.ts
+++ b/src/lib/oidc/signer-jwt-token-exchange.test.ts
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  handleSignerJwtTokenExchange,
+  isSignerJwtTokenExchangeRequest,
+  SUBJECT_ACCESS_TOKEN_TYPE,
+  type SignerJwtTokenExchangeDeps,
+} from "./signer-jwt-token-exchange";
+import { signerJwtAudience } from "./mint-user-signer-token";
+import type { DrizzleDb } from "./client-sibling";
+
+const TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
+const M2M_ID = "m2m_test123";
+const PUBLIC_ID = "app_testpublic";
+
+const m2mRowOk = {
+  id: "int-m2m",
+  clientSecretHash: "hash",
+  allowedScopes: "users:token sign:job",
+  clientId: M2M_ID,
+};
+
+/** Single `db.select().from().where().limit()` for the caller `oidcClients` lookup. */
+function dbMock(rows: unknown[][]): DrizzleDb {
+  let i = 0;
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => {
+            const r = rows[i++];
+            if (!r) throw new Error(`db mock exhausted at step ${i}`);
+            return Promise.resolve(r);
+          },
+        }),
+      }),
+    }),
+  } as unknown as DrizzleDb;
+}
+
+const happyDeps: Partial<SignerJwtTokenExchangeDeps> = {
+  validateClientSecret: async () => true,
+  resolveDeveloperAppAndPublicClientForOidcRow: async () => ({
+    developerAppId: "dev-app-1",
+    publicClientId: PUBLIC_ID,
+  }),
+  resolveSubjectAccessToken: async () => ({
+    payload: { scope: "sign:job" },
+    sub: "au-1",
+    publicClientId: PUBLIC_ID,
+    developerAppId: "dev-app-1",
+    externalUserId: "ext-1",
+  }),
+  mintSignerJwtForExternalUser: async () => ({
+    access_token: "eyJ.signer.jwt",
+    token_type: "Bearer" as const,
+    expires_in: 300,
+    scope: "sign:job",
+    balanceUsdMicros: "4200000",
+    lifetimeGrantedUsdMicros: "5000000",
+  }),
+};
+
+test("isSignerJwtTokenExchangeRequest is true when resource targets the signer audience", () => {
+  assert.equal(
+    isSignerJwtTokenExchangeRequest({
+      grantType: TOKEN_EXCHANGE_GRANT,
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+      resource: signerJwtAudience(),
+    }),
+    true,
+  );
+});
+
+test("handleSignerJwtTokenExchange sets issued_token_type (RFC 8693 §2.2.1)", async () => {
+  const out = await handleSignerJwtTokenExchange(
+    {
+      clientId: M2M_ID,
+      clientSecret: "secret",
+      subjectToken: "jwt",
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+      resource: signerJwtAudience(),
+    },
+    {
+      ...happyDeps,
+      db: dbMock([[m2mRowOk]]),
+    },
+  );
+
+  assert.equal(out.access_token, "eyJ.signer.jwt");
+  assert.equal(
+    out.issued_token_type,
+    "urn:ietf:params:oauth:token-type:access_token",
+  );
+  assert.equal(out.balanceUsdMicros, "4200000");
+});

--- a/src/lib/oidc/signer-jwt-token-exchange.ts
+++ b/src/lib/oidc/signer-jwt-token-exchange.ts
@@ -23,6 +23,14 @@ import { TokenExchangeError } from "@/lib/oidc/token-exchange";
 export const SUBJECT_ACCESS_TOKEN_TYPE =
   "urn:ietf:params:oauth:token-type:access_token";
 
+/**
+ * RFC 8693 §2.2.1 requires `issued_token_type` on every token-exchange
+ * response. The signer JWT is an access token (consistent with the device and
+ * gateway exchanges), so callers never have to derive this value client-side.
+ */
+const ISSUED_ACCESS_TOKEN_TYPE =
+  "urn:ietf:params:oauth:token-type:access_token";
+
 const TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
 const DEVICE_CODE_RESOURCE_PREFIX = "urn:pmth:device_code:";
 
@@ -119,6 +127,7 @@ export async function handleSignerJwtTokenExchange(
   token_type: "Bearer";
   expires_in: number;
   scope: string;
+  issued_token_type: string;
   balanceUsdMicros: string;
   lifetimeGrantedUsdMicros: string;
 }> {
@@ -238,6 +247,7 @@ export async function handleSignerJwtTokenExchange(
     token_type: "Bearer",
     expires_in: minted.expires_in,
     scope: minted.scope,
+    issued_token_type: ISSUED_ACCESS_TOKEN_TYPE,
     balanceUsdMicros: minted.balanceUsdMicros,
     lifetimeGrantedUsdMicros: minted.lifetimeGrantedUsdMicros,
   };


### PR DESCRIPTION
## Summary

Per maintainer feedback on builder-sdk#34: the SDK change to omit `resource`/`audience` is fine, but making `issued_token_type` optional in the SDK conflicts with **RFC 8693 §2.2.1**, which makes `issued_token_type` **REQUIRED** in a token-exchange response. The correct fix is to set it proactively on the issuer (pymthouse) so it is never derived client-side.

The signer-JWT exchange path (`handleSignerJwtTokenExchange`) was the only token-exchange response omitting `issued_token_type` — the device and gateway/opaque exchanges already set it. This emits it as an access token, consistent with those paths.

This lets builder-sdk keep **strict, RFC-compliant** `issued_token_type` validation instead of fail-open defaulting (follow-up tracked separately in builder-sdk).

## Changes

- `signer-jwt-token-exchange.ts`: add `issued_token_type: urn:ietf:params:oauth:token-type:access_token` to the response (and its return type).
- `signer-jwt-token-exchange.test.ts`: assert `issued_token_type` is present on a successful exchange.

## Test plan

- [x] `node --test` for signer-JWT + gateway exchange suites (14/14 pass)
- [x] `eslint` clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token exchange responses now include an `issued_token_type` field.

* **Tests**
  * Added tests for JWT token exchange request validation and response generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->