### PR TITLE
Bump @pymthouse/builder-sdk to 0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",
-        "@pymthouse/builder-sdk": "0.4.3",
+        "@pymthouse/builder-sdk": "^0.4.6",
         "@tailwindcss/postcss": "^4.1.18",
         "@turnkey/crypto": "^2.8.14",
         "@turnkey/react-wallet-kit": "^1.11.1",
@@ -2243,9 +2243,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@pymthouse/builder-sdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.3.tgz",
-      "integrity": "sha512-1cwK78PDekyd2BYC59OJeSorT8XT+laNp7dQj+JC9FNcO4TmJs32Yz4EzhWZohUXszIpejas3J+KXWh9HR8hrw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.6.tgz",
+      "integrity": "sha512-o00iwt4n+5mORHldio/NtDmr05YugFbj7x4Wi73IcybDJRfaHbGjGqde9BbdShljPeP5WgHUhREPopLjpJr7Cg==",
       "license": "MIT",
       "dependencies": {
         "oauth4webapi": "^3.8.5"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.2",
     "@openmeter/sdk": "^1.0.0-beta.228",
-    "@pymthouse/builder-sdk": "0.4.3",
+    "@pymthouse/builder-sdk": "^0.4.6",
     "@tailwindcss/postcss": "^4.1.18",
     "@turnkey/crypto": "^2.8.14",
     "@turnkey/react-wallet-kit": "^1.11.1",


### PR DESCRIPTION
## Summary
- Bumps `@pymthouse/builder-sdk` from 0.4.3 to 0.4.6
- Build passes with no breaking changes

## Test plan
- [x] `npm install` completes with 0 vulnerabilities
- [x] `npm run build` succeeds — all routes compile cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project package to a newer version range, which may include stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->