### PR TITLE
Dashboard: show Usage above Apps only when usage exists

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -103,7 +103,13 @@ async function AdminDashboard({ userId }: Readonly<{ userId: string }>) {
 }
 
 async function DeveloperDashboard({ userId }: Readonly<{ userId: string }>) {
-  const apps = userId ? await listUserAccessibleApps(userId) : [];
+  const [apps, usage] = await Promise.all([
+    userId ? listUserAccessibleApps(userId) : Promise.resolve([]),
+    getDashboardUsageSummary(true),
+  ]);
+  // Keep Apps above Usage until there is something to chart — creating an empty
+  // app should not rearrange the page.
+  const usageFirst = (usage?.appsWithUsage ?? 0) > 0;
 
   return (
     <>
@@ -112,11 +118,21 @@ async function DeveloperDashboard({ userId }: Readonly<{ userId: string }>) {
         <p className="text-zinc-500 mt-1">Developer overview</p>
       </div>
 
-      <MyAppsSection apps={apps} />
-
-      <div className="mt-6">
-        <DashboardUsagePanel />
-      </div>
+      {usageFirst ? (
+        <>
+          <DashboardUsagePanel summary={usage} />
+          <div className="mt-6">
+            <MyAppsSection apps={apps} />
+          </div>
+        </>
+      ) : (
+        <>
+          <MyAppsSection apps={apps} />
+          <div className="mt-6">
+            <DashboardUsagePanel summary={usage} />
+          </div>
+        </>
+      )}
 
       <div className="mt-6">
         <DocumentationCard />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,11 +17,11 @@ const metadataBase = (() => {
 })();
 
 export const metadata: Metadata = {
-  title: "pymthouse — Identity & Payment Infrastructure",
+  title: "pymthouse - Identity & Payment Infrastructure",
   description: siteDescription,
   metadataBase,
   openGraph: {
-    title: "pymthouse — Identity & Payment Infrastructure",
+    title: "pymthouse - Identity & Payment Infrastructure",
     description: siteDescription,
     siteName: "pymthouse",
     type: "website",
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "pymthouse — Identity & Payment Infrastructure",
+    title: "pymthouse - Identity & Payment Infrastructure",
     description: siteDescription,
   },
 };

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const alt = "pymthouse — Identity & Payment Infrastructure";
+export const alt = "pymthouse - Identity & Payment Infrastructure";
 export const size = {
   width: 1200,
   height: 630,

--- a/src/components/AdminDashboardOverview.tsx
+++ b/src/components/AdminDashboardOverview.tsx
@@ -9,9 +9,9 @@ import type { UserAppSummary } from "@/lib/user-apps";
 export type AdminStatCard = AdminPlatformStat;
 
 /**
- * Admin Dashboard interactive area: usage panel on top (My Usage / All Usage),
- * then the apps list with its own independent All apps toggle. Selecting an
- * app in the list filters the usage chart to that app.
+ * Admin Dashboard interactive area: Apps first until the viewer has usage to
+ * show this cycle, then Usage above Apps. Selecting an app in the list filters
+ * the usage chart. My Usage / All Usage is independent of the Apps "All apps" toggle.
  */
 export default function AdminDashboardOverview({
   myApps,
@@ -54,30 +54,48 @@ export default function AdminDashboardOverview({
     setSelectedApp(app);
   }, []);
 
+  // Keep Apps above Usage until there is something to chart — creating an empty
+  // app should not rearrange the page.
+  const usageFirst = (initialUsage?.appsWithUsage ?? 0) > 0;
+
+  const usagePanel = (
+    <AdminUsagePanel
+      initialOwnUsage={initialUsage}
+      allUsage={allUsage}
+      loadingAllUsage={loadingAllUsage}
+      allUsageError={allUsageError}
+      onEnsureAllUsage={ensureAllUsage}
+      onRetryAllUsage={fetchAllUsage}
+      volumeStat={volumeStat}
+      filterAppId={selectedApp?.id ?? null}
+      filterAppName={selectedApp?.name ?? null}
+      onClearAppFilter={() => setSelectedApp(null)}
+    />
+  );
+
+  const appsSection = (
+    <AdminAppsSection
+      initialApps={myApps}
+      showAll={showAllApps}
+      onToggleShowAll={setShowAllApps}
+      selectedAppId={selectedApp?.id ?? null}
+      onSelectApp={handleSelectApp}
+    />
+  );
+
   return (
     <>
-      <div className="mb-6">
-        <AdminUsagePanel
-          initialOwnUsage={initialUsage}
-          allUsage={allUsage}
-          loadingAllUsage={loadingAllUsage}
-          allUsageError={allUsageError}
-          onEnsureAllUsage={ensureAllUsage}
-          onRetryAllUsage={fetchAllUsage}
-          volumeStat={volumeStat}
-          filterAppId={selectedApp?.id ?? null}
-          filterAppName={selectedApp?.name ?? null}
-          onClearAppFilter={() => setSelectedApp(null)}
-        />
-      </div>
-
-      <AdminAppsSection
-        initialApps={myApps}
-        showAll={showAllApps}
-        onToggleShowAll={setShowAllApps}
-        selectedAppId={selectedApp?.id ?? null}
-        onSelectApp={handleSelectApp}
-      />
+      {usageFirst ? (
+        <>
+          <div className="mb-6">{usagePanel}</div>
+          {appsSection}
+        </>
+      ) : (
+        <>
+          {appsSection}
+          <div className="mt-6">{usagePanel}</div>
+        </>
+      )}
     </>
   );
 }

--- a/src/components/DashboardUsagePanel.tsx
+++ b/src/components/DashboardUsagePanel.tsx
@@ -43,9 +43,16 @@ function DashboardUsageChart({
  * viewer personally owns or administers. Chart series are app × pipeline/model
  * (signer constraint), not pipeline capability alone.
  * matching the Admin Dashboard usage panel.
+ *
+ * Pass `summary` when the parent already loaded it (avoids a second fetch).
  */
-export default async function DashboardUsagePanel() {
-  const summary = await getDashboardUsageSummary(true);
+export default async function DashboardUsagePanel({
+  summary: summaryProp,
+}: Readonly<{
+  summary?: DashboardUsageSummary | null;
+}> = {}) {
+  const summary =
+    summaryProp !== undefined ? summaryProp : await getDashboardUsageSummary(true);
 
   if (!summary) {
     return null;


### PR DESCRIPTION
## Summary
- Puts Usage above Apps on both Developer and Admin dashboards only when the current billing cycle has `appsWithUsage > 0`
- Keeps Apps first when there is no usage yet, so creating an empty app does not rearrange the page
- Passes a prefetched usage summary into `DashboardUsagePanel` to avoid a duplicate fetch on the Developer dashboard

## Test plan
- [ ] Developer with no apps: Apps section appears first
- [ ] Developer with apps but zero usage this cycle: Apps still first, Usage below
- [ ] Developer with usage this cycle: Usage appears above Apps
- [ ] Admin/operator: same reorder rule using own-apps usage summary
- [ ] Creating a new app does not flip section order until usage arrives