### PR TITLE
Fix GitHub logo links to point to official pymthouse repo

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -221,7 +221,7 @@ export default function MarketplacePage() {
               Home
             </Link>
             <a
-              href="https://github.com/eliteprox/pymthouse"
+              href="https://github.com/pymthouse/pymthouse"
               target="_blank"
               rel="noopener noreferrer"
               className="p-2 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60 border border-transparent hover:border-zinc-700 transition-colors"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -297,7 +297,7 @@ export default async function HomePage() {
               Marketplace
             </Link>
             <a
-              href="https://github.com/eliteprox/pymthouse"
+              href="https://github.com/pymthouse/pymthouse"
               target="_blank"
               rel="noopener noreferrer"
               className="p-2 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60 border border-transparent hover:border-zinc-700 transition-colors"

--- a/src/components/MarketingFooter.tsx
+++ b/src/components/MarketingFooter.tsx
@@ -44,7 +44,7 @@ export function MarketingFooter({ className = "" }: { className?: string }) {
           <p className="text-zinc-500 uppercase tracking-wider mb-2">Help</p>
           <div className="space-y-1.5">
             <a
-              href="https://github.com/eliteprox/pymthouse"
+              href="https://github.com/pymthouse/pymthouse"
               target="_blank"
               rel="noopener noreferrer"
               className="block text-zinc-400 hover:text-zinc-200 transition-colors"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The GitHub logo/icon links on the marketing pages pointed at the `eliteprox/pymthouse` fork instead of the official `pymthouse/pymthouse` repository.

## Changes

Updated the GitHub `href` in:
- `src/app/page.tsx` (homepage header GitHub icon)
- `src/app/marketplace/page.tsx` (marketplace header GitHub icon)
- `src/components/MarketingFooter.tsx` (footer GitHub link)

All now point to `https://github.com/pymthouse/pymthouse`.

## Test plan

- [ ] Open homepage and click the GitHub icon — should navigate to `github.com/pymthouse/pymthouse`
- [ ] Open `/marketplace` and click the GitHub icon — same destination
- [ ] Scroll to footer on a marketing page and click the GitHub link — same destination
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be81d086-fbc3-4431-bb06-f390eb99d754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be81d086-fbc3-4431-bb06-f390eb99d754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

