### PR TITLE
fix(signer): accept opaque session at /generate-live-payment (symmetric with /sign-orchestrator-info)

### DIFF
--- a/src/app/webhooks/remote-signer/route.ts
+++ b/src/app/webhooks/remote-signer/route.ts
@@ -1,7 +1,10 @@
 import { getIssuer } from "@/lib/oidc/issuer-urls";
+import { createOpaqueSessionEndUserVerifier } from "@/lib/signer/opaque-session-verifier";
 import {
+  createFirstMatchEndUserVerifier,
   createSignerDmzRemoteSignerWebhookConfig,
   handleRemoteSignerAuthorize,
+  type RemoteSignerWebhookConfig,
 } from "@pymthouse/builder-sdk/signer/webhook";
 
 function boolEnv(value: string | undefined): boolean {
@@ -19,12 +22,14 @@ function isHttpIssuer(issuer: string): boolean {
   }
 }
 
-function buildWebhookConfig() {
+function buildWebhookConfig(): RemoteSignerWebhookConfig {
   const jwtIssuer = process.env.JWT_ISSUER?.trim() || getIssuer();
   const jwtAudience = process.env.JWT_AUDIENCE?.trim() || jwtIssuer;
   const webhookSecret = process.env.WEBHOOK_SECRET?.trim() || "";
 
-  return createSignerDmzRemoteSignerWebhookConfig({
+  // Unchanged JWT + Apache trusted-headers verification (the intended,
+  // long-term per-user signer-JWT attribution contract).
+  const base = createSignerDmzRemoteSignerWebhookConfig({
     webhookSecret,
     jwtIssuer,
     jwtAudience,
@@ -38,6 +43,24 @@ function buildWebhookConfig() {
     allowInsecureHttp:
       boolEnv(process.env.ALLOW_INSECURE_HTTP) || isHttpIssuer(jwtIssuer),
   });
+
+  // Additive: also accept the opaque `pmth_*` remote-signer session so a billed
+  // `/generate-live-payment` is symmetric with the already-working
+  // `/sign-orchestrator-info`. The opaque verifier only matches `pmth_` bearers
+  // and validates them against PymtHouse; every other bearer falls through to
+  // the unchanged JWT path above.
+  const opaqueSessionVerifier = createOpaqueSessionEndUserVerifier({
+    issuer: jwtIssuer,
+  });
+
+  return {
+    webhookSecret: base.webhookSecret,
+    endUserAuth: createFirstMatchEndUserVerifier([
+      opaqueSessionVerifier,
+      base.endUserAuth,
+    ]),
+    afterVerify: base.afterVerify,
+  };
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/src/lib/signer/opaque-session-verifier.test.ts
+++ b/src/lib/signer/opaque-session-verifier.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createFirstMatchEndUserVerifier,
+  handleRemoteSignerAuthorize,
+  type EndUserAuthVerifier,
+  type PaymentWebhookResponse,
+} from "@pymthouse/builder-sdk/signer/webhook";
+
+import {
+  createOpaqueSessionEndUserVerifier,
+  type OpaqueSessionPrincipal,
+} from "./opaque-session-verifier";
+
+const ISSUER = "https://pymthouse.example/api/v1/oidc";
+const OPAQUE_TOKEN = "pmth_deadbeefdeadbeefdeadbeefdeadbeef";
+const JWT_TOKEN = "header.payload.signature";
+
+function principal(
+  overrides: Partial<OpaqueSessionPrincipal> = {},
+): OpaqueSessionPrincipal {
+  return {
+    clientId: "app_client_123",
+    externalUserId: "user-42",
+    ...overrides,
+  };
+}
+
+test("opaque session is accepted with symmetric attribution identity", async () => {
+  const verifier = createOpaqueSessionEndUserVerifier({
+    issuer: ISSUER,
+    resolvePrincipal: async (token) => {
+      assert.equal(token, OPAQUE_TOKEN);
+      return principal();
+    },
+  });
+
+  const before = Math.trunc(Date.now() / 1000);
+  const result = await verifier.verify({
+    authorization: `Bearer ${OPAQUE_TOKEN}`,
+    payload: {},
+    request: new Request("https://signer.invalid/authorize"),
+  });
+
+  assert.deepEqual(result.identity, {
+    issuer: ISSUER,
+    client_id: "app_client_123",
+    usage_subject: "user-42",
+    usage_subject_type: "external_user_id",
+  });
+  assert.ok(result.expiry > before, "expiry must be in the future");
+});
+
+test("issuer trailing slashes are stripped to match signer JWT aud", async () => {
+  const verifier = createOpaqueSessionEndUserVerifier({
+    issuer: `${ISSUER}//`,
+    resolvePrincipal: async () => principal(),
+  });
+
+  const result = await verifier.verify({
+    authorization: `Bearer ${OPAQUE_TOKEN}`,
+    payload: {},
+    request: new Request("https://signer.invalid/authorize"),
+  });
+
+  assert.equal(result.identity.issuer, ISSUER);
+});
+
+test("non-opaque bearer is passed through (throws so JWT path runs)", async () => {
+  let resolverCalled = false;
+  const verifier = createOpaqueSessionEndUserVerifier({
+    issuer: ISSUER,
+    resolvePrincipal: async () => {
+      resolverCalled = true;
+      return principal();
+    },
+  });
+
+  await assert.rejects(
+    verifier.verify({
+      authorization: `Bearer ${JWT_TOKEN}`,
+      payload: {},
+      request: new Request("https://signer.invalid/authorize"),
+    }),
+  );
+  assert.equal(resolverCalled, false, "JWTs must not hit the session resolver");
+});
+
+test("forged/expired opaque session is rejected", async () => {
+  const verifier = createOpaqueSessionEndUserVerifier({
+    issuer: ISSUER,
+    resolvePrincipal: async () => null,
+  });
+
+  await assert.rejects(
+    verifier.verify({
+      authorization: `Bearer ${OPAQUE_TOKEN}`,
+      payload: {},
+      request: new Request("https://signer.invalid/authorize"),
+    }),
+  );
+});
+
+// --- Composite / webhook integration (mirrors the route wiring) ---------------
+
+const WEBHOOK_SECRET = "test-webhook-secret";
+
+/** Stub OIDC verifier standing in for the unchanged JWT path. */
+function jwtStubVerifier(): EndUserAuthVerifier {
+  return {
+    kind: "oidc",
+    verify: async ({ authorization }) => {
+      if (authorization !== `Bearer ${JWT_TOKEN}`) {
+        throw new Error("Invalid JWT");
+      }
+      return {
+        identity: {
+          issuer: ISSUER,
+          client_id: "app_client_jwt",
+          usage_subject: "user-jwt",
+          usage_subject_type: "external_user_id",
+        },
+        expiry: Math.trunc(Date.now() / 1000) + 300,
+      };
+    },
+  };
+}
+
+function webhookRequest(bearer: string): Request {
+  return new Request("https://signer.invalid/authorize", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${WEBHOOK_SECRET}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ authorization: `Bearer ${bearer}` }),
+  });
+}
+
+function webhookConfig(resolve: (t: string) => Promise<OpaqueSessionPrincipal | null>) {
+  return {
+    webhookSecret: WEBHOOK_SECRET,
+    endUserAuth: createFirstMatchEndUserVerifier([
+      createOpaqueSessionEndUserVerifier({ issuer: ISSUER, resolvePrincipal: resolve }),
+      jwtStubVerifier(),
+    ]),
+  };
+}
+
+test("webhook: opaque session authorizes /generate-live-payment with attribution", async () => {
+  const response = await handleRemoteSignerAuthorize(
+    webhookRequest(OPAQUE_TOKEN),
+    webhookConfig(async () => principal()),
+  );
+  const body = (await response.json()) as PaymentWebhookResponse;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.status, 200);
+  assert.deepEqual(body.identity, {
+    issuer: ISSUER,
+    client_id: "app_client_123",
+    usage_subject: "user-42",
+    usage_subject_type: "external_user_id",
+  });
+  assert.equal(body.auth_id, "app_client_123:user-42");
+});
+
+test("webhook: JWT bearer still authorizes via the unchanged JWT path", async () => {
+  const response = await handleRemoteSignerAuthorize(
+    webhookRequest(JWT_TOKEN),
+    webhookConfig(async () => {
+      throw new Error("opaque resolver must not run for JWTs");
+    }),
+  );
+  const body = (await response.json()) as PaymentWebhookResponse;
+
+  assert.equal(body.status, 200);
+  assert.equal(body.identity?.client_id, "app_client_jwt");
+});
+
+test("webhook: forged opaque session is rejected", async () => {
+  const response = await handleRemoteSignerAuthorize(
+    webhookRequest(OPAQUE_TOKEN),
+    webhookConfig(async () => null),
+  );
+  const body = (await response.json()) as PaymentWebhookResponse;
+
+  // go-livepeer reads `status` from the body; a non-200 status denies the ticket.
+  assert.notEqual(body.status, 200);
+  assert.equal(body.identity, undefined);
+});

--- a/src/lib/signer/opaque-session-verifier.ts
+++ b/src/lib/signer/opaque-session-verifier.ts
@@ -1,0 +1,159 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { endUsers } from "@/db/schema";
+import { hasScope, validateBearerToken } from "@/lib/auth";
+import {
+  bearerTokenFromAuthorization,
+  type EndUserAuthVerifier,
+  type UsageIdentity,
+} from "@pymthouse/builder-sdk/signer/webhook";
+
+/**
+ * Opaque `pmth_*` remote-signer session acceptance for the remote-signer
+ * identity webhook.
+ *
+ * Context: the signer DMZ forwards the end-user `Authorization: Bearer …` to
+ * this webhook (`/webhooks/remote-signer`) so go-livepeer can attribute a
+ * billable `/generate-live-payment` ticket to `(client_id, external_user_id)`.
+ * The OIDC verifier only accepts signer **JWTs** (`aud = issuer`, JWKS-verifiable),
+ * so an opaque `pmth_…` remote-signer session — minted via the RFC 8693 gateway
+ * exchange (no `resource`, see `handleGatewayTokenExchange`) — is rejected with
+ * "Invalid JWT". The unbilled `/sign-orchestrator-info` path already works from
+ * that opaque session, so payment was the only asymmetric gate.
+ *
+ * This verifier closes that gap symmetrically: it validates the opaque session
+ * **against PymtHouse** (the same `validateBearerToken` session lookup the rest
+ * of the API relies on — not blind trust) and derives the identical attribution
+ * identity the signer JWT would have carried:
+ *   - `issuer`             ← the OIDC issuer
+ *   - `client_id`          ← the session's public app client id (`sessions.app_id`)
+ *   - `usage_subject`      ← the end user's `external_user_id`
+ *   - `usage_subject_type` ← `external_user_id`
+ *
+ * It is strictly **additive**: only opaque `pmth_` bearers are handled here; any
+ * other bearer is passed through (by throwing) so the composite verifier falls
+ * back to the unchanged JWT / trusted-headers paths.
+ */
+
+const OPAQUE_SESSION_PREFIX = "pmth_";
+const DEFAULT_REQUIRED_SCOPE = "sign:job";
+const DEFAULT_EXPIRY_TTL_SECONDS = 300;
+const USAGE_SUBJECT_TYPE = "external_user_id";
+
+/** Attribution principal resolved from a validated opaque session. */
+export type OpaqueSessionPrincipal = {
+  /** Public app client id used as the billing `client_id`. */
+  clientId: string;
+  /** End-user attribution subject (the app's external user id). */
+  externalUserId: string;
+};
+
+export type OpaqueSessionEndUserVerifierConfig = {
+  /** OIDC issuer URL; emitted verbatim (trailing slashes stripped) as `identity.issuer`. */
+  issuer: string;
+  /** Scope the session must carry to authorize signing. Defaults to `sign:job`. */
+  requiredScope?: string;
+  /** Auth-cache TTL (seconds) returned to go-livepeer. Defaults to 300. */
+  expiryTtlSeconds?: number;
+  /**
+   * Resolve a validated opaque session to its attribution principal. Injectable
+   * for tests; defaults to a PymtHouse session lookup (`validateBearerToken`)
+   * plus an `end_users.external_user_id` resolution.
+   */
+  resolvePrincipal?: (token: string) => Promise<OpaqueSessionPrincipal | null>;
+};
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+/**
+ * Default principal resolver: validate the opaque session against PymtHouse and
+ * map it to `(client_id, external_user_id)`. Returns `null` for any session that
+ * is unknown, expired, missing the required scope, or not bound to both a
+ * developer app and an end user (i.e. not attributable for billing).
+ */
+async function resolvePrincipalFromSession(
+  token: string,
+  requiredScope: string,
+): Promise<OpaqueSessionPrincipal | null> {
+  const auth = await validateBearerToken(token);
+  if (!auth) {
+    return null;
+  }
+  if (!hasScope(auth.scopes, requiredScope)) {
+    return null;
+  }
+  // Billable attribution requires a public app client id and an end user.
+  if (!auth.appId || !auth.endUserId) {
+    return null;
+  }
+
+  const rows = await db
+    .select({ externalUserId: endUsers.externalUserId })
+    .from(endUsers)
+    .where(eq(endUsers.id, auth.endUserId))
+    .limit(1);
+  const externalUserId = rows[0]?.externalUserId?.trim();
+  if (!externalUserId) {
+    return null;
+  }
+
+  return { clientId: auth.appId.trim(), externalUserId };
+}
+
+/**
+ * Build an {@link EndUserAuthVerifier} that authorizes opaque `pmth_*`
+ * remote-signer sessions. Intended to be composed (via
+ * `createFirstMatchEndUserVerifier`) ahead of the JWT / trusted-headers
+ * verifiers so the JWT path stays the default and remains unchanged.
+ */
+export function createOpaqueSessionEndUserVerifier(
+  config: OpaqueSessionEndUserVerifierConfig,
+): EndUserAuthVerifier {
+  const issuer = stripTrailingSlashes(config.issuer.trim());
+  if (!issuer) {
+    throw new Error("issuer is required for opaque session verification");
+  }
+  const requiredScope = config.requiredScope?.trim() || DEFAULT_REQUIRED_SCOPE;
+  const expiryTtlSeconds =
+    config.expiryTtlSeconds && config.expiryTtlSeconds > 0
+      ? Math.trunc(config.expiryTtlSeconds)
+      : DEFAULT_EXPIRY_TTL_SECONDS;
+  const resolvePrincipal =
+    config.resolvePrincipal ??
+    ((token: string) => resolvePrincipalFromSession(token, requiredScope));
+
+  return {
+    kind: "custom",
+    verify: async ({ authorization }) => {
+      const token = bearerTokenFromAuthorization(authorization);
+      // Only handle opaque sessions; let other bearers (JWTs) fall through to
+      // the next verifier in the composite chain.
+      if (!token.startsWith(OPAQUE_SESSION_PREFIX)) {
+        throw new Error("not an opaque remote-signer session");
+      }
+
+      const principal = await resolvePrincipal(token);
+      if (!principal) {
+        throw new Error("invalid or unauthorized remote-signer session");
+      }
+
+      const identity: UsageIdentity = {
+        issuer,
+        client_id: principal.clientId,
+        usage_subject: principal.externalUserId,
+        usage_subject_type: USAGE_SUBJECT_TYPE,
+      };
+
+      return {
+        identity,
+        expiry: Math.trunc(Date.now() / 1000) + expiryTtlSeconds,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Make the remote-signer DMZ accept an **opaque `pmth_*` remote-signer session** at the billed `/generate-live-payment` path, symmetric with the already-working unbilled `/sign-orchestrator-info` path — **without weakening the JWT contract**.

### The contract mismatch

The signer DMZ forwards the end-user `Authorization: Bearer …` to this app's identity webhook (`/webhooks/remote-signer`) so go-livepeer can attribute a billable payment ticket to `(client_id, external_user_id)`. That webhook (`createSignerDmzRemoteSignerWebhookConfig`) only accepts:

1. Apache **trusted `X-Livepeer-*` identity headers**, or
2. a signer **JWT** (OIDC verifier: `aud = issuer`, JWKS-verifiable, carrying `client_id` / `external_user_id`).

A consumer that holds an **opaque `pmth_…` remote-signer session** — minted via the RFC 8693 gateway exchange (`handleGatewayTokenExchange`, no `resource`) — is not a JWT, so the webhook rejects it with **`Invalid JWT`** and go-livepeer returns `502` on `/generate-live-payment`. The unbilled `/sign-orchestrator-info` path already authorizes from that same opaque session, so **payment was the only asymmetric gate**. This blocks any funded BYOC generation driven from an opaque session (e.g. the NaaP per-key remote-signer path), with **no change possible on the caller side** today.

### The fix (additive, backward-compatible)

Add an opaque-session verifier to the webhook's first-match verifier chain:

- It **only** matches `pmth_` bearers; every other bearer falls through to the **unchanged** JWT / trusted-headers verifiers.
- It **validates the session against PymtHouse** using the existing `validateBearerToken` lookup (DB-backed, expiry- and scope-checked) — not blind trust.
- It derives the **same attribution identity** a signer JWT would have carried:
  - `issuer` ← OIDC issuer
  - `client_id` ← `sessions.app_id` (the public app client)
  - `usage_subject` ← end user `external_user_id`
  - `usage_subject_type` ← `external_user_id`
- Sessions that are unknown, expired, lacking `sign:job`, or not bound to both an app and an end user are rejected.

Net effect: a billed `/generate-live-payment` now succeeds from an opaque session with the **identical** OpenMeter attribution it would have had via a JWT, and the real signer-JWT path is **byte-for-byte unchanged**.

## Files

- `src/lib/signer/opaque-session-verifier.ts` — new opaque-session `EndUserAuthVerifier` (DB-validated, attribution-preserving, injectable resolver for tests).
- `src/app/webhooks/remote-signer/route.ts` — prepend the opaque verifier to the existing `createSignerDmzRemoteSignerWebhookConfig` chain via `createFirstMatchEndUserVerifier`. JWT/trusted-headers config untouched.
- `src/lib/signer/opaque-session-verifier.test.ts` — coverage (see below).

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint` on changed files — clean
- [x] New unit/integration tests (7) — all pass:
  - opaque session accepted → correct `(issuer, client_id, usage_subject, usage_subject_type)` and future expiry
  - issuer trailing slashes stripped (matches signer-JWT `aud`)
  - non-opaque (JWT) bearer falls through; session resolver never runs
  - forged/expired opaque session rejected
  - webhook end-to-end: opaque authorizes with `auth_id = client_id:usage_subject`; JWT still authorizes via the unchanged path; forged opaque denied (non-200 `status` in body, no identity)
- [x] Full suite `npm test` — 209 pass / 22 skipped (DB-gated) / 0 fail

## Notes for the reviewer (@eliteprox)

- **Why this is safe:** strictly additive — the only new acceptance is for `pmth_` sessions that PymtHouse itself validates. The JWT and trusted-headers verifiers are unchanged and still run for every non-opaque bearer.
- **Verification limit (honest):** the go-livepeer remote signer that fronts `/generate-live-payment` and calls this webhook is not in this repo, so I could not line-trace go-livepeer's per-path behavior. This change is grounded in `docs/signer-deployment-options.md` ("signing HTTP paths … go-livepeer verifies identity via `REMOTE_SIGNER_WEBHOOK_URL`") and the existing OIDC verifier being the source of the `Invalid JWT` rejection. If go-livepeer pre-parses the bearer as a JWT *before* calling the webhook for this path, an additional go-livepeer-side tweak would be needed; the deployment doc indicates it does not (it forwards the bearer and trusts the webhook verdict).
- **Durable fast-follow (not in this PR):** make the signer-JWT `resource` token-exchange RFC 8693-conformant so callers can present a real per-user signer JWT (`aud = issuer`) and attribution rides JWT claims end-to-end. This PR unblocks the funded path now; the JWT path remains the intended steady state.

Please review — **do not merge on my behalf**; this needs owner approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote-signer requests now support an additional opaque session login path for end-user authorization, alongside the existing JWT-based flow.

* **Bug Fixes**
  * Improved authorization handling so valid remote-signer sessions are recognized more reliably, including consistent issuer matching and clearer fall-through for non-opaque tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->