### PR TITLE
Improve dashboard and app configuration UX

### DIFF
--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -22,6 +22,7 @@ interface AppSummary {
 }
 
 const STATUS_REVIEW = new Set(["submitted", "in_review"]);
+const APP_SKELETON_KEYS = ["app-sk-a", "app-sk-b", "app-sk-c"] as const;
 
 function AppStatusIndicator({
   status,
@@ -243,9 +244,9 @@ export default function AppsPage() {
 
       {loading ? (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-label="Loading apps" aria-busy="true">
-          {Array.from({ length: 3 }).map((_, i) => (
+          {APP_SKELETON_KEYS.map((key) => (
             <div
-              key={i}
+              key={key}
               className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-5 space-y-3 animate-pulse"
             >
               <div className="flex items-start gap-3">

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import Link from "next/link";
 import DashboardLayout from "@/components/DashboardLayout";
+import AppStatusBadge, { appStatusAriaLabel } from "@/components/apps/AppStatusBadge";
 
 interface AppSummary {
   id: string;
@@ -21,23 +22,6 @@ interface AppSummary {
 }
 
 const STATUS_REVIEW = new Set(["submitted", "in_review"]);
-
-function appStatusAriaLabel(status: string): string {
-  switch (status) {
-    case "approved":
-      return "Live — approved";
-    case "draft":
-      return "Draft";
-    case "submitted":
-      return "Submitted — awaiting review";
-    case "in_review":
-      return "In review";
-    case "rejected":
-      return "Rejected";
-    default:
-      return status.replaceAll("_", " ");
-  }
-}
 
 function AppStatusIndicator({
   status,
@@ -258,11 +242,30 @@ export default function AppsPage() {
       </div>
 
       {loading ? (
-        <div className="text-zinc-500 text-center py-12 animate-pulse">
-          Loading apps...
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-label="Loading apps" aria-busy="true">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-5 space-y-3 animate-pulse"
+            >
+              <div className="flex items-start gap-3">
+                <div className="h-10 w-10 rounded-lg bg-zinc-800 shrink-0" />
+                <div className="flex-1 space-y-2 pt-1">
+                  <div className="h-3.5 w-32 rounded bg-zinc-800" />
+                  <div className="h-2.5 w-48 rounded bg-zinc-800/70" />
+                </div>
+              </div>
+              <div className="h-2.5 w-24 rounded bg-zinc-800/60" />
+              <div className="h-px bg-zinc-800/60" />
+              <div className="flex justify-end gap-3">
+                <div className="h-2.5 w-10 rounded bg-zinc-800/50" />
+                <div className="h-2.5 w-12 rounded bg-zinc-800/50" />
+              </div>
+            </div>
+          ))}
         </div>
       ) : apps.length === 0 ? (
-        <div className="text-center py-16 border border-zinc-800 rounded-xl bg-zinc-900/20">
+          <div className="text-center py-16 rounded-xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-sm">
           <div className="w-16 h-16 bg-zinc-800 rounded-xl flex items-center justify-center mx-auto mb-4">
             <svg
               className="w-8 h-8 text-zinc-600"
@@ -297,7 +300,7 @@ export default function AppsPage() {
           {apps.map((app) => (
             <div
               key={app.id}
-              className="relative flex h-full min-h-0 flex-col rounded-xl border border-zinc-800 bg-zinc-900/30 transition-colors group hover:border-zinc-700 hover:bg-zinc-900/60"
+              className="relative flex h-full min-h-0 flex-col rounded-xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-sm transition-all duration-200 group hover:border-white/[0.10] hover:bg-white/[0.035] hover:shadow-[0_0_20px_rgba(52,211,153,0.04)]"
             >
               <Link
                 href={`/apps/${app.id}`}
@@ -339,11 +342,10 @@ export default function AppsPage() {
                   </div>
                   <Link
                     href={`/apps/${app.id}`}
-                    className="pointer-events-auto relative z-10 inline-flex shrink-0 rounded outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500/60"
-                    title={appStatusAriaLabel(app.status)}
+                    className="pointer-events-auto relative z-10 shrink-0 rounded outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500/60"
                     aria-label={`App status: ${appStatusAriaLabel(app.status)}`}
                   >
-                    <AppStatusIndicator status={app.status} suppressAccessibleLabel />
+                    <AppStatusBadge status={app.status} />
                   </Link>
                 </div>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -134,6 +134,7 @@ async function AdminDashboard() {
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
               <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
             </span>
+            {" "}
             Network live
           </div>
         )}
@@ -208,6 +209,7 @@ async function AdminDashboard() {
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-60" />
                   <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-blue-500" />
                 </span>
+                {" "}
                 Live
               </span>
             )}
@@ -271,7 +273,7 @@ function FreeUsageBanner() {
   );
 }
 
-async function DeveloperDashboard({ userId }: { userId: string }) {
+async function DeveloperDashboard({ userId }: Readonly<{ userId: string }>) {
   const apps = userId ? await listUserAccessibleApps(userId) : [];
 
   return (
@@ -292,16 +294,48 @@ async function DeveloperDashboard({ userId }: { userId: string }) {
   );
 }
 
-function MyAppsSection({ apps }: { apps: UserAppSummary[] }) {
+function myAppsSummaryText(appCount: number): string {
+  if (appCount === 0) {
+    return "Create an app to configure identity, plans, and payments.";
+  }
+  const noun = appCount === 1 ? "app" : "apps";
+  return `${appCount} ${noun} — open settings or usage from here.`;
+}
+
+function appListSecondaryLine(app: UserAppSummary): string | null {
+  if (app.subtitle) {
+    return app.subtitle;
+  }
+  if (app.clientId) {
+    return app.clientId;
+  }
+  return null;
+}
+
+function AppListSecondaryLine({ app }: Readonly<{ app: UserAppSummary }>) {
+  const secondaryLine = appListSecondaryLine(app);
+  if (!secondaryLine) {
+    return null;
+  }
+  return (
+    <p
+      className={`text-xs mt-0.5 truncate ${
+        app.subtitle ? "text-zinc-500" : "font-mono text-zinc-600"
+      }`}
+    >
+      {secondaryLine}
+    </p>
+  );
+}
+
+function MyAppsSection({ apps }: Readonly<{ apps: UserAppSummary[] }>) {
   return (
     <section className="rounded-xl border border-emerald-500/15 bg-white/[0.02] backdrop-blur-sm shadow-[inset_0_1px_0_rgba(52,211,153,0.06)]">
       <div className="flex flex-col gap-3 border-b border-white/[0.06] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h3 className="font-semibold text-zinc-100">My Apps</h3>
           <p className="text-sm text-zinc-500 mt-0.5">
-            {apps.length === 0
-              ? "Create an app to configure identity, plans, and payments."
-              : `${apps.length} app${apps.length === 1 ? "" : "s"} — open settings or usage from here.`}
+            {myAppsSummaryText(apps.length)}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2 shrink-0">
@@ -369,13 +403,7 @@ function MyAppsSection({ apps }: { apps: UserAppSummary[] }) {
                     </span>
                     <AppStatusBadge status={app.status} />
                   </div>
-                  {app.subtitle ? (
-                    <p className="text-xs text-zinc-500 mt-0.5 truncate">{app.subtitle}</p>
-                  ) : app.clientId ? (
-                    <p className="text-xs font-mono text-zinc-600 mt-0.5 truncate">
-                      {app.clientId}
-                    </p>
-                  ) : null}
+                  <AppListSecondaryLine app={app} />
                 </div>
               </Link>
               <div className="hidden sm:flex items-center gap-3 shrink-0 text-xs font-medium">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { db } from "@/db/index";
 import { signerConfig, transactions, endUsers } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import Link from "next/link";
+import AppStatusBadge from "@/components/apps/AppStatusBadge";
+import { listUserAccessibleApps, type UserAppSummary } from "@/lib/user-apps";
 import {
   ACTIVE_STREAM_PAYMENT_WINDOW_LABEL,
   countActiveStreamsByRecentPayment,
@@ -27,12 +29,13 @@ export default async function DashboardPage() {
   if (!session) redirect("/");
 
   const role = (session.user as Record<string, unknown>)?.role as string;
+  const userId = (session.user as Record<string, unknown>)?.id as string;
 
   if (role === "admin" || role === "operator") {
     return <AdminDashboard />;
   }
 
-  return <DeveloperDashboard />;
+  return <DeveloperDashboard userId={userId} />;
 }
 
 async function AdminDashboard() {
@@ -79,38 +82,61 @@ async function AdminDashboard() {
       value: signerOnline ? "Online" : signer?.status || "N/A",
       sub: signerSub,
       color: signerOnline ? "text-emerald-400" : "text-zinc-400",
+      glow: signerOnline
+        ? "border-emerald-500/20 shadow-[inset_0_1px_0_rgba(52,211,153,0.06)]"
+        : "border-white/[0.06]",
+      live: signerOnline,
     },
     {
       label: "Active Streams",
       value: activeStreamCount.toString(),
       sub: ACTIVE_STREAM_PAYMENT_WINDOW_LABEL,
       color: "text-blue-400",
+      glow: "border-blue-500/20 shadow-[inset_0_1px_0_rgba(96,165,250,0.06)]",
+      live: activeStreamCount > 0,
     },
     {
       label: "App Users",
       value: allEndUsers.length.toString(),
       sub: `${allEndUsers.filter((u) => u.isActive).length} active`,
       color: "text-cyan-400",
+      glow: "border-cyan-500/15 shadow-[inset_0_1px_0_rgba(34,211,238,0.05)]",
+      live: false,
     },
     {
       label: "Total Volume",
       value: formatWei(totalFeeWei.toString()),
       sub: `${allTransactions.length} transactions`,
       color: "text-amber-400",
+      glow: "border-amber-500/15 shadow-[inset_0_1px_0_rgba(251,191,36,0.05)]",
+      live: false,
     },
     {
       label: "Platform Revenue",
       value: formatWei(totalPlatformCutWei.toString()),
       sub: "total cut earned",
       color: "text-purple-400",
+      glow: "border-purple-500/15 shadow-[inset_0_1px_0_rgba(167,139,250,0.05)]",
+      live: false,
     },
   ];
 
   return (
     <>
-      <div className="mb-8">
-        <h2 className="text-2xl font-bold tracking-tight">Dashboard</h2>
-        <p className="text-zinc-500 mt-1">Platform overview</p>
+      <div className="mb-8 flex items-end justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Dashboard</h2>
+          <p className="text-zinc-500 mt-1">Platform overview</p>
+        </div>
+        {signerOnline && (
+          <div className="flex items-center gap-2 text-xs text-emerald-400 font-medium">
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+            </span>
+            Network live
+          </div>
+        )}
       </div>
 
       <FreeUsageBanner />
@@ -119,34 +145,44 @@ async function AdminDashboard() {
         {stats.map((stat) => (
           <div
             key={stat.label}
-            className="border border-zinc-800 rounded-xl p-5 bg-zinc-900/30"
+            className={`relative overflow-hidden rounded-xl border bg-white/[0.02] backdrop-blur-sm p-5 transition-colors hover:bg-white/[0.035] ${stat.glow}`}
           >
-            <p className="text-xs text-zinc-500 uppercase tracking-wider mb-2">
-              {stat.label}
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-[11px] font-semibold text-zinc-500 uppercase tracking-widest">
+                {stat.label}
+              </p>
+              {stat.live && (
+                <span className="relative flex h-1.5 w-1.5">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60" />
+                  <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
+                </span>
+              )}
+            </div>
+            <p className={`text-2xl font-bold tabular-nums leading-none ${stat.color}`}>
+              {stat.value}
             </p>
-            <p className={`text-2xl font-bold ${stat.color}`}>{stat.value}</p>
-            <p className="text-xs text-zinc-600 mt-1">{stat.sub}</p>
+            <p className="text-xs text-zinc-600 mt-2 leading-snug">{stat.sub}</p>
           </div>
         ))}
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="border border-zinc-800 rounded-xl p-5 bg-zinc-900/30">
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-sm p-5">
           <h3 className="font-semibold text-zinc-200 mb-4">App Users</h3>
           {allEndUsers.length === 0 ? (
             <p className="text-zinc-500 text-sm">
               No app users yet. Create one from the Users page.
             </p>
           ) : (
-            <div className="space-y-3">
+            <div className="divide-y divide-zinc-800/60">
               {allEndUsers.slice(0, 5).map((user) => (
                 <div
                   key={user.id}
-                  className="flex items-center justify-between text-sm"
+                  className="flex items-center justify-between py-2.5 first:pt-0 last:pb-0 text-sm"
                 >
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2.5">
                     <span
-                      className={`w-2 h-2 rounded-full ${
+                      className={`w-1.5 h-1.5 rounded-full shrink-0 ${
                         user.isActive ? "bg-emerald-400" : "bg-zinc-600"
                       }`}
                     />
@@ -163,23 +199,34 @@ async function AdminDashboard() {
           )}
         </div>
 
-        <div className="border border-zinc-800 rounded-xl p-5 bg-zinc-900/30">
-          <h3 className="font-semibold text-zinc-200 mb-4">Recent Streams</h3>
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-sm p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-semibold text-zinc-200">Recent Streams</h3>
+            {activeStreamCount > 0 && (
+              <span className="flex items-center gap-1.5 text-xs text-blue-400 font-medium">
+                <span className="relative flex h-1.5 w-1.5">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-60" />
+                  <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-blue-500" />
+                </span>
+                Live
+              </span>
+            )}
+          </div>
           {recentActiveSessions.length === 0 ? (
             <p className="text-zinc-500 text-sm">No active streams</p>
           ) : (
-            <div className="space-y-3">
+            <div className="divide-y divide-zinc-800/60">
               {recentActiveSessions.map((session) => (
                 <div
                   key={session.id}
-                  className="flex items-center justify-between text-sm"
+                  className="flex items-center justify-between py-2.5 first:pt-0 last:pb-0 text-sm"
                 >
                   <span className="text-zinc-300 font-mono text-xs">
                     {session.manifestId.length > 16
-                      ? `${session.manifestId.slice(0, 12)}...`
+                      ? `${session.manifestId.slice(0, 12)}…`
                       : session.manifestId}
                   </span>
-                  <span className="text-zinc-500 text-xs">
+                  <span className="text-emerald-400/80 text-xs font-mono tabular-nums">
                     {formatWei(session.totalFeeWei)}
                   </span>
                 </div>
@@ -194,35 +241,39 @@ async function AdminDashboard() {
 
 function FreeUsageBanner() {
   return (
-    <div className="mb-6 flex items-start gap-3 p-4 rounded-xl border border-teal-500/20 bg-teal-500/5">
-      <svg
-        className="w-5 h-5 text-teal-400 mt-0.5 shrink-0"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.5}
-          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-        />
-      </svg>
+    <div className="mb-6 flex items-start gap-3 p-4 rounded-xl border border-teal-500/15 bg-teal-500/[0.04] backdrop-blur-sm">
+      <div className="shrink-0 mt-0.5 w-7 h-7 rounded-lg bg-teal-500/10 flex items-center justify-center">
+        <svg
+          className="w-4 h-4 text-teal-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      </div>
       <div>
-        <p className="text-sm font-medium text-teal-300">
-          Free for a limited time
+        <p className="text-sm font-semibold text-teal-300">
+          $5 free credit during beta
         </p>
-        <p className="text-xs text-zinc-400 mt-0.5">
-          App usage is currently free for all users during our beta period.
-          Usage is tracked via signing requests and billing will be introduced
-          in a future update.
+        <p className="text-xs text-zinc-400 mt-0.5 leading-relaxed">
+          Users get $5 of free credit per month during beta. Usage is tracked via
+          signing requests.
         </p>
       </div>
     </div>
   );
 }
 
-function DeveloperDashboard() {
+async function DeveloperDashboard({ userId }: { userId: string }) {
+  const apps = userId ? await listUserAccessibleApps(userId) : [];
+
   return (
     <>
       <div className="mb-8">
@@ -232,62 +283,172 @@ function DeveloperDashboard() {
 
       <FreeUsageBanner />
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30">
-          <h3 className="font-semibold text-zinc-200 mb-2">My Apps</h3>
-          <p className="text-sm text-zinc-500 mb-4">
-            Register OIDC clients to authenticate your users.
-          </p>
-          <Link
-            href="/apps"
-            className="inline-flex px-4 py-2 bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 rounded-lg text-sm font-medium hover:bg-emerald-500/20 transition-colors"
-          >
-            Manage Apps
-          </Link>
-        </div>
+      <MyAppsSection apps={apps} />
 
-        <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30">
-          <h3 className="font-semibold text-zinc-200 mb-2">Documentation</h3>
-          <p className="text-sm text-zinc-500 mb-4">
-            Learn how to integrate OIDC authentication and payment flows
-            into your application.
-          </p>
-          <div className="flex flex-col gap-2 mb-4">
-            <a
-              href="https://docs.pymthouse.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-800/50 text-zinc-300 border border-zinc-700 rounded-lg text-sm font-medium hover:bg-zinc-700/50 hover:text-zinc-100 transition-colors"
-            >
-              <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-              </svg>
-              Docs
-              <svg className="w-3 h-3 ml-auto opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-            </a>
-            <a
-              href="https://pymthouse.com/api/v1/docs"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 rounded-lg text-sm font-medium hover:bg-emerald-500/20 transition-colors"
-            >
-              <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-              </svg>
-              API Reference
-              <svg className="w-3 h-3 ml-auto opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-            </a>
-          </div>
-          <div className="text-xs text-zinc-600">
-            OIDC Discovery:{" "}
-            <code className="text-zinc-500">/.well-known/openid-configuration</code>
-          </div>
-        </div>
+      <div className="mt-6">
+        <DocumentationCard />
       </div>
     </>
+  );
+}
+
+function MyAppsSection({ apps }: { apps: UserAppSummary[] }) {
+  return (
+    <section className="rounded-xl border border-emerald-500/15 bg-white/[0.02] backdrop-blur-sm shadow-[inset_0_1px_0_rgba(52,211,153,0.06)]">
+      <div className="flex flex-col gap-3 border-b border-white/[0.06] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="font-semibold text-zinc-100">My Apps</h3>
+          <p className="text-sm text-zinc-500 mt-0.5">
+            {apps.length === 0
+              ? "Create an app to configure identity, plans, and payments."
+              : `${apps.length} app${apps.length === 1 ? "" : "s"} — open settings or usage from here.`}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 shrink-0">
+          {apps.length > 0 && (
+            <Link
+              href="/apps"
+              className="px-3 py-1.5 text-sm font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
+            >
+              View all
+            </Link>
+          )}
+          <Link
+            href="/apps/new"
+            className="inline-flex items-center gap-1.5 px-4 py-2 bg-emerald-600 text-white rounded-lg text-sm font-medium hover:bg-emerald-500 transition-colors"
+          >
+            Create app
+          </Link>
+        </div>
+      </div>
+
+      {apps.length === 0 ? (
+        <div className="px-5 py-10 text-center">
+          <div className="w-12 h-12 bg-zinc-800/80 rounded-xl flex items-center justify-center mx-auto mb-3">
+            <svg
+              className="w-6 h-6 text-zinc-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+              />
+            </svg>
+          </div>
+          <p className="text-sm text-zinc-400 mb-4">No apps yet.</p>
+          <Link
+            href="/apps/new"
+            className="inline-flex px-4 py-2 bg-emerald-500/10 text-emerald-400 border border-emerald-500/25 rounded-lg text-sm font-medium hover:bg-emerald-500/20 transition-colors"
+          >
+            Create your first app
+          </Link>
+        </div>
+      ) : (
+        <ul className="divide-y divide-zinc-800/60">
+          {apps.map((app) => (
+            <li key={app.id} className="flex items-center gap-4 px-5 py-3.5 hover:bg-white/[0.03] transition-colors group">
+              <Link
+                href={`/apps/${app.id}`}
+                className="flex min-w-0 flex-1 items-center gap-4"
+              >
+                <div
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-linear-to-br from-emerald-500/20 to-teal-500/20 text-sm font-bold text-emerald-400"
+                  aria-hidden="true"
+                >
+                  {app.name[0]?.toUpperCase()}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-zinc-200 group-hover:text-emerald-400 transition-colors truncate">
+                      {app.name}
+                    </span>
+                    <AppStatusBadge status={app.status} />
+                  </div>
+                  {app.subtitle ? (
+                    <p className="text-xs text-zinc-500 mt-0.5 truncate">{app.subtitle}</p>
+                  ) : app.clientId ? (
+                    <p className="text-xs font-mono text-zinc-600 mt-0.5 truncate">
+                      {app.clientId}
+                    </p>
+                  ) : null}
+                </div>
+              </Link>
+              <div className="hidden sm:flex items-center gap-3 shrink-0 text-xs font-medium">
+                {app.clientId && (
+                  <Link
+                    href={`/apps/${app.id}/usage`}
+                    className="text-zinc-500 hover:text-emerald-400 transition-colors"
+                  >
+                    Usage
+                  </Link>
+                )}
+                <Link
+                  href={`/apps/${app.id}`}
+                  className="text-zinc-600 hover:text-zinc-300 transition-colors"
+                >
+                  Settings →
+                </Link>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function DocumentationCard() {
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-sm p-6">
+      <div className="w-9 h-9 rounded-xl bg-zinc-800/60 flex items-center justify-center mb-4">
+        <svg className="w-5 h-5 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+        </svg>
+      </div>
+      <h3 className="font-semibold text-zinc-100 mb-1.5">Documentation</h3>
+      <p className="text-sm text-zinc-500 mb-5 leading-relaxed">
+        Integrate OIDC authentication and payment flows into your
+        application.
+      </p>
+      <div className="flex flex-col gap-2 mb-4">
+        <a
+          href="https://docs.pymthouse.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-800/40 text-zinc-300 border border-zinc-700/60 rounded-lg text-sm font-medium hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+        >
+          <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+          Docs
+          <svg className="w-3 h-3 ml-auto opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </a>
+        <a
+          href="https://pymthouse.com/api/v1/docs"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-500/8 text-emerald-400 border border-emerald-500/25 rounded-lg text-sm font-medium hover:bg-emerald-500/15 transition-colors"
+        >
+          <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+          </svg>
+          API Reference
+          <svg className="w-3 h-3 ml-auto opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </a>
+      </div>
+      <div className="text-xs text-zinc-600">
+        Discovery:{" "}
+        <code className="text-zinc-500">/.well-known/openid-configuration</code>
+      </div>
+    </div>
   );
 }

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,39 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 32,
+  height: 32,
+};
+
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#09090b",
+          borderRadius: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 14,
+            fontWeight: 700,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          <span style={{ color: "#34d399" }}>p</span>
+          <span style={{ color: "#fafafa" }}>h</span>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,10 +8,18 @@ import { authOptions } from "@/lib/next-auth-options";
 const siteDescription =
   "Identity and payment infrastructure for Livepeer AI apps. OIDC authentication, usage metering, and managed payment signing.";
 
+const metadataBase = (() => {
+  try {
+    return new URL(process.env.NEXTAUTH_URL ?? "https://pymthouse.com");
+  } catch {
+    return new URL("https://pymthouse.com");
+  }
+})();
+
 export const metadata: Metadata = {
   title: "pymthouse — Identity & Payment Infrastructure",
   description: siteDescription,
-  metadataBase: new URL(process.env.NEXTAUTH_URL ?? "https://pymthouse.com"),
+  metadataBase,
   openGraph: {
     title: "pymthouse — Identity & Payment Infrastructure",
     description: siteDescription,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,10 +5,25 @@ import "./globals.css";
 import Providers from "@/components/Providers";
 import { authOptions } from "@/lib/next-auth-options";
 
+const siteDescription =
+  "Identity and payment infrastructure for Livepeer AI apps. OIDC authentication, usage metering, and managed payment signing.";
+
 export const metadata: Metadata = {
-  title: "pymthouse - Identity & Payment Infrastructure",
-  description:
-    "Whitelabel identity and payment infrastructure for Livepeer orchestrators",
+  title: "pymthouse — Identity & Payment Infrastructure",
+  description: siteDescription,
+  metadataBase: new URL(process.env.NEXTAUTH_URL ?? "https://pymthouse.com"),
+  openGraph: {
+    title: "pymthouse — Identity & Payment Infrastructure",
+    description: siteDescription,
+    siteName: "pymthouse",
+    type: "website",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "pymthouse — Identity & Payment Infrastructure",
+    description: siteDescription,
+  },
 };
 
 export default async function RootLayout({

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -11,6 +11,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { MarketingFooter } from "@/components/MarketingFooter";
 
+/** Temporarily hide direct Google OAuth on the login page. Re-enable when ready. */
+const SHOW_GOOGLE_LOGIN = false;
+
 interface AppBranding {
   mode: "blackLabel" | "whiteLabel";
   displayName: string;
@@ -335,15 +338,17 @@ export function LoginForm() {
                 For developer accounts only.
               </p>
               <div className="space-y-2">
-                <button
-                  type="button"
-                  onClick={() =>
-                    signIn("google", { callbackUrl: safeCallbackUrl })
-                  }
-                  className="w-full flex items-center justify-center gap-3 px-4 py-2.5 border border-zinc-700 rounded-lg hover:bg-zinc-800/50 transition-colors text-sm font-medium text-zinc-300"
-                >
-                  Google
-                </button>
+                {SHOW_GOOGLE_LOGIN ? (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      signIn("google", { callbackUrl: safeCallbackUrl })
+                    }
+                    className="w-full flex items-center justify-center gap-3 px-4 py-2.5 border border-zinc-700 rounded-lg hover:bg-zinc-800/50 transition-colors text-sm font-medium text-zinc-300"
+                  >
+                    Google
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   onClick={() =>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,82 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "pymthouse — Identity & Payment Infrastructure";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: 72,
+          background: "linear-gradient(145deg, #09090b 0%, #18181b 55%, #052e16 100%)",
+          color: "#fafafa",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 20,
+            marginBottom: 32,
+          }}
+        >
+          <div
+            style={{
+              width: 72,
+              height: 72,
+              borderRadius: 18,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "rgba(52, 211, 153, 0.12)",
+              border: "1px solid rgba(52, 211, 153, 0.35)",
+              fontSize: 28,
+              fontWeight: 700,
+            }}
+          >
+            <span style={{ color: "#34d399" }}>p</span>
+            <span style={{ color: "#fafafa" }}>h</span>
+          </div>
+          <div style={{ display: "flex", fontSize: 56, fontWeight: 700, letterSpacing: "-0.03em" }}>
+            <span style={{ color: "#34d399" }}>pymt</span>
+            <span style={{ color: "#fafafa" }}>house</span>
+          </div>
+        </div>
+        <div
+          style={{
+            fontSize: 34,
+            fontWeight: 600,
+            lineHeight: 1.25,
+            maxWidth: 900,
+            color: "#e4e4e7",
+          }}
+        >
+          Identity &amp; payment infrastructure for Livepeer AI apps
+        </div>
+        <div
+          style={{
+            marginTop: 20,
+            fontSize: 24,
+            lineHeight: 1.4,
+            maxWidth: 920,
+            color: "#a1a1aa",
+          }}
+        >
+          OIDC authentication, usage metering, and managed payment signing — so you ship features, not infrastructure.
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from "./opengraph-image";

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -120,8 +120,21 @@ export default function DashboardLayout({
 
   if (status === "loading") {
     return (
-      <div className="flex items-center justify-center h-screen bg-zinc-950 text-zinc-500">
-        <div className="animate-pulse">Loading...</div>
+      <div className="flex h-screen w-full bg-zinc-950">
+        <div className="w-64 shrink-0 border-r border-zinc-800 bg-zinc-900/50 p-4 space-y-2">
+          <div className="h-8 w-32 rounded-lg bg-zinc-800 animate-pulse mb-6" />
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-9 rounded-lg bg-zinc-800/60 animate-pulse" />
+          ))}
+        </div>
+        <div className="flex-1 p-8 space-y-6">
+          <div className="h-8 w-48 rounded-lg bg-zinc-800 animate-pulse" />
+          <div className="grid grid-cols-3 gap-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-28 rounded-xl bg-zinc-900/50 border border-zinc-800 animate-pulse" />
+            ))}
+          </div>
+        </div>
       </div>
     );
   }
@@ -169,7 +182,7 @@ export default function DashboardLayout({
 
       {/* Sidebar (drawer on small screens; in-flow left column from lg+) */}
       <aside
-        className={`fixed inset-y-0 left-0 z-50 flex h-full w-64 shrink-0 flex-col border-zinc-800 bg-zinc-900/50 transition-transform duration-200 ease-out lg:relative lg:inset-auto lg:z-auto lg:translate-x-0 lg:flex-shrink-0 lg:border-r ${
+        className={`fixed inset-y-0 left-0 z-50 flex h-full w-64 shrink-0 flex-col border-zinc-800/80 bg-zinc-950/80 backdrop-blur-md transition-transform duration-200 ease-out lg:relative lg:inset-auto lg:z-auto lg:translate-x-0 lg:shrink-0 lg:border-r ${
           mobileNavOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
         } lg:order-1`}
       >
@@ -204,10 +217,10 @@ export default function DashboardLayout({
             const otherItems = navItems.filter((i) => !i.group);
 
             const renderNavLink = (item: NavItem, isActive: boolean) => {
-              const linkClass = `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+              const linkClass = `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-150 ${
                 isActive
-                  ? "bg-emerald-500/10 text-emerald-400"
-                  : "text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/50"
+                  ? "bg-emerald-500/10 text-emerald-400 shadow-[inset_0_0_0_1px_rgba(52,211,153,0.12)]"
+                  : "text-zinc-400 hover:text-zinc-100 hover:bg-white/[0.04]"
               }`;
               const icon = (
                 <svg
@@ -304,24 +317,40 @@ export default function DashboardLayout({
 
         {/* User info */}
         {session?.user && (
-          <div className="p-4 border-t border-zinc-800">
+          <div className="p-4 border-t border-zinc-800 space-y-3">
             <div className="flex items-center gap-3">
-              <div className="w-8 h-8 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-400 text-sm font-bold">
+              <div className="w-8 h-8 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-400 text-sm font-bold shrink-0">
                 {session.user.name?.[0]?.toUpperCase() || "?"}
               </div>
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium truncate">
                   {session.user.name}
                 </p>
-                <p className="text-xs text-zinc-500 truncate">
-                  {session.user.email}
-                </p>
+                <div className="flex items-center gap-1.5 mt-0.5">
+                  <p className="text-xs text-zinc-500 truncate">
+                    {session.user.email}
+                  </p>
+                  {userRole && (
+                    <span className={`shrink-0 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                      userRole === "admin"
+                        ? "bg-amber-500/15 text-amber-400"
+                        : userRole === "operator"
+                          ? "bg-blue-500/15 text-blue-400"
+                          : "bg-zinc-700/60 text-zinc-400"
+                    }`}>
+                      {userRole}
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
             <button
               onClick={() => signOut({ callbackUrl: "/" })}
-              className="mt-3 w-full text-xs text-zinc-500 hover:text-zinc-300 transition-colors text-left"
+              className="w-full flex items-center justify-center gap-2 rounded-lg border border-zinc-700/60 bg-zinc-800/40 px-3 py-1.5 text-xs font-medium text-zinc-400 hover:border-zinc-600 hover:bg-zinc-800 hover:text-zinc-200 transition-colors"
             >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
               Sign out
             </button>
           </div>

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -82,6 +82,19 @@ const allNavItems: NavItem[] = [
   },
 ];
 
+const SKELETON_NAV_KEYS = ["nav-a", "nav-b", "nav-c", "nav-d", "nav-e"] as const;
+const SKELETON_CARD_KEYS = ["card-a", "card-b", "card-c"] as const;
+
+function roleBadgeClassName(role: string): string {
+  if (role === "admin") {
+    return "bg-amber-500/15 text-amber-400";
+  }
+  if (role === "operator") {
+    return "bg-blue-500/15 text-blue-400";
+  }
+  return "bg-zinc-700/60 text-zinc-400";
+}
+
 export default function DashboardLayout({
   children,
 }: {
@@ -123,15 +136,15 @@ export default function DashboardLayout({
       <div className="flex h-screen w-full bg-zinc-950">
         <div className="w-64 shrink-0 border-r border-zinc-800 bg-zinc-900/50 p-4 space-y-2">
           <div className="h-8 w-32 rounded-lg bg-zinc-800 animate-pulse mb-6" />
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="h-9 rounded-lg bg-zinc-800/60 animate-pulse" />
+          {SKELETON_NAV_KEYS.map((key) => (
+            <div key={key} className="h-9 rounded-lg bg-zinc-800/60 animate-pulse" />
           ))}
         </div>
         <div className="flex-1 p-8 space-y-6">
           <div className="h-8 w-48 rounded-lg bg-zinc-800 animate-pulse" />
           <div className="grid grid-cols-3 gap-4">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="h-28 rounded-xl bg-zinc-900/50 border border-zinc-800 animate-pulse" />
+            {SKELETON_CARD_KEYS.map((key) => (
+              <div key={key} className="h-28 rounded-xl bg-zinc-900/50 border border-zinc-800 animate-pulse" />
             ))}
           </div>
         </div>
@@ -331,13 +344,9 @@ export default function DashboardLayout({
                     {session.user.email}
                   </p>
                   {userRole && (
-                    <span className={`shrink-0 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
-                      userRole === "admin"
-                        ? "bg-amber-500/15 text-amber-400"
-                        : userRole === "operator"
-                          ? "bg-blue-500/15 text-blue-400"
-                          : "bg-zinc-700/60 text-zinc-400"
-                    }`}>
+                    <span
+                      className={`shrink-0 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${roleBadgeClassName(userRole)}`}
+                    >
                       {userRole}
                     </span>
                   )}

--- a/src/components/SignerConfigForm.tsx
+++ b/src/components/SignerConfigForm.tsx
@@ -42,7 +42,7 @@ function FormField({
   warning?: React.ReactNode;
   children: React.ReactNode;
   colSpan2?: boolean;
-  fieldId?: string;
+  fieldId: string;
 }>) {
   return (
     <div className={colSpan2 ? "sm:col-span-2" : ""}>
@@ -235,8 +235,9 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
             Identity &amp; Connection
           </h4>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <FormField label="Signer Name">
+            <FormField label="Signer Name" fieldId="signer-name">
               <input
+                id="signer-name"
                 type="text"
                 required
                 value={formData.name}
@@ -251,6 +252,7 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
 
             <FormField
               label="Signer Base URL"
+              fieldId="signer-base-url"
               colSpan2
               help={
                 signerUrlEnvLocked ? (
@@ -281,6 +283,7 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
               }
             >
               <input
+                id="signer-base-url"
                 type="url"
                 value={formData.signerUrl}
                 onChange={(e) => setFormData({ ...formData, signerUrl: e.target.value })}
@@ -293,11 +296,13 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
 
             <FormField
               label="Signer API Key"
+              fieldId="signer-api-key"
               colSpan2
               help="Optional shared secret sent to the remote signer for request authentication."
             >
               <div className="relative">
                 <input
+                  id="signer-api-key"
                   type={showApiKey ? "text" : "password"}
                   value={formData.signerApiKey}
                   onChange={(e) => setFormData({ ...formData, signerApiKey: e.target.value })}
@@ -335,10 +340,12 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <FormField
               label="Ethereum RPC URL"
+              fieldId="signer-eth-rpc-url"
               colSpan2
               help={localComposeLocked ? LOCAL_ONLY_HELP : undefined}
             >
               <input
+                id="signer-eth-rpc-url"
                 type="url"
                 required={!localComposeLocked}
                 value={formData.ethRpcUrl}
@@ -352,10 +359,12 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
 
             <FormField
               label="Eth Account Address"
+              fieldId="signer-eth-acct-addr"
               colSpan2
               help={localComposeLocked ? LOCAL_ONLY_HELP : undefined}
             >
               <input
+                id="signer-eth-acct-addr"
                 type="text"
                 value={formData.ethAcctAddr}
                 onChange={(e) => setFormData({ ...formData, ethAcctAddr: e.target.value })}
@@ -368,6 +377,7 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
 
             <FormField
               label="Signer Port (httpAddr)"
+              fieldId="signer-port"
               help={
                 localComposeLocked
                   ? LOCAL_ONLY_HELP
@@ -375,6 +385,7 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
               }
             >
               <input
+                id="signer-port"
                 type="number"
                 min="1024"
                 max="65535"
@@ -396,22 +407,27 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
             Billing
           </h4>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <FormField label="Platform Cut (%)">
+            <FormField label="Platform Cut (%)" fieldId="signer-platform-cut">
               <input
+                id="signer-platform-cut"
                 type="number"
                 min="0"
                 max="100"
                 step="0.1"
                 value={formData.defaultCutPercent}
                 onChange={(e) =>
-                  setFormData({ ...formData, defaultCutPercent: Number.parseFloat(e.target.value) })
+                  setFormData({
+                    ...formData,
+                    defaultCutPercent: Number.parseFloat(e.target.value) || 0,
+                  })
                 }
                 className={inputEnabled}
               />
             </FormField>
 
-            <FormField label="Billing Mode">
+            <FormField label="Billing Mode" fieldId="signer-billing-mode">
               <select
+                id="signer-billing-mode"
                 value={formData.billingMode}
                 onChange={(e) => setFormData({ ...formData, billingMode: e.target.value })}
                 className={inputEnabled}
@@ -460,9 +476,11 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2 border-t border-zinc-800/60">
               <FormField
                 label="Orch Webhook URL"
+                fieldId="signer-orch-webhook-url"
                 colSpan2
               >
                 <input
+                  id="signer-orch-webhook-url"
                   type="url"
                   value={formData.orchWebhookUrl}
                   onChange={(e) => setFormData({ ...formData, orchWebhookUrl: e.target.value })}
@@ -473,9 +491,11 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
 
               <FormField
                 label="Live AI Cap Report Interval"
+                fieldId="signer-live-ai-cap-interval"
                 help="Duration string, e.g. 5m, 10s, 1h"
               >
                 <input
+                  id="signer-live-ai-cap-interval"
                   type="text"
                   value={formData.liveAICapReportInterval}
                   onChange={(e) =>

--- a/src/components/SignerConfigForm.tsx
+++ b/src/components/SignerConfigForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 interface SignerConfigFormProps {
@@ -95,11 +95,20 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
   const router = useRouter();
   const signerUrlEnvLocked = config.signerUrlSource === "env";
   const localComposeLocked = config.managedRemote;
+  const saveStateResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [saving, setSaving] = useState(false);
   const [saveState, setSaveState] = useState<"idle" | "success" | "error">("idle");
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [showApiKey, setShowApiKey] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (saveStateResetTimerRef.current !== null) {
+        clearTimeout(saveStateResetTimerRef.current);
+      }
+    };
+  }, []);
 
   const [formData, setFormData] = useState({
     name: config.name,
@@ -120,6 +129,10 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (saveStateResetTimerRef.current !== null) {
+      clearTimeout(saveStateResetTimerRef.current);
+      saveStateResetTimerRef.current = null;
+    }
     setSaving(true);
     setSaveState("idle");
     setSaveMessage(null);
@@ -161,7 +174,10 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
         setSaveState("success");
         setSaveMessage(data.message || "Configuration saved.");
         router.refresh();
-        setTimeout(() => setSaveState("idle"), 4000);
+        saveStateResetTimerRef.current = setTimeout(() => {
+          saveStateResetTimerRef.current = null;
+          setSaveState("idle");
+        }, 4000);
       } else {
         setSaveState("error");
         setSaveMessage(data.error || "Failed to save configuration.");

--- a/src/components/SignerConfigForm.tsx
+++ b/src/components/SignerConfigForm.tsx
@@ -35,13 +35,13 @@ function FormField({
   warning,
   children,
   colSpan2 = false,
-}: {
+}: Readonly<{
   label: string;
   help?: React.ReactNode;
   warning?: React.ReactNode;
   children: React.ReactNode;
   colSpan2?: boolean;
-}) {
+}>) {
   return (
     <div className={colSpan2 ? "sm:col-span-2" : ""}>
       <label className="block text-sm font-medium text-zinc-300 mb-1.5">
@@ -55,14 +55,17 @@ function FormField({
 }
 
 function ReadonlyField({
+  id,
   value,
   mono = false,
-}: {
+}: Readonly<{
+  id: string;
   value: string;
   mono?: boolean;
-}) {
+}>) {
   return (
     <div
+      id={id}
       className={`w-full px-3 py-2 bg-zinc-900/50 border border-zinc-800 rounded-lg text-sm text-zinc-300 break-all select-all ${mono ? "font-mono text-xs" : ""}`}
     >
       {value}
@@ -82,7 +85,7 @@ function fieldClass(locked: boolean, mono = false) {
 const LOCAL_ONLY_HELP =
   "Only used when starting the local Docker signer from this app. Configure on Railway for remote deployments.";
 
-export default function SignerConfigForm({ config }: SignerConfigFormProps) {
+export default function SignerConfigForm({ config }: Readonly<SignerConfigFormProps>) {
   const router = useRouter();
   const signerUrlEnvLocked = config.signerUrlSource === "env";
   const localComposeLocked = config.managedRemote;
@@ -180,22 +183,22 @@ export default function SignerConfigForm({ config }: SignerConfigFormProps) {
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium text-zinc-400 mb-1.5">
+            <label htmlFor="signer-oidc-issuer" className="block text-sm font-medium text-zinc-400 mb-1.5">
               OIDC_ISSUER
             </label>
-            <ReadonlyField value={config.oidcIssuer} mono />
+            <ReadonlyField id="signer-oidc-issuer" value={config.oidcIssuer} mono />
           </div>
           <div>
-            <label className="block text-sm font-medium text-zinc-400 mb-1.5">
+            <label htmlFor="signer-oidc-audience" className="block text-sm font-medium text-zinc-400 mb-1.5">
               OIDC_AUDIENCE
             </label>
-            <ReadonlyField value={config.oidcAudience} mono />
+            <ReadonlyField id="signer-oidc-audience" value={config.oidcAudience} mono />
           </div>
           <div>
-            <label className="block text-sm font-medium text-zinc-400 mb-1.5">
+            <label htmlFor="signer-oidc-jwks" className="block text-sm font-medium text-zinc-400 mb-1.5">
               JWKS_URI
             </label>
-            <ReadonlyField value={config.oidcJwksUrl} mono />
+            <ReadonlyField id="signer-oidc-jwks" value={config.oidcJwksUrl} mono />
           </div>
         </div>
       </section>
@@ -237,7 +240,7 @@ export default function SignerConfigForm({ config }: SignerConfigFormProps) {
             </FormField>
 
             <FormField label="Network">
-              <ReadonlyField value="arbitrum-one-mainnet" />
+              <ReadonlyField id="signer-network" value="arbitrum-one-mainnet" />
             </FormField>
 
             <FormField
@@ -371,7 +374,7 @@ export default function SignerConfigForm({ config }: SignerConfigFormProps) {
                 max="65535"
                 value={formData.signerPort}
                 onChange={(e) =>
-                  setFormData({ ...formData, signerPort: parseInt(e.target.value, 10) || 8080 })
+                  setFormData({ ...formData, signerPort: Number.parseInt(e.target.value, 10) || 8080 })
                 }
                 disabled={localComposeLocked}
                 readOnly={localComposeLocked}
@@ -395,7 +398,7 @@ export default function SignerConfigForm({ config }: SignerConfigFormProps) {
                 step="0.1"
                 value={formData.defaultCutPercent}
                 onChange={(e) =>
-                  setFormData({ ...formData, defaultCutPercent: parseFloat(e.target.value) })
+                  setFormData({ ...formData, defaultCutPercent: Number.parseFloat(e.target.value) })
                 }
                 className={inputEnabled}
               />

--- a/src/components/SignerConfigForm.tsx
+++ b/src/components/SignerConfigForm.tsx
@@ -29,23 +29,69 @@ interface SignerConfigFormProps {
   };
 }
 
-function fieldInputClass(locked: boolean, mono = false): string {
-  const base = locked
-    ? "bg-zinc-900/50 border-zinc-800 text-zinc-400 cursor-not-allowed"
-    : "bg-zinc-800/50 border-zinc-700 text-zinc-200 focus:outline-none focus:border-emerald-500/50";
-  return `w-full px-3 py-2 border rounded-lg text-sm ${mono ? "font-mono text-xs" : ""} ${base}`;
+function FormField({
+  label,
+  help,
+  warning,
+  children,
+  colSpan2 = false,
+}: {
+  label: string;
+  help?: React.ReactNode;
+  warning?: React.ReactNode;
+  children: React.ReactNode;
+  colSpan2?: boolean;
+}) {
+  return (
+    <div className={colSpan2 ? "sm:col-span-2" : ""}>
+      <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+        {label}
+      </label>
+      {children}
+      {help && <p className="text-xs text-zinc-500 mt-1.5 leading-relaxed">{help}</p>}
+      {warning && <p className="text-xs text-amber-500/90 mt-1.5 leading-relaxed">{warning}</p>}
+    </div>
+  );
 }
 
-const LOCAL_ONLY_FIELD_HELP =
+function ReadonlyField({
+  value,
+  mono = false,
+}: {
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div
+      className={`w-full px-3 py-2 bg-zinc-900/50 border border-zinc-800 rounded-lg text-sm text-zinc-300 break-all select-all ${mono ? "font-mono text-xs" : ""}`}
+    >
+      {value}
+    </div>
+  );
+}
+
+const inputBase =
+  "w-full px-3 py-2 border rounded-lg text-sm focus:outline-none transition-colors";
+const inputEnabled = `${inputBase} bg-zinc-800/50 border-zinc-700 text-zinc-200 focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/20`;
+const inputDisabled = `${inputBase} bg-zinc-900/50 border-zinc-800 text-zinc-400 cursor-not-allowed`;
+
+function fieldClass(locked: boolean, mono = false) {
+  return `${locked ? inputDisabled : inputEnabled} ${mono ? "font-mono text-xs" : ""}`;
+}
+
+const LOCAL_ONLY_HELP =
   "Only used when starting the local Docker signer from this app. Configure on Railway for remote deployments.";
 
 export default function SignerConfigForm({ config }: SignerConfigFormProps) {
   const router = useRouter();
   const signerUrlEnvLocked = config.signerUrlSource === "env";
   const localComposeLocked = config.managedRemote;
+
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<"idle" | "success" | "error">("idle");
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [showApiKey, setShowApiKey] = useState(false);
+
   const [formData, setFormData] = useState({
     name: config.name,
     signerUrl: signerUrlEnvLocked
@@ -66,14 +112,13 @@ export default function SignerConfigForm({ config }: SignerConfigFormProps) {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setSaving(true);
-    setMessage(null);
-    setError(null);
+    setSaveState("idle");
+    setSaveMessage(null);
 
     try {
       const skipSignerUrlPersist =
         signerUrlEnvLocked ||
-        (!config.signerUrl &&
-          formData.signerUrl === config.effectiveSignerUrl);
+        (!config.signerUrl && formData.signerUrl === config.effectiveSignerUrl);
       const signerUrl = skipSignerUrlPersist ? undefined : formData.signerUrl;
       const res = await fetch("/api/v1/signer", {
         method: "PATCH",
@@ -103,257 +148,278 @@ export default function SignerConfigForm({ config }: SignerConfigFormProps) {
       });
 
       const data = await res.json();
-
       if (res.ok) {
-        setMessage(data.message || "Config saved");
+        setSaveState("success");
+        setSaveMessage(data.message || "Configuration saved.");
         router.refresh();
+        setTimeout(() => setSaveState("idle"), 4000);
       } else {
-        setError(data.error || "Failed to save config");
+        setSaveState("error");
+        setSaveMessage(data.error || "Failed to save configuration.");
       }
     } catch {
-      setError("Failed to connect to API");
+      setSaveState("error");
+      setSaveMessage("Failed to connect to API.");
     } finally {
       setSaving(false);
     }
   }
 
   return (
-    <>
-      <div className="mb-8 pb-8 border-b border-zinc-800">
-        <h3 className="font-semibold text-zinc-200 mb-1">
-          OIDC / JWKS (automatic)
+    <div className="space-y-8">
+      {/* OIDC / JWKS — read-only */}
+      <section className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-5">
+        <h3 className="text-sm font-semibold text-zinc-100 mb-0.5">
+          OIDC / JWKS
         </h3>
-        <p className="text-xs text-zinc-500 mb-4">
-          Values passed into the local signer-dmz stack: issuer and audience are
-          <code className="text-zinc-400"> getIssuer()</code> (from{" "}
+        <p className="text-xs text-zinc-500 mb-4 leading-relaxed">
+          Passed into the local signer-dmz stack. Issuer and audience come from{" "}
           <code className="text-zinc-400">NEXTAUTH_URL</code> /{" "}
-          <code className="text-zinc-400">OIDC_ISSUER</code>). JWKS is that issuer
-          plus <code className="text-zinc-400">/jwks</code>, with loopback rewritten
-          for the container. Override JWKS with{" "}
+          <code className="text-zinc-400">OIDC_ISSUER</code>. Override JWKS with{" "}
           <code className="text-zinc-400">SIGNER_DMZ_JWKS_URL</code>.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="sm:col-span-2">
-            <label className="block text-xs text-zinc-500 mb-1.5">
+            <label className="block text-sm font-medium text-zinc-400 mb-1.5">
               OIDC_ISSUER
             </label>
-            <div className="w-full px-3 py-2 bg-zinc-900/50 border border-zinc-800 rounded-lg text-xs text-zinc-300 font-mono break-all">
-              {config.oidcIssuer}
-            </div>
+            <ReadonlyField value={config.oidcIssuer} mono />
           </div>
           <div>
-            <label className="block text-xs text-zinc-500 mb-1.5">
+            <label className="block text-sm font-medium text-zinc-400 mb-1.5">
               OIDC_AUDIENCE
             </label>
-            <div className="w-full px-3 py-2 bg-zinc-900/50 border border-zinc-800 rounded-lg text-xs text-zinc-300 font-mono break-all">
-              {config.oidcAudience}
-            </div>
+            <ReadonlyField value={config.oidcAudience} mono />
           </div>
           <div>
-            <label className="block text-xs text-zinc-500 mb-1.5">
+            <label className="block text-sm font-medium text-zinc-400 mb-1.5">
               JWKS_URI
             </label>
-            <div className="w-full px-3 py-2 bg-zinc-900/50 border border-zinc-800 rounded-lg text-xs text-zinc-300 font-mono break-all">
-              {config.oidcJwksUrl}
-            </div>
+            <ReadonlyField value={config.oidcJwksUrl} mono />
           </div>
         </div>
-      </div>
+      </section>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <h3 className="font-semibold text-zinc-200">Saved settings</h3>
+      {/* Editable config */}
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-zinc-100">
+            Saved settings
+          </h3>
+          {localComposeLocked && (
+            <span className="text-xs text-blue-400 bg-blue-500/10 border border-blue-500/20 rounded px-2 py-0.5">
+              Remote managed
+            </span>
+          )}
+        </div>
+
         {localComposeLocked && (
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-zinc-500 -mt-2">
             Platform billing fields are saved here. Signer process settings (RPC,
             port, discovery) are managed on the remote host.
           </p>
         )}
 
-        <fieldset className="grid grid-cols-1 sm:grid-cols-2 gap-4 border-0 p-0 m-0 min-w-0">
-        <div>
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Signer Name
-          </label>
-          <input
-            type="text"
-            required
-            value={formData.name}
-            onChange={(e) =>
-              setFormData({ ...formData, name: e.target.value })
-            }
-            className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-200 focus:outline-none focus:border-emerald-500/50"
-          />
-        </div>
-        <div>
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Signer Base URL
-          </label>
-          <input
-            type="url"
-            value={formData.signerUrl}
-            onChange={(e) =>
-              setFormData({ ...formData, signerUrl: e.target.value })
-            }
-            disabled={signerUrlEnvLocked}
-            readOnly={signerUrlEnvLocked}
-            className={fieldInputClass(signerUrlEnvLocked)}
-            placeholder={config.effectiveSignerUrl}
-          />
-          <p className="text-xs text-zinc-600 mt-0.5">
-            {signerUrlEnvLocked ? (
-              <>
-                Locked by{" "}
-                <code className="text-zinc-500">SIGNER_INTERNAL_URL</code> in
-                the server environment (Vercel / Railway). Change it in the
-                deployment dashboard, not here.
-              </>
-            ) : (
-              <>
-                Effective signer HTTP base URL (
-                {config.signerUrlSource === "saved"
-                  ? "saved in database"
-                  : "default fallback"}
-                ). This must point to Apache/DMZ on the host, usually{" "}
-                <code className="text-zinc-500">http://127.0.0.1:8080</code>.
-                Do not use livepeer&apos;s in-container{" "}
-                <code className="text-zinc-500">127.0.0.1:8081</code> here.
-              </>
-            )}
-          </p>
-          {signerUrlEnvLocked &&
-            config.signerUrl &&
-            config.signerUrl.trim() !== config.effectiveSignerUrl && (
-              <p className="text-xs text-amber-600/80 mt-1">
-                Database has{" "}
-                <code className="text-amber-500/90">{config.signerUrl}</code> but
-                it is ignored while{" "}
-                <code className="text-amber-500/90">SIGNER_INTERNAL_URL</code> is
-                set.
-              </p>
-            )}
-        </div>
-        <div>
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Signer Port (httpAddr)
-          </label>
-          <input
-            type="number"
-            min="1024"
-            max="65535"
-            value={formData.signerPort}
-            onChange={(e) =>
-              setFormData({
-                ...formData,
-                signerPort: parseInt(e.target.value, 10) || 8080,
-              })
-            }
-            disabled={localComposeLocked}
-            readOnly={localComposeLocked}
-            className={fieldInputClass(localComposeLocked)}
-          />
-          <p className="text-xs text-zinc-600 mt-0.5">
-            {localComposeLocked
-              ? LOCAL_ONLY_FIELD_HELP
-              : "Host port mapped to Apache in signer-dmz (default 8080). Do not use 8081 here: that is livepeer’s in-container HTTP port, not published on the host. Set SIGNER_INTERNAL_URL in .env if this row is wrong. Restart signer after changing."}
-          </p>
-        </div>
-        <div>
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Network
-          </label>
-          <div className="w-full px-3 py-2 bg-zinc-900/50 border border-zinc-800 rounded-lg text-sm text-zinc-300">
-            arbitrum-one-mainnet
+        {/* Identity & Connection */}
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/20 p-5 space-y-4">
+          <h4 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+            Identity &amp; Connection
+          </h4>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField label="Signer Name">
+              <input
+                type="text"
+                required
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className={inputEnabled}
+              />
+            </FormField>
+
+            <FormField label="Network">
+              <ReadonlyField value="arbitrum-one-mainnet" />
+            </FormField>
+
+            <FormField
+              label="Signer Base URL"
+              colSpan2
+              help={
+                signerUrlEnvLocked ? (
+                  <>
+                    Locked by <code className="text-zinc-400">SIGNER_INTERNAL_URL</code>{" "}
+                    in the server environment. Change it in the deployment dashboard.
+                  </>
+                ) : (
+                  <>
+                    HTTP base URL for Apache/DMZ on the host. Use{" "}
+                    <code className="text-zinc-400">http://127.0.0.1:8080</code>{" "}
+                    (not livepeer&apos;s in-container{" "}
+                    <code className="text-zinc-400">:8081</code>).
+                  </>
+                )
+              }
+              warning={
+                signerUrlEnvLocked &&
+                config.signerUrl &&
+                config.signerUrl.trim() !== config.effectiveSignerUrl ? (
+                  <>
+                    Database has{" "}
+                    <code className="text-amber-500/90">{config.signerUrl}</code> but
+                    it is ignored while{" "}
+                    <code className="text-amber-500/90">SIGNER_INTERNAL_URL</code> is set.
+                  </>
+                ) : undefined
+              }
+            >
+              <input
+                type="url"
+                value={formData.signerUrl}
+                onChange={(e) => setFormData({ ...formData, signerUrl: e.target.value })}
+                disabled={signerUrlEnvLocked}
+                readOnly={signerUrlEnvLocked}
+                className={fieldClass(signerUrlEnvLocked)}
+                placeholder={config.effectiveSignerUrl}
+              />
+            </FormField>
+
+            <FormField
+              label="Signer API Key"
+              colSpan2
+              help="Optional shared secret sent to the remote signer for request authentication."
+            >
+              <div className="relative">
+                <input
+                  type={showApiKey ? "text" : "password"}
+                  value={formData.signerApiKey}
+                  onChange={(e) => setFormData({ ...formData, signerApiKey: e.target.value })}
+                  className={`${inputEnabled} pr-10 font-mono text-xs`}
+                  placeholder="Optional — leave blank to disable"
+                  autoComplete="new-password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowApiKey((v) => !v)}
+                  className="absolute inset-y-0 right-0 flex items-center px-3 text-zinc-500 hover:text-zinc-300 transition-colors"
+                  aria-label={showApiKey ? "Hide API key" : "Show API key"}
+                >
+                  {showApiKey ? (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </FormField>
           </div>
         </div>
-        <div className="sm:col-span-2">
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Ethereum RPC URL
-          </label>
-          <input
-            type="url"
-            required={!localComposeLocked}
-            value={formData.ethRpcUrl}
-            onChange={(e) =>
-              setFormData({ ...formData, ethRpcUrl: e.target.value })
-            }
-            disabled={localComposeLocked}
-            readOnly={localComposeLocked}
-            className={fieldInputClass(localComposeLocked, true)}
-            placeholder="https://arb1.arbitrum.io/rpc"
-          />
-          {localComposeLocked && (
-            <p className="text-xs text-zinc-600 mt-0.5">{LOCAL_ONLY_FIELD_HELP}</p>
-          )}
+
+        {/* Network & Process */}
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/20 p-5 space-y-4">
+          <h4 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+            Network &amp; Process
+          </h4>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField
+              label="Ethereum RPC URL"
+              colSpan2
+              help={localComposeLocked ? LOCAL_ONLY_HELP : undefined}
+            >
+              <input
+                type="url"
+                required={!localComposeLocked}
+                value={formData.ethRpcUrl}
+                onChange={(e) => setFormData({ ...formData, ethRpcUrl: e.target.value })}
+                disabled={localComposeLocked}
+                readOnly={localComposeLocked}
+                className={fieldClass(localComposeLocked, true)}
+                placeholder="https://arb1.arbitrum.io/rpc"
+              />
+            </FormField>
+
+            <FormField
+              label="Eth Account Address"
+              colSpan2
+              help={localComposeLocked ? LOCAL_ONLY_HELP : undefined}
+            >
+              <input
+                type="text"
+                value={formData.ethAcctAddr}
+                onChange={(e) => setFormData({ ...formData, ethAcctAddr: e.target.value })}
+                disabled={localComposeLocked}
+                readOnly={localComposeLocked}
+                className={fieldClass(localComposeLocked, true)}
+                placeholder="0x..."
+              />
+            </FormField>
+
+            <FormField
+              label="Signer Port (httpAddr)"
+              help={
+                localComposeLocked
+                  ? LOCAL_ONLY_HELP
+                  : "Host port mapped to Apache in signer-dmz (default 8080). Restart signer after changing."
+              }
+            >
+              <input
+                type="number"
+                min="1024"
+                max="65535"
+                value={formData.signerPort}
+                onChange={(e) =>
+                  setFormData({ ...formData, signerPort: parseInt(e.target.value, 10) || 8080 })
+                }
+                disabled={localComposeLocked}
+                readOnly={localComposeLocked}
+                className={fieldClass(localComposeLocked)}
+              />
+            </FormField>
+          </div>
         </div>
-        <div className="sm:col-span-2">
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Signer API Key
-          </label>
-          <input
-            type="text"
-            value={formData.signerApiKey}
-            onChange={(e) =>
-              setFormData({ ...formData, signerApiKey: e.target.value })
-            }
-            className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-200 focus:outline-none focus:border-emerald-500/50 font-mono text-xs"
-            placeholder="Optional shared secret for the remote signer"
-          />
+
+        {/* Billing */}
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/20 p-5 space-y-4">
+          <h4 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+            Billing
+          </h4>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField label="Platform Cut (%)">
+              <input
+                type="number"
+                min="0"
+                max="100"
+                step="0.1"
+                value={formData.defaultCutPercent}
+                onChange={(e) =>
+                  setFormData({ ...formData, defaultCutPercent: parseFloat(e.target.value) })
+                }
+                className={inputEnabled}
+              />
+            </FormField>
+
+            <FormField label="Billing Mode">
+              <select
+                value={formData.billingMode}
+                onChange={(e) => setFormData({ ...formData, billingMode: e.target.value })}
+                className={inputEnabled}
+              >
+                <option value="delegated">Delegated</option>
+                <option value="prepay">Prepay</option>
+              </select>
+            </FormField>
+          </div>
         </div>
-        <div className="sm:col-span-2">
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Eth Account Address
-          </label>
-          <input
-            type="text"
-            value={formData.ethAcctAddr}
-            onChange={(e) =>
-              setFormData({ ...formData, ethAcctAddr: e.target.value })
-            }
-            disabled={localComposeLocked}
-            readOnly={localComposeLocked}
-            className={fieldInputClass(localComposeLocked, true)}
-            placeholder="0x..."
-          />
-          {localComposeLocked && (
-            <p className="text-xs text-zinc-600 mt-0.5">{LOCAL_ONLY_FIELD_HELP}</p>
-          )}
-        </div>
-        <div>
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Platform Cut (%)
-          </label>
-          <input
-            type="number"
-            min="0"
-            max="100"
-            step="0.1"
-            value={formData.defaultCutPercent}
-            onChange={(e) =>
-              setFormData({
-                ...formData,
-                defaultCutPercent: parseFloat(e.target.value),
-              })
-            }
-            className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-200 focus:outline-none focus:border-emerald-500/50"
-          />
-        </div>
-        <div>
-          <label className="block text-xs text-zinc-500 mb-1.5">
-            Billing Mode
-          </label>
-          <select
-            value={formData.billingMode}
-            onChange={(e) =>
-              setFormData({ ...formData, billingMode: e.target.value })
-            }
-            className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-200 focus:outline-none focus:border-emerald-500/50"
-          >
-            <option value="delegated">Delegated</option>
-            <option value="prepay">Prepay</option>
-          </select>
-        </div>
-        <div className="sm:col-span-2">
-          <label className="flex items-center gap-2 text-xs text-zinc-500 mb-1.5">
+
+        {/* Discovery */}
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/20 p-5 space-y-4">
+          <h4 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+            Discovery
+          </h4>
+          <label className="flex items-start gap-3 cursor-pointer group">
             <input
               type="checkbox"
               checked={formData.remoteDiscovery}
@@ -363,74 +429,95 @@ export default function SignerConfigForm({ config }: SignerConfigFormProps) {
                   ...formData,
                   remoteDiscovery: e.target.checked,
                   orchWebhookUrl: e.target.checked ? formData.orchWebhookUrl : "",
-                  liveAICapReportInterval: e.target.checked
-                    ? formData.liveAICapReportInterval
-                    : "",
+                  liveAICapReportInterval: e.target.checked ? formData.liveAICapReportInterval : "",
                 })
               }
-              className="rounded border-zinc-600 bg-zinc-800 text-emerald-500 focus:ring-emerald-500/50 disabled:opacity-50"
+              className="mt-0.5 h-4 w-4 rounded border-zinc-600 bg-zinc-800 text-emerald-500 focus:ring-emerald-500/50 disabled:opacity-50 cursor-pointer"
             />
-            Remote Discovery (orchWebhookUrl + liveAICapReportInterval)
+            <div>
+              <span className="text-sm font-medium text-zinc-200 group-hover:text-zinc-100 transition-colors">
+                Remote Discovery
+              </span>
+              <p className="text-xs text-zinc-500 mt-0.5">
+                Enables orchestrator webhook and live AI capability reporting.
+              </p>
+              {localComposeLocked && (
+                <p className="text-xs text-zinc-600 mt-1">{LOCAL_ONLY_HELP}</p>
+              )}
+            </div>
           </label>
-          {localComposeLocked && (
-            <p className="text-xs text-zinc-600 mt-1">{LOCAL_ONLY_FIELD_HELP}</p>
+
+          {formData.remoteDiscovery && !localComposeLocked && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2 border-t border-zinc-800/60">
+              <FormField
+                label="Orch Webhook URL"
+                colSpan2
+              >
+                <input
+                  type="url"
+                  value={formData.orchWebhookUrl}
+                  onChange={(e) => setFormData({ ...formData, orchWebhookUrl: e.target.value })}
+                  className={`${inputEnabled} font-mono text-xs`}
+                  placeholder="https://example.com/orch-info.json"
+                />
+              </FormField>
+
+              <FormField
+                label="Live AI Cap Report Interval"
+                help="Duration string, e.g. 5m, 10s, 1h"
+              >
+                <input
+                  type="text"
+                  value={formData.liveAICapReportInterval}
+                  onChange={(e) =>
+                    setFormData({ ...formData, liveAICapReportInterval: e.target.value })
+                  }
+                  className={`${inputEnabled} font-mono text-xs`}
+                  placeholder="5m"
+                />
+              </FormField>
+            </div>
           )}
         </div>
-        {formData.remoteDiscovery && !localComposeLocked && (
-          <>
-            <div className="sm:col-span-2">
-              <label className="block text-xs text-zinc-500 mb-1.5">
-                Orch Webhook URL
-              </label>
-              <input
-                type="url"
-                value={formData.orchWebhookUrl}
-                onChange={(e) =>
-                  setFormData({ ...formData, orchWebhookUrl: e.target.value })
-                }
-                className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-200 focus:outline-none focus:border-emerald-500/50 font-mono text-xs"
-                placeholder="https://example.com/orch-info.json"
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-zinc-500 mb-1.5">
-                Live AI Cap Report Interval
-              </label>
-              <input
-                type="text"
-                value={formData.liveAICapReportInterval}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    liveAICapReportInterval: e.target.value,
-                  })
-                }
-                className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-200 focus:outline-none focus:border-emerald-500/50 font-mono text-xs"
-                placeholder="5m"
-              />
-              <p className="text-xs text-zinc-600 mt-0.5">
-                e.g. 5m, 10s, 1h
-              </p>
-            </div>
-          </>
-        )}
-      </fieldset>
 
-      <div className="flex items-center gap-3">
-        <button
-          type="submit"
-          disabled={saving}
-          className="px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-600 transition-colors disabled:opacity-50"
-        >
-          {saving ? "Saving..." : "Save Config"}
-        </button>
+        {/* Save row */}
+        <div className="flex items-center gap-4 pt-2">
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex items-center gap-2 px-5 py-2 bg-emerald-600 text-white rounded-lg text-sm font-medium hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? (
+              <>
+                <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Saving…
+              </>
+            ) : (
+              "Save configuration"
+            )}
+          </button>
 
-        {message && (
-          <span className="text-sm text-amber-400">{message}</span>
-        )}
-        {error && <span className="text-sm text-red-400">{error}</span>}
-      </div>
-    </form>
-    </>
+          {saveState === "success" && saveMessage && (
+            <span className="flex items-center gap-1.5 text-sm text-emerald-400">
+              <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              {saveMessage}
+            </span>
+          )}
+          {saveState === "error" && saveMessage && (
+            <span className="flex items-center gap-1.5 text-sm text-red-400">
+              <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              {saveMessage}
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
   );
 }

--- a/src/components/SignerConfigForm.tsx
+++ b/src/components/SignerConfigForm.tsx
@@ -35,16 +35,21 @@ function FormField({
   warning,
   children,
   colSpan2 = false,
+  fieldId,
 }: Readonly<{
   label: string;
   help?: React.ReactNode;
   warning?: React.ReactNode;
   children: React.ReactNode;
   colSpan2?: boolean;
+  fieldId?: string;
 }>) {
   return (
     <div className={colSpan2 ? "sm:col-span-2" : ""}>
-      <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+      <label
+        htmlFor={fieldId}
+        className="block text-sm font-medium text-zinc-300 mb-1.5"
+      >
         {label}
       </label>
       {children}
@@ -64,12 +69,13 @@ function ReadonlyField({
   mono?: boolean;
 }>) {
   return (
-    <div
+    <input
       id={id}
-      className={`w-full px-3 py-2 bg-zinc-900/50 border border-zinc-800 rounded-lg text-sm text-zinc-300 break-all select-all ${mono ? "font-mono text-xs" : ""}`}
-    >
-      {value}
-    </div>
+      type="text"
+      readOnly
+      value={value}
+      className={`w-full px-3 py-2 bg-zinc-900/50 border border-zinc-800 rounded-lg text-sm text-zinc-300 break-all select-all cursor-default ${mono ? "font-mono text-xs" : ""}`}
+    />
   );
 }
 
@@ -239,7 +245,7 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
               />
             </FormField>
 
-            <FormField label="Network">
+            <FormField label="Network" fieldId="signer-network">
               <ReadonlyField id="signer-network" value="arbitrum-one-mainnet" />
             </FormField>
 

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -225,6 +225,7 @@ export default function AppSettingsScreen({
         );
         return { ...prev, redirectUris: uris, grantTypes: nextGrantTypes };
       });
+      setIsDirty(true);
     },
     [appState.clientId],
   );

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -776,6 +776,7 @@ export default function AppSettingsScreen({
           {isDirty && !saving && (
             <span className="flex items-center gap-1.5 text-xs text-amber-400">
               <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+              {" "}
               Unsaved changes
             </span>
           )}

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -119,7 +119,11 @@ export default function AppSettingsScreen({
   const [message, setMessage] = useState<string | null>(null);
   const [submittingForReview, setSubmittingForReview] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [reverting, setReverting] = useState(false);
+  const [confirmRevert, setConfirmRevert] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const messageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [integrationSection, setIntegrationSection] =
     useState<IntegrationSection>(() => resolveInitialTab(initialTab));
   const tabRefs = useRef<Partial<Record<IntegrationSection, HTMLButtonElement | null>>>({});
@@ -176,9 +180,29 @@ export default function AppSettingsScreen({
     [selectIntegrationSection],
   );
 
+  const showMessage = useCallback((msg: string) => {
+    setMessage(msg);
+    if (messageTimerRef.current !== null) {
+      clearTimeout(messageTimerRef.current);
+    }
+    messageTimerRef.current = setTimeout(() => {
+      messageTimerRef.current = null;
+      setMessage(null);
+    }, 4000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (messageTimerRef.current !== null) {
+        clearTimeout(messageTimerRef.current);
+      }
+    };
+  }, []);
+
   const updateFormData = useCallback(
     (updates: Partial<AppFormData>) => {
       setFormData((prev) => ({ ...prev, ...updates }));
+      setIsDirty(true);
     },
     [],
   );
@@ -271,7 +295,8 @@ export default function AppSettingsScreen({
         );
       }
 
-      setMessage("All settings saved.");
+      setIsDirty(false);
+      showMessage("All settings saved.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
@@ -282,6 +307,7 @@ export default function AppSettingsScreen({
     formData,
     postLogoutRedirectUris,
     canEdit,
+    showMessage,
   ]);
 
   const submitForReview = useCallback(async () => {
@@ -307,26 +333,18 @@ export default function AppSettingsScreen({
       }
       setAppState((s) => ({ ...s, status: "submitted" }));
       onReviewSubmitted?.();
-      setMessage("App submitted for review. An administrator will approve it.");
+      showMessage("App submitted for review. An administrator will approve it.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setSubmittingForReview(false);
     }
-  }, [appId, canSubmitForReview, onReviewSubmitted]);
+  }, [appId, canSubmitForReview, onReviewSubmitted, showMessage]);
 
   const deleteDraftApp = useCallback(async () => {
     if (!canSubmitForReview || appState.status !== "draft") return;
-    if (
-      !confirm(
-        `Delete "${formData.name.trim() || "this app"}"? This permanently removes the draft app and cannot be undone.`,
-      )
-    ) {
-      return;
-    }
     setDeleting(true);
     setError(null);
-    setMessage(null);
     try {
       const res = await fetch(`/api/v1/apps/${appId}`, { method: "DELETE" });
       if (!res.ok) {
@@ -342,21 +360,14 @@ export default function AppSettingsScreen({
       setError(err instanceof Error ? err.message : "Delete failed");
     } finally {
       setDeleting(false);
+      setConfirmDelete(false);
     }
-  }, [appId, appState.status, canSubmitForReview, formData.name, router]);
+  }, [appId, appState.status, canSubmitForReview, router]);
 
   const revertToDraft = useCallback(async () => {
     if (!canSubmitForReview || appState.status !== "submitted") return;
-    if (
-      !confirm(
-        "Revert this app to draft? It will leave the review queue until you submit again.",
-      )
-    ) {
-      return;
-    }
     setReverting(true);
     setError(null);
-    setMessage(null);
     try {
       const res = await fetch(`/api/v1/apps/${appId}/revert-draft`, {
         method: "POST",
@@ -375,13 +386,14 @@ export default function AppSettingsScreen({
       }
       setAppState((s) => ({ ...s, status: "draft" }));
       onRevertedToDraft?.();
-      setMessage("App is back in draft. You can edit and submit again when ready.");
+      showMessage("App is back in draft. You can edit and submit again when ready.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Revert failed");
     } finally {
       setReverting(false);
+      setConfirmRevert(false);
     }
-  }, [appId, appState.status, canSubmitForReview, onRevertedToDraft]);
+  }, [appId, appState.status, canSubmitForReview, onRevertedToDraft, showMessage]);
 
   const addPostLogoutUri = () => {
     const trimmed = newPostLogoutUri.trim();
@@ -451,14 +463,34 @@ export default function AppSettingsScreen({
                   from the queue to make changes, then submit again.
                 </p>
               </div>
-              <button
-                type="button"
-                onClick={() => void revertToDraft()}
-                disabled={reverting}
-                className="px-4 py-2 text-sm font-medium rounded-md border border-amber-500/40 text-amber-200 hover:bg-amber-500/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {reverting ? "Reverting…" : "Revert to draft"}
-              </button>
+              {confirmRevert ? (
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-amber-300">Withdraw from review queue?</span>
+                  <button
+                    type="button"
+                    onClick={() => void revertToDraft()}
+                    disabled={reverting}
+                    className="px-3 py-1.5 text-sm font-medium rounded-md bg-amber-500/20 border border-amber-500/40 text-amber-200 hover:bg-amber-500/30 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {reverting ? "Reverting…" : "Yes, revert"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmRevert(false)}
+                    className="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirmRevert(true)}
+                  className="px-4 py-2 text-sm font-medium rounded-md border border-amber-500/40 text-amber-200 hover:bg-amber-500/10 transition-colors"
+                >
+                  Revert to draft
+                </button>
+              )}
             </div>
           )}
         {error && (
@@ -530,14 +562,36 @@ export default function AppSettingsScreen({
                 Permanently remove this app, its OIDC client, and related data. This
                 cannot be undone.
               </p>
-              <button
-                type="button"
-                onClick={() => void deleteDraftApp()}
-                disabled={deleting}
-                className="px-4 py-2 text-sm font-medium rounded-md border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {deleting ? "Deleting…" : "Delete app"}
-              </button>
+              {confirmDelete ? (
+                <div className="flex items-center gap-3 p-3 rounded-md bg-red-500/5 border border-red-500/20">
+                  <span className="text-sm text-red-300 flex-1">
+                    Delete &ldquo;{formData.name.trim() || "this app"}&rdquo;? This cannot be undone.
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => void deleteDraftApp()}
+                    disabled={deleting}
+                    className="px-3 py-1.5 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {deleting ? "Deleting…" : "Delete"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDelete(false)}
+                    className="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(true)}
+                  className="px-4 py-2 text-sm font-medium rounded-md border border-red-500/40 text-red-300 hover:bg-red-500/10 transition-colors"
+                >
+                  Delete app
+                </button>
+              )}
             </section>
           )}
         </div>
@@ -718,14 +772,34 @@ export default function AppSettingsScreen({
           <strong className="text-zinc-400">Save changes</strong> for metadata,
           auth mode, scopes, and OIDC fields.
         </p>
-        <button
-          type="button"
-          onClick={() => void saveChanges()}
-          disabled={!canEdit || saving || !formData.name.trim()}
-          className="px-5 py-2 text-sm font-medium rounded-md bg-emerald-600 text-white hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shrink-0"
-        >
-          {saving ? "Saving…" : "Save changes"}
-        </button>
+        <div className="flex items-center gap-3 shrink-0">
+          {isDirty && !saving && (
+            <span className="flex items-center gap-1.5 text-xs text-amber-400">
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+              Unsaved changes
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => void saveChanges()}
+            disabled={!canEdit || saving || !formData.name.trim()}
+            className={`px-5 py-2 text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+              isDirty
+                ? "bg-emerald-600 text-white hover:bg-emerald-500 ring-2 ring-emerald-500/20"
+                : "bg-emerald-600 text-white hover:bg-emerald-500"
+            }`}
+          >
+            {saving ? (
+              <span className="flex items-center gap-2">
+                <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Saving…
+              </span>
+            ) : "Save changes"}
+          </button>
+        </div>
       </div>
       )}
     </div>

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -207,6 +207,14 @@ export default function AppSettingsScreen({
     [],
   );
 
+  const updatePostLogoutRedirectUris = useCallback(
+    (updater: React.SetStateAction<string[]>) => {
+      setPostLogoutRedirectUris(updater);
+      setIsDirty(true);
+    },
+    [],
+  );
+
   const handleRedirectUrisChange = useCallback(
     (uris: string[]) => {
       setFormData((prev) => {
@@ -398,7 +406,7 @@ export default function AppSettingsScreen({
   const addPostLogoutUri = () => {
     const trimmed = newPostLogoutUri.trim();
     if (!trimmed || postLogoutRedirectUris.includes(trimmed)) return;
-    setPostLogoutRedirectUris((u) => [...u, trimmed]);
+    updatePostLogoutRedirectUris((u) => [...u, trimmed]);
     setNewPostLogoutUri("");
   };
 
@@ -477,7 +485,8 @@ export default function AppSettingsScreen({
                   <button
                     type="button"
                     onClick={() => setConfirmRevert(false)}
-                    className="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+                    disabled={reverting}
+                    className="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Cancel
                   </button>
@@ -578,7 +587,8 @@ export default function AppSettingsScreen({
                   <button
                     type="button"
                     onClick={() => setConfirmDelete(false)}
-                    className="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+                    disabled={deleting}
+                    className="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Cancel
                   </button>
@@ -703,7 +713,7 @@ export default function AppSettingsScreen({
                         <button
                           type="button"
                           onClick={() =>
-                            setPostLogoutRedirectUris((items) =>
+                            updatePostLogoutRedirectUris((items) =>
                               items.filter((item) => item !== uri),
                             )
                           }

--- a/src/components/apps/AppStatusBadge.tsx
+++ b/src/components/apps/AppStatusBadge.tsx
@@ -1,0 +1,57 @@
+export function appStatusAriaLabel(status: string): string {
+  switch (status) {
+    case "approved":
+      return "Live — approved";
+    case "draft":
+      return "Draft";
+    case "submitted":
+      return "Submitted — awaiting review";
+    case "in_review":
+      return "In review";
+    case "rejected":
+      return "Rejected";
+    default:
+      return status.replaceAll("_", " ");
+  }
+}
+
+export default function AppStatusBadge({ status }: { status: string }) {
+  const config: Record<string, { label: string; className: string }> = {
+    approved: {
+      label: "Live",
+      className: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20",
+    },
+    draft: {
+      label: "Draft",
+      className: "bg-zinc-700/40 text-zinc-400 border-zinc-700",
+    },
+    submitted: {
+      label: "In review",
+      className: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+    },
+    in_review: {
+      label: "In review",
+      className: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+    },
+    rejected: {
+      label: "Rejected",
+      className: "bg-red-500/10 text-red-400 border-red-500/20",
+    },
+  };
+
+  const { label, className } = config[status] ?? {
+    label: status.replaceAll("_", " "),
+    className: "bg-zinc-700/40 text-zinc-400 border-zinc-700",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium leading-none ${className}`}
+    >
+      {status === "approved" && (
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" aria-hidden="true" />
+      )}
+      {label}
+    </span>
+  );
+}

--- a/src/components/apps/AppStatusBadge.tsx
+++ b/src/components/apps/AppStatusBadge.tsx
@@ -5,7 +5,7 @@ export function appStatusAriaLabel(status: string): string {
     case "draft":
       return "Draft";
     case "submitted":
-      return "Submitted — awaiting review";
+      return "Submitted";
     case "in_review":
       return "In review";
     case "rejected":
@@ -26,7 +26,7 @@ export default function AppStatusBadge({ status }: Readonly<{ status: string }>)
       className: "bg-zinc-700/40 text-zinc-400 border-zinc-700",
     },
     submitted: {
-      label: "In review",
+      label: "Submitted",
       className: "bg-amber-500/10 text-amber-400 border-amber-500/20",
     },
     in_review: {

--- a/src/components/apps/AppStatusBadge.tsx
+++ b/src/components/apps/AppStatusBadge.tsx
@@ -15,7 +15,7 @@ export function appStatusAriaLabel(status: string): string {
   }
 }
 
-export default function AppStatusBadge({ status }: { status: string }) {
+export default function AppStatusBadge({ status }: Readonly<{ status: string }>) {
   const config: Record<string, { label: string; className: string }> = {
     approved: {
       label: "Live",

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -326,6 +326,8 @@ type SigningTokenFormatToggleProps = Readonly<{
   onChange: (next: SigningTokenFormat) => void;
   readOnly: boolean;
   clientId: string;
+  /** When true, omit top border/margin (used below the flow picker row). */
+  embedded?: boolean;
 }>;
 
 function SigningTokenFormatToggle({
@@ -333,9 +335,16 @@ function SigningTokenFormatToggle({
   onChange,
   readOnly,
   clientId,
+  embedded = false,
 }: SigningTokenFormatToggleProps) {
   return (
-    <div className="mt-2 pt-2 border-t border-zinc-700/50 flex justify-end">
+    <div
+      className={
+        embedded
+          ? "flex justify-end"
+          : "mt-2 pt-2 border-t border-zinc-700/50 flex justify-end"
+      }
+    >
       <fieldset
         aria-label="Signing token format"
         className="relative inline-grid grid-cols-2 w-[7.25rem] rounded-md bg-zinc-950 border border-zinc-600/90 p-px m-0 min-w-0"
@@ -395,7 +404,7 @@ type M2mTokenTestPanelProps = Readonly<{
 function m2mOptionButtonClass(kind: M2mTokenTestKind, activeKind: M2mTokenTestKind) {
   const selected = activeKind === kind;
   const base =
-    "rounded-lg border px-3 py-3 text-left transition-colors w-full h-full flex flex-col";
+    "rounded-lg border px-3 py-3 text-left transition-colors w-full h-full min-h-[4.5rem] flex flex-col justify-start";
   return [
     base,
     selected
@@ -419,12 +428,19 @@ function M2mSingleFlowHint({
 }>): ReactNode {
   if (showRemoteSigning) {
     return (
-      <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-3">
-        <span className="block text-xs font-semibold text-emerald-100/90">Remote signing</span>
-        <span className="mt-1 block text-[11px] text-zinc-500">
-          Payment signing tokens for your app owner identity.
-        </span>
-        {bearerFormatToggle}
+      <div className="space-y-2">
+        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-3">
+          <span className="block text-xs font-semibold text-emerald-100/90">Remote signing</span>
+          <span className="mt-1 block text-[11px] text-zinc-500">
+            Payment signing tokens for your app owner identity.
+          </span>
+        </div>
+        {bearerFormatToggle ? (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900/40 px-3 py-2">
+            <span className="text-[11px] text-zinc-500">Signing token format</span>
+            {bearerFormatToggle}
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -499,51 +515,51 @@ function M2mFlowSelection({
 }>): ReactNode {
   if (showFlowPicker) {
     return (
-      <div className="grid gap-2 sm:grid-cols-2 items-stretch" role="radiogroup" aria-label="Token type">
-        {showAdministrative ? (
-          <button
-            type="button"
-            role="radio"
-            aria-checked={activeKind === "admin"}
-            onClick={() => selectKind("admin")}
-            disabled={readOnly}
-            className={m2mOptionButtonClass("admin", activeKind)}
-          >
-            <span
-              className={`block text-xs font-semibold leading-4 min-h-8 ${m2mOptionTitleClass(activeKind === "admin")}`}
-            >
-              Administrative access
-            </span>
-            <span className="mt-1 block text-[11px] text-zinc-500">
-              Builder APIs, user provisioning, and device approval
-            </span>
-          </button>
-        ) : null}
-        {showRemoteSigning ? (
-          <div className="flex flex-col gap-2">
-            <div
+      <div className="space-y-2">
+        <div className="grid gap-2 sm:grid-cols-2 items-stretch" role="radiogroup" aria-label="Token type">
+          {showAdministrative ? (
+            <button
+              type="button"
               role="radio"
-              aria-checked={activeKind === "owner"}
-              onClick={() => !readOnly && selectKind("owner")}
-              onKeyDown={(e) => {
-                if (!readOnly && (e.key === "Enter" || e.key === " ")) {
-                  e.preventDefault();
-                  selectKind("owner");
-                }
-              }}
-              tabIndex={readOnly ? -1 : 0}
-              className={`${m2mOptionButtonClass("owner", activeKind)} cursor-pointer`}
+              aria-checked={activeKind === "admin"}
+              onClick={() => selectKind("admin")}
+              disabled={readOnly}
+              className={m2mOptionButtonClass("admin", activeKind)}
             >
               <span
-                className={`block text-xs font-semibold leading-4 min-h-8 ${m2mOptionTitleClass(activeKind === "owner")}`}
+                className={`block text-xs font-semibold leading-snug ${m2mOptionTitleClass(activeKind === "admin")}`}
+              >
+                Administrative access
+              </span>
+              <span className="mt-1 block text-[11px] leading-snug text-zinc-500">
+                Builder APIs, user provisioning, and device approval
+              </span>
+            </button>
+          ) : null}
+          {showRemoteSigning ? (
+            <button
+              type="button"
+              role="radio"
+              aria-checked={activeKind === "owner"}
+              onClick={() => selectKind("owner")}
+              disabled={readOnly}
+              className={m2mOptionButtonClass("owner", activeKind)}
+            >
+              <span
+                className={`block text-xs font-semibold leading-snug ${m2mOptionTitleClass(activeKind === "owner")}`}
               >
                 Remote signing
               </span>
-              <span className="mt-1 block text-[11px] text-zinc-500">
+              <span className="mt-1 block text-[11px] leading-snug text-zinc-500">
                 Payment signing tokens for your app owner identity
               </span>
-            </div>
-            {activeKind === "owner" ? bearerFormatToggle : null}
+            </button>
+          ) : null}
+        </div>
+        {activeKind === "owner" && bearerFormatToggle ? (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900/40 px-3 py-2">
+            <span className="text-[11px] text-zinc-500">Signing token format</span>
+            {bearerFormatToggle}
           </div>
         ) : null}
       </div>
@@ -637,6 +653,7 @@ function M2mTokenTestPanel({
       value={signingTokenFormat}
       clientId={clientId}
       readOnly={readOnly}
+      embedded
       onChange={(next) => {
         selectKind("owner");
         setSigningTokenFormat(next);

--- a/src/lib/user-apps.ts
+++ b/src/lib/user-apps.ts
@@ -1,0 +1,74 @@
+import { db } from "@/db/index";
+import { developerApps, oidcClients, providerAdmins } from "@/db/schema";
+import { eq, inArray } from "drizzle-orm";
+
+export type UserAppSummary = {
+  id: string;
+  name: string;
+  subtitle: string | null;
+  category: string | null;
+  status: string;
+  logoLightUrl: string | null;
+  clientId: string | null;
+  createdAt: string;
+};
+
+/** Apps the user owns or is an admin of (same set as GET /api/v1/apps). */
+export async function listUserAccessibleApps(userId: string): Promise<UserAppSummary[]> {
+  const memberships = await db
+    .select({ clientId: providerAdmins.clientId })
+    .from(providerAdmins)
+    .where(eq(providerAdmins.userId, userId));
+
+  const memberIds = memberships.map((membership) => membership.clientId);
+
+  const ownedApps = await db
+    .select({
+      id: oidcClients.clientId,
+      name: developerApps.name,
+      subtitle: developerApps.subtitle,
+      category: developerApps.category,
+      status: developerApps.status,
+      logoLightUrl: developerApps.logoLightUrl,
+      createdAt: developerApps.createdAt,
+      clientId: oidcClients.clientId,
+    })
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(developerApps.ownerId, userId));
+
+  const memberApps =
+    memberIds.length === 0
+      ? []
+      : await db
+          .select({
+            id: oidcClients.clientId,
+            name: developerApps.name,
+            subtitle: developerApps.subtitle,
+            category: developerApps.category,
+            status: developerApps.status,
+            logoLightUrl: developerApps.logoLightUrl,
+            createdAt: developerApps.createdAt,
+            clientId: oidcClients.clientId,
+          })
+          .from(developerApps)
+          .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+          .where(inArray(developerApps.id, memberIds));
+
+  return [...ownedApps, ...memberApps]
+    .filter(
+      (app, index, rows) => rows.findIndex((row) => row.id === app.id) === index,
+    )
+    .map((app) => ({
+      id: app.id ?? "",
+      name: app.name,
+      subtitle: app.subtitle,
+      category: app.category,
+      status: app.status,
+      logoLightUrl: app.logoLightUrl,
+      clientId: app.clientId,
+      createdAt: app.createdAt,
+    }))
+    .filter((app) => app.id.length > 0)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
## Summary
- Improve developer dashboard with owned-apps list, fintech-style glass KPI cards, and updated beta credit messaging ($5/month).
- Enhance app configuration UX: inline confirmations, dirty-state save indicator, sectioned signer config form, and shared status badges.
- Fix credentials tab layout for M2M token flow picker (equal-height cards, JWT/Bearer toggle below grid).

## Test plan
- [ ] Open `/dashboard` as a developer — verify My Apps list, beta banner copy, and documentation card
- [ ] Open `/apps` — verify status badges and loading skeletons
- [ ] Open app settings — verify inline delete/revert confirmations and unsaved changes indicator
- [ ] Open `/signer` — verify sectioned config form and API key show/hide
- [ ] Open app credentials tab — verify Administrative access / Remote signing cards align and JWT/Bearer toggle renders below

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer dashboard experience with a new “My Apps” section, plus a documentation card.
  * Added Open Graph/Twitter preview image generation (including dedicated icon).
* **Bug Fixes**
  * Improved loading UX with skeleton layouts and better accessibility for app status (screen-reader labels and live indicators).
  * Enhanced form feedback in app settings and signer configuration, including clearer save/error messaging and confirmations for destructive actions.
* **Style**
  * Refreshed dashboard/sidebar visuals, cards, and role badge presentation.
* **Chores**
  * Updated site SEO/social metadata to power consistent previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->