### PR TITLE
chore(signer): bump go-livepeer image to sha-7938edb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,7 @@ DATABASE_URL=postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neond
 # Start the full stack so Kafka events reach the OpenMeter collector:
 #   docker compose -f docker-compose.clearinghouse.railway.yml --env-file .env.local up -d --build
 # go-livepeer binary source for signer-dmz-local build (published CI image by default):
-# LIVEPEER_IMAGE=livepeer/go-livepeer:feat-add-model-id-signer-kafka
+# LIVEPEER_IMAGE=livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0
 # Or build DMZ only: ./scripts/build-local-signer.sh
 # Standalone signer (no kafka): docker compose up -d signer-dmz
 # The local compose image is signer-dmz: Apache validates RS256 bearer tokens

--- a/docker-compose.clearinghouse.railway.yml
+++ b/docker-compose.clearinghouse.railway.yml
@@ -57,7 +57,7 @@ services:
       dockerfile: docker/signer-dmz/Dockerfile
       target: signer-dmz-local
       args:
-        LIVEPEER_IMAGE: ${LIVEPEER_IMAGE:-livepeer/go-livepeer:feat-add-model-id-signer-kafka}
+        LIVEPEER_IMAGE: ${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0}
     restart: unless-stopped
     ports:
       - target: 8080

--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -5,7 +5,7 @@
 #   signer-dmz      — production; livepeer from livepeer/go-livepeer Docker image (Railway single service).
 
 # Base image for signer-dmz-local (override: docker build --build-arg LIVEPEER_IMAGE=...).
-ARG LIVEPEER_IMAGE=livepeer/go-livepeer:feat-add-model-id-signer-kafka
+ARG LIVEPEER_IMAGE=livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0
 
 FROM debian:bookworm-slim AS build-mod
 
@@ -167,7 +167,7 @@ ENV SIGNER_DMZ_ENABLE_CLI_LISTENER=1
 EXPOSE 8080 8082
 
 # Production / Railway: livepeer from official Docker image (default final stage).
-FROM livepeer/go-livepeer:feat-add-model-id-signer-kafka AS livepeer-prod
+FROM livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0 AS livepeer-prod
 
 FROM gateway AS signer-dmz
 

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -2,7 +2,7 @@
 # Copies livepeer + required CUDA NPP libs from the official image — do not wget
 # a bare binary into debian:slim; the binary links libnppig.so and other NPP libs.
 
-FROM livepeer/go-livepeer:feat-add-model-id-signer-kafka AS livepeer-src
+FROM livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0 AS livepeer-src
 
 FROM debian:bookworm-slim
 

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -16,8 +16,8 @@ Everything needed to run the go-livepeer signer with an optional **Apache + mod_
 | Image | Dockerfile | go-livepeer source | Use |
 |-------|------------|--------------------|-----|
 | `pymthouse/signer-dmz:local` | `Dockerfile` → `signer-dmz-local` | `../go-livepeer` via `lpclearinghouse` | **Local dev** with PymtHouse (`docker-compose.yml`) |
-| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:feat-add-model-id-signer-kafka` | **Production** (Railway / Render) and prod smoke tests |
-| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:feat-add-model-id-signer-kafka` | **Livepeer only** (no Apache; not for public deploy) |
+| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0` | **Production** (Railway / Render) and prod smoke tests |
+| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0` | **Livepeer only** (no Apache; not for public deploy) |
 
 ### Force rebuild
 

--- a/scripts/build-local-signer.sh
+++ b/scripts/build-local-signer.sh
@@ -3,7 +3,7 @@
 #
 # Default (fast): pull a published go-livepeer image and copy livepeer into the DMZ.
 #   ./scripts/build-local-signer.sh
-#   LIVEPEER_IMAGE=livepeer/go-livepeer:feat-add-model-id-signer-kafka ./scripts/build-local-signer.sh
+#   LIVEPEER_IMAGE=livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0 ./scripts/build-local-signer.sh
 #
 # From local checkout (slow — full CGO/FFmpeg build via lpclearinghouse):
 #   LIVEPEER_IMAGE= ./scripts/build-local-signer.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GO_LIVEPEER_DIR="${GO_LIVEPEER_DIR:-${ROOT}/../go-livepeer}"
 LPCLEARINGHOUSE_DIR="${LPCLEARINGHOUSE_DIR:-${ROOT}/../lpclearinghouse}"
-LIVEPEER_IMAGE="${LIVEPEER_IMAGE:-livepeer/go-livepeer:feat-add-model-id-signer-kafka}"
+LIVEPEER_IMAGE="${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0}"
 SIGNER_DMZ_IMAGE="${SIGNER_DMZ_IMAGE:-pymthouse/signer-dmz:local}"
 
 if [[ -n "${LIVEPEER_IMAGE}" ]]; then


### PR DESCRIPTION
## Summary
- Bump remote signer `LIVEPEER_IMAGE` defaults from `livepeer/go-livepeer:feat-add-model-id-signer-kafka` to `livepeer/go-livepeer:sha-7938edbdaf8e9f82882859b8001cc09c28f339c0`.
- Apply the new default consistently in compose, Dockerfiles, local build script, and signer DMZ docs.

## Test plan
- [x] Verify only signer-related image tag references changed.
- [ ] Optionally run `./scripts/build-local-signer.sh` to validate local image pull/build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default container image references to a fixed, pinned version across local build and deployment setups.
  * Aligned Docker-based build configurations to use the same immutable image version for consistency.
* **Documentation**
  * Refreshed build instructions and example environment values to match the latest pinned image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->