### PR TITLE
feat(openmeter): enhance billing profile management and customer attribution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,8 @@ OPENMETER_ROUTE_MODE=auto
 # Optional for local docker; required for OpenMeter Cloud / auth-enabled installs.
 # NOT the same as INGEST_SHARED_SECRET (see below).
 OPENMETER_API_KEY=
+# Optional override for free Starter subscriptions (sandbox billing profile id in Konnect).
+# OPENMETER_FREE_BILLING_PROFILE_ID=
 OPENMETER_TRIAL_FEATURE_KEY=network_spend
 # Bearer for go-livepeer → POST /api/v1/internal/ingest/signed-ticket (diagnostics only).
 # Does not authenticate OpenMeter plan sync or usage APIs.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "api-keys:hard-cutover": "npx tsx scripts/api-keys-hard-cutover.ts",
     "oidc:seed": "npx tsx scripts/seed-oidc.ts",
     "openmeter:bootstrap": "npx tsx scripts/openmeter-bootstrap.ts",
+    "openmeter:ensure-customer": "npx tsx scripts/openmeter-ensure-customer.ts",
     "openmeter:railway:bootstrap": "bash scripts/openmeter-railway-bootstrap.sh",
     "railway:stack:env": "bash scripts/railway-apply-stack-env.sh",
     "railway:stack:deploy": "bash scripts/railway-deploy-stack.sh",

--- a/scripts/openmeter-ensure-customer.ts
+++ b/scripts/openmeter-ensure-customer.ts
@@ -184,7 +184,7 @@ async function main() {
       } catch (err) {
         failed += 1;
         const message = err instanceof Error ? err.message : String(err);
-        console.error(`[fail] ${target.clientId}:${target.externalUserId} ${message}`);
+        console.error(`[fail] ${target.clientId} ${message}`);
       }
     }
 

--- a/scripts/openmeter-ensure-customer.ts
+++ b/scripts/openmeter-ensure-customer.ts
@@ -1,0 +1,198 @@
+/**
+ * Ensure OpenMeter/Konnect customer (+ optional Starter subscription) for app users.
+ *
+ * Use when ingest reports "no customer found for event subject" but pymthouse already
+ * minted signer tokens, or to backfill customers after billing-profile fixes.
+ *
+ * Usage:
+ *   npx tsx scripts/openmeter-ensure-customer.ts --customer-key 'app_xxx:external-user-id'
+ *   npx tsx scripts/openmeter-ensure-customer.ts --client-id app_xxx --external-user-id uuid
+ *   npx tsx scripts/openmeter-ensure-customer.ts --client-id app_xxx --all-users
+ *   npx tsx scripts/openmeter-ensure-customer.ts --client-id app_xxx --all-users --customer-only
+ */
+import "./load-env-first";
+import { eq } from "drizzle-orm";
+import { db } from "../src/db/index";
+import { appUsers } from "../src/db/schema";
+import {
+  ensureAppUserKonnectCustomer,
+  provisionAppUserBilling,
+} from "../src/lib/billing/provision-app-user";
+import { parseOpenMeterCustomerKey } from "../src/lib/openmeter/customer-key";
+import { getHostedAdminClient, isHostedAdminClientAvailable } from "../src/lib/openmeter/admin-client";
+import { ensureStarterSubscriptionForAppUser } from "../src/lib/openmeter/starter-subscription";
+
+type Args = {
+  customerKey?: string;
+  clientId?: string;
+  externalUserId?: string;
+  allUsers: boolean;
+  customerOnly: boolean;
+  provisionDb: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    allUsers: false,
+    customerOnly: false,
+    provisionDb: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--customer-key") {
+      args.customerKey = argv[++i]?.trim();
+      continue;
+    }
+    if (token === "--client-id") {
+      args.clientId = argv[++i]?.trim();
+      continue;
+    }
+    if (token === "--external-user-id") {
+      args.externalUserId = argv[++i]?.trim();
+      continue;
+    }
+    if (token === "--all-users") {
+      args.allUsers = true;
+      continue;
+    }
+    if (token === "--customer-only") {
+      args.customerOnly = true;
+      continue;
+    }
+    if (token === "--provision-db") {
+      args.provisionDb = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return args;
+}
+
+function usage(): string {
+  return [
+    "openmeter-ensure-customer",
+    "",
+    "  --customer-key <app_id:external_user_id>",
+    "  --client-id <app_id> --external-user-id <id>",
+    "  --client-id <app_id> --all-users",
+    "",
+    "Options:",
+    "  --customer-only   Upsert Konnect customer + subject keys only (no Starter subscription)",
+    "  --provision-db    Run full provisionAppUserBilling (DB rows + subscription + allowance)",
+  ].join("\n");
+}
+
+async function resolveTargets(args: Args): Promise<Array<{ clientId: string; externalUserId: string }>> {
+  if (args.customerKey) {
+    const parsed = parseOpenMeterCustomerKey(args.customerKey);
+    if (!parsed) {
+      throw new Error(`Invalid --customer-key: ${args.customerKey}`);
+    }
+    return [parsed];
+  }
+
+  if (!args.clientId) {
+    throw new Error(`Missing --client-id or --customer-key\n\n${usage()}`);
+  }
+
+  if (args.allUsers) {
+    const rows = await db
+      .select({ externalUserId: appUsers.externalUserId })
+      .from(appUsers)
+      .where(eq(appUsers.clientId, args.clientId));
+    if (rows.length === 0) {
+      throw new Error(`No app_users rows for client ${args.clientId}`);
+    }
+    return rows.map((row) => ({
+      clientId: args.clientId!,
+      externalUserId: row.externalUserId,
+    }));
+  }
+
+  if (!args.externalUserId) {
+    throw new Error(`Missing --external-user-id\n\n${usage()}`);
+  }
+
+  return [{ clientId: args.clientId, externalUserId: args.externalUserId }];
+}
+
+async function ensureOne(input: {
+  clientId: string;
+  externalUserId: string;
+  customerOnly: boolean;
+  provisionDb: boolean;
+}) {
+  const label = `${input.clientId}:${input.externalUserId}`;
+  if (input.provisionDb) {
+    const result = await provisionAppUserBilling({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+    });
+    console.log(
+      `[ok] ${label} provisioned appUser=${result.appUserId} starterReady=${result.starterSubscriptionReady} allowance=${result.allowance?.hasAccess ?? "n/a"}`,
+    );
+    return;
+  }
+
+  if (input.customerOnly) {
+    const customer = await ensureAppUserKonnectCustomer({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+    });
+    console.log(`[ok] ${label} customer id=${customer.id} key=${customer.key}`);
+    return;
+  }
+
+  const customer = await ensureAppUserKonnectCustomer({
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+  });
+  const sub = await ensureStarterSubscriptionForAppUser({
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+  });
+  console.log(
+    `[ok] ${label} customer id=${customer.id} subscription=${sub.openmeterSubscriptionId ?? "none"} created=${sub.created}`,
+  );
+}
+
+async function main() {
+  if (!isHostedAdminClientAvailable()) {
+    console.error("[openmeter-ensure-customer] OPENMETER_URL is not configured.");
+    process.exit(1);
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+  const targets = await resolveTargets(args);
+  getHostedAdminClient();
+
+  console.log(
+    `[openmeter-ensure-customer] ensuring ${targets.length} user(s) (customerOnly=${args.customerOnly}, provisionDb=${args.provisionDb})`,
+  );
+
+  let failed = 0;
+  for (const target of targets) {
+    try {
+      await ensureOne({
+        ...target,
+        customerOnly: args.customerOnly,
+        provisionDb: args.provisionDb,
+      });
+    } catch (err) {
+      failed += 1;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[fail] ${target.clientId}:${target.externalUserId} ${message}`);
+    }
+  }
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("[openmeter-ensure-customer] fatal:", err);
+  process.exit(1);
+});

--- a/scripts/openmeter-ensure-customer.ts
+++ b/scripts/openmeter-ensure-customer.ts
@@ -12,7 +12,7 @@
  */
 import "./load-env-first";
 import { eq } from "drizzle-orm";
-import { db } from "../src/db/index";
+import { db, postgresClient } from "../src/db/index";
 import { appUsers } from "../src/db/schema";
 import {
   ensureAppUserKonnectCustomer,
@@ -164,31 +164,35 @@ async function main() {
     process.exit(1);
   }
 
-  const args = parseArgs(process.argv.slice(2));
-  const targets = await resolveTargets(args);
-  getHostedAdminClient();
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const targets = await resolveTargets(args);
+    getHostedAdminClient();
 
-  console.log(
-    `[openmeter-ensure-customer] ensuring ${targets.length} user(s) (customerOnly=${args.customerOnly}, provisionDb=${args.provisionDb})`,
-  );
+    console.log(
+      `[openmeter-ensure-customer] ensuring ${targets.length} user(s) (customerOnly=${args.customerOnly}, provisionDb=${args.provisionDb})`,
+    );
 
-  let failed = 0;
-  for (const target of targets) {
-    try {
-      await ensureOne({
-        ...target,
-        customerOnly: args.customerOnly,
-        provisionDb: args.provisionDb,
-      });
-    } catch (err) {
-      failed += 1;
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(`[fail] ${target.clientId}:${target.externalUserId} ${message}`);
+    let failed = 0;
+    for (const target of targets) {
+      try {
+        await ensureOne({
+          ...target,
+          customerOnly: args.customerOnly,
+          provisionDb: args.provisionDb,
+        });
+      } catch (err) {
+        failed += 1;
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[fail] ${target.clientId}:${target.externalUserId} ${message}`);
+      }
     }
-  }
 
-  if (failed > 0) {
-    process.exit(1);
+    if (failed > 0) {
+      process.exit(1);
+    }
+  } finally {
+    await postgresClient.end({ timeout: 5 });
   }
 }
 

--- a/src/lib/billing/provision-app-user.ts
+++ b/src/lib/billing/provision-app-user.ts
@@ -1,4 +1,9 @@
 import { findOrCreateAppEndUser } from "@/lib/billing";
+import { getHostedAdminClient, isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
+import {
+  ensureOpenMeterCustomerForAppUser,
+  type OpenMeterCustomerIdentity,
+} from "@/lib/openmeter/customers";
 import { getTrialCreditBalance, type TrialCreditBalance } from "@/lib/openmeter/entitlements";
 import { ensureStarterSubscriptionForAppUser } from "@/lib/openmeter/starter-subscription";
 import { ensureTrialAllowanceForAppUser } from "@/lib/openmeter/trial-allowance";
@@ -10,7 +15,27 @@ export type ProvisionAppUserBillingResult = {
   externalUserId: string;
   allowance: TrialCreditBalance | null;
   starterSubscriptionCreated: boolean;
+  starterSubscriptionReady: boolean;
 };
+
+/** Konnect/OpenMeter customer + subject attribution only (no DB plan/subscription). */
+export async function ensureAppUserKonnectCustomer(input: {
+  clientId: string;
+  externalUserId: string;
+  displayName?: string;
+}): Promise<OpenMeterCustomerIdentity> {
+  if (!isHostedAdminClientAvailable()) {
+    throw new Error(
+      "OpenMeter is not configured (set OPENMETER_URL; OPENMETER_API_KEY for Konnect)",
+    );
+  }
+  return ensureOpenMeterCustomerForAppUser({
+    client: getHostedAdminClient(),
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+    displayName: input.displayName,
+  });
+}
 
 /**
  * Upsert app/end-user rows, ensure OpenMeter customer + Starter subscription,
@@ -47,5 +72,8 @@ export async function provisionAppUserBilling(input: {
     externalUserId,
     allowance,
     starterSubscriptionCreated: sub.created,
+    starterSubscriptionReady: isHostedAdminClientAvailable()
+      ? Boolean(sub.openmeterSubscriptionId)
+      : true,
   };
 }

--- a/src/lib/oidc/api-key-signer-session.ts
+++ b/src/lib/oidc/api-key-signer-session.ts
@@ -11,7 +11,7 @@ import {
   ProgrammaticTokenError,
 } from "@/lib/oidc/programmatic-tokens";
 import { resolveSubjectAccessToken, SubjectAccessTokenResolveError } from "@/lib/oidc/resolve-subject-access-token";
-import { mintSignerJwtForExternalUser } from "@/lib/oidc/mint-user-signer-token";
+import { mintSignerJwtForExternalUser, MintUserSignerTokenError } from "@/lib/oidc/mint-user-signer-token";
 import type { SignerSession } from "@/lib/openapi/schemas/credentials-types";
 
 const ISSUED_ACCESS_TOKEN_TYPE =
@@ -93,11 +93,19 @@ export async function mintSignerSessionFromAppApiKey(input: {
     );
   }
 
-  const minted = await mintSignerJwtForExternalUser({
-    publicClientId: resolved.publicClientId,
-    developerAppId: resolved.developerAppId,
-    externalUserId: subject.externalUserId,
-  });
+  let minted;
+  try {
+    minted = await mintSignerJwtForExternalUser({
+      publicClientId: resolved.publicClientId,
+      developerAppId: resolved.developerAppId,
+      externalUserId: subject.externalUserId,
+    });
+  } catch (err) {
+    if (err instanceof MintUserSignerTokenError) {
+      throw new ApiKeySignerSessionError(err.code, err.message, err.status);
+    }
+    throw err;
+  }
 
   return buildSignerSessionEnvelope({
     access_token: minted.access_token,

--- a/src/lib/oidc/mint-user-signer-token.test.ts
+++ b/src/lib/oidc/mint-user-signer-token.test.ts
@@ -2,8 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  enforceMintAllowanceGate,
   isM2mOwnerSignJobRequest,
   isMintUserSignerTokenRequest,
+  mintAllowanceGateDecision,
+  MintUserSignerTokenError,
 } from "./mint-user-signer-token";
 
 function params(entries: Record<string, string>): URLSearchParams {
@@ -78,4 +81,75 @@ test("isM2mOwnerSignJobRequest rejects admin-only scopes", () => {
     ),
     false,
   );
+});
+
+test("mintAllowanceGateDecision bypasses when hosted billing is disabled", () => {
+  assert.equal(
+    mintAllowanceGateDecision(null, false),
+    null,
+  );
+  assert.equal(
+    mintAllowanceGateDecision(
+      {
+        hasAccess: false,
+        balanceUsdMicros: "0",
+        consumedUsdMicros: "0",
+        lifetimeGrantedUsdMicros: "0",
+      },
+      false,
+    ),
+    null,
+  );
+});
+
+test("mintAllowanceGateDecision rejects unconfirmed allowance when hosted billing is enabled", () => {
+  assert.deepEqual(mintAllowanceGateDecision(null, true), {
+    code: "billing_unavailable",
+    message: "Billing allowance could not be confirmed",
+  });
+});
+
+test("mintAllowanceGateDecision rejects exhausted allowance when hosted billing is enabled", () => {
+  assert.deepEqual(
+    mintAllowanceGateDecision(
+      {
+        hasAccess: false,
+        balanceUsdMicros: "0",
+        consumedUsdMicros: "5000000",
+        lifetimeGrantedUsdMicros: "5000000",
+      },
+      true,
+    ),
+    {
+      code: "trial_credits_exhausted",
+      message: "Starter allowance exhausted",
+    },
+  );
+});
+
+test("enforceMintAllowanceGate throws billing_unavailable when allowance is null in test env", () => {
+  const previousUrl = process.env.OPENMETER_URL;
+  const previousLive = process.env.OPENMETER_TEST_LIVE;
+  process.env.OPENMETER_URL = "https://us.api.konghq.com/v3/openmeter";
+  process.env.OPENMETER_TEST_LIVE = "1";
+  try {
+    assert.throws(
+      () => enforceMintAllowanceGate(null),
+      (err: unknown) =>
+        err instanceof MintUserSignerTokenError &&
+        err.code === "billing_unavailable" &&
+        err.status === 402,
+    );
+  } finally {
+    if (previousUrl === undefined) {
+      delete process.env.OPENMETER_URL;
+    } else {
+      process.env.OPENMETER_URL = previousUrl;
+    }
+    if (previousLive === undefined) {
+      delete process.env.OPENMETER_TEST_LIVE;
+    } else {
+      process.env.OPENMETER_TEST_LIVE = previousLive;
+    }
+  }
 });

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -6,7 +6,12 @@ import { developerApps, oidcClients } from "@/db/schema";
 import { validateClientSecret } from "@/lib/oidc/clients";
 import { ACCESS_TOKEN_JWT_TYP, ensureSigningKey } from "@/lib/oidc/jwks";
 import { getIssuer } from "@/lib/oidc/issuer-urls";
-import { provisionAppUserBilling } from "@/lib/billing/provision-app-user";
+import {
+  ensureAppUserKonnectCustomer,
+  provisionAppUserBilling,
+} from "@/lib/billing/provision-app-user";
+import { isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
+import type { TrialCreditBalance } from "@/lib/openmeter/entitlements";
 import { SIGN_MINT_USER_TOKEN_SCOPE } from "@/lib/oidc/scopes";
 import { buildSignerSessionEnvelope } from "@/lib/openapi/signer-session";
 import { getClientSignerApiUrl } from "@/lib/signer-proxy";
@@ -145,6 +150,35 @@ export function signerJwtAudience(): string {
   return trimTrailingSlashes(getIssuer());
 }
 
+export function mintAllowanceGateDecision(
+  allowance: TrialCreditBalance | null,
+  hostedBillingEnabled: boolean,
+): { code: "billing_unavailable" | "trial_credits_exhausted"; message: string } | null {
+  if (!hostedBillingEnabled) {
+    return null;
+  }
+  if (!allowance) {
+    return {
+      code: "billing_unavailable",
+      message: "Billing allowance could not be confirmed",
+    };
+  }
+  if (!allowance.hasAccess) {
+    return {
+      code: "trial_credits_exhausted",
+      message: "Starter allowance exhausted",
+    };
+  }
+  return null;
+}
+
+export function enforceMintAllowanceGate(allowance: TrialCreditBalance | null): void {
+  const decision = mintAllowanceGateDecision(allowance, isHostedAdminClientAvailable());
+  if (decision) {
+    throw new MintUserSignerTokenError(decision.code, decision.message, 402);
+  }
+}
+
 export async function mintSignerJwtForExternalUser(input: {
   publicClientId: string;
   developerAppId: string;
@@ -158,18 +192,31 @@ export async function mintSignerJwtForExternalUser(input: {
     );
   }
 
-  const { allowance } = await provisionAppUserBilling({
-    clientId: input.developerAppId,
-    externalUserId,
-  });
-
-  if (allowance && !allowance.hasAccess) {
-    throw new MintUserSignerTokenError(
-      "trial_credits_exhausted",
-      "Starter allowance exhausted",
-      402,
-    );
+  if (isHostedAdminClientAvailable()) {
+    await ensureAppUserKonnectCustomer({
+      clientId: input.developerAppId,
+      externalUserId,
+    });
   }
+
+  let allowance: TrialCreditBalance | null;
+  try {
+    ({ allowance } = await provisionAppUserBilling({
+      clientId: input.developerAppId,
+      externalUserId,
+    }));
+  } catch (err) {
+    if (isHostedAdminClientAvailable()) {
+      throw new MintUserSignerTokenError(
+        "billing_unavailable",
+        err instanceof Error ? err.message : "Billing provisioning failed",
+        402,
+      );
+    }
+    throw err;
+  }
+
+  enforceMintAllowanceGate(allowance);
 
   const issuer = getIssuer();
   const audience = signerJwtAudience();

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -192,15 +192,14 @@ export async function mintSignerJwtForExternalUser(input: {
     );
   }
 
-  if (isHostedAdminClientAvailable()) {
-    await ensureAppUserKonnectCustomer({
-      clientId: input.developerAppId,
-      externalUserId,
-    });
-  }
-
   let allowance: TrialCreditBalance | null;
   try {
+    if (isHostedAdminClientAvailable()) {
+      await ensureAppUserKonnectCustomer({
+        clientId: input.developerAppId,
+        externalUserId,
+      });
+    }
     ({ allowance } = await provisionAppUserBilling({
       clientId: input.developerAppId,
       externalUserId,

--- a/src/lib/openmeter/billing-profiles.test.ts
+++ b/src/lib/openmeter/billing-profiles.test.ts
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { OpenMeter } from "@openmeter/sdk";
+
+import {
+  ensureFreeBillingProfile,
+  resetFreeBillingProfileCacheForTests,
+} from "./billing-profiles";
+
+function openMeterTestClient(mock: object): OpenMeter {
+  return mock as OpenMeter;
+}
+
+test("ensureFreeBillingProfile returns OPENMETER_FREE_BILLING_PROFILE_ID when set", async () => {
+  resetFreeBillingProfileCacheForTests();
+  const previous = process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+  process.env.OPENMETER_FREE_BILLING_PROFILE_ID = "profile_from_env";
+  try {
+    const profileId = await ensureFreeBillingProfile();
+    assert.equal(profileId, "profile_from_env");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+    } else {
+      process.env.OPENMETER_FREE_BILLING_PROFILE_ID = previous;
+    }
+    resetFreeBillingProfileCacheForTests();
+  }
+});
+
+test("ensureFreeBillingProfile reuses existing sandbox billing profile", async () => {
+  resetFreeBillingProfileCacheForTests();
+  const previous = process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+  delete process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+
+  const sandboxAppId = "app_sandbox_1";
+  let createCalls = 0;
+  const client = openMeterTestClient({
+    apps: {
+      list: async () => ({
+        items: [{ id: sandboxAppId, type: "sandbox" }],
+      }),
+    },
+    billing: {
+      profiles: {
+        list: async () => ({
+          items: [
+            {
+              id: "profile_sandbox_existing",
+              apps: {
+                tax: sandboxAppId,
+                invoicing: sandboxAppId,
+                payment: sandboxAppId,
+              },
+            },
+          ],
+        }),
+        create: async () => {
+          createCalls += 1;
+          return { id: "profile_should_not_be_created" };
+        },
+      },
+    },
+  });
+
+  try {
+    const profileId = await ensureFreeBillingProfile(client);
+    assert.equal(profileId, "profile_sandbox_existing");
+    assert.equal(createCalls, 0);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+    } else {
+      process.env.OPENMETER_FREE_BILLING_PROFILE_ID = previous;
+    }
+    resetFreeBillingProfileCacheForTests();
+  }
+});
+
+test("ensureFreeBillingProfile creates sandbox billing profile when missing", async () => {
+  resetFreeBillingProfileCacheForTests();
+  const previous = process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+  delete process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+
+  const sandboxAppId = "app_sandbox_1";
+  const client = openMeterTestClient({
+    apps: {
+      list: async () => ({
+        items: [{ id: sandboxAppId, type: "sandbox" }],
+      }),
+    },
+    billing: {
+      profiles: {
+        list: async () => ({ items: [] }),
+        create: async (body: { apps?: { tax?: string } }) => {
+          assert.equal(body.apps?.tax, sandboxAppId);
+          return { id: "profile_sandbox_created" };
+        },
+      },
+    },
+  });
+
+  try {
+    const profileId = await ensureFreeBillingProfile(client);
+    assert.equal(profileId, "profile_sandbox_created");
+    const cachedAgain = await ensureFreeBillingProfile(client);
+    assert.equal(cachedAgain, "profile_sandbox_created");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+    } else {
+      process.env.OPENMETER_FREE_BILLING_PROFILE_ID = previous;
+    }
+    resetFreeBillingProfileCacheForTests();
+  }
+});

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -183,7 +183,7 @@ export async function applyFreeBillingProfileToCustomer(input: {
   client: OpenMeter;
   customerId: string;
 }): Promise<void> {
-  const profileId = await ensureFreeBillingProfile();
+  const profileId = await ensureFreeBillingProfile(input.client);
   await assignCustomerBillingProfileOverride({
     client: input.client,
     customerId: input.customerId,

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -6,6 +6,69 @@ import type { OpenMeter } from "@openmeter/sdk";
 import { getHostedAdminClient } from "./admin-client";
 import { assignCustomerBillingProfileOverride } from "./customers";
 
+const FREE_BILLING_PROFILE_NAME = "pymthouse-free";
+
+let cachedFreeBillingProfileId: string | null = null;
+
+function billingProfileAppId(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (value && typeof value === "object" && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    if (typeof id === "string" && id.trim()) {
+      return id.trim();
+    }
+  }
+  return null;
+}
+
+function profileUsesApp(profile: { apps?: unknown }, appId: string): boolean {
+  const apps = profile.apps as Record<string, unknown> | undefined;
+  if (!apps) {
+    return false;
+  }
+  for (const slot of ["tax", "invoicing", "payment"] as const) {
+    if (billingProfileAppId(apps[slot]) !== appId) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function findInstalledSandboxAppId(client: OpenMeter): Promise<string> {
+  const listed = await client.apps.list({ page: 1, pageSize: 100 });
+  const sandbox = listed?.items?.find((app) => app.type === "sandbox");
+  if (!sandbox?.id) {
+    throw new Error(
+      "OpenMeter sandbox app is not installed; install it in Konnect or set OPENMETER_FREE_BILLING_PROFILE_ID",
+    );
+  }
+  return sandbox.id;
+}
+
+async function findBillingProfileForSandboxApp(
+  client: OpenMeter,
+  sandboxAppId: string,
+): Promise<string | null> {
+  let page = 1;
+  const pageSize = 100;
+  for (;;) {
+    const listed = await client.billing.profiles.list({ page, pageSize });
+    const items = listed?.items ?? [];
+    for (const profile of items) {
+      if (profile.id && profileUsesApp(profile, sandboxAppId)) {
+        return profile.id;
+      }
+    }
+    if (!listed || items.length < pageSize) {
+      break;
+    }
+    page += 1;
+  }
+  return null;
+}
+
 export async function getAppBillingConfig(clientId: string) {
   const rows = await db
     .select()
@@ -71,6 +134,63 @@ export async function ensureTenantBillingProfile(input: {
   return profile.id;
 }
 
+/**
+ * Namespace-level sandbox billing profile for free Starter subscriptions.
+ * Avoids Konnect's default Stripe-backed profile, which rejects customers
+ * without Stripe app data.
+ */
+export async function ensureFreeBillingProfile(client?: OpenMeter): Promise<string> {
+  const fromEnv = process.env.OPENMETER_FREE_BILLING_PROFILE_ID?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  if (cachedFreeBillingProfileId) {
+    return cachedFreeBillingProfileId;
+  }
+
+  const omClient = client ?? getHostedAdminClient();
+  const sandboxAppId = await findInstalledSandboxAppId(omClient);
+  const existing = await findBillingProfileForSandboxApp(omClient, sandboxAppId);
+  if (existing) {
+    cachedFreeBillingProfileId = existing;
+    return existing;
+  }
+
+  const profile = await omClient.billing.profiles.create({
+    name: FREE_BILLING_PROFILE_NAME,
+    default: false,
+    supplier: {
+      name: "PymtHouse Free",
+    },
+    workflow: {
+      invoicing: { autoAdvance: true, draftPeriod: "P0D" },
+      payment: { collectionMethod: "charge_automatically" },
+    },
+    apps: {
+      tax: sandboxAppId,
+      invoicing: sandboxAppId,
+      payment: sandboxAppId,
+    },
+  });
+  if (!profile?.id) {
+    throw new Error("Failed to create OpenMeter free (sandbox) billing profile");
+  }
+  cachedFreeBillingProfileId = profile.id;
+  return profile.id;
+}
+
+export async function applyFreeBillingProfileToCustomer(input: {
+  client: OpenMeter;
+  customerId: string;
+}): Promise<void> {
+  const profileId = await ensureFreeBillingProfile();
+  await assignCustomerBillingProfileOverride({
+    client: input.client,
+    customerId: input.customerId,
+    billingProfileId: profileId,
+  });
+}
+
 export async function applyTenantBillingProfileToCustomer(input: {
   client: OpenMeter;
   clientId: string;
@@ -89,6 +209,10 @@ export async function applyTenantBillingProfileToCustomer(input: {
     customerId: input.customerId,
     billingProfileId: config.openmeterBillingProfileId,
   });
+}
+
+export function resetFreeBillingProfileCacheForTests(): void {
+  cachedFreeBillingProfileId = null;
 }
 
 export async function upsertAppBillingConfig(

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -9,6 +9,30 @@ export type OpenMeterCustomerIdentity = {
   key: string;
 };
 
+type OpenMeterCustomerRecord = {
+  id: string;
+  key?: string;
+  name?: string;
+  usageAttribution?: { subjectKeys?: string[] };
+};
+
+async function ensureCustomerUsageAttribution(
+  client: OpenMeter,
+  customer: OpenMeterCustomerRecord,
+  customerKey: string,
+): Promise<void> {
+  const subjectKeys = customer.usageAttribution?.subjectKeys ?? [];
+  if (subjectKeys.includes(customerKey)) {
+    return;
+  }
+
+  const nextKeys = [...new Set([...subjectKeys, customerKey])];
+  await client.customers.update(customer.id, {
+    name: customer.name?.trim() || customerKey,
+    usageAttribution: { subjectKeys: nextKeys },
+  });
+}
+
 async function findOpenMeterCustomerByKey(
   client: OpenMeter,
   customerKey: string,
@@ -35,18 +59,28 @@ export async function ensureOpenMeterCustomer(
 ): Promise<OpenMeterCustomerIdentity> {
   const existing = await findOpenMeterCustomerByKey(client, customerKey);
   if (existing?.id) {
+    await ensureCustomerUsageAttribution(client, existing, customerKey);
     return { id: existing.id, key: customerKey };
   }
 
-  const created = await client.customers.create({
-    key: customerKey,
-    name: displayName || customerKey,
-    usageAttribution: { subjectKeys: [customerKey] },
-  });
-  if (!created?.id) {
-    throw new Error(`OpenMeter customer create failed for key ${customerKey}`);
+  try {
+    const created = await client.customers.create({
+      key: customerKey,
+      name: displayName || customerKey,
+      usageAttribution: { subjectKeys: [customerKey] },
+    });
+    if (!created?.id) {
+      throw new Error(`OpenMeter customer create failed for key ${customerKey}`);
+    }
+    return { id: created.id, key: customerKey };
+  } catch (err) {
+    const raced = await findOpenMeterCustomerByKey(client, customerKey);
+    if (raced?.id) {
+      await ensureCustomerUsageAttribution(client, raced, customerKey);
+      return { id: raced.id, key: customerKey };
+    }
+    throw err;
   }
-  return { id: created.id, key: customerKey };
 }
 
 export async function ensureOpenMeterCustomerForAppUser(input: {

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -13,7 +13,6 @@ import {
   getTrialFeatureKeyForApp,
 } from "./client-factory";
 import { defaultStarterIncludedUsdMicros } from "@/lib/starter-default-plan-display";
-import { isStripeBillingEnabledForApp } from "./billing-profiles";
 import { getKonnectEntitlementHasAccess } from "./konnect-entitlements";
 import { shouldUseKonnectRoutes } from "./route-mode";
 import {
@@ -115,17 +114,6 @@ async function getKonnectTrialCreditBalance(input: {
   }
 
   const defaultGrant = defaultStarterIncludedUsdMicros();
-  let stripeBillingEnabled = true;
-  try {
-    stripeBillingEnabled = await isStripeBillingEnabledForApp(input.clientId);
-  } catch {
-    stripeBillingEnabled = false;
-  }
-  if (!hasAccess && !stripeBillingEnabled) {
-    // Free Starter allowance without Stripe Connect — subscription optional.
-    hasAccess = true;
-  }
-
   if (!hasAccess) {
     return {
       hasAccess: false,

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -16,7 +16,7 @@ import { defaultStarterIncludedUsdMicros } from "@/lib/starter-default-plan-disp
 import { getKonnectEntitlementHasAccess } from "./konnect-entitlements";
 import { shouldUseKonnectRoutes } from "./route-mode";
 import {
-  getOpenMeterSubscriptionForAppUser,
+  getPrimaryOpenMeterSubscriptionForAppUser,
   isOpenMeterSubscriptionActive,
 } from "./subscription-read";
 import { queryOpenMeterUsage } from "./usage-read";
@@ -96,7 +96,7 @@ async function getKonnectTrialCreditBalance(input: {
 
   let periodStart: string | null = null;
   if (!hasAccess) {
-    const starterSubscription = await getOpenMeterSubscriptionForAppUser({
+    const starterSubscription = await getPrimaryOpenMeterSubscriptionForAppUser({
       clientId: input.clientId,
       externalUserId: input.externalUserId,
     });

--- a/src/lib/openmeter/meter-client-id.ts
+++ b/src/lib/openmeter/meter-client-id.ts
@@ -1,0 +1,28 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+
+/**
+ * OpenMeter meter groupBy `client_id` matches the public OIDC client_id emitted
+ * in signed-ticket CloudEvents (auth_id prefix), not developer_apps.id when those
+ * differ (legacy apps created before id === client_id).
+ */
+export async function resolveOpenMeterMeterClientId(appId: string): Promise<string> {
+  const trimmed = appId.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("app_")) {
+    return trimmed;
+  }
+
+  const rows = await db
+    .select({ publicClientId: oidcClients.clientId })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(developerApps.id, trimmed))
+    .limit(1);
+
+  const publicClientId = rows[0]?.publicClientId?.trim();
+  return publicClientId || trimmed;
+}

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -282,7 +282,14 @@ test("buildOpenMeterUsageResponse does not copy network fee into endUserBillable
 test("ensureOpenMeterCustomer returns existing id and key", async () => {
   const client = {
     customers: {
-      get: async (key: string) => ({ id: "om-cust-1", key }),
+      get: async (key: string) => ({
+        id: "om-cust-1",
+        key,
+        usageAttribution: { subjectKeys: [key] },
+      }),
+      update: async () => {
+        throw new Error("should not update when subject key present");
+      },
       create: async () => {
         throw new Error("should not create");
       },
@@ -295,6 +302,34 @@ test("ensureOpenMeterCustomer returns existing id and key", async () => {
     "User One",
   );
   assert.deepEqual(identity, { id: "om-cust-1", key: "app_1:user-1" });
+});
+
+test("ensureOpenMeterCustomer repairs missing usageAttribution subjectKeys", async () => {
+  let updatedSubjectKeys: string[] | undefined;
+  const client = {
+    customers: {
+      get: async (key: string) => ({
+        id: "om-cust-1",
+        key,
+        usageAttribution: { subjectKeys: [] },
+      }),
+      update: async (_id: string, input: { usageAttribution: { subjectKeys: string[] } }) => {
+        updatedSubjectKeys = input.usageAttribution.subjectKeys;
+        return { id: "om-cust-1", key: "app_1:user-1" };
+      },
+      create: async () => {
+        throw new Error("should not create");
+      },
+    },
+  };
+
+  const identity = await ensureOpenMeterCustomer(
+    openMeterTestClient(client),
+    "app_1:user-1",
+    "User One",
+  );
+  assert.deepEqual(identity, { id: "om-cust-1", key: "app_1:user-1" });
+  assert.deepEqual(updatedSubjectKeys, ["app_1:user-1"]);
 });
 
 test("ensureOpenMeterCustomer creates customer when missing", async () => {

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -17,8 +17,6 @@ import {
 } from "./plans-sync";
 import {
   findOpenMeterSubscriptionByPlanKey,
-  isOpenMeterSubscriptionActive,
-  listOpenMeterSubscriptionsForCustomer,
   type OpenMeterSubscriptionView,
   verifyOpenMeterSubscriptionId,
 } from "./subscription-read";
@@ -182,15 +180,6 @@ async function createStarterSubscriptionWithRecovery(input: {
         return { subscription: existing, starter: activeStarter, created: false };
       }
 
-      for (const item of await listOpenMeterSubscriptionsForCustomer(
-        input.client,
-        input.customerId,
-      )) {
-        if (isOpenMeterSubscriptionActive(item.status)) {
-          return { subscription: item, starter: activeStarter, created: false };
-        }
-      }
-
       await applyFreeBillingProfileToCustomer({
         client: input.client,
         customerId: input.customerId,
@@ -226,14 +215,6 @@ async function createStarterSubscriptionWithRecovery(input: {
             starter: activeStarter,
             created: false,
           };
-        }
-        for (const item of await listOpenMeterSubscriptionsForCustomer(
-          input.client,
-          input.customerId,
-        )) {
-          if (isOpenMeterSubscriptionActive(item.status)) {
-            return { subscription: item, starter: activeStarter, created: false };
-          }
         }
         throw retryErr;
       }
@@ -306,7 +287,7 @@ export async function ensureStarterSubscriptionForAppUser(input: {
 
   if (!omSubscription) {
     throw new Error(
-      `Failed to provision OpenMeter Starter subscription for ${input.clientId}:${input.externalUserId}`,
+      `Failed to provision OpenMeter Starter subscription for client ${input.clientId}`,
     );
   }
 

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -3,10 +3,7 @@ import type { OpenMeter, PlanReferenceInput } from "@openmeter/sdk";
 import { db } from "@/db/index";
 import { plans } from "@/db/schema";
 import { getOrCreateStarterPlan } from "@/lib/starter-default-plan";
-import {
-  applyFreeBillingProfileToCustomer,
-  isStripeBillingEnabledForApp,
-} from "./billing-profiles";
+import { applyFreeBillingProfileToCustomer } from "./billing-profiles";
 import { getHostedAdminClient, isHostedAdminClientAvailable } from "./admin-client";
 import { ensureOpenMeterCustomerForAppUser } from "./customers";
 import {
@@ -20,6 +17,8 @@ import {
 } from "./plans-sync";
 import {
   findOpenMeterSubscriptionByPlanKey,
+  isOpenMeterSubscriptionActive,
+  listOpenMeterSubscriptionsForCustomer,
   type OpenMeterSubscriptionView,
   verifyOpenMeterSubscriptionId,
 } from "./subscription-read";
@@ -118,6 +117,7 @@ function subscriptionViewFromCreateResult(
 async function createStarterSubscriptionWithRecovery(input: {
   client: OpenMeter;
   customerId: string;
+  clientId: string;
   starter: typeof plans.$inferSelect;
   planKey: string;
 }): Promise<{
@@ -178,10 +178,66 @@ async function createStarterSubscriptionWithRecovery(input: {
         input.planKey,
         { openmeterPlanId: activeStarter.openmeterPlanId },
       );
-      if (!existing) {
-        throw err;
+      if (existing) {
+        return { subscription: existing, starter: activeStarter, created: false };
       }
-      return { subscription: existing, starter: activeStarter, created: false };
+
+      for (const item of await listOpenMeterSubscriptionsForCustomer(
+        input.client,
+        input.customerId,
+      )) {
+        if (isOpenMeterSubscriptionActive(item.status)) {
+          return { subscription: item, starter: activeStarter, created: false };
+        }
+      }
+
+      await applyFreeBillingProfileToCustomer({
+        client: input.client,
+        customerId: input.customerId,
+      });
+      try {
+        const createdSub = await createStarterOpenMeterSubscription({
+          client: input.client,
+          customerId: input.customerId,
+          starter: activeStarter,
+          planKey: input.planKey,
+        });
+        if (createdSub?.id) {
+          return {
+            subscription: subscriptionViewFromCreateResult(
+              createdSub,
+              input.planKey,
+              activeStarter.openmeterPlanId,
+            ),
+            starter: activeStarter,
+            created: true,
+          };
+        }
+      } catch (retryErr) {
+        const existingAfterRetry = await findOpenMeterSubscriptionByPlanKey(
+          input.client,
+          input.customerId,
+          input.planKey,
+          { openmeterPlanId: activeStarter.openmeterPlanId },
+        );
+        if (existingAfterRetry) {
+          return {
+            subscription: existingAfterRetry,
+            starter: activeStarter,
+            created: false,
+          };
+        }
+        for (const item of await listOpenMeterSubscriptionsForCustomer(
+          input.client,
+          input.customerId,
+        )) {
+          if (isOpenMeterSubscriptionActive(item.status)) {
+            return { subscription: item, starter: activeStarter, created: false };
+          }
+        }
+        throw retryErr;
+      }
+      throw err;
     }
     throw err;
   }
@@ -216,12 +272,12 @@ export async function ensureStarterSubscriptionForAppUser(input: {
     clientId: input.clientId,
     externalUserId: input.externalUserId,
   });
-  if (!(await isStripeBillingEnabledForApp(input.clientId))) {
-    await applyFreeBillingProfileToCustomer({
-      client,
-      customerId: customer.id,
-    });
-  }
+  // Starter trial subscriptions always use the sandbox billing profile so Konnect
+  // does not require Stripe customer data, even when the app has Stripe Connect.
+  await applyFreeBillingProfileToCustomer({
+    client,
+    customerId: customer.id,
+  });
 
   const planKey = buildOpenMeterPlanKey(input.clientId, starter.id);
 
@@ -239,6 +295,7 @@ export async function ensureStarterSubscriptionForAppUser(input: {
     const provisioned = await createStarterSubscriptionWithRecovery({
       client,
       customerId: customer.id,
+      clientId: input.clientId,
       starter: activeStarter,
       planKey,
     });

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -3,12 +3,15 @@ import type { OpenMeter, PlanReferenceInput } from "@openmeter/sdk";
 import { db } from "@/db/index";
 import { plans } from "@/db/schema";
 import { getOrCreateStarterPlan } from "@/lib/starter-default-plan";
+import {
+  applyFreeBillingProfileToCustomer,
+  isStripeBillingEnabledForApp,
+} from "./billing-profiles";
 import { getHostedAdminClient, isHostedAdminClientAvailable } from "./admin-client";
 import { ensureOpenMeterCustomerForAppUser } from "./customers";
 import {
   isOpenMeterConflictError,
   isOpenMeterPlanNotFoundError,
-  isOpenMeterStripeBillingError,
 } from "./plan-errors";
 import {
   buildOpenMeterPlanKey,
@@ -168,13 +171,6 @@ async function createStarterSubscriptionWithRecovery(input: {
         created: true,
       };
     }
-    if (isOpenMeterStripeBillingError(err)) {
-      console.warn(
-        "[openmeter] Starter subscription skipped: Stripe billing is not ready for this customer",
-        err,
-      );
-      return { subscription: null, starter: activeStarter, created: false };
-    }
     if (isOpenMeterConflictError(err)) {
       const existing = await findOpenMeterSubscriptionByPlanKey(
         input.client,
@@ -220,8 +216,12 @@ export async function ensureStarterSubscriptionForAppUser(input: {
     clientId: input.clientId,
     externalUserId: input.externalUserId,
   });
-  // Starter is free — do not attach the tenant Stripe billing profile here.
-  // Paid checkout applies billing profiles in subscriptions-billing.ts.
+  if (!(await isStripeBillingEnabledForApp(input.clientId))) {
+    await applyFreeBillingProfileToCustomer({
+      client,
+      customerId: customer.id,
+    });
+  }
 
   const planKey = buildOpenMeterPlanKey(input.clientId, starter.id);
 
@@ -248,11 +248,9 @@ export async function ensureStarterSubscriptionForAppUser(input: {
   }
 
   if (!omSubscription) {
-    return {
-      openmeterSubscriptionId: null,
-      planId: activeStarter.id,
-      created: false,
-    };
+    throw new Error(
+      `Failed to provision OpenMeter Starter subscription for ${input.clientId}:${input.externalUserId}`,
+    );
   }
 
   return {

--- a/src/lib/openmeter/usage-read.ts
+++ b/src/lib/openmeter/usage-read.ts
@@ -3,6 +3,7 @@ import {
   getMeterSlugForApp,
 } from "@/lib/openmeter/client-factory";
 import { buildOpenMeterCustomerKey } from "@/lib/openmeter/customer-key";
+import { resolveOpenMeterMeterClientId } from "@/lib/openmeter/meter-client-id";
 import {
   openMeterUsesLiveNetworkInTests,
   requireOpenMeterForUsageReads,
@@ -617,6 +618,7 @@ export async function queryOpenMeterUserPipelineByModel(input: {
     return [];
   }
 
+  const meterClientId = await resolveOpenMeterMeterClientId(input.clientId);
   const client = await getOpenMeterClientForApp(input.clientId);
   if (!client) {
     return [];
@@ -624,7 +626,7 @@ export async function queryOpenMeterUserPipelineByModel(input: {
 
   const meterSlug = await getMeterSlugForApp(input.clientId);
   const periodQuery = buildMeterQuery({
-    clientId: input.clientId,
+    clientId: meterClientId,
     startDate: input.startDate,
     endDate: input.endDate,
     windowSize: "MONTH",
@@ -638,7 +640,7 @@ export async function queryOpenMeterUserPipelineByModel(input: {
   ]);
 
   return aggregatePipelineModelRows({
-    clientId: input.clientId,
+    clientId: meterClientId,
     feeRows: feeResult.data || [],
     countRows: countResult.data || [],
   });
@@ -666,6 +668,7 @@ export async function queryOpenMeterUserDailyByPipeline(input: {
     return [];
   }
 
+  const meterClientId = await resolveOpenMeterMeterClientId(input.clientId);
   const client = await getOpenMeterClientForApp(input.clientId);
   if (!client) {
     return [];
@@ -673,7 +676,7 @@ export async function queryOpenMeterUserDailyByPipeline(input: {
 
   const meterSlug = await getMeterSlugForApp(input.clientId);
   const dayQuery = buildMeterQuery({
-    clientId: input.clientId,
+    clientId: meterClientId,
     startDate: input.startDate,
     endDate: input.endDate,
     windowSize: "DAY",
@@ -687,7 +690,7 @@ export async function queryOpenMeterUserDailyByPipeline(input: {
   ]);
 
   return aggregateDailyPipelineModelRows({
-    clientId: input.clientId,
+    clientId: meterClientId,
     feeRows: feeResult.data || [],
     countRows: countResult.data || [],
   });
@@ -729,6 +732,7 @@ export async function queryOpenMeterUsage(input: {
     return [];
   }
 
+  const meterClientId = await resolveOpenMeterMeterClientId(input.clientId);
   const client = await getOpenMeterClientForApp(input.clientId);
   if (!client) {
     return [];
@@ -736,7 +740,7 @@ export async function queryOpenMeterUsage(input: {
 
   const meterSlug = await getMeterSlugForApp(input.clientId);
   const periodQuery = buildMeterQuery({
-    clientId: input.clientId,
+    clientId: meterClientId,
     startDate: input.startDate,
     endDate: input.endDate,
     windowSize: "MONTH",
@@ -750,7 +754,7 @@ export async function queryOpenMeterUsage(input: {
   ]);
 
   return aggregateUserRows({
-    clientId: input.clientId,
+    clientId: meterClientId,
     feeRows: feeResult.data || [],
     countRows: countResult.data || [],
     filterExternalUserId: input.externalUserId,
@@ -778,6 +782,7 @@ export async function queryOpenMeterAppDashboardUsage(input: {
     return null;
   }
 
+  const meterClientId = await resolveOpenMeterMeterClientId(input.clientId);
   const client = await getOpenMeterClientForApp(input.clientId);
   if (!client) {
     return null;
@@ -785,14 +790,14 @@ export async function queryOpenMeterAppDashboardUsage(input: {
 
   const meterSlug = await getMeterSlugForApp(input.clientId);
   const periodQuery = buildMeterQuery({
-    clientId: input.clientId,
+    clientId: meterClientId,
     startDate: input.startDate,
     endDate: input.endDate,
     windowSize: "MONTH",
     groupBy: METER_GROUP_BY_DETAIL,
   });
   const dayQuery = buildMeterQuery({
-    clientId: input.clientId,
+    clientId: meterClientId,
     startDate: input.startDate,
     endDate: input.endDate,
     windowSize: "DAY",
@@ -810,22 +815,22 @@ export async function queryOpenMeterAppDashboardUsage(input: {
 
   return {
     byUser: aggregateUserRows({
-      clientId: input.clientId,
+      clientId: meterClientId,
       feeRows,
       countRows,
     }),
     byPipelineModel: aggregatePipelineModelRows({
-      clientId: input.clientId,
+      clientId: meterClientId,
       feeRows,
       countRows,
     }),
     byUserPipelineModel: aggregateUserPipelineModelRows({
-      clientId: input.clientId,
+      clientId: meterClientId,
       feeRows,
       countRows,
     }),
     requestsByDay: aggregateDailyRequestCounts({
-      clientId: input.clientId,
+      clientId: meterClientId,
       countRows: dayCountResult.data || [],
     }),
   };


### PR DESCRIPTION
- Added support for free billing profiles for Starter subscriptions in OpenMeter.
- Introduced functions to ensure customer usage attribution and manage billing profiles.
- Updated `ensureOpenMeterCustomer` to handle existing customers and ensure proper usage attribution.
- Enhanced tests for customer creation and usage attribution logic.
- Added new script command for ensuring customer existence in the OpenMeter context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `OPENMETER_FREE_BILLING_PROFILE_ID` override for the default free billing profile.
  * Added an `openmeter:ensure-customer` CLI command to provision/repair customer billing setup (including optional starter subscription creation).
* **Bug Fixes**
  * OpenMeter customer usage attribution is now automatically repaired to stay consistent.
  * External-user signer JWT minting now enforces a trial-allowance gate and returns a 402-style billing-unavailable error when minting can’t proceed.
  * Starter subscription provisioning/recovery more reliably applies the free billing profile and improves conflict handling.
  * Usage queries now resolve and use the correct OpenMeter meter client id.
  * Trial access no longer falls back to Stripe when Konnect entitlement access is unavailable.
* **Tests**
  * Expanded coverage for free billing profile resolution, minting allowance gating, and usage attribution repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->