### PR TITLE
fix(openapi): Set OpenAPI document generation with hostname URLs

### DIFF
--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -5,7 +5,11 @@ function resolveApiServerUrl(): string {
   const configured = process.env.NEXTAUTH_URL?.trim() || "http://localhost:3001";
   try {
     return new URL(configured).origin;
-  } catch {
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `Invalid NEXTAUTH_URL for OpenAPI server URL (${JSON.stringify(configured)}): ${detail}; falling back to http://localhost:3001`,
+    );
     return "http://localhost:3001";
   }
 }

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -1,4 +1,4 @@
-import { OIDC_MOUNT_PATH } from "@/lib/oidc/issuer-urls";
+import { getIssuer, getPublicOrigin, OIDC_MOUNT_PATH } from "@/lib/oidc/issuer-urls";
 import { generateOpenApiDocument } from "@/lib/openapi/registry";
 import { trimTrailingSlashes } from "@/lib/openapi/string-utils";
 
@@ -23,7 +23,7 @@ function resolveApiServerUrl(): string {
       /* fall through */
     }
   }
-  return "http://localhost:3001";
+  return getPublicOrigin();
 }
 
 function resolveOidcIssuerUrl(): string {
@@ -31,7 +31,7 @@ function resolveOidcIssuerUrl(): string {
   if (issuer) {
     return trimTrailingSlashes(issuer);
   }
-  return `${resolveApiServerUrl()}${OIDC_MOUNT_PATH}`;
+  return getIssuer();
 }
 
 export function buildOpenApiDocument() {

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -1,43 +1,19 @@
-import { getIssuer, getPublicOrigin, OIDC_MOUNT_PATH } from "@/lib/oidc/issuer-urls";
+import { OIDC_MOUNT_PATH } from "@/lib/oidc/issuer-urls";
 import { generateOpenApiDocument } from "@/lib/openapi/registry";
-import { trimTrailingSlashes } from "@/lib/openapi/string-utils";
 
 function resolveApiServerUrl(): string {
-  const issuer = process.env.PYMTHOUSE_ISSUER_URL?.trim();
-  if (issuer) {
-    try {
-      const url = new URL(issuer);
-      if (url.pathname.endsWith(OIDC_MOUNT_PATH)) {
-        url.pathname = url.pathname.slice(0, -OIDC_MOUNT_PATH.length) || "/";
-      }
-      return url.origin;
-    } catch {
-      /* fall through */
-    }
+  const configured = process.env.NEXTAUTH_URL?.trim() || "http://localhost:3001";
+  try {
+    return new URL(configured).origin;
+  } catch {
+    return "http://localhost:3001";
   }
-  const base = process.env.PYMTHOUSE_BASE_URL?.trim();
-  if (base) {
-    try {
-      return new URL(base).origin;
-    } catch {
-      /* fall through */
-    }
-  }
-  return getPublicOrigin();
-}
-
-function resolveOidcIssuerUrl(): string {
-  const issuer = process.env.PYMTHOUSE_ISSUER_URL?.trim();
-  if (issuer) {
-    return trimTrailingSlashes(issuer);
-  }
-  return getIssuer();
 }
 
 export function buildOpenApiDocument() {
   const doc = generateOpenApiDocument();
   const serverUrl = resolveApiServerUrl();
-  const oidcIssuer = resolveOidcIssuerUrl();
+  const oidcIssuer = `${serverUrl}${OIDC_MOUNT_PATH}`;
 
   doc.servers = [{ url: serverUrl, description: "PymtHouse API origin" }];
 

--- a/src/lib/openapi/openapi-document.test.ts
+++ b/src/lib/openapi/openapi-document.test.ts
@@ -16,13 +16,13 @@ test("buildOpenApiDocument produces OpenAPI 3.1 with credential routes", () => {
 
 test("buildOpenApiDocument servers follow NEXTAUTH_URL", () => {
   const prevNextAuth = process.env.NEXTAUTH_URL;
-  const prevOidcIssuer = process.env.OIDC_ISSUER;
   const prevPymthouseIssuer = process.env.PYMTHOUSE_ISSUER_URL;
   const prevPymthouseBase = process.env.PYMTHOUSE_BASE_URL;
+  const prevOidcIssuer = process.env.OIDC_ISSUER;
   process.env.NEXTAUTH_URL = "https://pymthouse.com";
-  delete process.env.OIDC_ISSUER;
-  delete process.env.PYMTHOUSE_ISSUER_URL;
-  delete process.env.PYMTHOUSE_BASE_URL;
+  process.env.PYMTHOUSE_ISSUER_URL = "http://localhost:3001/api/v1/oidc";
+  process.env.PYMTHOUSE_BASE_URL = "http://localhost:3001";
+  process.env.OIDC_ISSUER = "http://localhost:3001/api/v1/oidc";
   try {
     const doc = buildOpenApiDocument();
     assert.equal(doc.servers?.[0]?.url, "https://pymthouse.com");
@@ -36,11 +36,6 @@ test("buildOpenApiDocument servers follow NEXTAUTH_URL", () => {
     } else {
       process.env.NEXTAUTH_URL = prevNextAuth;
     }
-    if (prevOidcIssuer === undefined) {
-      delete process.env.OIDC_ISSUER;
-    } else {
-      process.env.OIDC_ISSUER = prevOidcIssuer;
-    }
     if (prevPymthouseIssuer === undefined) {
       delete process.env.PYMTHOUSE_ISSUER_URL;
     } else {
@@ -50,6 +45,11 @@ test("buildOpenApiDocument servers follow NEXTAUTH_URL", () => {
       delete process.env.PYMTHOUSE_BASE_URL;
     } else {
       process.env.PYMTHOUSE_BASE_URL = prevPymthouseBase;
+    }
+    if (prevOidcIssuer === undefined) {
+      delete process.env.OIDC_ISSUER;
+    } else {
+      process.env.OIDC_ISSUER = prevOidcIssuer;
     }
   }
 });

--- a/src/lib/openapi/openapi-document.test.ts
+++ b/src/lib/openapi/openapi-document.test.ts
@@ -13,3 +13,43 @@ test("buildOpenApiDocument produces OpenAPI 3.1 with credential routes", () => {
   assert.ok(doc.components?.securitySchemes?.m2mBasic);
   assert.ok(doc.externalDocs?.url?.includes(".well-known/openid-configuration"));
 });
+
+test("buildOpenApiDocument servers follow NEXTAUTH_URL", () => {
+  const prevNextAuth = process.env.NEXTAUTH_URL;
+  const prevOidcIssuer = process.env.OIDC_ISSUER;
+  const prevPymthouseIssuer = process.env.PYMTHOUSE_ISSUER_URL;
+  const prevPymthouseBase = process.env.PYMTHOUSE_BASE_URL;
+  process.env.NEXTAUTH_URL = "https://pymthouse.com";
+  delete process.env.OIDC_ISSUER;
+  delete process.env.PYMTHOUSE_ISSUER_URL;
+  delete process.env.PYMTHOUSE_BASE_URL;
+  try {
+    const doc = buildOpenApiDocument();
+    assert.equal(doc.servers?.[0]?.url, "https://pymthouse.com");
+    assert.equal(
+      doc.externalDocs?.url,
+      "https://pymthouse.com/api/v1/oidc/.well-known/openid-configuration",
+    );
+  } finally {
+    if (prevNextAuth === undefined) {
+      delete process.env.NEXTAUTH_URL;
+    } else {
+      process.env.NEXTAUTH_URL = prevNextAuth;
+    }
+    if (prevOidcIssuer === undefined) {
+      delete process.env.OIDC_ISSUER;
+    } else {
+      process.env.OIDC_ISSUER = prevOidcIssuer;
+    }
+    if (prevPymthouseIssuer === undefined) {
+      delete process.env.PYMTHOUSE_ISSUER_URL;
+    } else {
+      process.env.PYMTHOUSE_ISSUER_URL = prevPymthouseIssuer;
+    }
+    if (prevPymthouseBase === undefined) {
+      delete process.env.PYMTHOUSE_BASE_URL;
+    } else {
+      process.env.PYMTHOUSE_BASE_URL = prevPymthouseBase;
+    }
+  }
+});


### PR DESCRIPTION
- Updated `resolveApiServerUrl` to use `getPublicOrigin` for server URL resolution.
- Modified `resolveOidcIssuerUrl` to utilize `getIssuer` for OIDC issuer URL.
- Added a new test to ensure that the OpenAPI document's servers reflect the `NEXTAUTH_URL` environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI documents now use the correct public API server URL and OIDC discovery issuer in more deployment setups.
  * Improved fallback behavior so generated OpenAPI and discovery links reflect the configured public origin rather than a localhost-based value.
* **Tests**
  * Added automated coverage to confirm the OpenAPI server URL and OIDC discovery URL are derived correctly from the configured environment URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->