### PR TITLE
fix(ci): SonarCloud script injection in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -43,10 +43,12 @@ jobs:
 
       - name: Bump package version
         id: bump
+        env:
+          VERSION_BUMP: ${{ inputs.version }}
         run: |
           CURRENT=$(node -p "require('./package.json').version")
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-          npm version "${{ inputs.version }}" --no-git-tag-version
+          npm version "$VERSION_BUMP" --no-git-tag-version
           NEW=$(node -p "require('./package.json').version")
           echo "version=$NEW" >> "$GITHUB_OUTPUT"
           echo "Bumped $CURRENT → $NEW"


### PR DESCRIPTION
## Summary

Fixes SonarCloud quality gate failure (`githubactions:S7630`) on `.github/workflows/bump-version.yml` by routing `inputs.version` through an environment variable instead of interpolating it directly in the `run` block.

## Test plan

- [ ] SonarCloud Code Analysis passes on this PR
- [ ] Other CI checks pass