### PR TITLE
fix(openmeter): durable, idempotent, acked signed-ticket usage ingest (flag-gated, default OFF)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,12 @@ OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS=5000000
 # Billing API v2 (see src/lib/billing/feature-flags.ts)
 BILLING_PLANS_API_V2=true
 BILLING_STABLE_FEATURE_KEYS=true
+# Durable, idempotent, acked OpenMeter write on POST /api/v1/internal/ingest/signed-ticket.
+# Default OFF (unset): endpoint stays diagnostic-only (ingested:false), OpenMeter is fed
+# solely by the legacy Kafka -> Benthos collector path (zero regression). Set to 1 to make
+# the endpoint synchronously write to OpenMeter and ack ingested:true; deduped on
+# (clientId, requestId) so it is safe to run alongside the Kafka path during rollout.
+# SIGNED_TICKET_DURABLE_INGEST=1
 
 # ---------- BPP ② subscriptionRef ----------
 # NaaP reads usage by PULLING from pymthouse (M2M client / builder-sdk usage

--- a/src/app/api/v1/internal/ingest/signed-ticket/route.test.ts
+++ b/src/app/api/v1/internal/ingest/signed-ticket/route.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { NextRequest } from "next/server";
+import { and, eq } from "drizzle-orm";
 
 import { run } from "@/test-utils/db-guard";
 import { cleanupTestApp, seedDeveloperAppWithClient } from "@/test-utils/fixtures";
@@ -10,6 +11,8 @@ import {
   queryOpenMeterUsage,
 } from "@/lib/openmeter/usage-read";
 import { withEnv } from "@/test-utils/env";
+import { db } from "@/db/index";
+import { usageIngestReceipts } from "@/db/schema";
 
 const URL_PATH = "http://localhost/api/v1/internal/ingest/signed-ticket";
 
@@ -219,6 +222,59 @@ run("flag ON: a duplicate (clientId, requestId) meters exactly once", async (t) 
     },
   );
 });
+
+run(
+  "flag ON: a transient OpenMeter failure returns 502 and writes no receipt (retryable)",
+  async (t) => {
+    // OPENMETER_TEST_LIVE bypasses the in-memory meter stub; with no
+    // OPENMETER_URL the durable writer cannot get a client and throws,
+    // standing in for a transient OpenMeter outage.
+    await withEnv(
+      {
+        INGEST_SHARED_SECRET: undefined,
+        SIGNED_TICKET_DURABLE_INGEST: "1",
+        OPENMETER_TEST_LIVE: "1",
+        OPENMETER_URL: undefined,
+      },
+      async () => {
+        const { POST } = await import("./route");
+        const app = await seedDeveloperAppWithClient({ status: "approved" });
+        t.after(() => cleanupTestApp(app));
+        t.after(() => __testClearOpenMeterUsageStubs());
+
+        const requestId = "req-5xx-1";
+        const res = await POST(
+          ingestRequest({
+            body: signedTicketBody({
+              clientId: app.clientId,
+              externalUserId: "naap-storyboard-preview",
+              requestId,
+            }),
+          }),
+        );
+
+        // Non-2xx so the collector retries; clearly distinct from 2xx ack.
+        assert.equal(res.status, 502);
+        const body = await readJson(res);
+        assert.equal(body.ingested, false);
+
+        // No receipt persisted on failure → a retry is a first write, not a dupe.
+        // The receipt's client_id column stores the developer-app id, which the
+        // fixture seeds equal to the public clientId.
+        const rows = await db
+          .select()
+          .from(usageIngestReceipts)
+          .where(
+            and(
+              eq(usageIngestReceipts.clientId, app.clientId),
+              eq(usageIngestReceipts.requestId, requestId),
+            ),
+          );
+        assert.equal(rows.length, 0);
+      },
+    );
+  },
+);
 
 run("flag ON: unknown client_id returns 404", async (t) => {
   await withEnv(

--- a/src/app/api/v1/internal/ingest/signed-ticket/route.test.ts
+++ b/src/app/api/v1/internal/ingest/signed-ticket/route.test.ts
@@ -1,0 +1,242 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { NextRequest } from "next/server";
+
+import { run } from "@/test-utils/db-guard";
+import { cleanupTestApp, seedDeveloperAppWithClient } from "@/test-utils/fixtures";
+import {
+  __testClearOpenMeterUsageStubs,
+  queryOpenMeterUsage,
+} from "@/lib/openmeter/usage-read";
+import { withEnv } from "@/test-utils/env";
+
+const URL_PATH = "http://localhost/api/v1/internal/ingest/signed-ticket";
+
+function ingestRequest(input: {
+  body: unknown;
+  bearer?: string;
+}): NextRequest {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (input.bearer !== undefined) {
+    headers.authorization = `Bearer ${input.bearer}`;
+  }
+  return new NextRequest(URL_PATH, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(input.body),
+  });
+}
+
+function signedTicketBody(input: {
+  clientId: string;
+  externalUserId: string;
+  requestId: string;
+  computedFeeUsdMicros?: string;
+}) {
+  return {
+    type: "create_signed_ticket",
+    data: {
+      client_id: input.clientId,
+      usage_subject: input.externalUserId,
+      request_id: input.requestId,
+      computed_fee_usd_micros: input.computedFeeUsdMicros ?? "547000",
+      pipeline: "live-video-to-video",
+      model_id: "streamdiffusion",
+    },
+  };
+}
+
+async function readJson(res: Response): Promise<Record<string, unknown>> {
+  return (await res.json()) as Record<string, unknown>;
+}
+
+test("ingest rejects callers without the configured shared secret", async () => {
+  await withEnv({ INGEST_SHARED_SECRET: "s3cr3t" }, async () => {
+    const { POST } = await import("./route");
+
+    const noAuth = await POST(
+      ingestRequest({
+        body: signedTicketBody({
+          clientId: "app_x",
+          externalUserId: "u",
+          requestId: "r",
+        }),
+      }),
+    );
+    assert.equal(noAuth.status, 401);
+
+    const wrong = await POST(
+      ingestRequest({
+        bearer: "nope",
+        body: signedTicketBody({
+          clientId: "app_x",
+          externalUserId: "u",
+          requestId: "r",
+        }),
+      }),
+    );
+    assert.equal(wrong.status, 401);
+  });
+});
+
+test("ingest rejects unsupported event types", async () => {
+  await withEnv({ INGEST_SHARED_SECRET: undefined }, async () => {
+    const { POST } = await import("./route");
+    const res = await POST(
+      ingestRequest({ body: { type: "something_else", data: {} } }),
+    );
+    assert.equal(res.status, 400);
+  });
+});
+
+test("ingest rejects invalid JSON", async () => {
+  await withEnv({ INGEST_SHARED_SECRET: undefined }, async () => {
+    const { POST } = await import("./route");
+    const req = new NextRequest(URL_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+    const res = await POST(req);
+    assert.equal(res.status, 400);
+  });
+});
+
+test("durable path rejects an event with no usable fee (flag ON)", async () => {
+  await withEnv(
+    { INGEST_SHARED_SECRET: undefined, SIGNED_TICKET_DURABLE_INGEST: "1" },
+    async () => {
+      const { POST } = await import("./route");
+      const res = await POST(
+        ingestRequest({
+          body: {
+            type: "create_signed_ticket",
+            data: {
+              client_id: "app_x",
+              usage_subject: "u",
+              request_id: "r",
+            },
+          },
+        }),
+      );
+      assert.equal(res.status, 400);
+    },
+  );
+});
+
+run("flag OFF is zero-regression: diagnostic receipt, no OpenMeter write", async (t) => {
+  await withEnv(
+    { INGEST_SHARED_SECRET: undefined, SIGNED_TICKET_DURABLE_INGEST: undefined },
+    async () => {
+      const { POST } = await import("./route");
+      const app = await seedDeveloperAppWithClient({ status: "approved" });
+      t.after(() => cleanupTestApp(app));
+      t.after(() => __testClearOpenMeterUsageStubs());
+
+      const res = await POST(
+        ingestRequest({
+          body: signedTicketBody({
+            clientId: app.clientId,
+            externalUserId: "naap-storyboard-preview",
+            requestId: "req-off-1",
+          }),
+        }),
+      );
+      assert.equal(res.status, 200);
+      const body = await readJson(res);
+      assert.equal(body.diagnostic, true);
+      assert.equal(body.ingested, false);
+      assert.equal(body.duplicate, false);
+
+      // OpenMeter must NOT have been written on the legacy/diagnostic path.
+      const rows = await queryOpenMeterUsage({ clientId: app.clientId });
+      const total = rows.reduce((sum, row) => sum + row.requestCount, 0);
+      assert.equal(total, 0);
+    },
+  );
+});
+
+run("flag ON: driving N events yields an OpenMeter delta of exactly N", async (t) => {
+  await withEnv(
+    { INGEST_SHARED_SECRET: undefined, SIGNED_TICKET_DURABLE_INGEST: "1" },
+    async () => {
+      const { POST } = await import("./route");
+      const app = await seedDeveloperAppWithClient({ status: "approved" });
+      t.after(() => cleanupTestApp(app));
+      t.after(() => __testClearOpenMeterUsageStubs());
+
+      const n = 5;
+      for (let i = 0; i < n; i++) {
+        const res = await POST(
+          ingestRequest({
+            body: signedTicketBody({
+              clientId: app.clientId,
+              externalUserId: "naap-storyboard-preview",
+              requestId: `req-on-${i}`,
+            }),
+          }),
+        );
+        assert.equal(res.status, 200);
+        const body = await readJson(res);
+        assert.equal(body.ingested, true);
+        assert.equal(body.duplicate, false);
+      }
+
+      const rows = await queryOpenMeterUsage({ clientId: app.clientId });
+      const total = rows.reduce((sum, row) => sum + row.requestCount, 0);
+      assert.equal(total, n);
+    },
+  );
+});
+
+run("flag ON: a duplicate (clientId, requestId) meters exactly once", async (t) => {
+  await withEnv(
+    { INGEST_SHARED_SECRET: undefined, SIGNED_TICKET_DURABLE_INGEST: "1" },
+    async () => {
+      const { POST } = await import("./route");
+      const app = await seedDeveloperAppWithClient({ status: "approved" });
+      t.after(() => cleanupTestApp(app));
+      t.after(() => __testClearOpenMeterUsageStubs());
+
+      const body = signedTicketBody({
+        clientId: app.clientId,
+        externalUserId: "naap-storyboard-preview",
+        requestId: "req-dupe-1",
+      });
+
+      const first = await POST(ingestRequest({ body }));
+      assert.equal(first.status, 200);
+      assert.equal((await readJson(first)).duplicate, false);
+
+      const second = await POST(ingestRequest({ body }));
+      assert.equal(second.status, 200);
+      assert.equal((await readJson(second)).duplicate, true);
+
+      const rows = await queryOpenMeterUsage({ clientId: app.clientId });
+      const total = rows.reduce((sum, row) => sum + row.requestCount, 0);
+      assert.equal(total, 1);
+    },
+  );
+});
+
+run("flag ON: unknown client_id returns 404", async (t) => {
+  await withEnv(
+    { INGEST_SHARED_SECRET: undefined, SIGNED_TICKET_DURABLE_INGEST: "1" },
+    async () => {
+      const { POST } = await import("./route");
+      t.after(() => __testClearOpenMeterUsageStubs());
+
+      const res = await POST(
+        ingestRequest({
+          body: signedTicketBody({
+            clientId: "app_does_not_exist_zzz",
+            externalUserId: "u",
+            requestId: "req-404",
+          }),
+        }),
+      );
+      assert.equal(res.status, 404);
+    },
+  );
+});

--- a/src/app/api/v1/internal/ingest/signed-ticket/route.ts
+++ b/src/app/api/v1/internal/ingest/signed-ticket/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createHash, timingSafeEqual } from "node:crypto";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db/index";
 import { usageIngestReceipts } from "@/db/schema";
@@ -15,6 +16,18 @@ type GatewayEventPayload = {
   data?: Record<string, unknown>;
 };
 
+/**
+ * Constant-time secret comparison. Both inputs are SHA-256 hashed to a fixed
+ * 32-byte digest before `timingSafeEqual`, so the comparison leaks neither the
+ * secret's value nor its length via timing (and never throws on length
+ * mismatch). Avoids the timing side-channel of a plain `===` on the raw secret.
+ */
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = createHash("sha256").update(provided, "utf8").digest();
+  const b = createHash("sha256").update(expected, "utf8").digest();
+  return timingSafeEqual(a, b);
+}
+
 function verifyIngestSecret(request: NextRequest): boolean {
   const expected = process.env.INGEST_SHARED_SECRET?.trim();
   if (!expected) {
@@ -24,7 +37,7 @@ function verifyIngestSecret(request: NextRequest): boolean {
   if (!auth.startsWith("Bearer ")) {
     return false;
   }
-  return auth.slice(7).trim() === expected;
+  return secretsMatch(auth.slice(7).trim(), expected);
 }
 
 function pickString(data: Record<string, unknown>, ...keys: string[]): string {
@@ -110,20 +123,34 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await ingestSignedTicketDurable({
-      clientId,
-      externalUserId,
-      requestId,
-      networkFeeUsdMicros,
-      feeWei: optionalString(computedFeeWei),
-      pixels: optionalString(pickString(data, "pixels")),
-      pipeline: optionalString(pickString(data, "pipeline")),
-      modelId: optionalString(pickString(data, "model_id")),
-      ethUsdPrice: optionalString(pickString(data, "eth_usd_price")),
-      ethUsdObservedAt: optionalString(
-        pickString(data, "eth_usd_updated_at", "eth_usd_observed_at"),
-      ),
-    });
+    let result;
+    try {
+      result = await ingestSignedTicketDurable({
+        clientId,
+        externalUserId,
+        requestId,
+        networkFeeUsdMicros,
+        feeWei: optionalString(computedFeeWei),
+        pixels: optionalString(pickString(data, "pixels")),
+        pipeline: optionalString(pickString(data, "pipeline")),
+        modelId: optionalString(pickString(data, "model_id")),
+        ethUsdPrice: optionalString(pickString(data, "eth_usd_price")),
+        ethUsdObservedAt: optionalString(
+          pickString(data, "eth_usd_updated_at", "eth_usd_observed_at"),
+        ),
+      });
+    } catch {
+      // Transient durable-write failure (e.g. OpenMeter unavailable). The
+      // receipt is written only AFTER a successful OpenMeter write, so nothing
+      // was persisted and the caller (the Benthos collector) can safely retry.
+      // Surface a 502 so the failure is never silently swallowed and is clearly
+      // distinct from an accepted/duplicate (2xx). Internal error details are
+      // intentionally not leaked to the caller.
+      return NextResponse.json(
+        { ok: false, ingested: false, error: "Ingest temporarily unavailable" },
+        { status: 502 },
+      );
+    }
 
     if (result.status === "unknown_client") {
       return NextResponse.json({ error: "Unknown client_id" }, { status: 404 });

--- a/src/app/api/v1/internal/ingest/signed-ticket/route.ts
+++ b/src/app/api/v1/internal/ingest/signed-ticket/route.ts
@@ -3,6 +3,11 @@ import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db/index";
 import { usageIngestReceipts } from "@/db/schema";
 import { getProviderApp } from "@/lib/provider-apps";
+import { durableSignedTicketIngestEnabled } from "@/lib/billing/feature-flags";
+import {
+  ingestSignedTicketDurable,
+  resolveNetworkFeeUsdMicros,
+} from "@/lib/openmeter/signed-ticket-ingest";
 
 type GatewayEventPayload = {
   type?: string;
@@ -35,7 +40,24 @@ function pickString(data: Record<string, unknown>, ...keys: string[]): string {
   return "";
 }
 
-/** Diagnostic-only ingest from go-livepeer monitor events. OpenMeter writes use Kafka → collector. */
+function optionalString(value: string): string | undefined {
+  return value ? value : undefined;
+}
+
+/**
+ * Synchronous ingest of `create_signed_ticket` usage events from the go-livepeer
+ * remote signer.
+ *
+ * Default (flag OFF, `SIGNED_TICKET_DURABLE_INGEST` unset): diagnostic-only —
+ * records a receipt and returns `ingested:false`. OpenMeter is fed exclusively by
+ * the legacy Kafka → Benthos `openmeter-collector` pipeline, so behavior is
+ * unchanged.
+ *
+ * Flag ON: durable, idempotent, acked path — synchronously writes the CloudEvent
+ * to OpenMeter and returns `ingested:true` only after the write is accepted.
+ * Deduped on `(clientId, requestId)` (and OpenMeter's CloudEvent-id dedupe), so
+ * it is safe to run alongside the legacy Kafka path during rollout.
+ */
 export async function POST(request: NextRequest) {
   if (!verifyIngestSecret(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -72,6 +94,49 @@ export async function POST(request: NextRequest) {
       { error: "client_id, usage_subject, and request_id are required" },
       { status: 400 },
     );
+  }
+
+  if (durableSignedTicketIngestEnabled()) {
+    const computedFeeWei = pickString(data, "computed_fee_wei", "computed_fee");
+    const networkFeeUsdMicros = resolveNetworkFeeUsdMicros({
+      computedFeeUsdMicros: pickString(data, "computed_fee_usd_micros"),
+      computedFeeWei,
+      ethUsdPrice: pickString(data, "eth_usd_price"),
+    });
+    if (networkFeeUsdMicros === null) {
+      return NextResponse.json(
+        { error: "computed_fee_usd_micros or computed_fee (wei) is required" },
+        { status: 400 },
+      );
+    }
+
+    const result = await ingestSignedTicketDurable({
+      clientId,
+      externalUserId,
+      requestId,
+      networkFeeUsdMicros,
+      feeWei: optionalString(computedFeeWei),
+      pixels: optionalString(pickString(data, "pixels")),
+      pipeline: optionalString(pickString(data, "pipeline")),
+      modelId: optionalString(pickString(data, "model_id")),
+      ethUsdPrice: optionalString(pickString(data, "eth_usd_price")),
+      ethUsdObservedAt: optionalString(
+        pickString(data, "eth_usd_updated_at", "eth_usd_observed_at"),
+      ),
+    });
+
+    if (result.status === "unknown_client") {
+      return NextResponse.json({ error: "Unknown client_id" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      diagnostic: false,
+      ingested: true,
+      duplicate: result.duplicate,
+      requestId,
+      openmeterEventId: result.openmeterEventId,
+    });
   }
 
   const app = await getProviderApp(clientId);

--- a/src/lib/billing/feature-flags.ts
+++ b/src/lib/billing/feature-flags.ts
@@ -19,6 +19,26 @@ export function billingStableFeatureKeysEnabled(): boolean {
 }
 
 /**
+ * Gate the durable, idempotent, acked OpenMeter write on the synchronous
+ * signed-ticket ingest endpoint (`POST /api/v1/internal/ingest/signed-ticket`).
+ *
+ * Default OFF: flag-off keeps the endpoint diagnostic-only (writes a receipt,
+ * returns `ingested:false`, never touches OpenMeter) — byte-identical to the
+ * legacy behavior, so the existing Kafka → Benthos → OpenMeter pipeline remains
+ * the only metering path and there is zero regression.
+ *
+ * Flip `SIGNED_TICKET_DURABLE_INGEST=1` to make the endpoint synchronously write
+ * the `create_signed_ticket` CloudEvent to OpenMeter and ACK with
+ * `ingested:true` only after the write is accepted. The write is idempotent on
+ * `(clientId, requestId)` (receipts table) and on the CloudEvent `id`
+ * (OpenMeter's own dedupe), so it is safe to run in parallel with the legacy
+ * Kafka path during rollout without double-counting.
+ */
+export function durableSignedTicketIngestEnabled(): boolean {
+  return envFlag("SIGNED_TICKET_DURABLE_INGEST", false);
+}
+
+/**
  * Gate the C0-conformant BPP ② `validate` shape (PYMT-3).
  *
  * `GET /api/v1/auth/validate` was removed. This flag controls

--- a/src/lib/openmeter/signed-ticket-ingest.test.ts
+++ b/src/lib/openmeter/signed-ticket-ingest.test.ts
@@ -78,6 +78,69 @@ test("durable ingest rejects an unknown client without writing", async () => {
   assert.equal(writes.length, 0);
 });
 
+test("concurrent duplicate (clientId, requestId) POSTs meter exactly once", async () => {
+  // Model production semantics: OpenMeter dedupes on the CloudEvent id
+  // (= requestId) and the receipts unique index makes the upsert idempotent.
+  const metered = new Set<string>();
+  const receipts = new Map<string, string>();
+  const key = (appId: string, requestId: string) => `${appId}|${requestId}`;
+  const deps: Partial<SignedTicketIngestDeps> = {
+    resolveAppId: async (clientId) => (clientId === "app_known" ? "app_known" : null),
+    findReceipt: async (appId, requestId) => {
+      const openmeterEventId = receipts.get(key(appId, requestId));
+      return openmeterEventId ? { openmeterEventId } : null;
+    },
+    // Last-writer-wins, never throws — mirrors onConflictDoUpdate on the unique index.
+    upsertReceipt: async ({ appId, requestId, openmeterEventId }) => {
+      receipts.set(key(appId, requestId), openmeterEventId);
+    },
+    // OpenMeter dedupes redundant writes by CloudEvent id (= requestId).
+    writeOpenMeterEvent: async (event) => {
+      metered.add(event.requestId);
+    },
+  };
+
+  const results = await Promise.all(
+    Array.from({ length: 8 }, () => ingestSignedTicketDurable(BASE_EVENT, deps)),
+  );
+
+  // Despite 8 concurrent duplicate calls, the meter records exactly one event.
+  assert.equal(metered.size, 1);
+  // Every concurrent call resolves cleanly (no crash on the unique-violation path).
+  assert.ok(
+    results.every((r) => r.status === "ingested" || r.status === "duplicate"),
+  );
+  // The receipt ends up keyed by (clientId, requestId) with the real event id.
+  assert.equal(receipts.get("app_known|req-1"), "req-1");
+});
+
+test("a transient OpenMeter write failure surfaces and records no receipt", async () => {
+  const receipts = new Map<string, string>();
+  const key = (appId: string, requestId: string) => `${appId}|${requestId}`;
+  const deps: Partial<SignedTicketIngestDeps> = {
+    resolveAppId: async () => "app_known",
+    findReceipt: async (appId, requestId) => {
+      const openmeterEventId = receipts.get(key(appId, requestId));
+      return openmeterEventId ? { openmeterEventId } : null;
+    },
+    upsertReceipt: async ({ appId, requestId, openmeterEventId }) => {
+      receipts.set(key(appId, requestId), openmeterEventId);
+    },
+    writeOpenMeterEvent: async () => {
+      throw new Error("openmeter 503");
+    },
+  };
+
+  // The failure propagates so the route can map it to a non-2xx (retryable).
+  await assert.rejects(
+    () => ingestSignedTicketDurable(BASE_EVENT, deps),
+    /openmeter 503/,
+  );
+  // The receipt is written only after a successful write, so nothing persisted:
+  // a later retry is treated as a first write, not as a duplicate.
+  assert.equal(receipts.size, 0);
+});
+
 test("durable ingest upgrades a prior diagnostic receipt to a real write", async () => {
   const { deps, writes, receipts } = makeDeps();
   // Simulate a receipt left by the legacy diagnostic path (no OpenMeter write).

--- a/src/lib/openmeter/signed-ticket-ingest.test.ts
+++ b/src/lib/openmeter/signed-ticket-ingest.test.ts
@@ -1,0 +1,135 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ingestSignedTicketDurable,
+  resolveNetworkFeeUsdMicros,
+  type DurableSignedTicketEvent,
+  type SignedTicketIngestDeps,
+} from "./signed-ticket-ingest";
+
+const BASE_EVENT: DurableSignedTicketEvent = {
+  clientId: "app_known",
+  externalUserId: "naap-storyboard-preview",
+  requestId: "req-1",
+  networkFeeUsdMicros: "547000",
+  pipeline: "live-video-to-video",
+  modelId: "streamdiffusion",
+};
+
+/** In-memory deps so the durable flow is exercised without a DB or OpenMeter. */
+function makeDeps(knownClientIds: string[] = ["app_known"]) {
+  const writes: DurableSignedTicketEvent[] = [];
+  const receipts = new Map<string, string>();
+  const key = (appId: string, requestId: string) => `${appId}|${requestId}`;
+
+  const deps: Partial<SignedTicketIngestDeps> = {
+    resolveAppId: async (clientId) =>
+      knownClientIds.includes(clientId) ? clientId : null,
+    findReceipt: async (appId, requestId) => {
+      const openmeterEventId = receipts.get(key(appId, requestId));
+      return openmeterEventId ? { openmeterEventId } : null;
+    },
+    upsertReceipt: async ({ appId, requestId, openmeterEventId }) => {
+      receipts.set(key(appId, requestId), openmeterEventId);
+    },
+    writeOpenMeterEvent: async (event) => {
+      writes.push(event);
+    },
+  };
+  return { deps, writes, receipts };
+}
+
+test("durable ingest writes to OpenMeter exactly once and acks ingested", async () => {
+  const { deps, writes, receipts } = makeDeps();
+
+  const result = await ingestSignedTicketDurable(BASE_EVENT, deps);
+
+  assert.equal(result.status, "ingested");
+  assert.equal(result.duplicate, false);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].requestId, "req-1");
+  assert.equal(writes[0].networkFeeUsdMicros, "547000");
+  // Receipt key is (clientId, requestId); openmeter event id is the request id.
+  assert.equal(receipts.get("app_known|req-1"), "req-1");
+  assert.equal(result.status === "ingested" && result.openmeterEventId, "req-1");
+});
+
+test("durable ingest is idempotent: a duplicate (clientId, requestId) meters once", async () => {
+  const { deps, writes } = makeDeps();
+
+  const first = await ingestSignedTicketDurable(BASE_EVENT, deps);
+  const second = await ingestSignedTicketDurable(BASE_EVENT, deps);
+
+  assert.equal(first.status, "ingested");
+  assert.equal(first.duplicate, false);
+  assert.equal(second.status, "duplicate");
+  assert.equal(second.duplicate, true);
+  // The OpenMeter write happened exactly once across both calls.
+  assert.equal(writes.length, 1);
+});
+
+test("durable ingest rejects an unknown client without writing", async () => {
+  const { deps, writes } = makeDeps([]);
+
+  const result = await ingestSignedTicketDurable(BASE_EVENT, deps);
+
+  assert.equal(result.status, "unknown_client");
+  assert.equal(writes.length, 0);
+});
+
+test("durable ingest upgrades a prior diagnostic receipt to a real write", async () => {
+  const { deps, writes, receipts } = makeDeps();
+  // Simulate a receipt left by the legacy diagnostic path (no OpenMeter write).
+  receipts.set("app_known|req-1", "diagnostic:req-1");
+
+  const result = await ingestSignedTicketDurable(BASE_EVENT, deps);
+
+  assert.equal(result.status, "ingested");
+  assert.equal(result.duplicate, false);
+  assert.equal(writes.length, 1);
+  assert.equal(receipts.get("app_known|req-1"), "req-1");
+});
+
+test("distinct request ids each produce one OpenMeter write (delta == N)", async () => {
+  const { deps, writes } = makeDeps();
+  const n = 5;
+
+  for (let i = 0; i < n; i++) {
+    const result = await ingestSignedTicketDurable(
+      { ...BASE_EVENT, requestId: `req-${i}` },
+      deps,
+    );
+    assert.equal(result.status, "ingested");
+  }
+
+  assert.equal(writes.length, n);
+});
+
+test("resolveNetworkFeeUsdMicros prefers the signer's pre-computed usd micros", () => {
+  const micros = resolveNetworkFeeUsdMicros({
+    computedFeeUsdMicros: "547000",
+    computedFeeWei: "1000000000",
+    ethUsdPrice: "3500",
+  });
+  assert.equal(micros, "547000");
+});
+
+test("resolveNetworkFeeUsdMicros falls back to fee_wei × eth_usd / 1e12", () => {
+  // 2e9 wei × 3500 / 1e12 = 7 USD micros.
+  const micros = resolveNetworkFeeUsdMicros({
+    computedFeeWei: "2000000000",
+    ethUsdPrice: "3500",
+  });
+  assert.equal(micros, "7");
+});
+
+test("resolveNetworkFeeUsdMicros returns null for missing or garbage fees", () => {
+  assert.equal(resolveNetworkFeeUsdMicros({}), null);
+  assert.equal(resolveNetworkFeeUsdMicros({ computedFeeWei: "abc" }), null);
+  assert.equal(resolveNetworkFeeUsdMicros({ computedFeeUsdMicros: "-5" }), null);
+});
+
+test("resolveNetworkFeeUsdMicros accepts a zero fee as a valid value", () => {
+  assert.equal(resolveNetworkFeeUsdMicros({ computedFeeUsdMicros: "0" }), "0");
+});

--- a/src/lib/openmeter/signed-ticket-ingest.ts
+++ b/src/lib/openmeter/signed-ticket-ingest.ts
@@ -1,0 +1,268 @@
+/**
+ * Durable, idempotent, acked OpenMeter writer for `create_signed_ticket` usage
+ * events posted synchronously to `POST /api/v1/internal/ingest/signed-ticket`.
+ *
+ * Background: billed BYOC usage historically reached OpenMeter only through a
+ * best-effort fire-and-forget pipeline (go-livepeer `SendQueueEventAsync` →
+ * in-process Kafka producer → Redpanda → Benthos `openmeter-collector` →
+ * OpenMeter) with several silent-drop branches and no delivery guarantee, so
+ * billed jobs were lost from metering. This module provides the missing durable
+ * path: it writes the CloudEvent to OpenMeter and only acks once the write is
+ * accepted, deduping on `(clientId, requestId)` so retries and a parallel legacy
+ * Kafka path never double-count.
+ *
+ * The CloudEvent shape (subject `client_id:external_user_id`, id = requestId,
+ * `network_fee_usd_micros`, etc.) is produced by the shared
+ * {@link ingestSignedTicketEvent} writer so it aggregates with the meters the
+ * Benthos collector already feeds. Idempotency is enforced at two layers:
+ *  1. the `usage_ingest_receipts` unique index on `(client_id, request_id)`, and
+ *  2. OpenMeter's own dedupe on the CloudEvent `id` (= request_id).
+ *
+ * All external effects (app resolution, receipt store, OpenMeter write) are
+ * injected through {@link SignedTicketIngestDeps} so the core flow is unit
+ * testable without a database or network.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+
+import { db } from "@/db/index";
+import { usageIngestReceipts } from "@/db/schema";
+import { getProviderApp } from "@/lib/provider-apps";
+import { getHostedOpenMeterClient } from "./client";
+import { openMeterUsesLiveNetworkInTests } from "./constants";
+import { ingestSignedTicketEvent } from "./entitlements";
+import { __testAccumulateOpenMeterUsage } from "./usage-read";
+
+/** Default ETH/USD price used to mirror the Benthos collector when the signer
+ * does not pre-compute `computed_fee_usd_micros`. Matches `deploy/collector.yaml`. */
+const DEFAULT_ETH_USD_PRICE = 3500;
+
+/** Marker prefix for diagnostic-only receipts (never a durable OpenMeter write). */
+const DIAGNOSTIC_RECEIPT_PREFIX = "diagnostic:";
+
+/** Normalized usage event extracted from the ingest request body. */
+export interface DurableSignedTicketEvent {
+  /** Public OIDC client id (becomes `data.client_id` + part of the subject). */
+  clientId: string;
+  /** End-user attribution, e.g. `naap-storyboard-preview`. */
+  externalUserId: string;
+  /** Unique per-job id; the CloudEvent `id` and idempotency key. */
+  requestId: string;
+  /** Network fee in USD micros (already resolved; non-negative integer string). */
+  networkFeeUsdMicros: string;
+  feeWei?: string;
+  pixels?: string;
+  pipeline?: string;
+  modelId?: string;
+  ethUsdPrice?: string;
+  ethUsdObservedAt?: string;
+}
+
+/** Receipt row shape the dedupe fast-path needs. */
+export interface SignedTicketReceipt {
+  openmeterEventId: string;
+}
+
+/** Injectable side effects so the core flow can be unit tested in isolation. */
+export interface SignedTicketIngestDeps {
+  /** Resolve the developer-app primary key for an incoming client id. */
+  resolveAppId(clientId: string): Promise<string | null>;
+  /** Look up an existing receipt for the `(appId, requestId)` idempotency key. */
+  findReceipt(appId: string, requestId: string): Promise<SignedTicketReceipt | null>;
+  /** Idempotently persist the receipt for the `(appId, requestId)` key. */
+  upsertReceipt(input: {
+    appId: string;
+    requestId: string;
+    openmeterEventId: string;
+    externalUserId: string;
+  }): Promise<void>;
+  /** Write the CloudEvent to OpenMeter (must be idempotent on the event id). */
+  writeOpenMeterEvent(event: DurableSignedTicketEvent): Promise<void>;
+}
+
+export type DurableSignedTicketIngestResult =
+  | { status: "unknown_client" }
+  | { status: "ingested"; openmeterEventId: string; duplicate: false }
+  | { status: "duplicate"; openmeterEventId: string; duplicate: true };
+
+/** Parse a non-negative integer string; returns null for invalid/negative input. */
+function parseNonNegativeIntString(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  // Normalize (strip leading zeros) via BigInt without losing precision.
+  return BigInt(trimmed).toString();
+}
+
+function resolveEthUsdPrice(explicit?: string): number {
+  const candidates = [explicit, process.env.ETH_USD_PRICE];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const parsed = parseFloat(candidate);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_ETH_USD_PRICE;
+}
+
+/**
+ * Resolve `network_fee_usd_micros` for the event, trusting the signer's
+ * pre-computed `computed_fee_usd_micros` when present and otherwise mirroring the
+ * Benthos collector mapping (`round(fee_wei * eth_usd / 1e12)`). Returns null
+ * when no usable fee can be derived.
+ */
+export function resolveNetworkFeeUsdMicros(input: {
+  computedFeeUsdMicros?: string;
+  computedFeeWei?: string;
+  ethUsdPrice?: string;
+}): string | null {
+  const preComputed = parseNonNegativeIntString(input.computedFeeUsdMicros);
+  if (preComputed !== null) {
+    return preComputed;
+  }
+
+  const wei = parseNonNegativeIntString(input.computedFeeWei);
+  if (wei === null) {
+    return null;
+  }
+  const ethUsd = resolveEthUsdPrice(input.ethUsdPrice);
+  // Mirror collector.yaml: ($fee_wei * $eth_usd / 1e12).round()
+  const micros = Math.round((Number(wei) * ethUsd) / 1_000_000_000_000);
+  if (!Number.isFinite(micros) || micros < 0) {
+    return null;
+  }
+  return String(micros);
+}
+
+/** Default OpenMeter writer; uses the in-memory test accumulator under test. */
+async function defaultWriteOpenMeterEvent(event: DurableSignedTicketEvent): Promise<void> {
+  if (process.env.NODE_ENV === "test" && !openMeterUsesLiveNetworkInTests()) {
+    // Route writes into the same in-memory meter stubs the usage reads consult,
+    // so integration tests can assert OpenMeter deltas without a live backend.
+    __testAccumulateOpenMeterUsage({
+      clientId: event.clientId,
+      externalUserId: event.externalUserId,
+      networkFeeUsdMicros: event.networkFeeUsdMicros,
+      pipeline: event.pipeline,
+      modelId: event.modelId,
+    });
+    return;
+  }
+
+  const client = getHostedOpenMeterClient();
+  if (!client) {
+    throw new Error("OpenMeter client is not configured (set OPENMETER_URL)");
+  }
+  await ingestSignedTicketEvent({
+    client,
+    event: {
+      requestId: event.requestId,
+      clientId: event.clientId,
+      externalUserId: event.externalUserId,
+      networkFeeUsdMicros: event.networkFeeUsdMicros,
+      feeWei: event.feeWei,
+      pixels: event.pixels,
+      pipeline: event.pipeline,
+      modelId: event.modelId,
+      gatewayRequestId: event.requestId,
+      ethUsdPrice: event.ethUsdPrice,
+      ethUsdObservedAt: event.ethUsdObservedAt,
+    },
+  });
+}
+
+/** Production wiring for the durable ingest side effects. */
+export function defaultSignedTicketIngestDeps(): SignedTicketIngestDeps {
+  return {
+    resolveAppId: async (clientId) => {
+      const app = await getProviderApp(clientId);
+      return app?.id ?? null;
+    },
+    findReceipt: async (appId, requestId) => {
+      const rows = await db
+        .select({ openmeterEventId: usageIngestReceipts.openmeterEventId })
+        .from(usageIngestReceipts)
+        .where(
+          and(
+            eq(usageIngestReceipts.clientId, appId),
+            eq(usageIngestReceipts.requestId, requestId),
+          ),
+        )
+        .limit(1);
+      return rows[0] ?? null;
+    },
+    upsertReceipt: async (input) => {
+      await db
+        .insert(usageIngestReceipts)
+        .values({
+          id: uuidv4(),
+          clientId: input.appId,
+          requestId: input.requestId,
+          openmeterEventId: input.openmeterEventId,
+          externalUserId: input.externalUserId,
+          createdAt: new Date().toISOString(),
+        })
+        .onConflictDoUpdate({
+          target: [usageIngestReceipts.clientId, usageIngestReceipts.requestId],
+          set: {
+            openmeterEventId: input.openmeterEventId,
+            externalUserId: input.externalUserId,
+          },
+        });
+    },
+    writeOpenMeterEvent: defaultWriteOpenMeterEvent,
+  };
+}
+
+function isDurableReceipt(receipt: SignedTicketReceipt | null): boolean {
+  return Boolean(
+    receipt && !receipt.openmeterEventId.startsWith(DIAGNOSTIC_RECEIPT_PREFIX),
+  );
+}
+
+/**
+ * Durably ingest one signed-ticket usage event into OpenMeter.
+ *
+ * Flow: resolve the app → short-circuit if a durable receipt already exists
+ * (return `duplicate`) → write the CloudEvent to OpenMeter (id = requestId, so
+ * OpenMeter dedupes redundant writes) → record/refresh the receipt. The
+ * OpenMeter write happens before the receipt is recorded so a receipt always
+ * implies an accepted write; this is what lets the caller ack `ingested:true`.
+ */
+export async function ingestSignedTicketDurable(
+  event: DurableSignedTicketEvent,
+  depsOverride?: Partial<SignedTicketIngestDeps>,
+): Promise<DurableSignedTicketIngestResult> {
+  const deps = { ...defaultSignedTicketIngestDeps(), ...depsOverride };
+
+  const appId = await deps.resolveAppId(event.clientId);
+  if (!appId) {
+    return { status: "unknown_client" };
+  }
+
+  const existing = await deps.findReceipt(appId, event.requestId);
+  if (isDurableReceipt(existing) && existing) {
+    return {
+      status: "duplicate",
+      openmeterEventId: existing.openmeterEventId,
+      duplicate: true,
+    };
+  }
+
+  const openmeterEventId = event.requestId;
+  await deps.writeOpenMeterEvent(event);
+  await deps.upsertReceipt({
+    appId,
+    requestId: event.requestId,
+    openmeterEventId,
+    externalUserId: event.externalUserId,
+  });
+
+  return { status: "ingested", openmeterEventId, duplicate: false };
+}


### PR DESCRIPTION
## What this PR does

Promotes the diagnostic `POST /api/v1/internal/ingest/signed-ticket` route into a **durable, idempotent, acked OpenMeter writer**, behind a new feature flag **`SIGNED_TICKET_DURABLE_INGEST` (default OFF)**.

This endpoint is a **general-purpose durable ingest sink**: anything that can POST a `create_signed_ticket` usage event can drive a guaranteed, deduped OpenMeter write. It is **not** coupled to any particular producer.

- **Durable + acked:** synchronously writes the `create_signed_ticket` CloudEvent to OpenMeter (via the shared `ingestSignedTicketEvent` writer — subject `client_id:external_user_id`, `id = request_id`, `network_fee_usd_micros`) and returns `ingested:true` **only after** the write is accepted. The receipt is recorded **after** the write, so a receipt always implies an accepted write.
- **Idempotent (race-safe):** deduped on `(clientId, requestId)` via the `usage_ingest_receipts` unique index **and** on the CloudEvent `id` via OpenMeter's own dedupe. The receipt upsert uses `onConflictDoUpdate`, so the unique-violation path is handled gracefully (no check-then-insert crash). Concurrent duplicate POSTs meter **exactly once** (covered by a new concurrency test).
- **Correct aggregation:** mirrors the Benthos collector's event shape, so usage aggregates under the same subject/`external_user_id` (e.g. `naap-storyboard-preview`) and rolls up with existing usage. Trusts the signer's pre-computed `computed_fee_usd_micros`, falling back to the collector formula `round(fee_wei * eth_usd / 1e12)`; missing/garbage fees are rejected with `400`.
- **Hardened auth:** `INGEST_SHARED_SECRET` Bearer (`verifyIngestSecret`), now using a **constant-time** SHA-256 + `timingSafeEqual` comparison (no timing side-channel; no secret logging). Accept/reject decisions are unchanged.
- **Clear failure semantics:** a transient OpenMeter/durable-write failure returns a structured **`502`** (retryable) with no internals leaked, clearly distinct from an accepted/duplicate **`2xx`**. Because the receipt is written only after a successful write, a `502` persists nothing and the caller can safely retry.

## Architecture / intended end-state (please read)

The intended clean end-state is: **the Benthos `openmeter-collector` POSTs into this durable endpoint** (idempotent on `(clientId, requestId)`) instead of writing OpenMeter directly. That makes this endpoint the **single durable write path**, while go-livepeer stays completely unaware of pymthouse (vendor-neutral).

- The companion go-livepeer change (the flagged orchestrator→endpoint POST, PR #3963) is being **closed/parked**. To keep go-livepeer vendor-neutral, the producer-side reliability fix will instead be done by **hardening go-livepeer's existing Kafka producer + the Benthos collector** (separate follow-up).
- **So this PR is not dependent on #3963.** Its intended caller is the **collector**, not a go-livepeer POST.

## Feature flag / zero regression

`SIGNED_TICKET_DURABLE_INGEST` defaults **OFF**. With the flag off the endpoint is **byte-identical to prior behavior**: it records a diagnostic receipt, returns `ingested:false`, and never touches OpenMeter — the legacy Kafka → Benthos pipeline remains the sole metering path. The flag is documented in `.env.example` and `src/lib/billing/feature-flags.ts`. **No prod/preview flag was flipped.**

## Files

| File | Change |
|---|---|
| `src/app/api/v1/internal/ingest/signed-ticket/route.ts` | Flag-gated durable branch; constant-time auth; structured `502` on transient failure; flag-off diagnostic path untouched |
| `src/lib/openmeter/signed-ticket-ingest.ts` | New durable writer: app resolution, `(clientId, requestId)` idempotency, OpenMeter write, fee resolution — all DI for testability |
| `src/lib/billing/feature-flags.ts` | New `durableSignedTicketIngestEnabled()` (`SIGNED_TICKET_DURABLE_INGEST`, default false) |
| `.env.example` | Document the flag |
| `*.test.ts` (2) | Unit + route integration tests (incl. concurrent-duplicate race and transient-failure→`502`) |

## Test plan (all green)

Full suite **279 passed / 0 failed / 0 skipped** against a local Postgres (`npm test`), `eslint .` clean (0 errors), `tsc` clean for changed source.

- **Unit** (`signed-ticket-ingest.test.ts`): write + ack; idempotency (duplicate meters once); **8 concurrent duplicates meter exactly once**; **transient write failure propagates and records no receipt**; unknown-client; diagnostic→durable upgrade; `delta == N` for N distinct ids; fee resolution (prefers `computed_fee_usd_micros`, wei fallback, garbage→null, zero allowed).
- **Route integration** (`route.test.ts`): auth rejection (`401`); invalid JSON / unsupported type / missing fee (`400`); **flag OFF = zero regression** (`diagnostic:true, ingested:false`, OpenMeter untouched); **flag ON delta == N** (drive 5 events → OpenMeter `requestCount` delta == 5); **flag ON duplicate meters exactly once**; **flag ON transient OpenMeter failure → `502` + no receipt**; unknown client → `404`.

## How the maintainer can verify (e2e recipe)

1. Point a Postgres at `DATABASE_URL`, run `npm run db:migrate`, then `npm test` → expect **279 passing**.
2. Functional check with the flag on:
   - Set `SIGNED_TICKET_DURABLE_INGEST=1` (and `INGEST_SHARED_SECRET` if testing auth).
   - POST **N** distinct `create_signed_ticket` events (distinct `request_id`s) to `/api/v1/internal/ingest/signed-ticket`.
   - Assert the OpenMeter `requestCount` **delta == N** (e.g. `scripts/openmeter-usage-probe.sh watch`).
   - Re-POST a duplicate `(client_id, request_id)` → response `duplicate:true`, OpenMeter delta unchanged (**metered once**).
   - Simulate an OpenMeter outage → endpoint returns **`502`**, no receipt persisted, retry succeeds.

## Remaining work for full production e2e (so #178 alone won't move prod OpenMeter)

This PR makes the endpoint a correct durable sink, but with #3963 parked it is **inert in production until**:
1. the **Benthos collector is repointed** to POST into this endpoint (instead of writing OpenMeter directly), and
2. **go-livepeer's Kafka producer is hardened** (the vendor-neutral producer-side reliability follow-up).

Until then, with the flag **OFF**, nothing changes; enabling the flag only activates the durable write for callers that actually POST here.

Root cause and full analysis: `OPENMETER-USAGE-FIX-PLAN.md`.

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feature-flagged durable mode for signed-ticket ingestion that acknowledges after persisting and safely handles duplicate `(clientId, requestId)` events.
  * Added sample configuration guidance for enabling the new durable ingest setting.
* **Bug Fixes**
  * Improved shared-secret verification to use constant-time comparison.
  * Added robust fee/USD-micros resolution with clear `400` responses when it can’t be derived, plus `404` for unknown clients and `502` on downstream write failures.
* **Tests**
  * Expanded end-to-end coverage for auth gating, validation errors, idempotency, concurrency behavior, and failure/receipt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->