### PR TITLE
feat(auth): composite app_*.pmth_* API keys + identity-webhook 0.3.3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,13 @@ ETH_USD_PRICE=3500
 # JWT_* / CLAIM_* names are unchanged — mapped to OIDC_* internally).
 # JWKS is resolved via OIDC discovery: {issuer}/.well-known/openid-configuration → jwks_uri.
 # Optional override: OIDC_JWKS_URI=https://staging.pymthouse.com/api/v1/oidc/jwks
+# Composite API keys (app_*.pmth_*): RFC 8693 exchange base URL (HTTPS; http loopback ok).
+# Defaults to NEXTAUTH_URL when unset.
+# OIDC_TOKEN_EXCHANGE_BASE_URL=https://staging.pymthouse.com
+# Optional M2M Basic auth for the exchange call (recommended in staging/prod):
+# OIDC_EXCHANGE_M2M_CLIENT_ID=
+# OIDC_EXCHANGE_M2M_CLIENT_SECRET=
+# Default required scope for minted JWTs is sign:job; override with OIDC_REQUIRED_SCOPES.
 JWT_ISSUER=
 JWT_AUDIENCE=
 CLAIM_CLIENT_ID=client_id

--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -51,9 +51,12 @@ M2M secret rotation remains at `POST /api/v1/apps/{clientId}/credentials` (provi
 
 | Prefix | Role | RFC usage |
 | --- | --- | --- |
-| `pmth_<hex>` | Per-app-user **API key** | `subject_token` on `POST /api/v1/apps/{clientId}/oidc/token` |
+| `pmth_<hex>` | Per-app-user **API key** (stored / hashed form) | `subject_token` on `POST /api/v1/apps/{clientId}/oidc/token` |
+| `app_<clientId>.pmth_<hex>` | **Presented** API key (issuance + remote-signer Bearer) | Same as bare `pmth_*`; prefix is public routing for the app-scoped exchange URL |
 | `pmth_cs_<hex>` | Confidential **M2M client secret** | HTTP Basic with `m2m_…` client id (RFC 6749 §2.3.1) — never the API-key bearer exchange |
 | `app_…` / `m2m_…` | Public / confidential OAuth client ids | Path params and token endpoint `client_id` |
+
+Newly issued keys are returned as `app_<clientId>.pmth_<hex>` (RFC 6750-safe `.` separator). The remote-signer identity webhook accepts that composite Bearer, parses the `app_*` prefix, and performs RFC 8693 exchange at `/api/v1/apps/{clientId}/oidc/token`. Bare `pmth_*` remains valid as `subject_token` when the path already supplies `{clientId}`.
 
 Do not pass `pmth_cs_*` as `subject_token` on the signer session exchange route — use M2M HTTP Basic instead.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",
         "@pymthouse/builder-sdk": "^0.5.0",
-        "@pymthouse/clearinghouse-identity-webhook": "^0.3.2",
+        "@pymthouse/clearinghouse-identity-webhook": "^0.3.3",
         "@tailwindcss/postcss": "^4.1.18",
         "@turnkey/crypto": "^2.10.0",
         "@turnkey/react-wallet-kit": "^1.11.1",
@@ -2260,9 +2260,9 @@
       }
     },
     "node_modules/@pymthouse/clearinghouse-identity-webhook": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@pymthouse/clearinghouse-identity-webhook/-/clearinghouse-identity-webhook-0.3.2.tgz",
-      "integrity": "sha512-qqXt7sFTszxNFMrsnfPo0KobwF5T9GTd2AKww9XZ+3oyHjwECaP8+IHTkKRfynwZk5RSTSKkanJqGwzt5Q6Y7w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@pymthouse/clearinghouse-identity-webhook/-/clearinghouse-identity-webhook-0.3.3.tgz",
+      "integrity": "sha512-yUOcDYDw55holf7ZKkbv+2tk3tyNklidGGQ9XkrtCfTUk6VR3f5KbTvkHExm+I5KwyWq6+UkkqXZRyMBGyN21w==",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.9.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",
         "@pymthouse/builder-sdk": "^0.5.0",
-        "@pymthouse/clearinghouse-identity-webhook": "^0.3.1",
+        "@pymthouse/clearinghouse-identity-webhook": "^0.3.2",
         "@tailwindcss/postcss": "^4.1.18",
         "@turnkey/crypto": "^2.10.0",
         "@turnkey/react-wallet-kit": "^1.11.1",
@@ -2260,9 +2260,9 @@
       }
     },
     "node_modules/@pymthouse/clearinghouse-identity-webhook": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@pymthouse/clearinghouse-identity-webhook/-/clearinghouse-identity-webhook-0.3.1.tgz",
-      "integrity": "sha512-J6kKzPi/2YI45980fFgHRwESWsxi6AKQ3mOZGqn4TPvRc8HIBzSaQpqoKhtGWBe6ZDtZrvl1s7gNY4UO9H5vqA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@pymthouse/clearinghouse-identity-webhook/-/clearinghouse-identity-webhook-0.3.2.tgz",
+      "integrity": "sha512-qqXt7sFTszxNFMrsnfPo0KobwF5T9GTd2AKww9XZ+3oyHjwECaP8+IHTkKRfynwZk5RSTSKkanJqGwzt5Q6Y7w==",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.9.6"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@braintree/sanitize-url": "^7.1.2",
     "@openmeter/sdk": "^1.0.0-beta.228",
     "@pymthouse/builder-sdk": "^0.5.0",
-    "@pymthouse/clearinghouse-identity-webhook": "^0.3.2",
+    "@pymthouse/clearinghouse-identity-webhook": "^0.3.3",
     "@tailwindcss/postcss": "^4.1.18",
     "@turnkey/crypto": "^2.10.0",
     "@turnkey/react-wallet-kit": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@braintree/sanitize-url": "^7.1.2",
     "@openmeter/sdk": "^1.0.0-beta.228",
     "@pymthouse/builder-sdk": "^0.5.0",
-    "@pymthouse/clearinghouse-identity-webhook": "^0.3.1",
+    "@pymthouse/clearinghouse-identity-webhook": "^0.3.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@turnkey/crypto": "^2.10.0",
     "@turnkey/react-wallet-kit": "^1.11.1",

--- a/src/app/api/v1/apps/[id]/users/[externalUserId]/keys/route.ts
+++ b/src/app/api/v1/apps/[id]/users/[externalUserId]/keys/route.ts
@@ -111,6 +111,7 @@ export async function POST(
   const created = await createAppUserApiKey({
     developerAppId: access.app.id,
     appUserId: appUser.id,
+    publicClientId: clientId,
     label,
   });
 
@@ -139,7 +140,8 @@ export async function POST(
       suffix: created.suffix,
       label: created.label,
       createdAt: created.createdAt,
-      message: "Store this API key securely. It will not be shown again.",
+      message:
+        "Store this API key securely. It will not be shown again. Use the full app_<clientId>.pmth_<key> value as Authorization Bearer for the remote signer.",
       correlation_id: correlationId,
     },
     { status: 201 },

--- a/src/app/api/v1/apps/[id]/users/[externalUserId]/keys/route.ts
+++ b/src/app/api/v1/apps/[id]/users/[externalUserId]/keys/route.ts
@@ -141,7 +141,7 @@ export async function POST(
       label: created.label,
       createdAt: created.createdAt,
       message:
-        "Store this API key securely. It will not be shown again. Use the full app_<clientId>.pmth_<key> value as Authorization Bearer for the remote signer.",
+        "Store this API key securely. It will not be shown again. Use the full app_<clientId>.pmth_<key> value as Authorization: Bearer <token> for the remote signer.",
       correlation_id: correlationId,
     },
     { status: 201 },

--- a/src/app/webhooks/remote-signer/route.test.mjs
+++ b/src/app/webhooks/remote-signer/route.test.mjs
@@ -67,3 +67,68 @@ test("remote-signer webhook rejects invalid request json", async () => {
   assert.equal(body.status, 400);
   assert.equal(body.reason, "invalid request json");
 });
+
+test("remote-signer webhook authorizes composite app_*.pmth_* via mocked exchange", async () => {
+  const { SignJWT, createLocalJWKSet, exportJWK, generateKeyPair } = await import("jose");
+  const { createOidcVerifier } = await import(
+    "@pymthouse/clearinghouse-identity-webhook/verifiers"
+  );
+
+  const { publicKey, privateKey } = await generateKeyPair("RS256");
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = "pymthouse-test";
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+  const jwks = createLocalJWKSet({ keys: [jwk] });
+  const clientId = "app_abc123";
+  const minted = await new SignJWT({
+    client_id: clientId,
+    external_user_id: "user-456",
+    scope: "sign:job",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: "pymthouse-test" })
+    .setIssuer(JWT_ISSUER)
+    .setAudience(JWT_ISSUER)
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(privateKey);
+
+  const fetchImpl = async (input) => {
+    const url = String(input);
+    assert.ok(url.includes(`/api/v1/apps/${clientId}/oidc/token`));
+    return Response.json({ access_token: minted, expires_in: 300 });
+  };
+
+  const config = {
+    webhookSecret: WEBHOOK_SECRET,
+    endUserAuth: createOidcVerifier({
+      jwtIssuer: JWT_ISSUER,
+      jwtAudience: JWT_ISSUER,
+      issuer: JWT_ISSUER,
+      jwks,
+      clientClaim: "client_id",
+      subjectClaim: "external_user_id",
+      subjectTypeValue: "external_user_id",
+      requiredScopes: ["sign:job"],
+      tokenExchangeBaseUrl: "http://localhost:3000",
+      fetchImpl,
+    }),
+  };
+
+  const request = new Request("http://localhost/webhooks/remote-signer", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${WEBHOOK_SECRET}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      headers: { Authorization: [`Bearer ${clientId}.pmth_deadbeef`] },
+    }),
+  });
+
+  const response = await handleAuthorize(request, config);
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.status, 200);
+  assert.equal(body.auth_id, "app_abc123:user-456");
+});

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -155,7 +155,7 @@ curl -sS -u "${m2mClientId}:YOUR_CLIENT_SECRET" \
   -X POST ${origin}/api/v1/apps/${encodedClientId}/users \
   -d ${createUserBody}
 
-# 2) Mint per-user API key (pmth_*) for livepeer-gateway:
+# 2) Mint per-user API key (returned as app_<clientId>.pmth_*):
 curl -sS -u "${m2mClientId}:YOUR_CLIENT_SECRET" \
   -H "Content-Type: application/json" \
   -X POST ${origin}/api/v1/apps/${encodedClientId}/users/${encodedUserId}/keys \
@@ -650,12 +650,16 @@ function M2mTokenTestResult({
           </pre>
           {tokenKind === "api_key" ? (
             <p className="text-[11px] text-zinc-500">
-              Returned <span className="font-mono text-zinc-400">pmth_*</span> is a per-user API
-              key and can be exchanged at{" "}
+              Returned{" "}
+              <span className="font-mono text-zinc-400">app_&lt;clientId&gt;.pmth_*</span> is a
+              per-user API key. Use it as{" "}
+              <span className="font-mono text-zinc-400">Authorization: Bearer</span> on the remote
+              signer (python-gateway <span className="font-mono text-zinc-400">--token</span>{" "}
+              blob), or as <span className="font-mono text-zinc-400">subject_token</span> at{" "}
               <span className="font-mono text-zinc-400">
                 POST /api/v1/apps/{`{clientId}`}/oidc/token
-              </span>{" "}
-              (for example from <span className="font-mono text-zinc-400">livepeer-gateway</span>).
+              </span>
+              .
             </p>
           ) : null}
           {tokenKind === "signer_session" ? (

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -659,7 +659,7 @@ function M2mTokenTestResult({
               <span className="font-mono text-zinc-400">
                 POST /api/v1/apps/{`{clientId}`}/oidc/token
               </span>
-              .
+              {"."}
             </p>
           ) : null}
           {tokenKind === "signer_session" ? (

--- a/src/lib/app-api-keys.test.ts
+++ b/src/lib/app-api-keys.test.ts
@@ -107,3 +107,66 @@ test("resolveActiveAppApiKey returns null for non-pmth tokens without DB", async
   const resolved = await resolveActiveAppApiKey("sk_not_pmth", "app_test");
   assert.equal(resolved, null);
 });
+
+test("splitCompositeApiKey parses app_*.pmth_* and rejects malformed forms", async () => {
+  const { splitCompositeApiKey, formatCompositeApiKey, normalizeAppApiKeySubjectToken } =
+    await import("@/lib/app-api-keys");
+
+  assert.deepEqual(
+    splitCompositeApiKey("app_abc123.pmth_deadbeef"),
+    { publicClientId: "app_abc123", apiKey: "pmth_deadbeef" },
+  );
+  assert.equal(splitCompositeApiKey("pmth_deadbeef"), null);
+  assert.equal(splitCompositeApiKey("app_abc:pmth_deadbeef"), null);
+  assert.equal(splitCompositeApiKey("app_abc.pmth_cs_secret"), null);
+  assert.equal(splitCompositeApiKey("app_ABC.pmth_x"), null);
+
+  assert.equal(
+    formatCompositeApiKey("app_abc123", "pmth_deadbeef"),
+    "app_abc123.pmth_deadbeef",
+  );
+  assert.equal(
+    normalizeAppApiKeySubjectToken("app_abc123.pmth_deadbeef", "app_abc123"),
+    "pmth_deadbeef",
+  );
+  assert.equal(
+    normalizeAppApiKeySubjectToken("app_other.pmth_deadbeef", "app_abc123"),
+    null,
+  );
+  assert.equal(
+    normalizeAppApiKeySubjectToken("pmth_deadbeef", "app_abc123"),
+    "pmth_deadbeef",
+  );
+});
+
+run("resolveActiveAppApiKey accepts composite app_*.pmth_* subject tokens", async (t) => {
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(app));
+
+  const appUser = await createAppUser({
+    clientId: app.clientId,
+    externalUserId: `user-${randomUUID()}`,
+  });
+  const bare = `pmth_${"e".repeat(64)}`;
+  const composite = `${app.clientId}.${bare}`;
+
+  await db.insert(apiKeys).values({
+    id: `key-${randomUUID()}`,
+    keyHash: hashToken(bare),
+    clientId: app.clientId,
+    appUserId: appUser.id,
+    label: "composite key",
+    status: "active",
+  });
+
+  const resolved = await resolveActiveAppApiKey(composite, app.clientId);
+  assert.ok(resolved);
+  assert.equal(resolved?.appUserId, appUser.id);
+  assert.equal(resolved?.publicClientId, app.clientId);
+
+  const mismatched = await resolveActiveAppApiKey(
+    `app_otherclientid000.${bare}`,
+    app.clientId,
+  );
+  assert.equal(mismatched, null);
+});

--- a/src/lib/app-api-keys.test.ts
+++ b/src/lib/app-api-keys.test.ts
@@ -112,29 +112,34 @@ test("splitCompositeApiKey parses app_*.pmth_* and rejects malformed forms", asy
   const { splitCompositeApiKey, formatCompositeApiKey, normalizeAppApiKeySubjectToken } =
     await import("@/lib/app-api-keys");
 
+  const clientId = "app_3b386c81a1db1169fd2c3986";
+  const otherClientId = "app_aaaaaaaaaaaaaaaaaaaaaaaa";
+
   assert.deepEqual(
-    splitCompositeApiKey("app_abc123.pmth_deadbeef"),
-    { publicClientId: "app_abc123", apiKey: "pmth_deadbeef" },
+    splitCompositeApiKey(`${clientId}.pmth_deadbeef`),
+    { publicClientId: clientId, apiKey: "pmth_deadbeef" },
   );
   assert.equal(splitCompositeApiKey("pmth_deadbeef"), null);
   assert.equal(splitCompositeApiKey("app_abc:pmth_deadbeef"), null);
   assert.equal(splitCompositeApiKey("app_abc.pmth_cs_secret"), null);
   assert.equal(splitCompositeApiKey("app_ABC.pmth_x"), null);
+  assert.equal(splitCompositeApiKey("app_abc123.pmth_deadbeef"), null);
+  assert.equal(splitCompositeApiKey("app_nothexnothexnothexnot!.pmth_x"), null);
 
   assert.equal(
-    formatCompositeApiKey("app_abc123", "pmth_deadbeef"),
-    "app_abc123.pmth_deadbeef",
+    formatCompositeApiKey(clientId, "pmth_deadbeef"),
+    `${clientId}.pmth_deadbeef`,
   );
   assert.equal(
-    normalizeAppApiKeySubjectToken("app_abc123.pmth_deadbeef", "app_abc123"),
+    normalizeAppApiKeySubjectToken(`${clientId}.pmth_deadbeef`, clientId),
     "pmth_deadbeef",
   );
   assert.equal(
-    normalizeAppApiKeySubjectToken("app_other.pmth_deadbeef", "app_abc123"),
+    normalizeAppApiKeySubjectToken(`${otherClientId}.pmth_deadbeef`, clientId),
     null,
   );
   assert.equal(
-    normalizeAppApiKeySubjectToken("pmth_deadbeef", "app_abc123"),
+    normalizeAppApiKeySubjectToken("pmth_deadbeef", clientId),
     "pmth_deadbeef",
   );
 });

--- a/src/lib/app-api-keys.ts
+++ b/src/lib/app-api-keys.ts
@@ -30,12 +30,68 @@ export function maskApiKeySuffix(keyPrefix: string | null | undefined): string {
   return raw.slice(-4);
 }
 
+/** Public client id segment: `app_` + lowercase hex (matches generateClientId). */
+const COMPOSITE_CLIENT_ID_RE = /^app_[a-z0-9]+$/;
+
+/**
+ * Split a composite credential `app_<clientId>.pmth_<key>` into parts.
+ * Returns null for bare `pmth_*`, JWTs, or malformed forms.
+ */
+export function splitCompositeApiKey(
+  token: string,
+): { publicClientId: string; apiKey: string } | null {
+  const trimmed = token.trim();
+  const dot = trimmed.indexOf(".");
+  if (dot <= 0 || trimmed.indexOf(".", dot + 1) !== -1) {
+    return null;
+  }
+  const publicClientId = trimmed.slice(0, dot);
+  const apiKey = trimmed.slice(dot + 1);
+  if (!COMPOSITE_CLIENT_ID_RE.test(publicClientId)) {
+    return null;
+  }
+  if (!apiKey.startsWith("pmth_") || apiKey.startsWith("pmth_cs_")) {
+    return null;
+  }
+  return { publicClientId, apiKey };
+}
+
+/** Format the one-time presented API key as `app_<clientId>.pmth_<key>`. */
+export function formatCompositeApiKey(
+  publicClientId: string,
+  bareApiKey: string,
+): string {
+  return `${publicClientId.trim()}.${bareApiKey.trim()}`;
+}
+
+/**
+ * Normalize a subject_token that may be bare `pmth_*` or composite
+ * `app_*.pmth_*`. When composite, the prefix must match `publicClientId`.
+ */
+export function normalizeAppApiKeySubjectToken(
+  subjectToken: string,
+  publicClientId: string,
+): string | null {
+  const trimmed = subjectToken.trim();
+  const composite = splitCompositeApiKey(trimmed);
+  if (composite) {
+    if (composite.publicClientId !== publicClientId.trim()) {
+      return null;
+    }
+    return composite.apiKey;
+  }
+  if (!trimmed.startsWith("pmth_") || trimmed.startsWith("pmth_cs_")) {
+    return null;
+  }
+  return trimmed;
+}
+
 export async function resolveActiveAppApiKey(
   bearerToken: string,
   publicClientId: string,
 ): Promise<ResolvedAppApiKey | null> {
-  const token = bearerToken.trim();
-  if (!token.startsWith("pmth_")) {
+  const token = normalizeAppApiKeySubjectToken(bearerToken, publicClientId);
+  if (!token) {
     return null;
   }
 
@@ -125,6 +181,8 @@ export async function listAppUserApiKeys(input: {
 export async function createAppUserApiKey(input: {
   developerAppId: string;
   appUserId: string;
+  /** Public OIDC client id (`app_*`); when set, returned `apiKey` is composite. */
+  publicClientId?: string | null;
   label?: string | null;
 }) {
   const apiKeyValue = generateApiKeyValue();
@@ -145,9 +203,14 @@ export async function createAppUserApiKey(input: {
     revokedAt: null,
   });
 
+  const publicClientId = input.publicClientId?.trim() || "";
+  const presented = publicClientId
+    ? formatCompositeApiKey(publicClientId, apiKeyValue)
+    : apiKeyValue;
+
   return {
     id,
-    apiKey: apiKeyValue,
+    apiKey: presented,
     prefix: maskApiKeyPrefix(apiKeyValue.slice(0, 16)),
     suffix: maskApiKeySuffix(apiKeyValue),
     label: input.label?.trim() || null,

--- a/src/lib/app-api-keys.ts
+++ b/src/lib/app-api-keys.ts
@@ -30,8 +30,8 @@ export function maskApiKeySuffix(keyPrefix: string | null | undefined): string {
   return raw.slice(-4);
 }
 
-/** Public client id segment: `app_` + lowercase hex (matches generateClientId). */
-const COMPOSITE_CLIENT_ID_RE = /^app_[a-z0-9]+$/;
+/** Public client id segment: `app_` + 24 lowercase hex chars (matches generateClientId). */
+const COMPOSITE_CLIENT_ID_RE = /^app_[a-f0-9]{24}$/;
 
 /**
  * Split a composite credential `app_<clientId>.pmth_<key>` into parts.
@@ -42,7 +42,7 @@ export function splitCompositeApiKey(
 ): { publicClientId: string; apiKey: string } | null {
   const trimmed = token.trim();
   const dot = trimmed.indexOf(".");
-  if (dot <= 0 || trimmed.indexOf(".", dot + 1) !== -1) {
+  if (dot <= 0 || trimmed.slice(dot + 1).includes(".")) {
     return null;
   }
   const publicClientId = trimmed.slice(0, dot);

--- a/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
@@ -101,6 +101,45 @@ test("resolveAppScopedSubjectToken rejects pmth_cs_* client secrets as subject_t
   );
 });
 
+test("resolveAppScopedSubjectToken accepts composite app_*.pmth_* via resolveActiveAppApiKey", async () => {
+  const bare = "pmth_compositesubject";
+  const composite = `${PUBLIC_ID}.${bare}`;
+  const resolved = await resolveAppScopedSubjectToken(composite, PUBLIC_ID, {
+    resolveActiveAppApiKey: async (token, publicClientId) => {
+      assert.equal(token, composite);
+      assert.equal(publicClientId, PUBLIC_ID);
+      return {
+        apiKeyId: "key-1",
+        developerAppId: "dev-1",
+        publicClientId: PUBLIC_ID,
+        appUserId: "au-1",
+        externalUserId: "ext-1",
+        label: null,
+      };
+    },
+  });
+  assert.equal(resolved.externalUserId, "ext-1");
+  assert.equal(resolved.publicClientId, PUBLIC_ID);
+});
+
+test("resolveAppScopedSubjectToken rejects composite with mismatched app_ prefix", async () => {
+  await assert.rejects(
+    () =>
+      resolveAppScopedSubjectToken(
+        "app_otherclientid000.pmth_compositesubject",
+        PUBLIC_ID,
+        {
+          resolveActiveAppApiKey: async () => null,
+        },
+      ),
+    (err: unknown) => {
+      assert.ok(err instanceof AppScopedSignerTokenExchangeError);
+      assert.equal(err.code, "invalid_grant");
+      return true;
+    },
+  );
+});
+
 test("handleAppScopedSignerTokenExchange rejects wrong grant_type", async () => {
   await assert.rejects(
     () =>

--- a/src/lib/oidc/app-scoped-signer-token-exchange.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.ts
@@ -87,6 +87,10 @@ function isJwtSubjectToken(subjectToken: string): boolean {
   if (subjectToken.startsWith("pmth_")) {
     return false;
   }
+  // Composite API keys are `app_*.pmth_*` (one dot); JWTs have three segments.
+  if (subjectToken.startsWith("app_") && subjectToken.includes(".pmth_")) {
+    return false;
+  }
   return subjectToken.split(".").length === 3;
 }
 
@@ -202,7 +206,11 @@ export async function resolveAppScopedSubjectToken(
     }
   }
 
-  if (!token.startsWith("pmth_") || token.startsWith("pmth_cs_")) {
+  // Bare pmth_* or composite app_*.pmth_* (resolved via resolveActiveAppApiKey).
+  const looksLikeApiKey =
+    (token.startsWith("pmth_") && !token.startsWith("pmth_cs_")) ||
+    (token.startsWith("app_") && token.includes(".pmth_"));
+  if (!looksLikeApiKey) {
     throw new AppScopedSignerTokenExchangeError(
       "invalid_grant",
       "subject_token is not a valid access token for this issuer",


### PR DESCRIPTION
## Summary
- Issue per-user API keys as `app_<clientId>.pmth_<key>` (storage still hashes the bare `pmth_*` value) and accept that form as `subject_token` on the app-scoped RFC 8693 exchange.
- Bump `@pymthouse/clearinghouse-identity-webhook` to **0.3.3** so OIDC mode can authorize composite Bearers via server-side exchange (JWKS discovery + `OIDC_TOKEN_EXCHANGE_BASE_URL`).
- Docs / TestingStep / webhook unit test updated for the composite credential path.

Split out of #208 so approval-workflow work stays separate from auth/OIDC changes.

## Test plan
- [ ] `npm test` — app-api-keys, app-scoped-signer-token-exchange, remote-signer route tests
- [ ] Mint a key via `POST /api/v1/apps/{clientId}/users/{externalUserId}/keys` and confirm response is `app_….pmth_…`
- [ ] Exchange bare `pmth_*` and composite `app_*.pmth_*` as `subject_token` against `/oidc/token`
- [ ] Staging: python-gateway `--token` blob with `signer_headers.Authorization: Bearer app_….pmth_…` authorizes (no client-side JWT exchange)