### PR TITLE
feat(apps): add owner API key minting and improve app ownership UX

### DIFF
--- a/src/app/api/v1/apps/route.ts
+++ b/src/app/api/v1/apps/route.ts
@@ -78,7 +78,19 @@ export async function GET() {
         .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
         .where(inArray(developerApps.id, memberIds));
 
-  const apps = [...ownedApps, ...memberApps].filter(
+  const ownedWithFlags = ownedApps.map((app) => ({
+    ...app,
+    isOwner: true,
+    ownerExternalUserId: userId,
+  }));
+
+  const memberWithFlags = memberApps.map((app) => ({
+    ...app,
+    isOwner: false,
+    ownerExternalUserId: null,
+  }));
+
+  const apps = [...ownedWithFlags, ...memberWithFlags].filter(
     (app, index, rows) => rows.findIndex((row) => row.id === app.id) === index,
   );
 

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  useCallback,
   useEffect,
   useRef,
   useState,
@@ -9,50 +8,8 @@ import {
 import Link from "next/link";
 import DashboardLayout from "@/components/DashboardLayout";
 import AppStatusBadge, { appStatusAriaLabel } from "@/components/apps/AppStatusBadge";
-import GenerateSigningTokenDialog from "@/components/apps/GenerateSigningTokenDialog";
-
-async function postJson(
-  path: string,
-  body: Record<string, unknown>,
-): Promise<Record<string, unknown>> {
-  const response = await fetch(path, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Accept: "application/json" },
-    body: JSON.stringify(body),
-  });
-  const text = await response.text();
-  let parsed: Record<string, unknown> = {};
-  try { parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {}; } catch { parsed = {}; }
-  if (!response.ok) {
-    const message =
-      (typeof parsed.error_description === "string" && parsed.error_description) ||
-      (typeof parsed.error === "string" && parsed.error) ||
-      text || `Request failed (${response.status})`;
-    throw new Error(message);
-  }
-  return parsed;
-}
-
-async function mintOwnerApiKey(input: {
-  clientId: string;
-  ownerExternalUserId: string;
-}): Promise<Record<string, unknown>> {
-  const externalUserId = input.ownerExternalUserId.trim();
-  if (!externalUserId) throw new Error("Owner identity is unavailable.");
-  await postJson(`/api/v1/apps/${encodeURIComponent(input.clientId)}/users`, {
-    externalUserId,
-    status: "active",
-  });
-  return postJson(
-    `/api/v1/apps/${encodeURIComponent(input.clientId)}/users/${encodeURIComponent(externalUserId)}/keys`,
-    { label: "signing-token" },
-  );
-}
-
-type CardMintState =
-  | { phase: "minting"; appId: string }
-  | { phase: "success"; app: AppSummary; apiKey: string; response: Record<string, unknown> }
-  | { phase: "error"; app: AppSummary; message: string };
+import OwnerApiKeyMintDialog from "@/components/apps/OwnerApiKeyMintDialog";
+import { useOwnerApiKeyMint } from "@/components/apps/use-owner-api-key-mint";
 
 interface AppSummary {
   id: string;
@@ -263,28 +220,13 @@ function CopyPublicAppIdButton({
 export default function AppsPage() {
   const [apps, setApps] = useState<AppSummary[]>([]);
   const [loading, setLoading] = useState(true);
-  const [mintState, setMintState] = useState<CardMintState | null>(null);
+  const { mintState, handleGetApiKey, closeMintDialog } = useOwnerApiKeyMint<AppSummary>();
 
   useEffect(() => {
     fetch("/api/v1/apps")
       .then((r) => r.json())
       .then((data) => setApps(data.apps || []))
       .finally(() => setLoading(false));
-  }, []);
-
-  const handleGetApiKey = useCallback((app: AppSummary) => {
-    if (!app.clientId || !app.ownerExternalUserId) return;
-    setMintState({ phase: "minting", appId: app.id });
-    void mintOwnerApiKey({ clientId: app.clientId, ownerExternalUserId: app.ownerExternalUserId })
-      .then((data) => {
-        const apiKey = typeof data.apiKey === "string" && data.apiKey.trim() ? data.apiKey.trim() : null;
-        if (!apiKey) throw new Error("API key mint response missing apiKey.");
-        setMintState({ phase: "success", app, apiKey, response: data });
-      })
-      .catch((err) => {
-        const message = err instanceof Error ? err.message : "Failed to mint API key.";
-        setMintState({ phase: "error", app, message });
-      });
   }, []);
 
   return (
@@ -476,25 +418,13 @@ export default function AppsPage() {
           ))}
         </div>
       )}
-      {mintState?.phase === "success" ? (
-        <GenerateSigningTokenDialog
-          phase="success"
-          appName={mintState.app.name}
-          ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
-          apiKey={mintState.apiKey}
-          response={mintState.response}
-          onClose={() => setMintState(null)}
-        />
-      ) : mintState?.phase === "error" ? (
-        <GenerateSigningTokenDialog
-          phase="error"
-          appName={mintState.app.name}
-          ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
-          message={mintState.message}
-          onClose={() => setMintState(null)}
-          onRetry={() => handleGetApiKey(mintState.app)}
-        />
-      ) : null}
+      <OwnerApiKeyMintDialog
+        mintState={
+          mintState?.phase === "minting" ? null : mintState
+        }
+        onClose={closeMintDialog}
+        onRetry={handleGetApiKey}
+      />
     </DashboardLayout>
   );
 }

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -9,6 +9,50 @@ import {
 import Link from "next/link";
 import DashboardLayout from "@/components/DashboardLayout";
 import AppStatusBadge, { appStatusAriaLabel } from "@/components/apps/AppStatusBadge";
+import GenerateSigningTokenDialog from "@/components/apps/GenerateSigningTokenDialog";
+
+async function postJson(
+  path: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  let parsed: Record<string, unknown> = {};
+  try { parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {}; } catch { parsed = {}; }
+  if (!response.ok) {
+    const message =
+      (typeof parsed.error_description === "string" && parsed.error_description) ||
+      (typeof parsed.error === "string" && parsed.error) ||
+      text || `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+  return parsed;
+}
+
+async function mintOwnerApiKey(input: {
+  clientId: string;
+  ownerExternalUserId: string;
+}): Promise<Record<string, unknown>> {
+  const externalUserId = input.ownerExternalUserId.trim();
+  if (!externalUserId) throw new Error("Owner identity is unavailable.");
+  await postJson(`/api/v1/apps/${encodeURIComponent(input.clientId)}/users`, {
+    externalUserId,
+    status: "active",
+  });
+  return postJson(
+    `/api/v1/apps/${encodeURIComponent(input.clientId)}/users/${encodeURIComponent(externalUserId)}/keys`,
+    { label: "signing-token" },
+  );
+}
+
+type CardMintState =
+  | { phase: "minting"; appId: string }
+  | { phase: "success"; app: AppSummary; apiKey: string; response: Record<string, unknown> }
+  | { phase: "error"; app: AppSummary; message: string };
 
 interface AppSummary {
   id: string;
@@ -19,6 +63,8 @@ interface AppSummary {
   logoLightUrl: string | null;
   clientId: string | null;
   createdAt: string;
+  isOwner: boolean;
+  ownerExternalUserId: string | null;
 }
 
 const STATUS_REVIEW = new Set(["submitted", "in_review"]);
@@ -217,12 +263,28 @@ function CopyPublicAppIdButton({
 export default function AppsPage() {
   const [apps, setApps] = useState<AppSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [mintState, setMintState] = useState<CardMintState | null>(null);
 
   useEffect(() => {
     fetch("/api/v1/apps")
       .then((r) => r.json())
       .then((data) => setApps(data.apps || []))
       .finally(() => setLoading(false));
+  }, []);
+
+  const handleGetApiKey = useCallback((app: AppSummary) => {
+    if (!app.clientId || !app.ownerExternalUserId) return;
+    setMintState({ phase: "minting", appId: app.id });
+    void mintOwnerApiKey({ clientId: app.clientId, ownerExternalUserId: app.ownerExternalUserId })
+      .then((data) => {
+        const apiKey = typeof data.apiKey === "string" && data.apiKey.trim() ? data.apiKey.trim() : null;
+        if (!apiKey) throw new Error("API key mint response missing apiKey.");
+        setMintState({ phase: "success", app, apiKey, response: data });
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : "Failed to mint API key.";
+        setMintState({ phase: "error", app, message });
+      });
   }, []);
 
   return (
@@ -365,21 +427,48 @@ export default function AppsPage() {
 
                 {app.clientId ? (
                   <nav
-                    className="pointer-events-auto relative z-10 mt-auto flex flex-wrap justify-end gap-x-3 gap-y-1 border-t border-zinc-800/80 pt-3 text-sm font-medium"
+                    className="pointer-events-auto relative z-10 mt-auto flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-t border-zinc-800/80 pt-3 text-sm font-medium"
                     aria-label={`Shortcuts for ${app.name}`}
                   >
-                    <Link
-                      href={`/apps/${app.id}/usage`}
-                      className="shrink-0 text-zinc-400 underline decoration-zinc-600/45 decoration-1 underline-offset-[3px] hover:text-emerald-400 hover:decoration-emerald-500/35"
-                    >
-                      Usage
-                    </Link>
-                    <Link
-                      href={`/apps/${app.id}`}
-                      className="shrink-0 text-zinc-400 underline decoration-zinc-600/45 decoration-1 underline-offset-[3px] hover:text-emerald-400 hover:decoration-emerald-500/35"
-                    >
-                      Settings
-                    </Link>
+                    <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1">
+                      <Link
+                        href={`/apps/${app.id}/usage`}
+                        className="shrink-0 text-zinc-400 underline decoration-zinc-600/45 decoration-1 underline-offset-[3px] hover:text-emerald-400 hover:decoration-emerald-500/35"
+                      >
+                        Usage
+                      </Link>
+                      <Link
+                        href={`/apps/${app.id}`}
+                        className="shrink-0 text-zinc-400 underline decoration-zinc-600/45 decoration-1 underline-offset-[3px] hover:text-emerald-400 hover:decoration-emerald-500/35"
+                      >
+                        Settings
+                      </Link>
+                    </div>
+                    {app.isOwner && app.ownerExternalUserId ? (
+                      <button
+                        type="button"
+                        onClick={() => handleGetApiKey(app)}
+                        disabled={mintState?.phase === "minting" && mintState.appId === app.id}
+                        className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-emerald-600/50 px-2.5 py-1 text-xs font-medium text-emerald-400 transition-colors hover:border-emerald-500 hover:bg-emerald-500/10 hover:text-emerald-300 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {mintState?.phase === "minting" && mintState.appId === app.id ? (
+                          <span
+                            className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-emerald-600/40 border-t-emerald-400"
+                            aria-hidden
+                          />
+                        ) : (
+                          <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.75}
+                              d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+                            />
+                          </svg>
+                        )}
+                        {mintState?.phase === "minting" && mintState.appId === app.id ? "Getting…" : "Get API Key"}
+                      </button>
+                    ) : null}
                   </nav>
                 ) : null}
               </div>
@@ -387,6 +476,25 @@ export default function AppsPage() {
           ))}
         </div>
       )}
+      {mintState?.phase === "success" ? (
+        <GenerateSigningTokenDialog
+          phase="success"
+          appName={mintState.app.name}
+          ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
+          apiKey={mintState.apiKey}
+          response={mintState.response}
+          onClose={() => setMintState(null)}
+        />
+      ) : mintState?.phase === "error" ? (
+        <GenerateSigningTokenDialog
+          phase="error"
+          appName={mintState.app.name}
+          ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
+          message={mintState.message}
+          onClose={() => setMintState(null)}
+          onRetry={() => handleGetApiKey(mintState.app)}
+        />
+      ) : null}
     </DashboardLayout>
   );
 }

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  useCallback,
   useEffect,
   useRef,
   useState,

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -222,6 +222,7 @@ export default function AppsPage() {
   const [apps, setApps] = useState<AppSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const { mintState, handleGetApiKey, closeMintDialog } = useOwnerApiKeyMint<AppSummary>();
+  const isMintingApiKey = mintState?.phase === "minting";
 
   useEffect(() => {
     fetch("/api/v1/apps")
@@ -391,10 +392,10 @@ export default function AppsPage() {
                       <button
                         type="button"
                         onClick={() => handleGetApiKey(app)}
-                        disabled={mintState?.phase === "minting" && mintState.appId === app.id}
+                        disabled={isMintingApiKey}
                         className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-emerald-600/50 px-2.5 py-1 text-xs font-medium text-emerald-400 transition-colors hover:border-emerald-500 hover:bg-emerald-500/10 hover:text-emerald-300 disabled:cursor-not-allowed disabled:opacity-60"
                       >
-                        {mintState?.phase === "minting" && mintState.appId === app.id ? (
+                        {isMintingApiKey && mintState.appId === app.id ? (
                           <span
                             className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-emerald-600/40 border-t-emerald-400"
                             aria-hidden
@@ -409,7 +410,7 @@ export default function AppsPage() {
                             />
                           </svg>
                         )}
-                        {mintState?.phase === "minting" && mintState.appId === app.id ? "Getting…" : "Get API Key"}
+                        {isMintingApiKey && mintState.appId === app.id ? "Getting…" : "Get API Key"}
                       </button>
                     ) : null}
                   </nav>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,8 +7,8 @@ import { db } from "@/db/index";
 import { signerConfig, transactions, endUsers } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import Link from "next/link";
-import AppStatusBadge from "@/components/apps/AppStatusBadge";
-import { listUserAccessibleApps, type UserAppSummary } from "@/lib/user-apps";
+import { listUserAccessibleApps } from "@/lib/user-apps";
+import MyAppsSection from "@/components/apps/MyAppsSection";
 import {
   ACTIVE_STREAM_PAYMENT_WINDOW_LABEL,
   countActiveStreamsByRecentPayment,
@@ -291,142 +291,6 @@ async function DeveloperDashboard({ userId }: Readonly<{ userId: string }>) {
         <DocumentationCard />
       </div>
     </>
-  );
-}
-
-function myAppsSummaryText(appCount: number): string {
-  if (appCount === 0) {
-    return "Create an app to configure identity, plans, and payments.";
-  }
-  const noun = appCount === 1 ? "app" : "apps";
-  return `${appCount} ${noun} — open settings or usage from here.`;
-}
-
-function appListSecondaryLine(app: UserAppSummary): string | null {
-  if (app.subtitle) {
-    return app.subtitle;
-  }
-  if (app.clientId) {
-    return app.clientId;
-  }
-  return null;
-}
-
-function AppListSecondaryLine({ app }: Readonly<{ app: UserAppSummary }>) {
-  const secondaryLine = appListSecondaryLine(app);
-  if (!secondaryLine) {
-    return null;
-  }
-  return (
-    <p
-      className={`text-xs mt-0.5 truncate ${
-        app.subtitle ? "text-zinc-500" : "font-mono text-zinc-600"
-      }`}
-    >
-      {secondaryLine}
-    </p>
-  );
-}
-
-function MyAppsSection({ apps }: Readonly<{ apps: UserAppSummary[] }>) {
-  return (
-    <section className="rounded-xl border border-emerald-500/15 bg-white/[0.02] backdrop-blur-sm shadow-[inset_0_1px_0_rgba(52,211,153,0.06)]">
-      <div className="flex flex-col gap-3 border-b border-white/[0.06] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h3 className="font-semibold text-zinc-100">My Apps</h3>
-          <p className="text-sm text-zinc-500 mt-0.5">
-            {myAppsSummaryText(apps.length)}
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2 shrink-0">
-          {apps.length > 0 && (
-            <Link
-              href="/apps"
-              className="px-3 py-1.5 text-sm font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
-            >
-              View all
-            </Link>
-          )}
-          <Link
-            href="/apps/new"
-            className="inline-flex items-center gap-1.5 px-4 py-2 bg-emerald-600 text-white rounded-lg text-sm font-medium hover:bg-emerald-500 transition-colors"
-          >
-            Create app
-          </Link>
-        </div>
-      </div>
-
-      {apps.length === 0 ? (
-        <div className="px-5 py-10 text-center">
-          <div className="w-12 h-12 bg-zinc-800/80 rounded-xl flex items-center justify-center mx-auto mb-3">
-            <svg
-              className="w-6 h-6 text-zinc-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
-              />
-            </svg>
-          </div>
-          <p className="text-sm text-zinc-400 mb-4">No apps yet.</p>
-          <Link
-            href="/apps/new"
-            className="inline-flex px-4 py-2 bg-emerald-500/10 text-emerald-400 border border-emerald-500/25 rounded-lg text-sm font-medium hover:bg-emerald-500/20 transition-colors"
-          >
-            Create your first app
-          </Link>
-        </div>
-      ) : (
-        <ul className="divide-y divide-zinc-800/60">
-          {apps.map((app) => (
-            <li key={app.id} className="flex items-center gap-4 px-5 py-3.5 hover:bg-white/[0.03] transition-colors group">
-              <Link
-                href={`/apps/${app.id}`}
-                className="flex min-w-0 flex-1 items-center gap-4"
-              >
-                <div
-                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-linear-to-br from-emerald-500/20 to-teal-500/20 text-sm font-bold text-emerald-400"
-                  aria-hidden="true"
-                >
-                  {app.name[0]?.toUpperCase()}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium text-zinc-200 group-hover:text-emerald-400 transition-colors truncate">
-                      {app.name}
-                    </span>
-                    <AppStatusBadge status={app.status} />
-                  </div>
-                  <AppListSecondaryLine app={app} />
-                </div>
-              </Link>
-              <div className="hidden sm:flex items-center gap-3 shrink-0 text-xs font-medium">
-                {app.clientId && (
-                  <Link
-                    href={`/apps/${app.id}/usage`}
-                    className="text-zinc-500 hover:text-emerald-400 transition-colors"
-                  >
-                    Usage
-                  </Link>
-                )}
-                <Link
-                  href={`/apps/${app.id}`}
-                  className="text-zinc-600 hover:text-zinc-300 transition-colors"
-                >
-                  Settings →
-                </Link>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
   );
 }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,7 +6,6 @@ import { redirect } from "next/navigation";
 import { db } from "@/db/index";
 import { signerConfig, transactions, endUsers } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import Link from "next/link";
 import { listUserAccessibleApps } from "@/lib/user-apps";
 import MyAppsSection from "@/components/apps/MyAppsSection";
 import {

--- a/src/components/apps/GenerateSigningTokenDialog.tsx
+++ b/src/components/apps/GenerateSigningTokenDialog.tsx
@@ -16,7 +16,15 @@ type GenerateSigningTokenDialogProps = Readonly<{
   | { phase: "error"; message: string; onRetry: () => void }
 )>;
 
-function CopyApiKeyButton({ apiKey }: { apiKey: string }) {
+function maskApiKey(apiKey: unknown): unknown {
+  if (typeof apiKey !== "string" || apiKey.length <= 24) {
+    return apiKey;
+  }
+
+  return `${apiKey.slice(0, 12)}…${apiKey.slice(-8)}`;
+}
+
+function CopyApiKeyButton({ apiKey }: Readonly<{ apiKey: string }>) {
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -45,13 +53,20 @@ function CopyApiKeyButton({ apiKey }: { apiKey: string }) {
     );
   }, [apiKey]);
 
+  let buttonLabel = "Copy";
+  if (copied) {
+    buttonLabel = "Copied";
+  } else if (copyFailed) {
+    buttonLabel = "Copy failed";
+  }
+
   return (
     <button
       type="button"
       onClick={copy}
       className="shrink-0 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors"
     >
-      {copied ? "Copied" : copyFailed ? "Copy failed" : "Copy"}
+      {buttonLabel}
     </button>
   );
 }
@@ -75,11 +90,11 @@ export default function GenerateSigningTokenDialog(props: GenerateSigningTokenDi
         aria-label="Close dialog"
         onClick={onClose}
       />
-      <div
-        role="dialog"
+      <dialog
+        open
         aria-modal="true"
         aria-labelledby="signing-token-dialog-title"
-        className="relative z-10 w-full max-w-lg rounded-xl border border-zinc-800 bg-zinc-900 p-6 shadow-xl"
+        className="relative z-10 m-0 w-full max-w-lg rounded-xl border border-zinc-800 bg-zinc-900 p-6 shadow-xl"
       >
         <div className="flex items-start justify-between gap-4 mb-4">
           <div>
@@ -153,10 +168,7 @@ export default function GenerateSigningTokenDialog(props: GenerateSigningTokenDi
                 {JSON.stringify(
                   {
                     ...props.response,
-                    apiKey:
-                      typeof props.response.apiKey === "string" && props.response.apiKey.length > 24
-                        ? `${props.response.apiKey.slice(0, 12)}…${props.response.apiKey.slice(-8)}`
-                        : props.response.apiKey,
+                    apiKey: maskApiKey(props.response.apiKey),
                   },
                   null,
                   2,
@@ -174,7 +186,7 @@ export default function GenerateSigningTokenDialog(props: GenerateSigningTokenDi
             </div>
           </div>
         ) : null}
-      </div>
+      </dialog>
     </div>
   );
 }

--- a/src/components/apps/GenerateSigningTokenDialog.tsx
+++ b/src/components/apps/GenerateSigningTokenDialog.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+type GenerateSigningTokenDialogProps = Readonly<{
+  appName: string;
+  ownerExternalUserId: string;
+  onClose: () => void;
+} & (
+  | { phase: "success"; apiKey: string; response: Record<string, unknown> }
+  | { phase: "error"; message: string; onRetry: () => void }
+)>;
+
+function CopyApiKeyButton({ apiKey }: { apiKey: string }) {
+  const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const copy = useCallback(() => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      setCopyFailed(true);
+      timeoutRef.current = setTimeout(() => { timeoutRef.current = null; setCopyFailed(false); }, 2000);
+      return;
+    }
+    void navigator.clipboard.writeText(apiKey).then(
+      () => {
+        setCopied(true);
+        timeoutRef.current = setTimeout(() => { timeoutRef.current = null; setCopied(false); }, 2000);
+      },
+      () => {
+        setCopyFailed(true);
+        timeoutRef.current = setTimeout(() => { timeoutRef.current = null; setCopyFailed(false); }, 2000);
+      },
+    );
+  }, [apiKey]);
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="shrink-0 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors"
+    >
+      {copied ? "Copied" : copyFailed ? "Copy failed" : "Copy"}
+    </button>
+  );
+}
+
+export default function GenerateSigningTokenDialog(props: GenerateSigningTokenDialogProps) {
+  const { appName, ownerExternalUserId, onClose } = props;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/60"
+        aria-label="Close dialog"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="signing-token-dialog-title"
+        className="relative z-10 w-full max-w-lg rounded-xl border border-zinc-800 bg-zinc-900 p-6 shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div>
+            <h2
+              id="signing-token-dialog-title"
+              className="text-base font-semibold text-zinc-100"
+            >
+              Get API Key
+            </h2>
+            <p className="text-sm text-zinc-500 mt-1">{appName}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="shrink-0 rounded-md p-1.5 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <p className="text-xs text-zinc-500 mb-4">
+          Bound to owner identity:{" "}
+          <span className="font-mono text-zinc-400">{ownerExternalUserId}</span>
+        </p>
+
+        {props.phase === "error" ? (
+          <div className="space-y-4">
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3">
+              <p className="text-sm text-red-300">{props.message}</p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                onClick={props.onRetry}
+                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {props.phase === "success" ? (
+          <div className="space-y-4">
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+              <p className="text-sm text-amber-200">
+                Store this API key securely. It will not be shown again.
+              </p>
+            </div>
+            <div className="rounded-lg border border-zinc-800 bg-zinc-950/50 p-4">
+              <div className="flex items-start justify-between gap-3">
+                <code className="min-w-0 flex-1 break-all font-mono text-xs text-emerald-400 leading-relaxed">
+                  {props.apiKey}
+                </code>
+                <CopyApiKeyButton apiKey={props.apiKey} />
+              </div>
+            </div>
+            <details className="text-xs text-zinc-500">
+              <summary className="cursor-pointer hover:text-zinc-400">Response details</summary>
+              <pre className="mt-2 overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-950/50 p-3 font-mono text-[11px] text-zinc-400">
+                {JSON.stringify(
+                  {
+                    ...props.response,
+                    apiKey:
+                      typeof props.response.apiKey === "string" && props.response.apiKey.length > 24
+                        ? `${props.response.apiKey.slice(0, 12)}…${props.response.apiKey.slice(-8)}`
+                        : props.response.apiKey,
+                  },
+                  null,
+                  2,
+                )}
+              </pre>
+            </details>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/apps/MyAppsSection.tsx
+++ b/src/components/apps/MyAppsSection.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import AppStatusBadge from "@/components/apps/AppStatusBadge";
+import GenerateSigningTokenDialog from "@/components/apps/GenerateSigningTokenDialog";
+import type { UserAppSummary } from "@/lib/user-apps";
+
+async function postJson(
+  path: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  let parsed: Record<string, unknown> = {};
+  try { parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {}; } catch { parsed = {}; }
+  if (!response.ok) {
+    const message =
+      (typeof parsed.error_description === "string" && parsed.error_description) ||
+      (typeof parsed.error === "string" && parsed.error) ||
+      text || `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+  return parsed;
+}
+
+async function mintOwnerApiKey(input: {
+  clientId: string;
+  ownerExternalUserId: string;
+}): Promise<Record<string, unknown>> {
+  const externalUserId = input.ownerExternalUserId.trim();
+  if (!externalUserId) throw new Error("Owner identity is unavailable.");
+  await postJson(`/api/v1/apps/${encodeURIComponent(input.clientId)}/users`, {
+    externalUserId,
+    status: "active",
+  });
+  return postJson(
+    `/api/v1/apps/${encodeURIComponent(input.clientId)}/users/${encodeURIComponent(externalUserId)}/keys`,
+    { label: "signing-token" },
+  );
+}
+
+type CardMintState =
+  | { phase: "minting"; appId: string }
+  | { phase: "success"; app: UserAppSummary; apiKey: string; response: Record<string, unknown> }
+  | { phase: "error"; app: UserAppSummary; message: string };
+
+function myAppsSummaryText(count: number): string {
+  if (count === 0) return "No apps yet — create one to get started.";
+  if (count === 1) return "1 app — open settings or usage from here.";
+  return `${count} apps — open settings or usage from here.`;
+}
+
+type AppListSecondaryLineProps = Readonly<{ app: UserAppSummary }>;
+
+function AppListSecondaryLine({ app }: AppListSecondaryLineProps) {
+  if (app.clientId) {
+    return (
+      <p className="text-xs text-zinc-500 font-mono mt-0.5 truncate">
+        {app.clientId}
+      </p>
+    );
+  }
+  if (app.subtitle) {
+    return (
+      <p className="text-xs text-zinc-500 mt-0.5 truncate">{app.subtitle}</p>
+    );
+  }
+  return null;
+}
+
+export default function MyAppsSection({ apps }: Readonly<{ apps: UserAppSummary[] }>) {
+  const [mintState, setMintState] = useState<CardMintState | null>(null);
+
+  const handleGetApiKey = useCallback((app: UserAppSummary) => {
+    if (!app.clientId || !app.ownerExternalUserId) return;
+    setMintState({ phase: "minting", appId: app.id });
+    void mintOwnerApiKey({ clientId: app.clientId, ownerExternalUserId: app.ownerExternalUserId })
+      .then((data) => {
+        const apiKey = typeof data.apiKey === "string" && data.apiKey.trim() ? data.apiKey.trim() : null;
+        if (!apiKey) throw new Error("API key mint response missing apiKey.");
+        setMintState({ phase: "success", app, apiKey, response: data });
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : "Failed to mint API key.";
+        setMintState({ phase: "error", app, message });
+      });
+  }, []);
+
+  return (
+    <>
+      <section className="rounded-xl border border-emerald-500/15 bg-white/[0.02] backdrop-blur-sm shadow-[inset_0_1px_0_rgba(52,211,153,0.06)]">
+        <div className="flex flex-col gap-3 border-b border-white/[0.06] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="font-semibold text-zinc-100">My Apps</h3>
+            <p className="text-sm text-zinc-500 mt-0.5">
+              {myAppsSummaryText(apps.length)}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 shrink-0">
+            {apps.length > 0 && (
+              <Link
+                href="/apps"
+                className="px-3 py-1.5 text-sm font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
+              >
+                View all
+              </Link>
+            )}
+            <Link
+              href="/apps/new"
+              className="inline-flex items-center gap-1.5 px-4 py-2 bg-emerald-600 text-white rounded-lg text-sm font-medium hover:bg-emerald-500 transition-colors"
+            >
+              Create app
+            </Link>
+          </div>
+        </div>
+
+        {apps.length === 0 ? (
+          <div className="px-5 py-10 text-center">
+            <div className="w-12 h-12 bg-zinc-800/80 rounded-xl flex items-center justify-center mx-auto mb-3">
+              <svg
+                className="w-6 h-6 text-zinc-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+                />
+              </svg>
+            </div>
+            <p className="text-sm text-zinc-400 mb-4">No apps yet.</p>
+            <Link
+              href="/apps/new"
+              className="inline-flex px-4 py-2 bg-emerald-500/10 text-emerald-400 border border-emerald-500/25 rounded-lg text-sm font-medium hover:bg-emerald-500/20 transition-colors"
+            >
+              Create your first app
+            </Link>
+          </div>
+        ) : (
+          <ul className="divide-y divide-zinc-800/60">
+            {apps.map((app) => (
+              <li key={app.id} className="flex items-center gap-4 px-5 py-3.5 hover:bg-white/[0.03] transition-colors group">
+                <Link
+                  href={`/apps/${app.id}`}
+                  className="flex min-w-0 flex-1 items-center gap-4"
+                >
+                  <div
+                    className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-linear-to-br from-emerald-500/20 to-teal-500/20 text-sm font-bold text-emerald-400"
+                    aria-hidden="true"
+                  >
+                    {app.name[0]?.toUpperCase()}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium text-zinc-200 group-hover:text-emerald-400 transition-colors truncate">
+                        {app.name}
+                      </span>
+                      <AppStatusBadge status={app.status} />
+                    </div>
+                    <AppListSecondaryLine app={app} />
+                  </div>
+                </Link>
+                <div className="hidden sm:flex items-center gap-3 shrink-0 text-xs font-medium">
+                  {app.clientId && (
+                    <Link
+                      href={`/apps/${app.id}/usage`}
+                      className="text-zinc-500 hover:text-emerald-400 transition-colors"
+                    >
+                      Usage
+                    </Link>
+                  )}
+                  <Link
+                    href={`/apps/${app.id}`}
+                    className="text-zinc-600 hover:text-zinc-300 transition-colors"
+                  >
+                    Settings →
+                  </Link>
+                  {app.isOwner && app.ownerExternalUserId && app.clientId ? (
+                    <button
+                      type="button"
+                      onClick={() => handleGetApiKey(app)}
+                      disabled={mintState?.phase === "minting" && mintState.appId === app.id}
+                      className="inline-flex items-center gap-1 rounded-md border border-emerald-600/50 px-2 py-0.5 text-xs font-medium text-emerald-400 transition-colors hover:border-emerald-500 hover:bg-emerald-500/10 hover:text-emerald-300 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {mintState?.phase === "minting" && mintState.appId === app.id ? (
+                        <span
+                          className="h-3 w-3 animate-spin rounded-full border-2 border-emerald-600/40 border-t-emerald-400"
+                          aria-hidden
+                        />
+                      ) : (
+                        <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.75}
+                            d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+                          />
+                        </svg>
+                      )}
+                      {mintState?.phase === "minting" && mintState.appId === app.id ? "Getting…" : "Get API Key"}
+                    </button>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {mintState?.phase === "success" ? (
+        <GenerateSigningTokenDialog
+          phase="success"
+          appName={mintState.app.name}
+          ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
+          apiKey={mintState.apiKey}
+          response={mintState.response}
+          onClose={() => setMintState(null)}
+        />
+      ) : mintState?.phase === "error" ? (
+        <GenerateSigningTokenDialog
+          phase="error"
+          appName={mintState.app.name}
+          ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
+          message={mintState.message}
+          onClose={() => setMintState(null)}
+          onRetry={() => handleGetApiKey(mintState.app)}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/components/apps/MyAppsSection.tsx
+++ b/src/components/apps/MyAppsSection.tsx
@@ -1,53 +1,10 @@
 "use client";
 
-import { useCallback, useState } from "react";
 import Link from "next/link";
 import AppStatusBadge from "@/components/apps/AppStatusBadge";
-import GenerateSigningTokenDialog from "@/components/apps/GenerateSigningTokenDialog";
+import OwnerApiKeyMintDialog from "@/components/apps/OwnerApiKeyMintDialog";
+import { useOwnerApiKeyMint } from "@/components/apps/use-owner-api-key-mint";
 import type { UserAppSummary } from "@/lib/user-apps";
-
-async function postJson(
-  path: string,
-  body: Record<string, unknown>,
-): Promise<Record<string, unknown>> {
-  const response = await fetch(path, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Accept: "application/json" },
-    body: JSON.stringify(body),
-  });
-  const text = await response.text();
-  let parsed: Record<string, unknown> = {};
-  try { parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {}; } catch { parsed = {}; }
-  if (!response.ok) {
-    const message =
-      (typeof parsed.error_description === "string" && parsed.error_description) ||
-      (typeof parsed.error === "string" && parsed.error) ||
-      text || `Request failed (${response.status})`;
-    throw new Error(message);
-  }
-  return parsed;
-}
-
-async function mintOwnerApiKey(input: {
-  clientId: string;
-  ownerExternalUserId: string;
-}): Promise<Record<string, unknown>> {
-  const externalUserId = input.ownerExternalUserId.trim();
-  if (!externalUserId) throw new Error("Owner identity is unavailable.");
-  await postJson(`/api/v1/apps/${encodeURIComponent(input.clientId)}/users`, {
-    externalUserId,
-    status: "active",
-  });
-  return postJson(
-    `/api/v1/apps/${encodeURIComponent(input.clientId)}/users/${encodeURIComponent(externalUserId)}/keys`,
-    { label: "signing-token" },
-  );
-}
-
-type CardMintState =
-  | { phase: "minting"; appId: string }
-  | { phase: "success"; app: UserAppSummary; apiKey: string; response: Record<string, unknown> }
-  | { phase: "error"; app: UserAppSummary; message: string };
 
 function myAppsSummaryText(count: number): string {
   if (count === 0) return "No apps yet — create one to get started.";
@@ -74,22 +31,8 @@ function AppListSecondaryLine({ app }: AppListSecondaryLineProps) {
 }
 
 export default function MyAppsSection({ apps }: Readonly<{ apps: UserAppSummary[] }>) {
-  const [mintState, setMintState] = useState<CardMintState | null>(null);
-
-  const handleGetApiKey = useCallback((app: UserAppSummary) => {
-    if (!app.clientId || !app.ownerExternalUserId) return;
-    setMintState({ phase: "minting", appId: app.id });
-    void mintOwnerApiKey({ clientId: app.clientId, ownerExternalUserId: app.ownerExternalUserId })
-      .then((data) => {
-        const apiKey = typeof data.apiKey === "string" && data.apiKey.trim() ? data.apiKey.trim() : null;
-        if (!apiKey) throw new Error("API key mint response missing apiKey.");
-        setMintState({ phase: "success", app, apiKey, response: data });
-      })
-      .catch((err) => {
-        const message = err instanceof Error ? err.message : "Failed to mint API key.";
-        setMintState({ phase: "error", app, message });
-      });
-  }, []);
+  const { mintState, handleGetApiKey, closeMintDialog } =
+    useOwnerApiKeyMint<UserAppSummary>();
 
   return (
     <>
@@ -216,25 +159,13 @@ export default function MyAppsSection({ apps }: Readonly<{ apps: UserAppSummary[
         )}
       </section>
 
-      {mintState?.phase === "success" ? (
-        <GenerateSigningTokenDialog
-          phase="success"
-          appName={mintState.app.name}
-          ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
-          apiKey={mintState.apiKey}
-          response={mintState.response}
-          onClose={() => setMintState(null)}
-        />
-      ) : mintState?.phase === "error" ? (
-        <GenerateSigningTokenDialog
-          phase="error"
-          appName={mintState.app.name}
-          ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
-          message={mintState.message}
-          onClose={() => setMintState(null)}
-          onRetry={() => handleGetApiKey(mintState.app)}
-        />
-      ) : null}
+      <OwnerApiKeyMintDialog
+        mintState={
+          mintState?.phase === "minting" ? null : mintState
+        }
+        onClose={closeMintDialog}
+        onRetry={handleGetApiKey}
+      />
     </>
   );
 }

--- a/src/components/apps/OwnerApiKeyMintDialog.tsx
+++ b/src/components/apps/OwnerApiKeyMintDialog.tsx
@@ -4,6 +4,8 @@ import GenerateSigningTokenDialog from "@/components/apps/GenerateSigningTokenDi
 import type { OwnerApiKeyMintState } from "@/components/apps/use-owner-api-key-mint";
 
 type DialogApp = {
+  id: string;
+  clientId: string | null;
   name: string;
   ownerExternalUserId: string | null;
 };

--- a/src/components/apps/OwnerApiKeyMintDialog.tsx
+++ b/src/components/apps/OwnerApiKeyMintDialog.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import GenerateSigningTokenDialog from "@/components/apps/GenerateSigningTokenDialog";
+import type { OwnerApiKeyMintState } from "@/components/apps/use-owner-api-key-mint";
+
+type DialogApp = {
+  name: string;
+  ownerExternalUserId: string | null;
+};
+
+type DialogState<TApp extends DialogApp> =
+  | Extract<OwnerApiKeyMintState<TApp>, { phase: "success" }>
+  | Extract<OwnerApiKeyMintState<TApp>, { phase: "error" }>;
+
+type OwnerApiKeyMintDialogProps<TApp extends DialogApp> = Readonly<{
+  mintState: DialogState<TApp> | null;
+  onClose: () => void;
+  onRetry: (app: TApp) => void;
+}>;
+
+export default function OwnerApiKeyMintDialog<TApp extends DialogApp>({
+  mintState,
+  onClose,
+  onRetry,
+}: OwnerApiKeyMintDialogProps<TApp>) {
+  if (!mintState) return null;
+
+  if (mintState.phase === "success") {
+    return (
+      <GenerateSigningTokenDialog
+        phase="success"
+        appName={mintState.app.name}
+        ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
+        apiKey={mintState.apiKey}
+        response={mintState.response}
+        onClose={onClose}
+      />
+    );
+  }
+
+  return (
+    <GenerateSigningTokenDialog
+      phase="error"
+      appName={mintState.app.name}
+      ownerExternalUserId={mintState.app.ownerExternalUserId ?? ""}
+      message={mintState.message}
+      onClose={onClose}
+      onRetry={() => onRetry(mintState.app)}
+    />
+  );
+}

--- a/src/components/apps/mint-owner-api-key.ts
+++ b/src/components/apps/mint-owner-api-key.ts
@@ -17,7 +17,7 @@ async function postJson(
       parsed?.error_description,
       parsed?.error,
       `Request failed (${response.status})`,
-    ].find((value): value is string => typeof value === "string" && value.trim());
+    ].find((value): value is string => typeof value === "string" && value.trim().length > 0);
     throw new Error(message);
   }
 

--- a/src/components/apps/mint-owner-api-key.ts
+++ b/src/components/apps/mint-owner-api-key.ts
@@ -8,25 +8,20 @@ async function postJson(
     body: JSON.stringify(body),
   });
 
-  const text = await response.text();
-  let parsed: Record<string, unknown> = {};
-
-  try {
-    parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {};
-  } catch {
-    parsed = {};
-  }
+  const parsed = (await response.json().catch(() => null)) as
+    | { error_description?: unknown; error?: unknown }
+    | null;
 
   if (!response.ok) {
-    const message =
-      (typeof parsed.error_description === "string" && parsed.error_description) ||
-      (typeof parsed.error === "string" && parsed.error) ||
-      text ||
-      `Request failed (${response.status})`;
+    const message = [
+      parsed?.error_description,
+      parsed?.error,
+      `Request failed (${response.status})`,
+    ].find((value): value is string => typeof value === "string" && value.trim());
     throw new Error(message);
   }
 
-  return parsed;
+  return parsed ? (parsed as Record<string, unknown>) : {};
 }
 
 export async function mintOwnerApiKey(input: {

--- a/src/components/apps/mint-owner-api-key.ts
+++ b/src/components/apps/mint-owner-api-key.ts
@@ -1,0 +1,48 @@
+async function postJson(
+  path: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  let parsed: Record<string, unknown> = {};
+
+  try {
+    parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+  } catch {
+    parsed = {};
+  }
+
+  if (!response.ok) {
+    const message =
+      (typeof parsed.error_description === "string" && parsed.error_description) ||
+      (typeof parsed.error === "string" && parsed.error) ||
+      text ||
+      `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  return parsed;
+}
+
+export async function mintOwnerApiKey(input: {
+  clientId: string;
+  ownerExternalUserId: string;
+}): Promise<Record<string, unknown>> {
+  const externalUserId = input.ownerExternalUserId.trim();
+  if (!externalUserId) throw new Error("Owner identity is unavailable.");
+
+  await postJson(`/api/v1/apps/${encodeURIComponent(input.clientId)}/users`, {
+    externalUserId,
+    status: "active",
+  });
+
+  return postJson(
+    `/api/v1/apps/${encodeURIComponent(input.clientId)}/users/${encodeURIComponent(externalUserId)}/keys`,
+    { label: "signing-token" },
+  );
+}

--- a/src/components/apps/use-owner-api-key-mint.ts
+++ b/src/components/apps/use-owner-api-key-mint.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { mintOwnerApiKey } from "@/components/apps/mint-owner-api-key";
+
+type MintableApp = {
+  id: string;
+  clientId: string | null;
+  ownerExternalUserId: string | null;
+};
+
+export type OwnerApiKeyMintState<TApp extends MintableApp> =
+  | { phase: "minting"; appId: string }
+  | { phase: "success"; app: TApp; apiKey: string; response: Record<string, unknown> }
+  | { phase: "error"; app: TApp; message: string };
+
+export function useOwnerApiKeyMint<TApp extends MintableApp>() {
+  const [mintState, setMintState] = useState<OwnerApiKeyMintState<TApp> | null>(
+    null,
+  );
+
+  const handleGetApiKey = useCallback((app: TApp) => {
+    if (!app.clientId || !app.ownerExternalUserId) return;
+
+    setMintState({ phase: "minting", appId: app.id });
+    mintOwnerApiKey({
+      clientId: app.clientId,
+      ownerExternalUserId: app.ownerExternalUserId,
+    })
+      .then((data) => {
+        const apiKey =
+          typeof data.apiKey === "string" && data.apiKey.trim()
+            ? data.apiKey.trim()
+            : null;
+        if (!apiKey) throw new Error("API key mint response missing apiKey.");
+        setMintState({ phase: "success", app, apiKey, response: data });
+      })
+      .catch((err) => {
+        const message =
+          err instanceof Error ? err.message : "Failed to mint API key.";
+        setMintState({ phase: "error", app, message });
+      });
+  }, []);
+
+  return {
+    mintState,
+    handleGetApiKey,
+    closeMintDialog: () => setMintState(null),
+  };
+}

--- a/src/components/apps/use-owner-api-key-mint.ts
+++ b/src/components/apps/use-owner-api-key-mint.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { mintOwnerApiKey } from "@/components/apps/mint-owner-api-key";
 
 type MintableApp = {
@@ -18,10 +18,12 @@ export function useOwnerApiKeyMint<TApp extends MintableApp>() {
   const [mintState, setMintState] = useState<OwnerApiKeyMintState<TApp> | null>(
     null,
   );
+  const isMintingRef = useRef(false);
 
   const handleGetApiKey = useCallback((app: TApp) => {
-    if (!app.clientId || !app.ownerExternalUserId) return;
+    if (!app.clientId || !app.ownerExternalUserId || isMintingRef.current) return;
 
+    isMintingRef.current = true;
     setMintState({ phase: "minting", appId: app.id });
     mintOwnerApiKey({
       clientId: app.clientId,
@@ -39,6 +41,9 @@ export function useOwnerApiKeyMint<TApp extends MintableApp>() {
         const message =
           err instanceof Error ? err.message : "Failed to mint API key.";
         setMintState({ phase: "error", app, message });
+      })
+      .finally(() => {
+        isMintingRef.current = false;
       });
   }, []);
 

--- a/src/lib/user-apps.ts
+++ b/src/lib/user-apps.ts
@@ -11,6 +11,8 @@ export type UserAppSummary = {
   logoLightUrl: string | null;
   clientId: string | null;
   createdAt: string;
+  isOwner: boolean;
+  ownerExternalUserId: string | null;
 };
 
 /** Apps the user owns or is an admin of (same set as GET /api/v1/apps). */
@@ -55,6 +57,8 @@ export async function listUserAccessibleApps(userId: string): Promise<UserAppSum
           .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
           .where(inArray(developerApps.id, memberIds));
 
+  const ownedIds = new Set(ownedApps.map((a) => a.id).filter(Boolean));
+
   return [...ownedApps, ...memberApps]
     .filter(
       (app, index, rows) => rows.findIndex((row) => row.id === app.id) === index,
@@ -68,6 +72,8 @@ export async function listUserAccessibleApps(userId: string): Promise<UserAppSum
       logoLightUrl: app.logoLightUrl,
       clientId: app.clientId,
       createdAt: app.createdAt,
+      isOwner: ownedIds.has(app.id ?? ""),
+      ownerExternalUserId: ownedIds.has(app.id ?? "") ? userId : null,
     }))
     .filter((app) => app.id.length > 0)
     .sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary

Add owner API key minting so app owners can generate and copy a signing API key directly from `/apps` and the dashboard.

- Add `OwnerApiKeyMintDialog`, `useOwnerApiKeyMint`, and `mintOwnerApiKey` with masked key display, copy-to-clipboard, error/retry handling, and serialized mint state to prevent concurrent requests from clobbering shared UI
- Extend app listings with `isOwner` and `ownerExternalUserId` in `listUserAccessibleApps` and `/api/v1/apps`
- Extract `MyAppsSection` from the dashboard and wire ownership-aware "Get API Key" actions into both `/apps` and the dashboard
- Fix a dropped `useCallback` import in `CopyPublicAppIdButton`, simplify mint helper JSON/error parsing, and tighten the mint helper type predicate for Vercel type-checking

## Test plan

- [ ] Sign in as an app owner and confirm "Get API Key" appears only on owned apps on `/apps` and the dashboard
- [ ] Mint an API key and verify the dialog shows a masked key, copy works, and retry/close behave correctly
- [ ] Start a mint on one app and confirm a second mint cannot clobber the in-flight state
- [ ] Confirm member (non-owner) apps do not show the mint action
- [ ] Verify `/api/v1/apps` returns `isOwner` and `ownerExternalUserId` as expected
- [ ] Confirm `CopyPublicAppIdButton` works on `/apps` without a runtime error