### PR TITLE
fix(oidc): include external_user_id on programmatic user JWTs

### DIFF
--- a/src/lib/oidc/programmatic-tokens.ts
+++ b/src/lib/oidc/programmatic-tokens.ts
@@ -57,6 +57,7 @@ export async function issueProgrammaticTokens(input: {
     .select({
       oauthClientId: oidcClients.clientId,
       appUserId: appUsers.id,
+      externalUserId: appUsers.externalUserId,
     })
     .from(developerApps)
     .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
@@ -80,6 +81,14 @@ export async function issueProgrammaticTokens(input: {
     );
   }
 
+  const externalUserId = binding.externalUserId?.trim();
+  if (!externalUserId) {
+    throw new ProgrammaticTokenError(
+      "invalid_request",
+      "App user is missing external_user_id",
+    );
+  }
+
   const issuer = getIssuer();
   const keyPair = await ensureSigningKey();
   const nowSeconds = Math.floor(Date.now() / 1000);
@@ -89,6 +98,7 @@ export async function issueProgrammaticTokens(input: {
     scope,
     scp: input.scopes,
     client_id: binding.oauthClientId,
+    external_user_id: externalUserId,
     user_type: "app_user",
   })
     .setProtectedHeader({ alg: "RS256", kid: keyPair.kid, typ: ACCESS_TOKEN_JWT_TYP })


### PR DESCRIPTION
## Summary

- Adds `external_user_id` to JWTs minted by `POST /api/v1/apps/{clientId}/users/{externalUserId}/token` (and refresh rotation via the same `issueProgrammaticTokens` path).
- Unblocks remote signer billed generation (`POST /generate-live-payment`) for integrators using Builder user tokens (`sign:job`) without requiring `sign:mint_user_token`.
- Fixes [#167](https://github.com/pymthouse/pymthouse/issues/167) **403** path: the identity webhook defaults to `CLAIM_USAGE_SUBJECT=external_user_id`, but programmatic tokens only carried `sub` (internal `app_users.id`).

## Context

| Endpoint | Webhook? | Token requirement |
|----------|----------|-------------------|
| `POST /sign-orchestrator-info` | No | Valid JWT (sig + aud + scope) |
| `POST /generate-live-payment` | Yes | JWT with `iss`, `client_id`, **`external_user_id`** |

Programmatic tokens had `client_id` and `sub` but not `external_user_id`, so read paths worked while billed paths returned `403 JWT missing required identity claims`.

This does **not** address the separate `sign:mint_user_token` **500** (OpenMeter provisioning in `provisionAppUserBilling`); that needs a follow-up.

## Test plan

- [ ] Mint a user token: `POST /api/v1/apps/{clientId}/users/{externalUserId}/token` with `scope=sign:job`
- [ ] Decode JWT — confirm `external_user_id` matches the path param and `client_id` is the public `app_…` id
- [ ] `POST {signerUrl}/sign-orchestrator-info` with Bearer JWT → 200 (unchanged)
- [ ] `POST {signerUrl}/generate-live-payment` with same JWT → 200 (was 403)
- [ ] Confirm OpenMeter metering attributes usage to `(client_id, external_user_id)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved programmatic token generation to include a validated external user identifier when available.
  * Requests with missing or empty external user information now fail cleanly instead of issuing incomplete tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->