### PR TITLE
fix(collector): repoint Benthos collector to PR #178 durable ingest endpoint (flag-gated, default OFF) — fix-step (a)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,23 @@ KAFKA_BROKERS=kafka.railway.internal:9092
 KAFKA_GATEWAY_TOPIC=livepeer-gateway-events
 # Collector Wei->USD conversion fallback; align with your oracle if needed.
 ETH_USD_PRICE=3500
+# ----- Collector durable-ingest repoint (fix-step (a); see deploy/collector.yaml) -----
+# Repoints the Benthos openmeter-collector to deliver served-job usage into the
+# durable, idempotent ingest endpoint added by PR #178, and routes malformed events
+# to an observable dead-letter instead of dropping them silently.
+# Default (COLLECTOR_DURABLE_INGEST unset/false): byte-identical legacy behavior —
+# the collector POSTs CloudEvents directly to ${OPENMETER_INGEST_URL} as today.
+# Set to true (+ PYMTHOUSE_INGEST_URL + INGEST_SHARED_SECRET) to enable. Idempotency
+# on (clientId, requestId) makes retries and double-writes safe.
+# COLLECTOR_DURABLE_INGEST=false
+# Delivery mode when the toggle is ON:
+#   double_write (default) = fan out to BOTH the legacy OpenMeter sink AND the
+#     durable endpoint (recommended rollout; legacy stays a safety net).
+#   cutover               = deliver ONLY to the durable endpoint.
+# COLLECTOR_DURABLE_INGEST_MODE=double_write
+# Base URL of the pymthouse app exposing PR #178's endpoint. The collector appends
+# /api/v1/internal/ingest/signed-ticket. Required when COLLECTOR_DURABLE_INGEST is ON.
+# PYMTHOUSE_INGEST_URL=https://pymthouse.com
 # OIDC webhook verifier config (aud defaults to JWT_ISSUER / issuer URL).
 JWT_ISSUER=
 JWT_AUDIENCE=
@@ -111,7 +128,10 @@ OPENMETER_ROUTE_MODE=auto
 # NOT the same as INGEST_SHARED_SECRET (see below).
 OPENMETER_API_KEY=
 OPENMETER_TRIAL_FEATURE_KEY=network_spend
-# Bearer for go-livepeer → POST /api/v1/internal/ingest/signed-ticket (diagnostics only).
+# Bearer for POST /api/v1/internal/ingest/signed-ticket. Verified by the endpoint
+# (PR #178) and sent by callers as `Authorization: Bearer ${INGEST_SHARED_SECRET}`.
+# Callers: the go-livepeer remote signer and the Benthos openmeter-collector when
+# COLLECTOR_DURABLE_INGEST is enabled (see the collector repoint section above).
 # Does not authenticate OpenMeter plan sync or usage APIs.
 INGEST_SHARED_SECRET=
 # Default included usage (USD micros) when seeding per-app Starter plan (5000000 = $5)

--- a/deploy/collector.yaml
+++ b/deploy/collector.yaml
@@ -1,9 +1,28 @@
-# OpenMeter Collector: go-livepeer remote signer Kafka -> hosted OpenMeter/Konnect.
+# OpenMeter Collector: go-livepeer remote signer Kafka -> OpenMeter.
 #
 # Notes:
 # - Topic carries multiple event types; filter to create_signed_ticket only.
 # - auth_id is expected as "client_id:external_user_id" from signer webhook response.
 # - Uses first-colon split semantics to preserve compatibility with builder-sdk.
+#
+# Safe-rollout toggle (fix-step (a), depends on pymthouse PR #178):
+#   COLLECTOR_DURABLE_INGEST  (default unset/false)
+#     OFF (default): byte-identical legacy behavior — every create_signed_ticket
+#       CloudEvent is POSTed directly to OpenMeter (${OPENMETER_INGEST_URL}); empty
+#       auth_id and mapping errors are dropped exactly as before.
+#     ON ("true"/"1"/"yes"/"on"): served-job events are also delivered to the
+#       durable, idempotent ingest endpoint added by PR #178
+#       (POST ${PYMTHOUSE_INGEST_URL}/api/v1/internal/ingest/signed-ticket) and
+#       malformed events are routed to an observable dead-letter instead of being
+#       silently dropped. Idempotency is enforced server-side on (clientId,
+#       requestId), so retries and double-writes never double-count.
+#   COLLECTOR_DURABLE_INGEST_MODE  (default "double_write" when the toggle is ON)
+#     double_write: fan out to BOTH the legacy OpenMeter sink AND the durable
+#       endpoint (recommended for rollout; the legacy path stays a safety net while
+#       the durable path is validated, and idempotency dedupes the overlap).
+#     cutover: deliver ONLY to the durable endpoint.
+#   COLLECTOR_DLQ_TOPIC  (optional) — reserved for a future durable dead-letter
+#       topic; the current dead-letter is an ERROR-logged drop (observable).
 
 input:
   kafka:
@@ -20,10 +39,26 @@ pipeline:
         root = if this.type != "create_signed_ticket" { deleted() }
 
     - mapping: |
+        # --- Safe-rollout toggle (default OFF => byte-identical legacy behavior) ---
+        let toggle = env("COLLECTOR_DURABLE_INGEST").or("").string().trim().lowercase()
+        let durable_on = $toggle == "true" || $toggle == "1" || $toggle == "yes" || $toggle == "on"
+        let mode = env("COLLECTOR_DURABLE_INGEST_MODE").or("double_write").string().trim().lowercase()
+        let cutover = $mode == "cutover"
+
         let data = this.data.or({})
         let auth_id = $data.auth_id.or("").string().trim()
+
         if $auth_id == "" {
-          root = deleted()
+          # Empty auth_id: legacy silently drops it. With the toggle ON we instead
+          # keep the original event and route it to the dead-letter (observable).
+          meta collector_error = "empty_auth_id"
+          if $durable_on {
+            meta target = "dlq"
+            root = this
+          } else {
+            meta target = "legacy"
+            root = deleted()
+          }
         } else {
           let colon = $auth_id.index_of(":")
           let is_compound = $colon > 0 && $colon < $auth_id.length() - 1
@@ -56,25 +91,127 @@ pipeline:
               "auth_id": $auth_id,
             }
           }
+
+          # Routing target consumed by the `switch` output below. With the toggle
+          # OFF every surviving event goes to the legacy OpenMeter sink (unchanged).
+          if $durable_on {
+            meta target = if $cutover { "durable" } else { "double" }
+          } else {
+            meta target = "legacy"
+          }
         }
 
     - catch:
         - log:
             level: ERROR
             message: "signed_ticket mapping failed: ${! error() }"
-        - mapping: root = deleted()
+        - mapping: |
+            # Legacy: drop on mapping error (unchanged). Durable: keep + dead-letter.
+            let toggle = env("COLLECTOR_DURABLE_INGEST").or("").string().trim().lowercase()
+            let durable_on = $toggle == "true" || $toggle == "1" || $toggle == "yes" || $toggle == "on"
+            root = if $durable_on { this } else { deleted() }
+            meta target = "dlq"
+            meta collector_error = "mapping_error"
 
 # Konnect ingest is POST {OPENMETER_URL}/events (not /api/v1/events). For self-hosted
 # OpenMeter, set OPENMETER_INGEST_URL to ${OPENMETER_URL}/api/v1/events in compose.
 
 output:
-  http_client:
-    url: ${OPENMETER_INGEST_URL}
-    verb: POST
-    headers:
-      Authorization: "Bearer ${OPENMETER_API_KEY}"
-      Content-Type: application/cloudevents+json
-    successful_on:
-      - 200
-      - 202
-      - 204
+  switch:
+    # Cases are evaluated in order; the first match wins. With the toggle OFF the
+    # `meta target` is always "legacy", so only the final (legacy) case is ever hit.
+    cases:
+      # 1) Dead-letter: malformed events (empty auth_id / mapping error). Reached
+      #    ONLY when COLLECTOR_DURABLE_INGEST is ON. OFF keeps the legacy drop.
+      - check: 'meta("target") == "dlq"'
+        output:
+          resource: dlq_sink
+
+      # 2) Cutover: deliver ONLY to PR #178's durable, idempotent endpoint.
+      - check: 'meta("target") == "durable"'
+        output:
+          resource: durable_sink
+
+      # 3) Double-write (recommended rollout): legacy OpenMeter sink AND durable
+      #    endpoint. Idempotency on (clientId, requestId) dedupes the overlap.
+      - check: 'meta("target") == "double"'
+        output:
+          broker:
+            pattern: fan_out
+            outputs:
+              - resource: openmeter_sink
+              - resource: durable_sink
+
+      # 4) DEFAULT (toggle OFF): legacy direct-to-OpenMeter sink, unchanged.
+      - output:
+          resource: openmeter_sink
+
+output_resources:
+  # Legacy direct-to-OpenMeter CloudEvents sink (byte-identical to pre-toggle).
+  - label: openmeter_sink
+    http_client:
+      url: ${OPENMETER_INGEST_URL}
+      verb: POST
+      headers:
+        Authorization: "Bearer ${OPENMETER_API_KEY}"
+        Content-Type: application/cloudevents+json
+      successful_on:
+        - 200
+        - 202
+        - 204
+
+  # Durable, idempotent ingest endpoint added by PR #178. Bounded retry with
+  # backoff on connection errors + 5xx (incl. the endpoint's transient 502); on
+  # exhaustion (or a permanent 4xx) the event falls through to the dead-letter so
+  # nothing is lost unobserved. The reshape processor maps the CloudEvent into the
+  # endpoint's request contract.
+  - label: durable_sink
+    fallback:
+      - http_client:
+          url: ${PYMTHOUSE_INGEST_URL}/api/v1/internal/ingest/signed-ticket
+          verb: POST
+          headers:
+            Authorization: "Bearer ${INGEST_SHARED_SECRET}"
+            Content-Type: application/json
+          successful_on:
+            - 200
+            - 201
+            - 202
+            - 204
+          backoff_on:
+            - 429
+            - 500
+            - 502
+            - 503
+            - 504
+          retries: 4
+          retry_period: 1s
+          max_retry_backoff: 30s
+        processors:
+          - mapping: |
+              root = {
+                "type": "create_signed_ticket",
+                "id": this.id,
+                "data": {
+                  "client_id": this.data.client_id,
+                  "external_user_id": this.data.external_user_id,
+                  "usage_subject": this.data.external_user_id,
+                  "request_id": this.data.gateway_request_id.or(this.id),
+                  "computed_fee_usd_micros": this.data.network_fee_usd_micros.string(),
+                  "computed_fee": this.data.fee_wei.string(),
+                  "pixels": this.data.pixels,
+                  "pipeline": this.data.pipeline,
+                  "model_id": this.data.model_id,
+                }
+              }
+      - resource: dlq_sink
+
+  # Observable dead-letter: log at ERROR with full context, then discard. Replaces
+  # the previous silent drops so malformed / undeliverable events are never lost
+  # unobserved. A durable topic can be wired here later via COLLECTOR_DLQ_TOPIC.
+  - label: dlq_sink
+    drop: {}
+    processors:
+      - log:
+          level: ERROR
+          message: 'openmeter-collector dead-letter: reason=${! meta("collector_error").or("durable_ingest_failed") } request_id=${! json("data.request_id").catch(json("data.gateway_request_id").catch("unknown")) } subject=${! json("subject").catch("") } event=${! content().string() }'

--- a/docs/openmeter-railway.md
+++ b/docs/openmeter-railway.md
@@ -25,6 +25,75 @@ Set `OPENMETER_URL` to the hosted Konnect endpoint (`https://{region}.api.konghq
 └─────────────────────────────┘
 ```
 
+## Collector durable-ingest repoint (fix-step (a), opt-in)
+
+Historically the `openmeter-collector` was the only path feeding OpenMeter, and it
+delivered events **fire-and-forget** straight to the OpenMeter ingest URL with no
+durability and several silent-drop branches (empty `auth_id`, mapping errors).
+`deploy/collector.yaml` can now repoint the collector to the **durable, idempotent,
+acked** ingest endpoint added by [PR #178](https://github.com/pymthouse/pymthouse/pull/178)
+(`POST /api/v1/internal/ingest/signed-ticket`) and route malformed events to an
+observable dead-letter instead of dropping them.
+
+This is **opt-in and zero-regression by default**. With `COLLECTOR_DURABLE_INGEST`
+unset/false the collector behaves byte-identically to before (direct-to-OpenMeter).
+
+| Env (on the `openmeter-collector` service) | Default | Purpose |
+|---|---|---|
+| `COLLECTOR_DURABLE_INGEST` | unset (OFF) | Master toggle. `true`/`1`/`yes`/`on` enables the durable repoint. |
+| `COLLECTOR_DURABLE_INGEST_MODE` | `double_write` | `double_write` = fan out to BOTH the legacy OpenMeter sink and the durable endpoint (recommended rollout). `cutover` = durable endpoint only. |
+| `PYMTHOUSE_INGEST_URL` | — | Base URL of the pymthouse app (e.g. `https://pymthouse.com`); the collector appends `/api/v1/internal/ingest/signed-ticket`. Required when ON. |
+| `INGEST_SHARED_SECRET` | — | Shared bearer secret the endpoint (PR #178) verifies; sent as `Authorization: Bearer …`. Required when ON. |
+
+`scripts/railway-apply-stack-env.sh` applies these to the collector **only when set**
+in the calling environment, so leaving them unset keeps the legacy behavior.
+
+Retry / idempotency semantics:
+
+- The durable `http_client` retries with bounded backoff on connection errors and
+  `429`/`5xx` (including the endpoint's transient `502`); `2xx` (including an
+  idempotent duplicate) is success.
+- Idempotency is enforced server-side on `(clientId, requestId)`, so retries and the
+  `double_write` overlap never double-count (OpenMeter also dedupes on the
+  CloudEvent `id = request_id`).
+- On exhausted retries or a permanent `4xx`, the event falls through to the
+  dead-letter (ERROR-logged) instead of vanishing silently. In `double_write` the
+  legacy OpenMeter sink has already delivered it, so there is no metering loss.
+
+> **Dependency / scope.** This repoint only fixes losses **from the collector onward**;
+> it relies on PR #178 being deployed (endpoint live, `SIGNED_TICKET_DURABLE_INGEST=1`
+> on the pymthouse app) to actually write to OpenMeter. Events dropped **before**
+> reaching Kafka (the go-livepeer in-process producer) are a separate producer-side
+> follow-up (b); go-livepeer webhook #3963 was parked to keep go-livepeer vendor-neutral.
+
+### Manual verification recipe
+
+Pre-req: PR #178 deployed with `SIGNED_TICKET_DURABLE_INGEST=1` and `INGEST_SHARED_SECRET`
+set on the pymthouse app; the collector configured with the four vars above.
+
+1. **Lint / start check (no cluster needed):**
+   ```bash
+   docker run --rm -e KAFKA_BROKERS=x -e KAFKA_GATEWAY_TOPIC=t \
+     -e OPENMETER_URL=http://om -e OPENMETER_INGEST_URL=http://om/events \
+     -e OPENMETER_API_KEY=k -e ETH_USD_PRICE=3500 \
+     -e PYMTHOUSE_INGEST_URL=https://pymthouse.com -e INGEST_SHARED_SECRET=s \
+     -v "$PWD/deploy:/deploy:ro" --entrypoint benthos \
+     ghcr.io/openmeterio/benthos-collector:latest lint /deploy/collector.yaml
+   ```
+2. **Baseline read:** `GET /api/v1/apps/{app}/usage?groupBy=user` → record `requestCount`.
+3. **Enable** `COLLECTOR_DURABLE_INGEST=true` on the collector (start with
+   `double_write`) and redeploy the stack.
+4. **Drive N** generations against the preview chain, recording each `request_id`.
+5. **Re-read** usage: `requestCount` delta should be **== N** (within idempotency),
+   and `networkFeeUsdMicros` delta ≈ N × per-job fee.
+6. **Duplicate test:** re-send a `request_id` already ingested → no extra count
+   (server dedupe on `(clientId, requestId)`).
+7. **Malformed test:** emit an event with empty `auth_id` → it appears in the
+   collector logs as `openmeter-collector dead-letter: reason=empty_auth_id …`
+   (dead-lettered, **not** silently dropped) and does not advance usage.
+8. **Resilience:** with `double_write` on, the legacy sink remains a safety net while
+   you compare counts; switch to `cutover` only after the durable path is trusted.
+
 ## Legacy self-hosted OpenMeter
 
 The rest of this document describes the older self-hosted OpenMeter topology (`docker-compose.openmeter.railway.yml`) and is kept for future on-prem deployments.

--- a/scripts/railway-apply-stack-env.sh
+++ b/scripts/railway-apply-stack-env.sh
@@ -78,13 +78,37 @@ REMOTE_SIGNER_WEBHOOK_URL="${REMOTE_SIGNER_WEBHOOK_URL:-${NEXTAUTH_URL:-https://
 
 OPENMETER_INGEST_URL="${OPENMETER_INGEST_URL:-${OPENMETER_URL}/events}"
 
-set_kv openmeter-collector \
-  "KAFKA_BROKERS=${KAFKA_BROKERS}" \
-  "KAFKA_GATEWAY_TOPIC=${KAFKA_GATEWAY_TOPIC}" \
-  "OPENMETER_URL=${OPENMETER_URL}" \
-  "OPENMETER_INGEST_URL=${OPENMETER_INGEST_URL}" \
-  "OPENMETER_API_KEY=${OPENMETER_API_KEY}" \
+# Collector env. Base vars below are the long-standing legacy direct-to-OpenMeter
+# config and are always applied. The COLLECTOR_DURABLE_INGEST_* / PYMTHOUSE_INGEST_URL
+# / INGEST_SHARED_SECRET vars wire the durable-ingest repoint added in
+# deploy/collector.yaml (fix-step (a), depends on PR #178). They are OPT-IN: when
+# unset in the calling environment they are NOT applied, so the collector keeps its
+# byte-identical legacy behavior. Set COLLECTOR_DURABLE_INGEST=true (+ PYMTHOUSE_INGEST_URL
+# and INGEST_SHARED_SECRET) only when you intend to enable the durable path.
+COLLECTOR_ENV=(
+  "KAFKA_BROKERS=${KAFKA_BROKERS}"
+  "KAFKA_GATEWAY_TOPIC=${KAFKA_GATEWAY_TOPIC}"
+  "OPENMETER_URL=${OPENMETER_URL}"
+  "OPENMETER_INGEST_URL=${OPENMETER_INGEST_URL}"
+  "OPENMETER_API_KEY=${OPENMETER_API_KEY}"
   "ETH_USD_PRICE=${ETH_USD_PRICE}"
+)
+if [[ -n "${COLLECTOR_DURABLE_INGEST:-}" ]]; then
+  COLLECTOR_ENV+=("COLLECTOR_DURABLE_INGEST=${COLLECTOR_DURABLE_INGEST}")
+fi
+if [[ -n "${COLLECTOR_DURABLE_INGEST_MODE:-}" ]]; then
+  COLLECTOR_ENV+=("COLLECTOR_DURABLE_INGEST_MODE=${COLLECTOR_DURABLE_INGEST_MODE}")
+fi
+if [[ -n "${PYMTHOUSE_INGEST_URL:-}" ]]; then
+  COLLECTOR_ENV+=("PYMTHOUSE_INGEST_URL=${PYMTHOUSE_INGEST_URL}")
+fi
+if [[ -n "${INGEST_SHARED_SECRET:-}" ]]; then
+  # Same shared secret the ingest endpoint (PR #178) verifies; sent by the collector
+  # as `Authorization: Bearer ${INGEST_SHARED_SECRET}`.
+  COLLECTOR_ENV+=("INGEST_SHARED_SECRET=${INGEST_SHARED_SECRET}")
+fi
+
+set_kv openmeter-collector "${COLLECTOR_ENV[@]}"
 
 # Signer DMZ (pymthouse service). For signer-only updates use scripts/railway-apply-signer-env.sh.
 export NEXTAUTH_URL="${NEXTAUTH_URL:-https://pymthouse.com}"


### PR DESCRIPTION
## Summary — fix-step (a) of the BYOC usage-loss fix

Billed BYOC usage is lost on the way to OpenMeter via a lossy fire-and-forget pipeline (go-livepeer Kafka producer → Redpanda → Benthos `openmeter-collector` → OpenMeter). **PR #178** (https://github.com/pymthouse/pymthouse/pull/178) added a durable, idempotent, acked usage-ingest endpoint but **nothing posts to it yet**.

This PR is **fix-step (a)**: repoint the Benthos `openmeter-collector` to deliver served-job usage into PR #178's endpoint and **stop the collector's silent drops** — behind an **opt-in toggle with a byte-identical default** (zero regression).

> Depends on **#178**. Must be merged/deployed after #178 (endpoint live + `SIGNED_TICKET_DURABLE_INGEST=1` on the app). Do **not** merge or enable the toggle yet.

## What changed

### `deploy/collector.yaml`
- **`COLLECTOR_DURABLE_INGEST`** toggle (default unset/false ⇒ **unchanged** legacy direct-to-OpenMeter behavior; proven byte-identical — see Validation).
- When **ON**, each served-job CloudEvent is reshaped to #178's contract and POSTed to `${PYMTHOUSE_INGEST_URL}/api/v1/internal/ingest/signed-ticket` with `Authorization: Bearer ${INGEST_SHARED_SECRET}`.
- **Bounded retry + backoff** on connection errors and `429`/`5xx` (including the endpoint's transient `502`); `2xx` (incl. idempotent duplicate) = success. Idempotency is server-side on `(clientId, requestId)`, so retries / double-writes never double-count.
- **`COLLECTOR_DURABLE_INGEST_MODE`**: `double_write` (default — fan out to **both** the legacy OpenMeter sink and the durable endpoint; legacy stays a safety net during rollout) or `cutover` (durable endpoint only).
- **Stops silent drops**: the previous silent `empty auth_id` / mapping-error drops now route to an **observable ERROR-logged dead-letter** (only when the toggle is ON; OFF keeps the exact legacy drop).
- Pipeline reworked to bloblang the collector image accepts; structurally lints clean.

### Env / docs wiring (all opt-in; default unchanged)
- `scripts/railway-apply-stack-env.sh` — applies the new collector vars **only when set** in the environment.
- `.env.example` + `docs/openmeter-railway.md` — document the toggle, modes, `PYMTHOUSE_INGEST_URL` / `INGEST_SHARED_SECRET`, retry/idempotency semantics, and a manual verification recipe.

## Request body matches #178's contract exactly
Reshaped per event (CloudEvent → endpoint body):
- `type: "create_signed_ticket"`, `id` = request_id
- `data.client_id`, `data.external_user_id`, `data.usage_subject` (= external_user_id)
- `data.request_id` (idempotency key)
- `data.computed_fee_usd_micros` (pre-computed, non-negative int string — endpoint prefers this)
- `data.computed_fee` (wei, fallback), `data.pixels`, `data.pipeline`, `data.model_id`
- Auth header `Authorization: Bearer ${INGEST_SHARED_SECRET}`

## Validation
Benthos config isn't unit-testable, so validated against the OpenMeter collector image (`benthos` v4.73 — the version `main`'s bloblang already requires):
- **Lint**: clean (no errors) with all env set.
- **Startup**: full config initializes successfully (`switch` / `broker fan_out` / `fallback` / `output_resources` / durable `http_client` retry / dead-letter), only expected kafka-connection errors against a dummy broker.
- **Zero-regression**: with the toggle OFF, pipeline output is **byte-identical** to the current `main` config (`diff` empty over a deterministic event set; empty-`auth_id` + non-matching types dropped exactly as today, valid events → legacy sink unchanged).
- **Routing** (toggle ON): valid → `double_write` (legacy + durable) or `cutover` (durable only); empty-`auth_id` and mapping errors (e.g. missing `ETH_USD_PRICE`) → **dead-letter** (not silent drop).

### Manual verification recipe (post-deploy)
1. Baseline `GET /api/v1/apps/{app}/usage?groupBy=user` → record `requestCount`.
2. Enable `COLLECTOR_DURABLE_INGEST=true` (start `double_write`), redeploy.
3. Drive N generations (record `request_id`s) → usage `requestCount` delta == N; `networkFeeUsdMicros` delta ≈ N × per-job fee.
4. Re-send an existing `request_id` → no extra count (server dedupe on `(clientId, requestId)`).
5. Emit empty `auth_id` → appears as `openmeter-collector dead-letter: reason=empty_auth_id …` in logs (dead-lettered, not silently dropped) and does not advance usage.

## Scope / dependency on follow-up (b)
This (a) fixes losses **from the collector onward** and depends on **#178**. go-livepeer webhook **#3963 was parked** to keep go-livepeer vendor-neutral, so **producer-side reliability hardening (b)** (events dropped in the go-livepeer in-process Kafka producer **before** reaching Kafka) is a **separate follow-up**. (a) alone does not recover events lost before they reach Kafka.

## Not for merge yet
Do **not** merge before #178, and do **not** enable `COLLECTOR_DURABLE_INGEST` in any environment until #178 is deployed and verified.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional durable-ingest rollout path with support for double-write or cutover behavior.
  * Introduced dead-letter handling for malformed or failed events instead of silently dropping them.

* **Documentation**
  * Updated setup notes with the new configuration options and required environment values.
  * Added verification steps for enabling and validating the durable-ingest flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->