### PR TITLE
Fix NaN grid lines in UsageLineChart when usage is all zero

### DIFF
--- a/src/components/UsageLineChart.tsx
+++ b/src/components/UsageLineChart.tsx
@@ -46,8 +46,8 @@ function chartPointRadius(activeIndex: number | null, index: number, value: numb
 }
 
 function buildYTicks(maxValue: number, tickCount = 4): number[] {
-  if (maxValue <= 0) {
-    return [0];
+  if (!Number.isFinite(maxValue) || maxValue <= 0) {
+    return Array.from({ length: tickCount + 1 }, (_, i) => i);
   }
   const padded = Math.ceil(maxValue * 1.1);
   const step = Math.max(1, Math.ceil(padded / tickCount));
@@ -76,10 +76,13 @@ export default function UsageLineChart({
   const plotW = width - padLeft - padRight;
   const plotH = height - padTop - padBottom;
 
-  const values = useMemo(() => data.map((d) => d.value), [data]);
+  const values = useMemo(
+    () => data.map((d) => (Number.isFinite(d.value) ? d.value : 0)),
+    [data],
+  );
   const maxValue = Math.max(0, ...values);
   const yTicks = useMemo(() => buildYTicks(maxValue), [maxValue]);
-  const yMax = yTicks.at(-1) ?? 1;
+  const yMax = Math.max(1, yTicks.at(-1) ?? 1);
   const n = data.length;
   const todayKey = utcTodayKey();
 

--- a/src/components/UsageLineChart.tsx
+++ b/src/components/UsageLineChart.tsx
@@ -45,6 +45,10 @@ function chartPointRadius(activeIndex: number | null, index: number, value: numb
   return value > 0 ? 3 : 2;
 }
 
+function sanitizeChartValue(value: number): number {
+  return Number.isFinite(value) ? value : 0;
+}
+
 function buildYTicks(maxValue: number, tickCount = 4): number[] {
   if (!Number.isFinite(maxValue) || maxValue <= 0) {
     return Array.from({ length: tickCount + 1 }, (_, i) => i);
@@ -77,7 +81,7 @@ export default function UsageLineChart({
   const plotH = height - padTop - padBottom;
 
   const values = useMemo(
-    () => data.map((d) => (Number.isFinite(d.value) ? d.value : 0)),
+    () => data.map((d) => sanitizeChartValue(d.value)),
     [data],
   );
   const maxValue = Math.max(0, ...values);
@@ -96,18 +100,18 @@ export default function UsageLineChart({
   );
 
   const linePoints = useMemo(
-    () => data.map((d, i) => `${xAt(i)},${yAt(d.value)}`).join(" "),
-    [data, xAt, yAt],
+    () => values.map((v, i) => `${xAt(i)},${yAt(v)}`).join(" "),
+    [values, xAt, yAt],
   );
 
   const areaPath = useMemo(() => {
     if (n === 0) {
       return "";
     }
-    const top = data.map((d, i) => `${i === 0 ? "M" : "L"}${xAt(i)},${yAt(d.value)}`).join(" ");
+    const top = values.map((v, i) => `${i === 0 ? "M" : "L"}${xAt(i)},${yAt(v)}`).join(" ");
     const baseY = yAt(0);
     return `${top} L${xAt(n - 1)},${baseY} L${xAt(0)},${baseY} Z`;
-  }, [data, n, xAt, yAt]);
+  }, [values, n, xAt, yAt]);
 
   const xLabelTicks = useMemo(
     () =>
@@ -203,18 +207,21 @@ export default function UsageLineChart({
           strokeLinejoin="round"
           points={linePoints}
         />
-        {data.map((d, i) => (
-          <circle
-            key={d.date}
-            cx={xAt(i)}
-            cy={yAt(d.value)}
-            r={chartPointRadius(activeIndex, i, d.value)}
-            fill="rgb(16 185 129)"
-            stroke={activeIndex === i ? "rgb(24 24 27)" : "none"}
-            strokeWidth={activeIndex === i ? 1.5 : 0}
-            opacity={d.value > 0 || activeIndex === i ? 1 : 0.35}
-          />
-        ))}
+        {data.map((d, i) => {
+          const value = values[i] ?? 0;
+          return (
+            <circle
+              key={d.date}
+              cx={xAt(i)}
+              cy={yAt(value)}
+              r={chartPointRadius(activeIndex, i, value)}
+              fill="rgb(16 185 129)"
+              stroke={activeIndex === i ? "rgb(24 24 27)" : "none"}
+              strokeWidth={activeIndex === i ? 1.5 : 0}
+              opacity={value > 0 || activeIndex === i ? 1 : 0.35}
+            />
+          );
+        })}
         {activeIndex !== null && (
           <line
             x1={xAt(activeIndex)}
@@ -303,13 +310,16 @@ export default function UsageLineChart({
         }}
       >
         <div className="flex h-full w-full">
-          {data.map((d, i) => (
-            <div
-              key={d.date}
-              className="h-full min-w-0 flex-1"
-              aria-label={`${formatDayTooltipTitle(d.date, todayKey)}: ${d.value} ${valueUnit}`}
-            />
-          ))}
+          {data.map((d, i) => {
+            const value = values[i] ?? 0;
+            return (
+              <div
+                key={d.date}
+                className="h-full min-w-0 flex-1"
+                aria-label={`${formatDayTooltipTitle(d.date, todayKey)}: ${value} ${valueUnit}`}
+              />
+            );
+          })}
         </div>
 
         {activeIndex !== null && data[activeIndex] && (
@@ -328,9 +338,9 @@ export default function UsageLineChart({
             </p>
             <p className="mt-0.5 font-mono text-[10px] tabular-nums text-zinc-400">
               <span className="font-medium text-emerald-400">
-                {data[activeIndex].value.toLocaleString("en-US")}
+                {(values[activeIndex] ?? 0).toLocaleString("en-US")}
               </span>{" "}
-              {data[activeIndex].value === 1 ? valueUnit.replace(/s$/, "") : valueUnit}
+              {(values[activeIndex] ?? 0) === 1 ? valueUnit.replace(/s$/, "") : valueUnit}
             </p>
             <p className="mt-1 border-t border-zinc-800 pt-1 font-mono text-[9px] text-zinc-500">
               {valueLabel}


### PR DESCRIPTION
## Summary
- Prevent division by zero in the Y scale when all usage values are 0.
- Coerce non-finite data points to 0 so bad API values cannot poison `Math.max`.
- Use a default 0–4 tick range for empty charts instead of a single `[0]` tick.

## Test plan
- [ ] Open `/billing` with zero usage for the billing period
- [ ] Confirm no React console warning about `NaN` for `y1`
- [ ] Chart renders a flat line at the bottom with readable Y-axis ticks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved line/area chart rendering when usage data contains invalid or non-finite values.
  * Made y-axis tick generation more resilient to empty, zero, or non-finite maximum values.
  * Ensured chart geometry, markers, and tooltip values consistently use sanitized numeric inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->