### PR TITLE
chore(release): bump version to 0.2.4

### DIFF
--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -205,13 +205,13 @@ Canonical URLs for the Deployments sidebar (`VERCEL_PRODUCTION_URL`, `VERCEL_PRE
 2. Tag and push from your machine (a user push fires deploy workflows; tags pushed by `GITHUB_TOKEN` in CI do **not** re-trigger workflows):
 
 ```bash
-git tag v0.2.3
-git push origin v0.2.3
+git tag v0.2.4
+git push origin v0.2.4
 ```
 
 The tag push fires [deploy-production-vercel.yml](../.github/workflows/deploy-production-vercel.yml) and [deploy-railway-production.yml](../.github/workflows/deploy-railway-production.yml) via their `on: push: tags` triggers (each runs in its own environment so env-scoped secrets resolve).
 
-Optionally create a GitHub Release for the tag: `gh release create v0.2.3 --generate-notes`
+Optionally create a GitHub Release for the tag: `gh release create v0.2.4 --generate-notes`
 
 **Manual staging deploy** (paired Railway + Vercel):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymthouse",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pymthouse",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@braintree/sanitize-url": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymthouse",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "engines": {
     "node": ">=20.18.1"


### PR DESCRIPTION
## Summary
- Bump `package.json` and `package-lock.json` to **0.2.4**
- Update release docs examples to `v0.2.4`

## After merge
Tag and push from your machine to trigger production deploys:

```bash
git checkout main && git pull
git tag v0.2.4
git push origin v0.2.4
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to reference the latest release version.
* **Chores**
  * Bumped the app version to `0.2.4` to match the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->