### PR TITLE
ci: promote Vercel production deploys to assign custom domains

### DIFF
--- a/.github/workflows/deploy-production-vercel.yml
+++ b/.github/workflows/deploy-production-vercel.yml
@@ -80,3 +80,6 @@ jobs:
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "Vercel alias: $deployment_url"
           echo "Canonical URL: ${{ vars.VERCEL_PRODUCTION_URL || 'https://pymthouse.com' }}"
+
+      - name: Promote deployment (assign custom domains)
+        run: vercel promote "${{ steps.vercel_deploy.outputs.deployment_url }}" --yes --token="$VERCEL_TOKEN"

--- a/scripts/deploy-production-vercel.sh
+++ b/scripts/deploy-production-vercel.sh
@@ -19,6 +19,7 @@ fi
 
 vercel pull --yes --environment=production ${VERCEL_TOKEN:+--token="$VERCEL_TOKEN"}
 vercel build --prod ${VERCEL_TOKEN:+--token="$VERCEL_TOKEN"}
-vercel deploy --prebuilt --prod ${VERCEL_TOKEN:+--token="$VERCEL_TOKEN"}
+deployment_url=$(vercel deploy --prebuilt --prod ${VERCEL_TOKEN:+--token="$VERCEL_TOKEN"})
+vercel promote "$deployment_url" --yes ${VERCEL_TOKEN:+--token="$VERCEL_TOKEN"}
 
-echo "Deployed to pymthouse production (https://pymthouse.com)."
+echo "Deployed and promoted to pymthouse production (https://pymthouse.com)."


### PR DESCRIPTION
## Summary
- Add `vercel promote` after production deploy in GitHub Actions so `pymthouse.com` is assigned when auto-assign custom production domains is disabled on Vercel.
- Mirror the same promote step in `scripts/deploy-production-vercel.sh` for manual CLI deploys.

## Test plan
- [ ] Merge and re-run [Deploy production (Vercel)](https://github.com/pymthouse/pymthouse/actions/workflows/deploy-production-vercel.yml) (manual dispatch)
- [ ] Confirm deployment is promoted and `pymthouse.com` appears under deployment aliases in Vercel dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments now include an explicit promotion step, ensuring the deployed version is assigned to the configured custom domains.
  * Deployment messaging was updated to reflect the full deploy-and-promote flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->