### PR TITLE
chore: bump version to v0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymthouse",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pymthouse",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@braintree/sanitize-url": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymthouse",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "private": true,
   "engines": {
     "node": ">=20.18.1"


### PR DESCRIPTION
## Summary

Version-only bump: `package.json` / `package-lock.json` → **0.3.2**.

No workflow or other changes.

## Test plan

- [ ] CI passes

After merge, tag from your machine to trigger production deploys:

```bash
git pull origin main
git tag v0.3.2
git push origin v0.3.2
```