### PR TITLE
fix(db): repair skipped auto-approve developer apps migration

### DIFF
--- a/drizzle/0026_auto_approve_developer_apps_repair.sql
+++ b/drizzle/0026_auto_approve_developer_apps_repair.sql
@@ -1,0 +1,24 @@
+-- Repair: 0025_auto_approve_developer_apps used journal `when` 1778100000000, but
+-- production already had 0025_turnkey_funding_events_repair at 1778500000000, so
+-- Drizzle skipped the auto-approve UPDATE (folderMillis must be strictly greater
+-- than the latest __drizzle_migrations.created_at). Idempotent.
+UPDATE "developer_apps"
+SET
+  "status" = 'approved',
+  "published_at" = COALESCE("published_at", "updated_at", "created_at"),
+  "updated_at" = COALESCE("updated_at", "created_at")
+WHERE "status" IN ('draft', 'submitted', 'in_review', 'rejected');
+
+UPDATE "developer_apps"
+SET
+  "submitted_at" = NULL,
+  "pending_scopes" = NULL,
+  "pending_grant_types" = NULL,
+  "pending_revision_submitted_at" = NULL
+WHERE
+  "submitted_at" IS NOT NULL
+  OR "pending_scopes" IS NOT NULL
+  OR "pending_grant_types" IS NOT NULL
+  OR "pending_revision_submitted_at" IS NOT NULL;
+
+ALTER TABLE "developer_apps" ALTER COLUMN "status" SET DEFAULT 'approved';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1778100000000,
       "tag": "0025_auto_approve_developer_apps",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1778600000000,
+      "tag": "0026_auto_approve_developer_apps_repair",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Production still showed apps as `draft` after #208 because `0025_auto_approve_developer_apps` reused journal `when` `1778100000000`, while prod already had `0025_turnkey_funding_events_repair` at `1778500000000`. Drizzle only applies migrations with `when` strictly greater than the latest `__drizzle_migrations.created_at`, so the auto-approve SQL never ran (status default stayed `draft`).
- Adds idempotent `0026_auto_approve_developer_apps_repair` at `1778600000000` and applies the same approve/`published_at`/default fix.
- Already applied to Neon production, Preview, and pre-production; this PR keeps the journal in sync for future deploys.

## Test plan
- [x] Production: all `developer_apps` are `approved`; Test App `app_6e8e26f1…` has `published_at`; status default is `'approved'`
- [x] Preview + pre-production migrated
- [x] After merge, confirm CI `db-migrate` is a no-op / records 0026 only where missing
- [x] Reload `/apps/app_6e8e26f1d15d455c967c1ca2` while signed in and confirm Live badge