### PR TITLE
fix(collector): drop empty auth_id Kafka events instead of retrying forever

### DIFF
--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -21,8 +21,16 @@ pipeline:
 
     - mapping: |
         let data = this.data.or({})
-        let auth_id = $data.auth_id.or("").string().trim()
-        root = if $auth_id == "" { deleted() }
+        let auth_id_raw = $data.auth_id.or("").string().trim()
+        let client_id_field = $data.client_id.or("").string().trim()
+        let usage_subject = $data.usage_subject.or("").string().trim()
+        let auth_id = if $auth_id_raw != "" {
+          $auth_id_raw
+        } else if $client_id_field != "" && $usage_subject != "" {
+          $client_id_field + ":" + $usage_subject
+        } else {
+          ""
+        }
 
         let colon = $auth_id.index_of(":")
         let is_compound = $colon > 0 && $colon < $auth_id.length() - 1
@@ -33,23 +41,27 @@ pipeline:
         let fee_wei = $data.computed_fee.number().or(0)
         let fee_usd_micros = ($fee_wei * $eth_usd / 1000000000000).round()
 
-        root = {
-          "specversion": "1.0",
-          "type": "create_signed_ticket",
-          "id": $data.request_id.or(uuid_v4()),
-          "source": "go-livepeer-remote-signer",
-          "subject": $auth_id,
-          "time": $data.current_time.or(now()),
-          "data": {
-            "client_id": $client_id,
-            "external_user_id": $external_user_id,
-            "network_fee_usd_micros": $fee_usd_micros,
-            "pipeline": if $data.pipeline != "" && $data.pipeline != null { $data.pipeline } else { "unknown" },
-            "model_id": if $data.model_id != "" && $data.model_id != null { $data.model_id } else { "unknown" },
-            "pixels": $data.pixels.string().or("0"),
-            "fee_wei": $data.computed_fee.or("0"),
-            "gateway_request_id": $data.request_id,
-            "auth_id": $auth_id,
+        root = if $auth_id == "" {
+          deleted()
+        } else {
+          {
+            "specversion": "1.0",
+            "type": "create_signed_ticket",
+            "id": $data.request_id.or(uuid_v4()),
+            "source": "go-livepeer-remote-signer",
+            "subject": $auth_id,
+            "time": $data.current_time.or(now()),
+            "data": {
+              "client_id": $client_id,
+              "external_user_id": $external_user_id,
+              "network_fee_usd_micros": $fee_usd_micros,
+              "pipeline": if $data.pipeline != "" && $data.pipeline != null { $data.pipeline } else { "unknown" },
+              "model_id": if $data.model_id != "" && $data.model_id != null { $data.model_id } else { "unknown" },
+              "pixels": $data.pixels.string().or("0"),
+              "fee_wei": $data.computed_fee.or("0"),
+              "gateway_request_id": $data.request_id,
+              "auth_id": $auth_id,
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- Fix Bloblang mapping so `deleted()` is not overwritten by a second `root = { ... }` assignment — empty/missing `auth_id` events were still posted to Konnect with `subject: ""`, got 400s, and blocked the `openmeter-collector` consumer group on preview.
- Fall back to `client_id:usage_subject` when `auth_id` is absent (newer signer event shapes).

## Test plan
- [x] `benthos lint /config.yaml` passes in collector Docker image
- [x] Deployed to Railway preview — no more `subject [min_length]` errors in collector logs
- [ ] Merge and redeploy preview/production clearinghouse stack via CI or `bash scripts/railway-deploy-stack.sh preview`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ticket-creation events when some identifier fields are missing, reducing dropped or incomplete requests.
  * Added fallback logic to better preserve event data and only skip records when required identifying information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->