### PR TITLE
fix(security): bump protobufjs and Go for Snyk high findings

### DIFF
--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -54,7 +54,7 @@ RUN git clone https://github.com/AnthonyDeroche/mod_authnz_jwt.git && \
     make && \
     make install
 
-FROM golang:1.25.11-bookworm AS turnkey-bootstrap-build
+FROM golang:1.25.12-bookworm AS turnkey-bootstrap-build
 
 WORKDIR /src
 COPY docker/signer-dmz/turnkey-bootstrap/go.mod ./go.mod

--- a/docker/signer-dmz/turnkey-bootstrap/go.mod
+++ b/docker/signer-dmz/turnkey-bootstrap/go.mod
@@ -1,6 +1,6 @@
 module github.com/pymthouse/signer-turnkey-bootstrap
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/ethereum/go-ethereum v1.17.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -8975,9 +8975,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Bump `protobufjs` lockfile resolve from 7.6.4 → 7.6.5 ([SNYK-JS-PROTOBUFJS-17900550](https://security.snyk.io/vuln/SNYK-JS-PROTOBUFJS-17900550) infinite loop)
- Bump turnkey-bootstrap Go toolchain / Docker build image from 1.25.11 → 1.25.12 ([SNYK-GOLANG-STDOS-17905377](https://security.snyk.io/vuln/SNYK-GOLANG-STDOS-17905377) std/os symlink attack)

Addresses the failing Snyk Open Source check on main: https://github.com/pymthouse/pymthouse/actions/runs/29043745440/job/86207152083

## Test plan
- [ ] Snyk Code and Open Source workflow passes (no high-severity SCA findings for these packages)
- [ ] Confirm CI installs Go from `docker/signer-dmz/turnkey-bootstrap/go.mod` (`go-version-file`)
- [ ] Signer DMZ image still builds with `golang:1.25.12-bookworm`