### PR TITLE
fix(openmeter): restore usage after nanos meter cutover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,8 +129,7 @@ OPENMETER_TRIAL_FEATURE_KEY=network_spend
 OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS=5000000
 # Nanos meter cutover (ISO-8601). Usage reads merge legacy micros before this instant.
 # OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT=2026-07-10T00:00:00.000Z
-# Stop dual-emitting network_fee_usd_micros from the collector after this date (default: cutover + 2 months).
-# OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER=2026-09-10T00:00:00.000Z
+# Collector dual-emits network_fee_usd_micros until 2026-09-10 (NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER).
 # Required for usage totals, allowance balance, and signed-ticket metering
 # OPENMETER_URL=http://127.0.0.1:48888
 

--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,10 @@ OPENMETER_INGEST_API_KEY=
 OPENMETER_TRIAL_FEATURE_KEY=network_spend
 # Default included usage (USD micros) when seeding per-app Starter plan (5000000 = $5)
 OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS=5000000
+# Nanos meter cutover (ISO-8601). Usage reads merge legacy micros before this instant.
+# OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT=2026-07-10T00:00:00.000Z
+# Stop dual-emitting network_fee_usd_micros from the collector after this date (default: cutover + 2 months).
+# OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER=2026-09-10T00:00:00.000Z
 # Required for usage totals, allowance balance, and signed-ticket metering
 # OPENMETER_URL=http://127.0.0.1:48888
 

--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -125,8 +125,7 @@ pipeline:
         # Nanos avoid .round() collapsing sub-micro staging fees to 0.
         # Also emit micros (nanos/1000) so the legacy network_fee_usd_micros
         # meter keeps accepting events during cutover. Remove network_fee_usd_micros
-        # from this payload after OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER
-        # (default: nanos cutover + 2 months).
+        # from this payload on/after 2026-09-10 (NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER).
         let fee_wei = $data.computed_fee.number().or(0)
         let fee_usd_nanos = ($fee_wei * $eth_usd / 1000000000).round()
         let fee_usd_micros = ($fee_usd_nanos / 1000).round()

--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -124,7 +124,8 @@ pipeline:
         # USD nanos = fee_wei * eth_usd / 1e9  (1 USD = 1e9 nanos).
         # Nanos avoid .round() collapsing sub-micro staging fees to 0.
         # Also emit micros (nanos/1000) so the legacy network_fee_usd_micros
-        # meter does not reject create_signed_ticket events during cutover.
+        # meter keeps accepting events during cutover. Remove network_fee_usd_micros
+        # from this payload after 2026-09-10 (2 months post nanos cutover).
         let fee_wei = $data.computed_fee.number().or(0)
         let fee_usd_nanos = ($fee_wei * $eth_usd / 1000000000).round()
         let fee_usd_micros = ($fee_usd_nanos / 1000).round()

--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -125,7 +125,8 @@ pipeline:
         # Nanos avoid .round() collapsing sub-micro staging fees to 0.
         # Also emit micros (nanos/1000) so the legacy network_fee_usd_micros
         # meter keeps accepting events during cutover. Remove network_fee_usd_micros
-        # from this payload after 2026-09-10 (2 months post nanos cutover).
+        # from this payload after OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER
+        # (default: nanos cutover + 2 months).
         let fee_wei = $data.computed_fee.number().or(0)
         let fee_usd_nanos = ($fee_wei * $eth_usd / 1000000000).round()
         let fee_usd_micros = ($fee_usd_nanos / 1000).round()

--- a/src/lib/openmeter/constants.ts
+++ b/src/lib/openmeter/constants.ts
@@ -1,8 +1,12 @@
 /** OpenMeter meter slug for network fee aggregation (USD nanos; 1 USD = 1e9). */
 export const NETWORK_FEE_USD_NANOS_METER = "network_fee_usd_nanos";
 
-/** @deprecated Use NETWORK_FEE_USD_NANOS_METER. Kept as alias for older app meterSlug rows. */
-export const NETWORK_FEE_USD_MICROS_METER = NETWORK_FEE_USD_NANOS_METER;
+/**
+ * Legacy network-fee meter (USD micros). Historical usage before the nanos cutover
+ * still lives here. Usage reads time-split across micros + nanos; collector dual-emits
+ * until NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER.
+ */
+export const NETWORK_FEE_USD_MICROS_METER = "network_fee_usd_micros";
 
 /** 1 USD micro = 1_000 USD nanos. Meter stores nanos; app ledger/UI stays in micros. */
 export const USD_NANOS_PER_MICRO = 1000n;
@@ -13,6 +17,40 @@ export function usdNanosToMicros(nanos: bigint): bigint {
 
 export function usdMicrosToNanos(micros: bigint): bigint {
   return micros * USD_NANOS_PER_MICRO;
+}
+
+/**
+ * Instant when `network_fee_usd_nanos` became the authoritative fee meter.
+ * Override with OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT (ISO-8601).
+ * Default: day of the nanos meter cutover (#220).
+ */
+export function getNetworkFeeNanosCutoverAt(): Date {
+  const raw = process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT?.trim();
+  if (raw) {
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return new Date("2026-07-10T00:00:00.000Z");
+}
+
+/**
+ * After this date, stop dual-emitting `network_fee_usd_micros` from the collector
+ * (legacy meter can remain for historical queries). Default: cutover + 2 months.
+ */
+export function getNetworkFeeMicrosEmitDeprecateAfter(): Date {
+  const raw = process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER?.trim();
+  if (raw) {
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  const cutover = getNetworkFeeNanosCutoverAt();
+  const deprecate = new Date(cutover);
+  deprecate.setUTCMonth(deprecate.getUTCMonth() + 2);
+  return deprecate;
 }
 
 /** OpenMeter meter slug for signed-ticket request counts. */

--- a/src/lib/openmeter/constants.ts
+++ b/src/lib/openmeter/constants.ts
@@ -4,9 +4,15 @@ export const NETWORK_FEE_USD_NANOS_METER = "network_fee_usd_nanos";
 /**
  * Legacy network-fee meter (USD micros). Historical usage before the nanos cutover
  * still lives here. Usage reads time-split across micros + nanos; collector dual-emits
- * until getNetworkFeeMicrosEmitDeprecateAfter() / OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER.
+ * until NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER.
  */
 export const NETWORK_FEE_USD_MICROS_METER = "network_fee_usd_micros";
+
+/**
+ * Stop dual-emitting `network_fee_usd_micros` from the collector on/after this date
+ * (2026-07-10 cutover + 2 months). Legacy meter stays for historical reads.
+ */
+export const NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER = new Date("2026-09-10T00:00:00.000Z");
 
 /** 1 USD micro = 1_000 USD nanos. Meter stores nanos; app ledger/UI stays in micros. */
 export const USD_NANOS_PER_MICRO = 1000n;
@@ -37,23 +43,9 @@ export function getNetworkFeeNanosCutoverAt(env: EnvLike = process.env): Date {
   return new Date("2026-07-10T00:00:00.000Z");
 }
 
-/**
- * After this date, stop dual-emitting `network_fee_usd_micros` from the collector
- * (legacy meter can remain for historical queries). Default: cutover + 2 months.
- * Override with OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER (ISO-8601).
- */
-export function getNetworkFeeMicrosEmitDeprecateAfter(env: EnvLike = process.env): Date {
-  const raw = env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER?.trim();
-  if (raw) {
-    const parsed = new Date(raw);
-    if (!Number.isNaN(parsed.getTime())) {
-      return parsed;
-    }
-  }
-  const cutover = getNetworkFeeNanosCutoverAt(env);
-  const deprecate = new Date(cutover);
-  deprecate.setUTCMonth(deprecate.getUTCMonth() + 2);
-  return deprecate;
+/** Fixed date to stop dual-emitting legacy micros fields from the collector. */
+export function getNetworkFeeMicrosEmitDeprecateAfter(): Date {
+  return NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER;
 }
 
 /** OpenMeter meter slug for signed-ticket request counts. */

--- a/src/lib/openmeter/constants.ts
+++ b/src/lib/openmeter/constants.ts
@@ -4,7 +4,7 @@ export const NETWORK_FEE_USD_NANOS_METER = "network_fee_usd_nanos";
 /**
  * Legacy network-fee meter (USD micros). Historical usage before the nanos cutover
  * still lives here. Usage reads time-split across micros + nanos; collector dual-emits
- * until NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER.
+ * until getNetworkFeeMicrosEmitDeprecateAfter() / OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER.
  */
 export const NETWORK_FEE_USD_MICROS_METER = "network_fee_usd_micros";
 
@@ -19,13 +19,15 @@ export function usdMicrosToNanos(micros: bigint): bigint {
   return micros * USD_NANOS_PER_MICRO;
 }
 
+type EnvLike = Record<string, string | undefined>;
+
 /**
  * Instant when `network_fee_usd_nanos` became the authoritative fee meter.
  * Override with OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT (ISO-8601).
  * Default: day of the nanos meter cutover (#220).
  */
-export function getNetworkFeeNanosCutoverAt(): Date {
-  const raw = process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT?.trim();
+export function getNetworkFeeNanosCutoverAt(env: EnvLike = process.env): Date {
+  const raw = env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT?.trim();
   if (raw) {
     const parsed = new Date(raw);
     if (!Number.isNaN(parsed.getTime())) {
@@ -38,16 +40,17 @@ export function getNetworkFeeNanosCutoverAt(): Date {
 /**
  * After this date, stop dual-emitting `network_fee_usd_micros` from the collector
  * (legacy meter can remain for historical queries). Default: cutover + 2 months.
+ * Override with OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER (ISO-8601).
  */
-export function getNetworkFeeMicrosEmitDeprecateAfter(): Date {
-  const raw = process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER?.trim();
+export function getNetworkFeeMicrosEmitDeprecateAfter(env: EnvLike = process.env): Date {
+  const raw = env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER?.trim();
   if (raw) {
     const parsed = new Date(raw);
     if (!Number.isNaN(parsed.getTime())) {
       return parsed;
     }
   }
-  const cutover = getNetworkFeeNanosCutoverAt();
+  const cutover = getNetworkFeeNanosCutoverAt(env);
   const deprecate = new Date(cutover);
   deprecate.setUTCMonth(deprecate.getUTCMonth() + 2);
   return deprecate;

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   getNetworkFeeMicrosEmitDeprecateAfter,
   getNetworkFeeNanosCutoverAt,
+  NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER,
   NETWORK_FEE_USD_MICROS_METER,
   NETWORK_FEE_USD_NANOS_METER,
 } from "@/lib/openmeter/constants";
@@ -740,19 +741,14 @@ test("getNetworkFeeNanosCutoverAt defaults to 2026-07-10 and honors env override
   );
 });
 
-test("getNetworkFeeMicrosEmitDeprecateAfter defaults to cutover plus two months", () => {
+test("NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER is fixed at 2026-09-10", () => {
   assert.equal(
-    getNetworkFeeMicrosEmitDeprecateAfter({
-      OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT: "2026-07-10T00:00:00.000Z",
-    }).toISOString(),
+    NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER.toISOString(),
     "2026-09-10T00:00:00.000Z",
   );
   assert.equal(
-    getNetworkFeeMicrosEmitDeprecateAfter({
-      OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT: "2026-07-10T00:00:00.000Z",
-      OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER: "2026-10-01T00:00:00.000Z",
-    }).toISOString(),
-    "2026-10-01T00:00:00.000Z",
+    getNetworkFeeMicrosEmitDeprecateAfter().toISOString(),
+    "2026-09-10T00:00:00.000Z",
   );
 });
 

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -731,43 +731,29 @@ test("NETWORK_FEE_USD_MICROS_METER keeps the legacy slug for historical reads", 
 });
 
 test("getNetworkFeeNanosCutoverAt defaults to 2026-07-10 and honors env override", () => {
-  const prev = process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
-  try {
-    delete process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
-    assert.equal(getNetworkFeeNanosCutoverAt().toISOString(), "2026-07-10T00:00:00.000Z");
-    process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT = "2026-07-11T12:00:00.000Z";
-    assert.equal(getNetworkFeeNanosCutoverAt().toISOString(), "2026-07-11T12:00:00.000Z");
-  } finally {
-    if (prev === undefined) {
-      delete process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
-    } else {
-      process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT = prev;
-    }
-  }
+  assert.equal(getNetworkFeeNanosCutoverAt({}).toISOString(), "2026-07-10T00:00:00.000Z");
+  assert.equal(
+    getNetworkFeeNanosCutoverAt({
+      OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT: "2026-07-11T12:00:00.000Z",
+    }).toISOString(),
+    "2026-07-11T12:00:00.000Z",
+  );
 });
 
 test("getNetworkFeeMicrosEmitDeprecateAfter defaults to cutover plus two months", () => {
-  const prevCutover = process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
-  const prevDeprecate = process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER;
-  try {
-    delete process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER;
-    process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT = "2026-07-10T00:00:00.000Z";
-    assert.equal(
-      getNetworkFeeMicrosEmitDeprecateAfter().toISOString(),
-      "2026-09-10T00:00:00.000Z",
-    );
-  } finally {
-    if (prevCutover === undefined) {
-      delete process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
-    } else {
-      process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT = prevCutover;
-    }
-    if (prevDeprecate === undefined) {
-      delete process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER;
-    } else {
-      process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER = prevDeprecate;
-    }
-  }
+  assert.equal(
+    getNetworkFeeMicrosEmitDeprecateAfter({
+      OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT: "2026-07-10T00:00:00.000Z",
+    }).toISOString(),
+    "2026-09-10T00:00:00.000Z",
+  );
+  assert.equal(
+    getNetworkFeeMicrosEmitDeprecateAfter({
+      OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT: "2026-07-10T00:00:00.000Z",
+      OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER: "2026-10-01T00:00:00.000Z",
+    }).toISOString(),
+    "2026-10-01T00:00:00.000Z",
+  );
 });
 
 test("splitMeterQueryAtCutover isolates legacy micros and current nanos windows", () => {

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -17,7 +17,14 @@ import {
   aggregatePipelineModelRows,
   aggregateUserPipelineModelRows,
   dateKeyFromMeterWindow,
+  splitMeterQueryAtCutover,
 } from "@/lib/openmeter/usage-read";
+import {
+  getNetworkFeeMicrosEmitDeprecateAfter,
+  getNetworkFeeNanosCutoverAt,
+  NETWORK_FEE_USD_MICROS_METER,
+  NETWORK_FEE_USD_NANOS_METER,
+} from "@/lib/openmeter/constants";
 import {
   isOpenMeterSubscriptionActive,
   verifyOpenMeterSubscriptionId,
@@ -66,7 +73,7 @@ test("aggregatePipelineModelRows sums fee and count by pipeline/model", () => {
     clientId: "app_1",
     feeRows: [
       {
-        value: 1_000_000, // nanos → 1000 micros
+        value: 1000, // USD micros
         windowStart: new Date("2026-05-01"),
         groupBy: {
           client_id: "app_1",
@@ -75,7 +82,7 @@ test("aggregatePipelineModelRows sums fee and count by pipeline/model", () => {
         },
       },
       {
-        value: 500_000,
+        value: 500,
         windowStart: new Date("2026-05-01"),
         groupBy: {
           client_id: "app_1",
@@ -109,7 +116,7 @@ test("aggregateUserPipelineModelRows sums fee and count by user/pipeline/model",
     clientId: "app_1",
     feeRows: [
       {
-        value: 1_000_000,
+        value: 1000,
         windowStart: new Date("2026-05-01"),
         groupBy: {
           client_id: "app_1",
@@ -119,7 +126,7 @@ test("aggregateUserPipelineModelRows sums fee and count by user/pipeline/model",
         },
       },
       {
-        value: 500_000,
+        value: 500,
         windowStart: new Date("2026-05-01"),
         groupBy: {
           client_id: "app_1",
@@ -169,7 +176,7 @@ test("aggregateDailyPipelineModelRows sums fee and count by pipeline/model/day",
     clientId: "app_1",
     feeRows: [
       {
-        value: 100_000,
+        value: 100,
         windowStart: new Date("2026-06-02T00:00:00Z"),
         groupBy: {
           client_id: "app_1",
@@ -715,4 +722,95 @@ test("verifyOpenMeterPlanId returns null when remote plan missing", async () => 
 
   const view = await verifyOpenMeterPlanId(openMeterTestClient(client), "missing");
   assert.equal(view, null);
+});
+
+test("NETWORK_FEE_USD_MICROS_METER keeps the legacy slug for historical reads", () => {
+  assert.equal(NETWORK_FEE_USD_MICROS_METER, "network_fee_usd_micros");
+  assert.equal(NETWORK_FEE_USD_NANOS_METER, "network_fee_usd_nanos");
+  assert.notEqual(NETWORK_FEE_USD_MICROS_METER, NETWORK_FEE_USD_NANOS_METER);
+});
+
+test("getNetworkFeeNanosCutoverAt defaults to 2026-07-10 and honors env override", () => {
+  const prev = process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
+  try {
+    delete process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
+    assert.equal(getNetworkFeeNanosCutoverAt().toISOString(), "2026-07-10T00:00:00.000Z");
+    process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT = "2026-07-11T12:00:00.000Z";
+    assert.equal(getNetworkFeeNanosCutoverAt().toISOString(), "2026-07-11T12:00:00.000Z");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
+    } else {
+      process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT = prev;
+    }
+  }
+});
+
+test("getNetworkFeeMicrosEmitDeprecateAfter defaults to cutover plus two months", () => {
+  const prevCutover = process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
+  const prevDeprecate = process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER;
+  try {
+    delete process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER;
+    process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT = "2026-07-10T00:00:00.000Z";
+    assert.equal(
+      getNetworkFeeMicrosEmitDeprecateAfter().toISOString(),
+      "2026-09-10T00:00:00.000Z",
+    );
+  } finally {
+    if (prevCutover === undefined) {
+      delete process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT;
+    } else {
+      process.env.OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT = prevCutover;
+    }
+    if (prevDeprecate === undefined) {
+      delete process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER;
+    } else {
+      process.env.OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER = prevDeprecate;
+    }
+  }
+});
+
+test("splitMeterQueryAtCutover isolates legacy micros and current nanos windows", () => {
+  const cutover = new Date("2026-07-10T00:00:00.000Z");
+  const { legacy, current } = splitMeterQueryAtCutover(
+    {
+      windowSize: "MONTH",
+      from: new Date("2026-06-01T00:00:00.000Z"),
+      to: new Date("2026-08-01T00:00:00.000Z"),
+      groupBy: ["client_id"],
+    },
+    cutover,
+  );
+  assert.ok(legacy);
+  assert.ok(current);
+  assert.equal((legacy.to as Date).toISOString(), cutover.toISOString());
+  assert.equal((legacy.from as Date).toISOString(), "2026-06-01T00:00:00.000Z");
+  assert.equal((current.from as Date).toISOString(), cutover.toISOString());
+  assert.equal((current.to as Date).toISOString(), "2026-08-01T00:00:00.000Z");
+});
+
+test("splitMeterQueryAtCutover returns only legacy when range ends at cutover", () => {
+  const cutover = new Date("2026-07-10T00:00:00.000Z");
+  const { legacy, current } = splitMeterQueryAtCutover(
+    {
+      from: new Date("2026-07-01T00:00:00.000Z"),
+      to: cutover,
+    },
+    cutover,
+  );
+  assert.ok(legacy);
+  assert.equal(current, null);
+});
+
+test("splitMeterQueryAtCutover returns only current when range starts at cutover", () => {
+  const cutover = new Date("2026-07-10T00:00:00.000Z");
+  const { legacy, current } = splitMeterQueryAtCutover(
+    {
+      from: cutover,
+      to: new Date("2026-08-01T00:00:00.000Z"),
+    },
+    cutover,
+  );
+  assert.equal(legacy, null);
+  assert.ok(current);
 });

--- a/src/lib/openmeter/usage-read.ts
+++ b/src/lib/openmeter/usage-read.ts
@@ -1,27 +1,138 @@
 import {
   getOpenMeterClientForApp,
-  getMeterSlugForApp,
 } from "@/lib/openmeter/client-factory";
 import { resolveOpenMeterMeterClientId } from "@/lib/openmeter/meter-client-id";
 import { buildOpenMeterCustomerKey } from "@/lib/openmeter/customer-key";
 import {
+  getNetworkFeeNanosCutoverAt,
+  NETWORK_FEE_USD_MICROS_METER,
+  NETWORK_FEE_USD_NANOS_METER,
   openMeterUsesLiveNetworkInTests,
   requireOpenMeterForUsageReads,
   SIGNED_TICKET_COUNT_METER,
   usdNanosToMicros,
 } from "@/lib/openmeter/constants";
-import type { MeterQueryRow } from "@openmeter/sdk";
+import type { MeterQueryRow, OpenMeter } from "@openmeter/sdk";
 
 function avoidOpenMeterNetworkInTests(): boolean {
   return process.env.NODE_ENV === "test" && !openMeterUsesLiveNetworkInTests();
 }
 
 /**
- * OpenMeter `network_fee_usd_nanos` meter values → USD micros for ledger/UI.
- * Display with `formatUsdMicros` from `@/lib/format-usd` (not formatUsdNanos).
+ * Fee meter query rows are normalized to USD micros before aggregation.
+ * Display with `formatUsdMicros` from `@/lib/format-usd`.
  */
 function feeMicrosFromMeterValue(value: unknown): bigint {
-  return usdNanosToMicros(BigInt(Math.floor(Number(value ?? 0))));
+  return BigInt(Math.floor(Number(value ?? 0)));
+}
+
+function asQueryDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}
+
+/**
+ * Split a meter query at the nanos cutover so legacy micros and current nanos
+ * windows do not overlap (avoids double-count while collector dual-emits).
+ */
+export function splitMeterQueryAtCutover(
+  query: Record<string, unknown>,
+  cutover: Date = getNetworkFeeNanosCutoverAt(),
+): { legacy: Record<string, unknown> | null; current: Record<string, unknown> | null } {
+  const from = asQueryDate(query.from);
+  const to = asQueryDate(query.to);
+
+  let legacy: Record<string, unknown> | null = null;
+  let current: Record<string, unknown> | null = null;
+
+  if (!from || from < cutover) {
+    if (to && to <= cutover) {
+      legacy = { ...query };
+    } else {
+      legacy = { ...query, to: cutover };
+    }
+  }
+
+  if (!to || to > cutover) {
+    if (from && from >= cutover) {
+      current = { ...query };
+    } else {
+      current = { ...query, from: cutover };
+    }
+  }
+
+  return { legacy, current };
+}
+
+function mapRowsToFeeMicros(
+  rows: MeterQueryRow[],
+  unit: "micros" | "nanos",
+): MeterQueryRow[] {
+  return rows.map((row) => {
+    const raw = BigInt(Math.floor(Number(row.value ?? 0)));
+    const micros = unit === "nanos" ? usdNanosToMicros(raw) : raw;
+    return { ...row, value: Number(micros) };
+  });
+}
+
+function isMeterNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const record = err as { statusCode?: number; status?: number; message?: string };
+  const status = record.statusCode ?? record.status;
+  if (status === 404) {
+    return true;
+  }
+  const message = typeof record.message === "string" ? record.message.toLowerCase() : "";
+  return message.includes("not found") && message.includes("meter");
+}
+
+async function queryMeterRowsSafe(
+  client: OpenMeter,
+  meterSlug: string,
+  query: Record<string, unknown>,
+): Promise<MeterQueryRow[]> {
+  try {
+    const result = await client.meters.query(meterSlug, query);
+    return result.data || [];
+  } catch (err) {
+    if (meterSlug === NETWORK_FEE_USD_MICROS_METER && isMeterNotFoundError(err)) {
+      return [];
+    }
+    throw err;
+  }
+}
+
+/**
+ * Query network-fee usage as USD micros, merging legacy micros (pre-cutover)
+ * with nanos (post-cutover) without double-counting the dual-emit window.
+ */
+export async function queryNetworkFeeMeterRowsAsMicros(
+  client: OpenMeter,
+  query: Record<string, unknown>,
+  cutover: Date = getNetworkFeeNanosCutoverAt(),
+): Promise<MeterQueryRow[]> {
+  const { legacy, current } = splitMeterQueryAtCutover(query, cutover);
+  const [legacyRows, currentRows] = await Promise.all([
+    legacy
+      ? queryMeterRowsSafe(client, NETWORK_FEE_USD_MICROS_METER, legacy).then((rows) =>
+          mapRowsToFeeMicros(rows, "micros"),
+        )
+      : Promise.resolve([] as MeterQueryRow[]),
+    current
+      ? queryMeterRowsSafe(client, NETWORK_FEE_USD_NANOS_METER, current).then((rows) =>
+          mapRowsToFeeMicros(rows, "nanos"),
+        )
+      : Promise.resolve([] as MeterQueryRow[]),
+  ]);
+  return [...legacyRows, ...currentRows];
 }
 
 export type OpenMeterUsageRow = {
@@ -635,7 +746,6 @@ export async function queryOpenMeterUserPipelineByModel(input: {
     return [];
   }
 
-  const meterSlug = await getMeterSlugForApp(input.clientId);
   const periodQuery = buildMeterQuery({
     clientId: meterClientId,
     startDate: input.startDate,
@@ -645,14 +755,14 @@ export async function queryOpenMeterUserPipelineByModel(input: {
     groupBy: METER_GROUP_BY_DETAIL,
   });
 
-  const [feeResult, countResult] = await Promise.all([
-    client.meters.query(meterSlug, periodQuery),
+  const [feeRows, countResult] = await Promise.all([
+    queryNetworkFeeMeterRowsAsMicros(client, periodQuery),
     client.meters.query(SIGNED_TICKET_COUNT_METER, periodQuery),
   ]);
 
   return aggregatePipelineModelRows({
     clientId: meterClientId,
-    feeRows: feeResult.data || [],
+    feeRows,
     countRows: countResult.data || [],
   });
 }
@@ -685,7 +795,6 @@ export async function queryOpenMeterUserDailyByPipeline(input: {
     return [];
   }
 
-  const meterSlug = await getMeterSlugForApp(input.clientId);
   const dayQuery = buildMeterQuery({
     clientId: meterClientId,
     startDate: input.startDate,
@@ -695,14 +804,14 @@ export async function queryOpenMeterUserDailyByPipeline(input: {
     groupBy: METER_GROUP_BY_DETAIL,
   });
 
-  const [feeResult, countResult] = await Promise.all([
-    client.meters.query(meterSlug, dayQuery),
+  const [feeRows, countResult] = await Promise.all([
+    queryNetworkFeeMeterRowsAsMicros(client, dayQuery),
     client.meters.query(SIGNED_TICKET_COUNT_METER, dayQuery),
   ]);
 
   return aggregateDailyPipelineModelRows({
     clientId: meterClientId,
-    feeRows: feeResult.data || [],
+    feeRows,
     countRows: countResult.data || [],
   });
 }
@@ -749,7 +858,6 @@ export async function queryOpenMeterUsage(input: {
     return [];
   }
 
-  const meterSlug = await getMeterSlugForApp(input.clientId);
   const periodQuery = buildMeterQuery({
     clientId: meterClientId,
     startDate: input.startDate,
@@ -759,14 +867,14 @@ export async function queryOpenMeterUsage(input: {
     groupBy: METER_GROUP_BY_USER,
   });
 
-  const [feeResult, countResult] = await Promise.all([
-    client.meters.query(meterSlug, periodQuery),
+  const [feeRows, countResult] = await Promise.all([
+    queryNetworkFeeMeterRowsAsMicros(client, periodQuery),
     client.meters.query(SIGNED_TICKET_COUNT_METER, periodQuery),
   ]);
 
   return aggregateUserRows({
     clientId: meterClientId,
-    feeRows: feeResult.data || [],
+    feeRows,
     countRows: countResult.data || [],
     filterExternalUserId: input.externalUserId,
   });
@@ -799,7 +907,6 @@ export async function queryOpenMeterAppDashboardUsage(input: {
     return null;
   }
 
-  const meterSlug = await getMeterSlugForApp(input.clientId);
   const periodQuery = buildMeterQuery({
     clientId: meterClientId,
     startDate: input.startDate,
@@ -815,13 +922,12 @@ export async function queryOpenMeterAppDashboardUsage(input: {
     groupBy: METER_GROUP_BY_DETAIL,
   });
 
-  const [feeResult, countResult, dayCountResult] = await Promise.all([
-    client.meters.query(meterSlug, periodQuery),
+  const [feeRows, countResult, dayCountResult] = await Promise.all([
+    queryNetworkFeeMeterRowsAsMicros(client, periodQuery),
     client.meters.query(SIGNED_TICKET_COUNT_METER, periodQuery),
     client.meters.query(SIGNED_TICKET_COUNT_METER, dayQuery),
   ]);
 
-  const feeRows = feeResult.data || [];
   const countRows = countResult.data || [];
 
   const dayCountRows = dayCountResult.data || [];

--- a/src/lib/openmeter/usage-read.ts
+++ b/src/lib/openmeter/usage-read.ts
@@ -75,7 +75,7 @@ function mapRowsToFeeMicros(
   unit: "micros" | "nanos",
 ): MeterQueryRow[] {
   return rows.map((row) => {
-    const raw = BigInt(Math.floor(Number(row.value ?? 0)));
+    const raw = feeMicrosFromMeterValue(row.value);
     const micros = unit === "nanos" ? usdNanosToMicros(raw) : raw;
     return { ...row, value: Number(micros) };
   });


### PR DESCRIPTION
## Summary
- Time-split usage fee queries across `network_fee_usd_micros` (pre-cutover) and `network_fee_usd_nanos` (post-cutover) so historical usage is preserved without double-counting while the collector dual-emits.
- Restore the real legacy micros meter slug and document cutover / 2-month micros-emit deprecation env knobs (`OPENMETER_NETWORK_FEE_NANOS_CUTOVER_AT`, `OPENMETER_NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER`).
- Keep collector micros dual-emit until ~2026-09-10, then remove that field from the payload.

## Test plan
- [x] `node --import tsx --test src/lib/openmeter/openmeter.test.ts` (cutover split + aggregate fixtures)
- [x] Confirm a user with pre-cutover spend shows non-zero usage again in dashboard / Builder usage API
- [x] Confirm post-cutover usage still accumulates on nanos without double-count across the cutover instant
- [x] CI + SonarQube green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for transitioning network fee reporting from legacy micros-based data to nanos-based data.
  * Usage and dashboard reports now combine legacy and current fee data without double-counting.
  * Added configurable cutover and deprecation dates, with sensible defaults.

* **Bug Fixes**
  * Improved handling when legacy fee meters are unavailable.
  * Standardized network fee values in usage calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->