### PR TITLE
feat(billing): integrate Stripe billing checks into OpenMeter

### DIFF
--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -15,6 +15,16 @@ export async function getAppBillingConfig(clientId: string) {
   return rows[0] ?? null;
 }
 
+/** Stripe Connect completed and wired into OpenMeter billing profiles. */
+export async function isStripeBillingEnabledForApp(clientId: string): Promise<boolean> {
+  const config = await getAppBillingConfig(clientId);
+  return (
+    config?.stripeConnectStatus === "connected" &&
+    Boolean(config.openmeterStripeAppId?.trim()) &&
+    Boolean(config.openmeterBillingProfileId?.trim())
+  );
+}
+
 export async function ensureTenantBillingProfile(input: {
   clientId: string;
   openmeterStripeAppId: string;
@@ -66,6 +76,9 @@ export async function applyTenantBillingProfileToCustomer(input: {
   clientId: string;
   customerId: string;
 }): Promise<void> {
+  if (!(await isStripeBillingEnabledForApp(input.clientId))) {
+    return;
+  }
   const config = await getAppBillingConfig(input.clientId);
   if (!config?.openmeterBillingProfileId) {
     return;

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -76,11 +76,12 @@ export async function applyTenantBillingProfileToCustomer(input: {
   clientId: string;
   customerId: string;
 }): Promise<void> {
-  if (!(await isStripeBillingEnabledForApp(input.clientId))) {
-    return;
-  }
   const config = await getAppBillingConfig(input.clientId);
-  if (!config?.openmeterBillingProfileId) {
+  if (
+    config?.stripeConnectStatus !== "connected" ||
+    !config.openmeterStripeAppId?.trim() ||
+    !config.openmeterBillingProfileId?.trim()
+  ) {
     return;
   }
   await assignCustomerBillingProfileOverride({

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -13,6 +13,7 @@ import {
   getTrialFeatureKeyForApp,
 } from "./client-factory";
 import { defaultStarterIncludedUsdMicros } from "@/lib/starter-default-plan-display";
+import { isStripeBillingEnabledForApp } from "./billing-profiles";
 import { getKonnectEntitlementHasAccess } from "./konnect-entitlements";
 import { shouldUseKonnectRoutes } from "./route-mode";
 import {
@@ -114,6 +115,11 @@ async function getKonnectTrialCreditBalance(input: {
   }
 
   const defaultGrant = defaultStarterIncludedUsdMicros();
+  if (!hasAccess && !(await isStripeBillingEnabledForApp(input.clientId))) {
+    // Free Starter allowance without Stripe Connect — subscription optional.
+    hasAccess = true;
+  }
+
   if (!hasAccess) {
     return {
       hasAccess: false,

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -115,7 +115,13 @@ async function getKonnectTrialCreditBalance(input: {
   }
 
   const defaultGrant = defaultStarterIncludedUsdMicros();
-  if (!hasAccess && !(await isStripeBillingEnabledForApp(input.clientId))) {
+  let stripeBillingEnabled = true;
+  try {
+    stripeBillingEnabled = await isStripeBillingEnabledForApp(input.clientId);
+  } catch {
+    stripeBillingEnabled = false;
+  }
+  if (!hasAccess && !stripeBillingEnabled) {
     // Free Starter allowance without Stripe Connect — subscription optional.
     hasAccess = true;
   }

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -491,6 +491,17 @@ test("isOpenMeterConflictError detects duplicate entitlement failures", async ()
   assert.equal(isOpenMeterConflictError(new Error("validation failed")), false);
 });
 
+test("isOpenMeterStripeBillingError detects Stripe precondition failures on 409", async () => {
+  const { isOpenMeterStripeBillingError, isOpenMeterConflictError } = await import("./plan-errors");
+  const stripeErr = new Error(
+    "conflict error: invalid billing setup: failed to get stripe customer data: " +
+      "customer has no data for stripe app",
+  );
+  (stripeErr as { status: number }).status = 409;
+  assert.equal(isOpenMeterStripeBillingError(stripeErr), true);
+  assert.equal(isOpenMeterConflictError(stripeErr), true);
+});
+
 test("mapPymthousePlanToOpenMeterCreate skips network default plans", async () => {
   const omPlan = await mapPymthousePlanToOpenMeterCreate({
     clientId: "app_1",

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -500,6 +500,10 @@ test("isOpenMeterStripeBillingError detects Stripe precondition failures on 409"
   (stripeErr as { status: number }).status = 409;
   assert.equal(isOpenMeterStripeBillingError(stripeErr), true);
   assert.equal(isOpenMeterConflictError(stripeErr), true);
+
+  const stripeMessageOnly = new Error(stripeErr.message);
+  (stripeMessageOnly as { status: number }).status = 500;
+  assert.equal(isOpenMeterStripeBillingError(stripeMessageOnly), false);
 });
 
 test("mapPymthousePlanToOpenMeterCreate skips network default plans", async () => {

--- a/src/lib/openmeter/plan-errors.ts
+++ b/src/lib/openmeter/plan-errors.ts
@@ -32,6 +32,9 @@ export function isOpenMeterConflictError(err: unknown): boolean {
 
 /** True when OpenMeter refuses subscription/billing because Stripe app data is missing on the customer. */
 export function isOpenMeterStripeBillingError(err: unknown): boolean {
+  if (!isOpenMeterConflictError(err)) {
+    return false;
+  }
   const message = errorMessage(err);
   return (
     /invalid billing setup/i.test(message) ||

--- a/src/lib/openmeter/plan-errors.ts
+++ b/src/lib/openmeter/plan-errors.ts
@@ -29,3 +29,13 @@ export function isOpenMeterConflictError(err: unknown): boolean {
     (err as { status?: number }).status ?? (err as { statusCode?: number }).statusCode;
   return status === 409;
 }
+
+/** True when OpenMeter refuses subscription/billing because Stripe app data is missing on the customer. */
+export function isOpenMeterStripeBillingError(err: unknown): boolean {
+  const message = errorMessage(err);
+  return (
+    /invalid billing setup/i.test(message) ||
+    /failed to get stripe customer data/i.test(message) ||
+    /customer has no data for stripe app/i.test(message)
+  );
+}

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -120,6 +120,7 @@ async function createStarterSubscriptionWithRecovery(input: {
 }): Promise<{
   subscription: OpenMeterSubscriptionView | null;
   starter: typeof plans.$inferSelect;
+  created: boolean;
 }> {
   let activeStarter = input.starter;
   try {
@@ -139,6 +140,7 @@ async function createStarterSubscriptionWithRecovery(input: {
         activeStarter.openmeterPlanId,
       ),
       starter: activeStarter,
+      created: true,
     };
   } catch (err) {
     if (isOpenMeterPlanNotFoundError(err)) {
@@ -163,6 +165,7 @@ async function createStarterSubscriptionWithRecovery(input: {
           activeStarter.openmeterPlanId,
         ),
         starter: activeStarter,
+        created: true,
       };
     }
     if (isOpenMeterStripeBillingError(err)) {
@@ -170,7 +173,7 @@ async function createStarterSubscriptionWithRecovery(input: {
         "[openmeter] Starter subscription skipped: Stripe billing is not ready for this customer",
         err,
       );
-      return { subscription: null, starter: activeStarter };
+      return { subscription: null, starter: activeStarter, created: false };
     }
     if (isOpenMeterConflictError(err)) {
       const existing = await findOpenMeterSubscriptionByPlanKey(
@@ -182,7 +185,7 @@ async function createStarterSubscriptionWithRecovery(input: {
       if (!existing) {
         throw err;
       }
-      return { subscription: existing, starter: activeStarter };
+      return { subscription: existing, starter: activeStarter, created: false };
     }
     throw err;
   }
@@ -241,7 +244,7 @@ export async function ensureStarterSubscriptionForAppUser(input: {
     });
     omSubscription = provisioned.subscription;
     activeStarter = provisioned.starter;
-    created = provisioned.subscription !== null;
+    created = provisioned.created;
   }
 
   if (!omSubscription) {

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -4,11 +4,11 @@ import { db } from "@/db/index";
 import { plans } from "@/db/schema";
 import { getOrCreateStarterPlan } from "@/lib/starter-default-plan";
 import { getHostedAdminClient, isHostedAdminClientAvailable } from "./admin-client";
-import { applyTenantBillingProfileToCustomer } from "./billing-profiles";
 import { ensureOpenMeterCustomerForAppUser } from "./customers";
 import {
   isOpenMeterConflictError,
   isOpenMeterPlanNotFoundError,
+  isOpenMeterStripeBillingError,
 } from "./plan-errors";
 import {
   buildOpenMeterPlanKey,
@@ -117,7 +117,10 @@ async function createStarterSubscriptionWithRecovery(input: {
   customerId: string;
   starter: typeof plans.$inferSelect;
   planKey: string;
-}): Promise<{ subscription: OpenMeterSubscriptionView; starter: typeof plans.$inferSelect }> {
+}): Promise<{
+  subscription: OpenMeterSubscriptionView | null;
+  starter: typeof plans.$inferSelect;
+}> {
   let activeStarter = input.starter;
   try {
     const createdSub = await createStarterOpenMeterSubscription({
@@ -161,6 +164,13 @@ async function createStarterSubscriptionWithRecovery(input: {
         ),
         starter: activeStarter,
       };
+    }
+    if (isOpenMeterStripeBillingError(err)) {
+      console.warn(
+        "[openmeter] Starter subscription skipped: Stripe billing is not ready for this customer",
+        err,
+      );
+      return { subscription: null, starter: activeStarter };
     }
     if (isOpenMeterConflictError(err)) {
       const existing = await findOpenMeterSubscriptionByPlanKey(
@@ -207,11 +217,8 @@ export async function ensureStarterSubscriptionForAppUser(input: {
     clientId: input.clientId,
     externalUserId: input.externalUserId,
   });
-  await applyTenantBillingProfileToCustomer({
-    client,
-    clientId: input.clientId,
-    customerId: customer.id,
-  });
+  // Starter is free — do not attach the tenant Stripe billing profile here.
+  // Paid checkout applies billing profiles in subscriptions-billing.ts.
 
   const planKey = buildOpenMeterPlanKey(input.clientId, starter.id);
 
@@ -234,11 +241,15 @@ export async function ensureStarterSubscriptionForAppUser(input: {
     });
     omSubscription = provisioned.subscription;
     activeStarter = provisioned.starter;
-    created = true;
+    created = provisioned.subscription !== null;
   }
 
   if (!omSubscription) {
-    throw new Error("Failed to provision OpenMeter Starter subscription");
+    return {
+      openmeterSubscriptionId: null,
+      planId: activeStarter.id,
+      created: false,
+    };
   }
 
   return {


### PR DESCRIPTION
- Added `isStripeBillingEnabledForApp` function to verify Stripe billing configuration for applications.
- Updated `applyTenantBillingProfileToCustomer` to skip processing if Stripe billing is not enabled.
- Enhanced entitlement checks in `getKonnectTrialCreditBalance` to allow free access when Stripe billing is not set up.
- Introduced `isOpenMeterStripeBillingError` function to identify specific Stripe-related errors in billing processes.
- Updated tests to cover new Stripe billing error handling scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps without fully connected Stripe billing can still receive “Free Starter” access and trial balance calculations.

* **Bug Fixes**
  * Starter subscription provisioning now handles Stripe “not ready” billing/setup issues by recovering gracefully instead of failing.
  * Customer billing profile overrides are only applied when Stripe billing is fully enabled.
  * Stripe billing/setup errors are detected more reliably, improving conflict handling and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->