### PR TITLE
fix(signer): accept opaque pmth_ session at generate-live-payment webhook

### DIFF
--- a/src/app/webhooks/remote-signer/route.ts
+++ b/src/app/webhooks/remote-signer/route.ts
@@ -1,11 +1,28 @@
 import { getIssuer } from "@/lib/oidc/issuer-urls";
+import { createFirstMatchEndUserVerifier } from "@/lib/signer/first-match-verifier";
+import { createOpaqueSessionEndUserVerifier } from "@/lib/signer/opaque-session-verifier";
 import { handleAuthorize } from "@pymthouse/clearinghouse-identity-webhook/protocol";
-import { createLegacyWebhookConfigFromEnv } from "@pymthouse/clearinghouse-identity-webhook/legacy-env";
+import {
+  createLegacyOidcVerifierFromEnv,
+  createLegacyWebhookConfigFromEnv,
+} from "@pymthouse/clearinghouse-identity-webhook/legacy-env";
+import type { RemoteSignerWebhookConfig } from "@pymthouse/clearinghouse-identity-webhook/protocol";
 
-function buildWebhookConfig() {
-  return createLegacyWebhookConfigFromEnv(process.env, {
-    jwtIssuer: process.env.JWT_ISSUER?.trim() || getIssuer(),
+function buildWebhookConfig(): RemoteSignerWebhookConfig {
+  const jwtIssuer = process.env.JWT_ISSUER?.trim() || getIssuer();
+  const base = createLegacyWebhookConfigFromEnv(process.env, { jwtIssuer });
+
+  const opaqueSessionVerifier = createOpaqueSessionEndUserVerifier({
+    issuer: jwtIssuer,
   });
+
+  return {
+    webhookSecret: base.webhookSecret,
+    endUserAuth: createFirstMatchEndUserVerifier([
+      opaqueSessionVerifier,
+      createLegacyOidcVerifierFromEnv(process.env, { jwtIssuer }),
+    ]),
+  };
 }
 
 export async function POST(request: Request): Promise<Response> {

--- a/src/lib/signer/first-match-verifier.ts
+++ b/src/lib/signer/first-match-verifier.ts
@@ -1,0 +1,43 @@
+import {
+  WebhookError,
+  type EndUserAuthVerifier,
+} from "@pymthouse/clearinghouse-identity-webhook/protocol";
+
+/**
+ * Try verifiers in order; return the first successful result. Re-throws the last
+ * {@link WebhookError} or wraps other errors so the JWT/OIDC path stays unchanged.
+ */
+export function createFirstMatchEndUserVerifier(
+  verifiers: EndUserAuthVerifier[],
+): EndUserAuthVerifier {
+  if (verifiers.length === 0) {
+    throw new WebhookError("at least one verifier is required", {
+      status: 500,
+      code: "invalid_verifier_config",
+    });
+  }
+
+  return {
+    kind: "composite",
+    verify: async (context) => {
+      let lastError: unknown;
+      for (const verifier of verifiers) {
+        try {
+          return await verifier.verify(context);
+        } catch (err) {
+          lastError = err;
+        }
+      }
+      if (lastError instanceof WebhookError) {
+        throw lastError;
+      }
+      if (lastError instanceof Error) {
+        throw new WebhookError(lastError.message, {
+          status: 401,
+          code: "invalid_credentials",
+        });
+      }
+      throw new WebhookError("authorization rejected", { status: 403 });
+    },
+  };
+}

--- a/src/lib/signer/opaque-session-verifier.ts
+++ b/src/lib/signer/opaque-session-verifier.ts
@@ -1,0 +1,116 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import { endUsers } from "@/db/schema";
+import { hasScope, validateBearerToken } from "@/lib/auth";
+import {
+  bearerToken,
+  type EndUserAuthVerifier,
+  type UsageIdentity,
+} from "@pymthouse/clearinghouse-identity-webhook/protocol";
+
+/**
+ * Opaque `pmth_*` remote-signer session acceptance for the remote-signer
+ * identity webhook.
+ *
+ * The OIDC verifier only accepts signer JWTs (`aud = issuer`, JWKS-verifiable),
+ * so an opaque `pmth_…` remote-signer session is rejected with "Invalid JWT".
+ * `/sign-orchestrator-info` already works from that opaque session; payment was
+ * the only asymmetric gate.
+ */
+
+const OPAQUE_SESSION_PREFIX = "pmth_";
+const DEFAULT_REQUIRED_SCOPE = "sign:job";
+const DEFAULT_EXPIRY_TTL_SECONDS = 300;
+const USAGE_SUBJECT_TYPE = "external_user_id";
+
+export type OpaqueSessionPrincipal = {
+  clientId: string;
+  externalUserId: string;
+};
+
+export type OpaqueSessionEndUserVerifierConfig = {
+  issuer: string;
+  requiredScope?: string;
+  expiryTtlSeconds?: number;
+  resolvePrincipal?: (token: string) => Promise<OpaqueSessionPrincipal | null>;
+};
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+async function resolvePrincipalFromSession(
+  token: string,
+  requiredScope: string,
+): Promise<OpaqueSessionPrincipal | null> {
+  const auth = await validateBearerToken(token);
+  if (!auth) {
+    return null;
+  }
+  if (!hasScope(auth.scopes, requiredScope)) {
+    return null;
+  }
+  if (!auth.appId || !auth.endUserId) {
+    return null;
+  }
+
+  const rows = await db
+    .select({ externalUserId: endUsers.externalUserId })
+    .from(endUsers)
+    .where(eq(endUsers.id, auth.endUserId))
+    .limit(1);
+  const externalUserId = rows[0]?.externalUserId?.trim();
+  if (!externalUserId) {
+    return null;
+  }
+
+  return { clientId: auth.appId.trim(), externalUserId };
+}
+
+export function createOpaqueSessionEndUserVerifier(
+  config: OpaqueSessionEndUserVerifierConfig,
+): EndUserAuthVerifier {
+  const issuer = stripTrailingSlashes(config.issuer.trim());
+  if (!issuer) {
+    throw new Error("issuer is required for opaque session verification");
+  }
+  const requiredScope = config.requiredScope?.trim() || DEFAULT_REQUIRED_SCOPE;
+  const expiryTtlSeconds =
+    config.expiryTtlSeconds && config.expiryTtlSeconds > 0
+      ? Math.trunc(config.expiryTtlSeconds)
+      : DEFAULT_EXPIRY_TTL_SECONDS;
+  const resolvePrincipal =
+    config.resolvePrincipal ??
+    ((token: string) => resolvePrincipalFromSession(token, requiredScope));
+
+  return {
+    kind: "opaque_session",
+    verify: async ({ authorization }) => {
+      const token = bearerToken(authorization);
+      if (!token.startsWith(OPAQUE_SESSION_PREFIX)) {
+        throw new Error("not an opaque remote-signer session");
+      }
+
+      const principal = await resolvePrincipal(token);
+      if (!principal) {
+        throw new Error("invalid or unauthorized remote-signer session");
+      }
+
+      const identity: UsageIdentity = {
+        issuer,
+        client_id: principal.clientId,
+        usage_subject: principal.externalUserId,
+        usage_subject_type: USAGE_SUBJECT_TYPE,
+      };
+
+      return {
+        identity,
+        expiry: Math.trunc(Date.now() / 1000) + expiryTtlSeconds,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds an **additive** opaque `pmth_*` session verifier to `/webhooks/remote-signer`, composed ahead of the existing OIDC JWT verifier via `createFirstMatchEndUserVerifier`.
- Validates opaque sessions with the same `validateBearerToken` lookup the rest of PymtHouse uses (not blind trust) and emits identical billing attribution: `client_id` + `external_user_id`.
- Makes billed `/generate-live-payment` symmetric with the already-working `/sign-orchestrator-info` path for opaque signer sessions.

**Note for Run 13 (JWT path):** NaaP now forwards a Builder user-token JWT (`scope=sign:job`), not an opaque `pmth_*` session. This PR fixes the opaque-session contract gap; the Run 13 `IncompleteRead` blocker additionally needs John to verify Railway signer runtime (see handoff below).

## Root cause context (IncompleteRead)

Python gateway (`livepeer-python-gateway/src/livepeer_gateway/byoc.py:_create_byoc_payment`) POSTs the DMZ `/generate-live-payment` and surfaces `IncompleteRead(N, M)` when the HTTP body is truncated mid-read (~193 bytes total in Runs 10–13). Empty-body probes return complete `400 {"error":{"message":"missing orchestrator"}}` — auth/routing OK; truncation happens only on real payment requests after orchestrator protobuf is supplied.

Deployed signer image (`docker/signer-dmz/Dockerfile` → `livepeer/go-livepeer:sha-33380bc…`) runs `GenerateLivePayment` + `authLivePayment()` webhook to this route. Truncation indicates the signer process or Apache proxy aborts mid-response — check Railway logs for panics/OOM during ticket generation or webhook auth.

## Test plan

- [ ] Deploy Vercel preview with this branch; confirm `WEBHOOK_SECRET` matches Railway signer env.
- [ ] `POST /webhooks/remote-signer` with `Authorization: Bearer <WEBHOOK_SECRET>` and body `{ "authorization": "Bearer pmth_<valid-session>" }` → `200 { status:200, auth_id:"<client_id>:<external_user_id>", identity:{...} }`
- [ ] Same with a freshly minted signer JWT (`aud=issuer`, `scope=sign:job`) → still `status:200` (JWT path unchanged)
- [ ] Forged/expired `pmth_*` → `status:403` in body
- [ ] Redeploy Railway signer DMZ after Vercel promote; re-run NaaP billed E2E (`app_98575870`) and confirm `/generate-live-payment` returns complete JSON (not `IncompleteRead`)
- [ ] Railway logs: grep `generate-live-payment`, `authLivePayment`, `Could not create payment` around failure timestamp


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote signer requests can now authenticate using either the newer session-based flow or the existing legacy sign-in flow.
  * Authentication handling now supports trying multiple verification methods and using the first one that succeeds.

* **Bug Fixes**
  * Improved error handling for invalid or missing authentication credentials.
  * Preserved existing secret-based webhook behavior while updating request authorization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->