### PR TITLE
Configure preview signer account during deploy

### DIFF
--- a/.github/workflows/deploy-railway-preview.yml
+++ b/.github/workflows/deploy-railway-preview.yml
@@ -65,6 +65,7 @@ jobs:
       OPENMETER_API_KEY: ${{ secrets.OPENMETER_API_KEY }}
       WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
       NEXTAUTH_URL: ${{ vars.RAILWAY_PREVIEW_NEXTAUTH_URL || 'https://staging.pymthouse.com' }}
+      TURNKEY_WALLET_NAME: livepeer-remote-signer-staging
       SIGNER_ETH_ADDR: 0xB3ac0AeBC3209C17F4c7Ea107476f848042e21e8
 
     steps:
@@ -84,7 +85,9 @@ jobs:
           railway_export_auth
           PE_FLAGS="$(railway_pe_flags "$RAILWAY_ENVIRONMENT")"
           # shellcheck disable=SC2086
-          railway_retry railway variable set "SIGNER_ETH_ADDR=$SIGNER_ETH_ADDR" \
+          railway_retry railway variable set \
+            "TURNKEY_WALLET_NAME=$TURNKEY_WALLET_NAME" \
+            "SIGNER_ETH_ADDR=$SIGNER_ETH_ADDR" \
             --service pymthouse $PE_FLAGS --skip-deploys
 
       - name: Apply preview environment variables

--- a/.github/workflows/deploy-railway-preview.yml
+++ b/.github/workflows/deploy-railway-preview.yml
@@ -65,6 +65,7 @@ jobs:
       OPENMETER_API_KEY: ${{ secrets.OPENMETER_API_KEY }}
       WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
       NEXTAUTH_URL: ${{ vars.RAILWAY_PREVIEW_NEXTAUTH_URL || 'https://staging.pymthouse.com' }}
+      SIGNER_ETH_ADDR: 0xB3ac0AeBC3209C17F4c7Ea107476f848042e21e8
 
     steps:
       - name: Checkout
@@ -75,6 +76,16 @@ jobs:
 
       - name: Install Railway CLI
         run: npm install -g @railway/cli@latest
+
+      - name: Configure preview signer account
+        run: |
+          set -euo pipefail
+          source scripts/lib/railway-auth.sh
+          railway_export_auth
+          PE_FLAGS="$(railway_pe_flags "$RAILWAY_ENVIRONMENT")"
+          # shellcheck disable=SC2086
+          railway_retry railway variable set "SIGNER_ETH_ADDR=$SIGNER_ETH_ADDR" \
+            --service pymthouse $PE_FLAGS --skip-deploys
 
       - name: Apply preview environment variables
         if: inputs.apply_env == true || vars.RAILWAY_PREVIEW_APPLY_ENV == 'true'

--- a/.github/workflows/deploy-railway-production.yml
+++ b/.github/workflows/deploy-railway-production.yml
@@ -24,6 +24,8 @@ name: Deploy Railway production clearinghouse stack
 #   RAILWAY_PRODUCTION_NEXTAUTH_URL → https://pymthouse.com
 #   RAILWAY_PRODUCTION_BOOTSTRAP_OPENMETER=true — post-deploy meter bootstrap
 #   SIGNER_NETWORK → arbitrum-one-mainnet
+#   TURNKEY_WALLET_NAME → livepeer-remote-signer
+#   SIGNER_ETH_ADDR — optional 0x pin for the Turnkey wallet account
 #
 # OIDC_ISSUER / OIDC_AUDIENCE / JWKS_URI on the pymthouse service are derived from
 # NEXTAUTH_URL in scripts/railway-apply-stack-env.sh (see config/railway/production.env.example).
@@ -74,7 +76,7 @@ jobs:
       TURNKEY_API_PUBLIC_KEY: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
       TURNKEY_API_PRIVATE_KEY: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
       SIGNER_ETH_KEYSTORE_PASSWORD: ${{ secrets.SIGNER_ETH_KEYSTORE_PASSWORD }}
-      TURNKEY_WALLET_NAME: ${{ vars.TURNKEY_WALLET_NAME }}
+      TURNKEY_WALLET_NAME: ${{ vars.TURNKEY_WALLET_NAME || 'livepeer-remote-signer' }}
       SIGNER_ETH_ADDR: ${{ vars.SIGNER_ETH_ADDR }}
 
     steps:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Configure Railway signer Turnkey settings per environment during deploy:

- **Preview:** set `TURNKEY_WALLET_NAME=livepeer-remote-signer-staging` and `SIGNER_ETH_ADDR=0xB3ac0AeBC3209C17F4c7Ea107476f848042e21e8` on the `pymthouse` service before deploy.
- **Production:** default `TURNKEY_WALLET_NAME` to `livepeer-remote-signer` (still overridable via the `TURNKEY_WALLET_NAME` repo variable).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-094dea50-b63a-49b3-94a2-1e3297bb7f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-094dea50-b63a-49b3-94a2-1e3297bb7f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment**
  * Preview deployments now automatically configure the signer account using fixed signer settings.
  * Added support for configurable Turnkey signer wallet variables in production, with a default wallet name when unset.
  * Added retry handling to improve reliability when applying preview environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->