### PR TITLE
Fix ambiguous selection state in M2M token flow picker

### DIFF
--- a/src/components/UsageLineChart.tsx
+++ b/src/components/UsageLineChart.tsx
@@ -46,8 +46,8 @@ function chartPointRadius(activeIndex: number | null, index: number, value: numb
 }
 
 function buildYTicks(maxValue: number, tickCount = 4): number[] {
-  if (maxValue <= 0) {
-    return [0];
+  if (!Number.isFinite(maxValue) || maxValue <= 0) {
+    return Array.from({ length: tickCount + 1 }, (_, i) => i);
   }
   const padded = Math.ceil(maxValue * 1.1);
   const step = Math.max(1, Math.ceil(padded / tickCount));
@@ -76,10 +76,13 @@ export default function UsageLineChart({
   const plotW = width - padLeft - padRight;
   const plotH = height - padTop - padBottom;
 
-  const values = useMemo(() => data.map((d) => d.value), [data]);
+  const values = useMemo(
+    () => data.map((d) => (Number.isFinite(d.value) ? d.value : 0)),
+    [data],
+  );
   const maxValue = Math.max(0, ...values);
   const yTicks = useMemo(() => buildYTicks(maxValue), [maxValue]);
-  const yMax = yTicks.at(-1) ?? 1;
+  const yMax = Math.max(1, yTicks.at(-1) ?? 1);
   const n = data.length;
   const todayKey = utcTodayKey();
 

--- a/src/components/UsageLineChart.tsx
+++ b/src/components/UsageLineChart.tsx
@@ -45,6 +45,10 @@ function chartPointRadius(activeIndex: number | null, index: number, value: numb
   return value > 0 ? 3 : 2;
 }
 
+function sanitizeChartValue(value: number): number {
+  return Number.isFinite(value) ? value : 0;
+}
+
 function buildYTicks(maxValue: number, tickCount = 4): number[] {
   if (!Number.isFinite(maxValue) || maxValue <= 0) {
     return Array.from({ length: tickCount + 1 }, (_, i) => i);
@@ -77,7 +81,7 @@ export default function UsageLineChart({
   const plotH = height - padTop - padBottom;
 
   const values = useMemo(
-    () => data.map((d) => (Number.isFinite(d.value) ? d.value : 0)),
+    () => data.map((d) => sanitizeChartValue(d.value)),
     [data],
   );
   const maxValue = Math.max(0, ...values);
@@ -96,18 +100,18 @@ export default function UsageLineChart({
   );
 
   const linePoints = useMemo(
-    () => data.map((d, i) => `${xAt(i)},${yAt(d.value)}`).join(" "),
-    [data, xAt, yAt],
+    () => values.map((v, i) => `${xAt(i)},${yAt(v)}`).join(" "),
+    [values, xAt, yAt],
   );
 
   const areaPath = useMemo(() => {
     if (n === 0) {
       return "";
     }
-    const top = data.map((d, i) => `${i === 0 ? "M" : "L"}${xAt(i)},${yAt(d.value)}`).join(" ");
+    const top = values.map((v, i) => `${i === 0 ? "M" : "L"}${xAt(i)},${yAt(v)}`).join(" ");
     const baseY = yAt(0);
     return `${top} L${xAt(n - 1)},${baseY} L${xAt(0)},${baseY} Z`;
-  }, [data, n, xAt, yAt]);
+  }, [values, n, xAt, yAt]);
 
   const xLabelTicks = useMemo(
     () =>
@@ -203,18 +207,21 @@ export default function UsageLineChart({
           strokeLinejoin="round"
           points={linePoints}
         />
-        {data.map((d, i) => (
-          <circle
-            key={d.date}
-            cx={xAt(i)}
-            cy={yAt(d.value)}
-            r={chartPointRadius(activeIndex, i, d.value)}
-            fill="rgb(16 185 129)"
-            stroke={activeIndex === i ? "rgb(24 24 27)" : "none"}
-            strokeWidth={activeIndex === i ? 1.5 : 0}
-            opacity={d.value > 0 || activeIndex === i ? 1 : 0.35}
-          />
-        ))}
+        {data.map((d, i) => {
+          const value = values[i] ?? 0;
+          return (
+            <circle
+              key={d.date}
+              cx={xAt(i)}
+              cy={yAt(value)}
+              r={chartPointRadius(activeIndex, i, value)}
+              fill="rgb(16 185 129)"
+              stroke={activeIndex === i ? "rgb(24 24 27)" : "none"}
+              strokeWidth={activeIndex === i ? 1.5 : 0}
+              opacity={value > 0 || activeIndex === i ? 1 : 0.35}
+            />
+          );
+        })}
         {activeIndex !== null && (
           <line
             x1={xAt(activeIndex)}
@@ -303,13 +310,16 @@ export default function UsageLineChart({
         }}
       >
         <div className="flex h-full w-full">
-          {data.map((d, i) => (
-            <div
-              key={d.date}
-              className="h-full min-w-0 flex-1"
-              aria-label={`${formatDayTooltipTitle(d.date, todayKey)}: ${d.value} ${valueUnit}`}
-            />
-          ))}
+          {data.map((d, i) => {
+            const value = values[i] ?? 0;
+            return (
+              <div
+                key={d.date}
+                className="h-full min-w-0 flex-1"
+                aria-label={`${formatDayTooltipTitle(d.date, todayKey)}: ${value} ${valueUnit}`}
+              />
+            );
+          })}
         </div>
 
         {activeIndex !== null && data[activeIndex] && (
@@ -328,9 +338,9 @@ export default function UsageLineChart({
             </p>
             <p className="mt-0.5 font-mono text-[10px] tabular-nums text-zinc-400">
               <span className="font-medium text-emerald-400">
-                {data[activeIndex].value.toLocaleString("en-US")}
+                {(values[activeIndex] ?? 0).toLocaleString("en-US")}
               </span>{" "}
-              {data[activeIndex].value === 1 ? valueUnit.replace(/s$/, "") : valueUnit}
+              {(values[activeIndex] ?? 0) === 1 ? valueUnit.replace(/s$/, "") : valueUnit}
             </p>
             <p className="mt-1 border-t border-zinc-800 pt-1 font-mono text-[9px] text-zinc-500">
               {valueLabel}

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -392,24 +392,20 @@ type M2mTokenTestPanelProps = Readonly<{
   hasM2mBackend: boolean;
 }>;
 
-function m2mOptionButtonClass(kind: M2mTokenTestKind, activeKind: M2mTokenTestKind, accent: "zinc" | "emerald") {
+function m2mOptionButtonClass(kind: M2mTokenTestKind, activeKind: M2mTokenTestKind) {
   const selected = activeKind === kind;
   const base =
     "rounded-lg border px-3 py-3 text-left transition-colors w-full h-full flex flex-col";
-  if (accent === "emerald") {
-    return [
-      base,
-      selected
-        ? "border-emerald-500/50 bg-emerald-500/10 ring-1 ring-emerald-500/40"
-        : "border-zinc-700 bg-zinc-800/50 hover:bg-zinc-800",
-    ].join(" ");
-  }
   return [
     base,
     selected
-      ? "border-zinc-500 bg-zinc-800 ring-1 ring-zinc-500/50"
-      : "border-zinc-700 bg-zinc-800/50 hover:bg-zinc-800",
+      ? "border-emerald-500/50 bg-emerald-500/10 ring-1 ring-emerald-500/40"
+      : "border-zinc-700 bg-zinc-800/50 hover:bg-zinc-800 hover:border-zinc-600",
   ].join(" ");
+}
+
+function m2mOptionTitleClass(selected: boolean) {
+  return selected ? "text-emerald-100" : "text-zinc-300";
 }
 
 function M2mSingleFlowHint({
@@ -511,9 +507,11 @@ function M2mFlowSelection({
             aria-checked={activeKind === "admin"}
             onClick={() => selectKind("admin")}
             disabled={readOnly}
-            className={m2mOptionButtonClass("admin", activeKind, "zinc")}
+            className={m2mOptionButtonClass("admin", activeKind)}
           >
-            <span className="block text-xs font-semibold leading-4 min-h-8 text-zinc-100">
+            <span
+              className={`block text-xs font-semibold leading-4 min-h-8 ${m2mOptionTitleClass(activeKind === "admin")}`}
+            >
               Administrative access
             </span>
             <span className="mt-1 block text-[11px] text-zinc-500">
@@ -533,15 +531,17 @@ function M2mFlowSelection({
               }
             }}
             tabIndex={readOnly ? -1 : 0}
-            className={`${m2mOptionButtonClass("owner", activeKind, "emerald")} cursor-pointer`}
+            className={`${m2mOptionButtonClass("owner", activeKind)} cursor-pointer`}
           >
-            <span className="block text-xs font-semibold leading-4 min-h-8 text-emerald-100">
+            <span
+              className={`block text-xs font-semibold leading-4 min-h-8 ${m2mOptionTitleClass(activeKind === "owner")}`}
+            >
               Remote signing
             </span>
             <span className="mt-1 block text-[11px] text-zinc-500">
               Payment signing tokens for your app owner identity
             </span>
-            {bearerFormatToggle}
+            {activeKind === "owner" ? bearerFormatToggle : null}
           </div>
         ) : null}
       </div>

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -574,7 +574,7 @@ function M2mTokenTestPanel({
   const [error, setError] = useState<string | null>(null);
   const [clientSecretInput, setClientSecretInput] = useState("");
   const [selectedKind, setSelectedKind] = useState<M2mTokenTestKind>("admin");
-  const [signingTokenFormat, setSigningTokenFormat] = useState<SigningTokenFormat>("jwt");
+  const [signingTokenFormat, setSigningTokenFormat] = useState<SigningTokenFormat>("bearer");
   const [curlDetailsOpen, setCurlDetailsOpen] = useState(true);
 
   const adminScopes = computeBackendM2mClientCredentialsScopes(

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -520,27 +520,29 @@ function M2mFlowSelection({
           </button>
         ) : null}
         {showRemoteSigning ? (
-          <div
-            role="radio"
-            aria-checked={activeKind === "owner"}
-            onClick={() => !readOnly && selectKind("owner")}
-            onKeyDown={(e) => {
-              if (!readOnly && (e.key === "Enter" || e.key === " ")) {
-                e.preventDefault();
-                selectKind("owner");
-              }
-            }}
-            tabIndex={readOnly ? -1 : 0}
-            className={`${m2mOptionButtonClass("owner", activeKind)} cursor-pointer`}
-          >
-            <span
-              className={`block text-xs font-semibold leading-4 min-h-8 ${m2mOptionTitleClass(activeKind === "owner")}`}
+          <div className="flex flex-col gap-2">
+            <div
+              role="radio"
+              aria-checked={activeKind === "owner"}
+              onClick={() => !readOnly && selectKind("owner")}
+              onKeyDown={(e) => {
+                if (!readOnly && (e.key === "Enter" || e.key === " ")) {
+                  e.preventDefault();
+                  selectKind("owner");
+                }
+              }}
+              tabIndex={readOnly ? -1 : 0}
+              className={`${m2mOptionButtonClass("owner", activeKind)} cursor-pointer`}
             >
-              Remote signing
-            </span>
-            <span className="mt-1 block text-[11px] text-zinc-500">
-              Payment signing tokens for your app owner identity
-            </span>
+              <span
+                className={`block text-xs font-semibold leading-4 min-h-8 ${m2mOptionTitleClass(activeKind === "owner")}`}
+              >
+                Remote signing
+              </span>
+              <span className="mt-1 block text-[11px] text-zinc-500">
+                Payment signing tokens for your app owner identity
+              </span>
+            </div>
             {activeKind === "owner" ? bearerFormatToggle : null}
           </div>
         ) : null}


### PR DESCRIPTION
## Summary
- Unify selected/unselected styling for Administrative access and Remote signing flow cards.
- Only the active card gets the emerald border, ring, and title highlight.
- Show the JWT/Bearer toggle only when Remote signing is selected.

## Problem
Remote signing always used emerald title styling, so it looked selected even when Administrative access was the default active flow (matching the admin-scopes curl below).

## Test plan
- [ ] Open app Credentials & URLs with both flows available
- [ ] Confirm Administrative access is green-highlighted by default and curl shows admin scopes
- [ ] Click Remote signing — only that card highlights green and curl updates to `sign:job`
- [ ] JWT/Bearer toggle appears only when Remote signing is selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the M2M token test flow selector visuals by refining how the active option and selected title are styled.
  * Updated the bearer format toggle so it only appears when the owner flow is selected.
  * Hardened the Usage Line Chart to safely handle non-finite and zero values, preventing broken/stable tick marks and chart rendering.
* **Chores**
  * Changed the default signing token format to **bearer** (from **jwt**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->