### PR TITLE
feat(openmeter): USD picos as authoritative network fee meter

### DIFF
--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -121,14 +121,18 @@ pipeline:
         let eth_usd = meta("eth_usd_price").number()
         root = if $eth_usd == null { throw("eth_usd price cache miss") }
 
-        # USD nanos = fee_wei * eth_usd / 1e9  (1 USD = 1e9 nanos).
-        # Nanos avoid .round() collapsing sub-micro staging fees to 0.
-        # Also emit micros (nanos/1000) so the legacy network_fee_usd_micros
-        # meter keeps accepting events during cutover. Remove network_fee_usd_micros
-        # from this payload on/after 2026-09-10 (NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER).
+        # Authoritative fee unit: USD picos (1 USD = 1e12).
+        # Hard cutover from nanos: emit picos only (no network_fee_usd_nanos).
+        # picos = ceil(fee_wei * eth_usd / 1e6)  (== ceil(fee_usd * 1e12))
+        # Any fee_wei > 0 meters at least 1 pico — no free usage from dust.
+        # Dual-emit micros = floor(picos / 1e6) until 2026-09-10
+        # (NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER).
         let fee_wei = $data.computed_fee.number().or(0)
-        let fee_usd_nanos = ($fee_wei * $eth_usd / 1000000000).round()
-        let fee_usd_micros = ($fee_usd_nanos / 1000).round()
+        let fee_usd_picos_raw = ($fee_wei * $eth_usd / 1000000).ceil().or(0)
+        let fee_usd_picos = if $fee_wei > 0 && $fee_usd_picos_raw < 1 { 1 } else { $fee_usd_picos_raw }
+        # Always emit concrete integers — OpenMeter SUM meters reject events
+        # when valueProperty paths are absent/null.
+        let fee_usd_micros = ($fee_usd_picos / 1000000).floor().or(0)
 
         root = if $auth_id == "" {
           deleted()
@@ -145,7 +149,7 @@ pipeline:
               "usage_subject": $usage_subject_parsed,
               "usage_subject_type": $usage_subject_type,
               "external_user_id": $usage_subject_parsed,
-              "network_fee_usd_nanos": $fee_usd_nanos,
+              "network_fee_usd_picos": $fee_usd_picos,
               "network_fee_usd_micros": $fee_usd_micros,
               "pipeline": if $data.pipeline != "" && $data.pipeline != null { $data.pipeline } else { "unknown" },
               "model_id": if $data.model_id != "" && $data.model_id != null { $data.model_id } else { "unknown" },

--- a/docker-compose.clearinghouse.railway.yml
+++ b/docker-compose.clearinghouse.railway.yml
@@ -34,7 +34,10 @@ services:
       start_period: 15s
 
   openmeter-collector:
-    image: ghcr.io/openmeterio/benthos-collector:latest
+    image: ${OPENMETER_COLLECTOR_IMAGE:-pymthouse/openmeter-collector:local}
+    build:
+      context: ./deploy/openmeter-collector
+      dockerfile: Dockerfile
     restart: unless-stopped
     depends_on:
       kafka:

--- a/docker/openmeter/config.railway.yaml
+++ b/docker/openmeter/config.railway.yaml
@@ -49,17 +49,6 @@ meters:
       pipeline: $.pipeline
       model_id: $.model_id
 
-  - slug: network_fee_usd_nanos
-    description: Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — historical before picos hard cutover
-    eventType: create_signed_ticket
-    aggregation: SUM
-    valueProperty: $.network_fee_usd_nanos
-    groupBy:
-      client_id: $.client_id
-      external_user_id: $.external_user_id
-      pipeline: $.pipeline
-      model_id: $.model_id
-
   - slug: signed_ticket_count
     description: Signed ticket count per user
     eventType: create_signed_ticket

--- a/docker/openmeter/config.railway.yaml
+++ b/docker/openmeter/config.railway.yaml
@@ -38,8 +38,19 @@ telemetry:
     level: info
 
 meters:
+  - slug: network_fee_usd_picos
+    description: Livepeer signed-ticket network fee (USD picos; 1 USD = 1e12)
+    eventType: create_signed_ticket
+    aggregation: SUM
+    valueProperty: $.network_fee_usd_picos
+    groupBy:
+      client_id: $.client_id
+      external_user_id: $.external_user_id
+      pipeline: $.pipeline
+      model_id: $.model_id
+
   - slug: network_fee_usd_nanos
-    description: Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9)
+    description: Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — historical before picos hard cutover
     eventType: create_signed_ticket
     aggregation: SUM
     valueProperty: $.network_fee_usd_nanos

--- a/docker/openmeter/config.yaml
+++ b/docker/openmeter/config.yaml
@@ -49,17 +49,6 @@ meters:
       pipeline: $.pipeline
       model_id: $.model_id
 
-  - slug: network_fee_usd_nanos
-    description: Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — historical before picos hard cutover
-    eventType: create_signed_ticket
-    aggregation: SUM
-    valueProperty: $.network_fee_usd_nanos
-    groupBy:
-      client_id: $.client_id
-      external_user_id: $.external_user_id
-      pipeline: $.pipeline
-      model_id: $.model_id
-
   - slug: signed_ticket_count
     description: Signed ticket count per user
     eventType: create_signed_ticket

--- a/docker/openmeter/config.yaml
+++ b/docker/openmeter/config.yaml
@@ -38,8 +38,19 @@ telemetry:
     level: info
 
 meters:
+  - slug: network_fee_usd_picos
+    description: Livepeer signed-ticket network fee (USD picos; 1 USD = 1e12)
+    eventType: create_signed_ticket
+    aggregation: SUM
+    valueProperty: $.network_fee_usd_picos
+    groupBy:
+      client_id: $.client_id
+      external_user_id: $.external_user_id
+      pipeline: $.pipeline
+      model_id: $.model_id
+
   - slug: network_fee_usd_nanos
-    description: Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9)
+    description: Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — historical before picos hard cutover
     eventType: create_signed_ticket
     aggregation: SUM
     valueProperty: $.network_fee_usd_nanos

--- a/scripts/openmeter-bootstrap.ts
+++ b/scripts/openmeter-bootstrap.ts
@@ -5,7 +5,7 @@ dotenv.config();
 import { createOpenMeterClient } from "../src/lib/openmeter/client";
 import {
   isKonnectMeteringUrl,
-  NETWORK_FEE_USD_NANOS_METER,
+  NETWORK_FEE_USD_PICOS_METER,
   normalizeKonnectMeteringUrl,
   SIGNED_TICKET_COUNT_METER,
 } from "../src/lib/openmeter/constants";
@@ -68,10 +68,10 @@ async function bootstrapKonnect(baseUrl: string, apiKey: string, featureKey: str
 
   await ensureKonnectTenantCatalog(featureKey);
 
-  const networkFeeMeterId = await resolveKonnectMeterId(NETWORK_FEE_USD_NANOS_METER);
+  const networkFeeMeterId = await resolveKonnectMeterId(NETWORK_FEE_USD_PICOS_METER);
   const ticketCountMeterId = await resolveKonnectMeterId(SIGNED_TICKET_COUNT_METER);
   console.log(
-    `[openmeter-bootstrap] Konnect meter ready: ${NETWORK_FEE_USD_NANOS_METER} id=${networkFeeMeterId}`,
+    `[openmeter-bootstrap] Konnect meter ready: ${NETWORK_FEE_USD_PICOS_METER} id=${networkFeeMeterId}`,
   );
   console.log(
     `[openmeter-bootstrap] Konnect meter ready: ${SIGNED_TICKET_COUNT_METER} id=${ticketCountMeterId}`,
@@ -127,7 +127,7 @@ async function ensureSelfHostedFeature(
     await client.features.create({
       key: featureKey,
       name: "Network spend",
-      meterSlug: NETWORK_FEE_USD_NANOS_METER,
+      meterSlug: NETWORK_FEE_USD_PICOS_METER,
     });
     console.log(`[openmeter-bootstrap] created feature: ${featureKey}`);
   } catch (err) {

--- a/src/app/api/v1/apps/[id]/openmeter/route.ts
+++ b/src/app/api/v1/apps/[id]/openmeter/route.ts
@@ -84,7 +84,7 @@ export async function PUT(
     baseUrl: mode === "pymthouse_hosted" ? null : String(body.baseUrl).trim(),
     apiKeyEncrypted,
     meterSlug: resolveNetworkFeeMeterSlug(
-      String(body.meterSlug || existing?.meterSlug || "network_fee_usd_nanos"),
+      String(body.meterSlug || existing?.meterSlug || "network_fee_usd_picos"),
     ),
     trialFeatureKey: String(body.trialFeatureKey || existing?.trialFeatureKey || "network_spend"),
     updatedAt: new Date().toISOString(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -512,7 +512,7 @@ export const appOpenMeterConfig = pgTable(
     mode: text("mode").notNull().default("pymthouse_hosted"),
     baseUrl: text("base_url"),
     apiKeyEncrypted: text("api_key_encrypted"),
-    meterSlug: text("meter_slug").notNull().default("network_fee_usd_nanos"),
+    meterSlug: text("meter_slug").notNull().default("network_fee_usd_picos"),
     trialFeatureKey: text("trial_feature_key").notNull().default("network_spend"),
     createdAt: text("created_at")
       .notNull()

--- a/src/lib/bpp/forbidden-fields.test.ts
+++ b/src/lib/bpp/forbidden-fields.test.ts
@@ -12,6 +12,7 @@ test("the forbidden list mirrors the C0 provider-internal-openmeter contract", (
   const expected = [
     "openmeter_subscription_id",
     "openmeter_customer_id",
+    "network_fee_usd_picos",
     "network_fee_usd_nanos",
     "fee_wei",
     "eth_usd_price",

--- a/src/lib/bpp/forbidden-fields.ts
+++ b/src/lib/bpp/forbidden-fields.ts
@@ -20,6 +20,7 @@
 export const FORBIDDEN_INTERNAL_FIELD_NAMES: readonly string[] = [
   "openmeter_subscription_id",
   "openmeter_customer_id",
+  "network_fee_usd_picos",
   "network_fee_usd_nanos",
   "fee_wei",
   "eth_usd_price",

--- a/src/lib/format-usd.test.ts
+++ b/src/lib/format-usd.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 import {
   formatUsdMicros,
   formatUsdNanos,
+  formatUsdPicos,
   formatUsdMicrosDisplay,
   formatUsdNanosDisplay,
+  formatUsdPicosDisplay,
 } from "./format-usd";
 
 test("formatUsdMicros shows sub-cent fees at 6 digits", () => {
@@ -17,9 +19,19 @@ test("formatUsdNanos formats OpenMeter meter units", () => {
   assert.equal(formatUsdNanos("14873", 9), "$0.000014873");
 });
 
+test("formatUsdPicos formats sub-micro dust", () => {
+  assert.equal(formatUsdPicos("2", 12), "$0.000000000002");
+  assert.equal(formatUsdPicos("1500000", 6), "$0.000001");
+});
+
 test("formatUsdNanosDisplay adapts fraction digits", () => {
   assert.equal(formatUsdNanosDisplay("0"), "$0");
   assert.equal(formatUsdNanosDisplay("14873"), "$0.000014");
+});
+
+test("formatUsdPicosDisplay shows dust below one micro", () => {
+  assert.equal(formatUsdPicosDisplay("0"), "$0");
+  assert.equal(formatUsdPicosDisplay("2"), "$0.000000000002");
 });
 
 test("formatUsdMicrosDisplay uses fixed $0.00 cents for allowance UI", () => {

--- a/src/lib/format-usd.ts
+++ b/src/lib/format-usd.ts
@@ -4,6 +4,9 @@ export const USD_MICROS_PER_DOLLAR = 1_000_000n;
 /** 1 USD = 1_000_000_000 nanos (OpenMeter network_fee_usd_nanos meter). */
 export const USD_NANOS_PER_DOLLAR = 1_000_000_000n;
 
+/** 1 USD = 1_000_000_000_000 picos (OpenMeter network_fee_usd_picos meter). */
+export const USD_PICOS_PER_DOLLAR = 1_000_000_000_000n;
+
 function isIntegerAmountString(value: string): boolean {
   if (value.length === 0) return false;
   let i = 0;
@@ -72,12 +75,20 @@ export function formatUsdMicros(
   return formatUsdMinorUnits(microsStr, USD_MICROS_PER_DOLLAR, maxFractionDigits);
 }
 
-/** Format integer USD nanos (1 USD = 1e9) — OpenMeter network fee meter unit. */
+/** Format integer USD nanos (1 USD = 1e9) — legacy OpenMeter network fee dual-emit unit. */
 export function formatUsdNanos(
   nanosStr: string | undefined | null,
   maxFractionDigits: number,
 ): string | null {
   return formatUsdMinorUnits(nanosStr, USD_NANOS_PER_DOLLAR, maxFractionDigits);
+}
+
+/** Format integer USD picos (1 USD = 1e12) — authoritative OpenMeter network fee meter unit. */
+export function formatUsdPicos(
+  picosStr: string | undefined | null,
+  maxFractionDigits: number,
+): string | null {
+  return formatUsdMinorUnits(picosStr, USD_PICOS_PER_DOLLAR, maxFractionDigits);
 }
 
 function formatUsdMinorUnitsDisplay(
@@ -98,6 +109,8 @@ function formatUsdMinorUnitsDisplay(
     if (usdApprox >= 1) digits = 2;
     else if (usdApprox >= 0.01) digits = 3;
     else if (usdApprox >= 0.0001) digits = 4;
+    // Picos (1e12) need full scale to show sub-micro dust; nanos stay at 6.
+    else if (usdApprox > 0 && scale >= 12) digits = scale;
     return (
       formatUsdMinorUnits(amountStr, subunitsPerDollar, digits) ??
       `${negative ? "-" : ""}$0`
@@ -130,4 +143,9 @@ export function formatUsdMicrosDisplay(microsStr: string | undefined | null): st
 /** Always returns a `$…` string for OpenMeter nanos fee UI. */
 export function formatUsdNanosDisplay(nanosStr: string | undefined | null): string {
   return formatUsdMinorUnitsDisplay(nanosStr, USD_NANOS_PER_DOLLAR);
+}
+
+/** Always returns a `$…` string for OpenMeter picos fee UI (sub-micro dust). */
+export function formatUsdPicosDisplay(picosStr: string | undefined | null): string {
+  return formatUsdMinorUnitsDisplay(picosStr, USD_PICOS_PER_DOLLAR);
 }

--- a/src/lib/openmeter/capability-features.ts
+++ b/src/lib/openmeter/capability-features.ts
@@ -1,6 +1,6 @@
 import type { OpenMeter } from "@openmeter/sdk";
 import { billingStableFeatureKeysEnabled } from "@/lib/billing/feature-flags";
-import { NETWORK_FEE_USD_NANOS_METER } from "./constants";
+import { NETWORK_FEE_USD_PICOS_METER } from "./constants";
 import { unwrapOpenMeterListResult } from "./konnect-catalog";
 import {
   compactClientSlug,
@@ -134,7 +134,7 @@ export async function ensureCapabilityOpenMeterFeature(input: {
   await input.client.features.create({
     key,
     name: input.displayName,
-    meterSlug: NETWORK_FEE_USD_NANOS_METER,
+    meterSlug: NETWORK_FEE_USD_PICOS_METER,
     advancedMeterGroupByFilters: buildCapabilityMeterGroupByFilters({
       pipeline: input.pipeline,
       modelId: input.modelId,

--- a/src/lib/openmeter/client-factory.ts
+++ b/src/lib/openmeter/client-factory.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/index";
 import { appOpenMeterConfig } from "@/db/schema";
 import type { OpenMeterBackendMode } from "./constants";
-import { NETWORK_FEE_USD_NANOS_METER } from "./constants";
+import { NETWORK_FEE_USD_PICOS_METER } from "./constants";
 import { createOpenMeterClient, getHostedOpenMeterClient } from "./client";
 import type { OpenMeter } from "@openmeter/sdk";
 
@@ -14,12 +14,17 @@ export type ResolvedAppOpenMeterConfig = {
   trialFeatureKey: string;
 };
 
-/** Map legacy micros meter rows onto the nanos meter used by collector ingest. */
+/** Map legacy micros/nanos meter rows onto the picos meter used by collector ingest. */
 export function resolveNetworkFeeMeterSlug(raw: string | null | undefined): string {
-  if (!raw?.trim() || raw.trim() === "network_fee_usd_micros") {
-    return NETWORK_FEE_USD_NANOS_METER;
+  const slug = raw?.trim();
+  if (
+    !slug ||
+    slug === "network_fee_usd_micros" ||
+    slug === "network_fee_usd_nanos"
+  ) {
+    return NETWORK_FEE_USD_PICOS_METER;
   }
-  return raw.trim();
+  return slug;
 }
 
 function decodeApiKey(stored: string | null | undefined): string | undefined {

--- a/src/lib/openmeter/constants.ts
+++ b/src/lib/openmeter/constants.ts
@@ -1,10 +1,13 @@
+/** OpenMeter meter slug for network fee aggregation (USD picos; 1 USD = 1e12). */
+export const NETWORK_FEE_USD_PICOS_METER = "network_fee_usd_picos";
+
 /** OpenMeter meter slug for network fee aggregation (USD nanos; 1 USD = 1e9). */
 export const NETWORK_FEE_USD_NANOS_METER = "network_fee_usd_nanos";
 
 /**
  * Legacy network-fee meter (USD micros). Historical usage before the nanos cutover
- * still lives here. Usage reads time-split across micros + nanos; collector dual-emits
- * until NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER.
+ * still lives here. Usage reads: micros|nanos before the picos hard cutover, then
+ * picos only. Collector dual-emits micros until NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER.
  */
 export const NETWORK_FEE_USD_MICROS_METER = "network_fee_usd_micros";
 
@@ -14,8 +17,17 @@ export const NETWORK_FEE_USD_MICROS_METER = "network_fee_usd_micros";
  */
 export const NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER = new Date("2026-09-10T00:00:00.000Z");
 
-/** 1 USD micro = 1_000 USD nanos. Meter stores nanos; app ledger/UI stays in micros. */
+/** 1 USD micro = 1_000 USD nanos. */
 export const USD_NANOS_PER_MICRO = 1000n;
+
+/** 1 USD nano = 1_000 USD picos. */
+export const USD_PICOS_PER_NANO = 1000n;
+
+/** 1 USD micro = 1_000_000 USD picos. */
+export const USD_PICOS_PER_MICRO = 1_000_000n;
+
+/** 1 USD = 1_000_000_000_000 USD picos. */
+export const USD_PICOS_PER_DOLLAR = 1_000_000_000_000n;
 
 export function usdNanosToMicros(nanos: bigint): bigint {
   return nanos / USD_NANOS_PER_MICRO;
@@ -23,6 +35,31 @@ export function usdNanosToMicros(nanos: bigint): bigint {
 
 export function usdMicrosToNanos(micros: bigint): bigint {
   return micros * USD_NANOS_PER_MICRO;
+}
+
+export function usdPicosToMicros(picos: bigint): bigint {
+  return picos / USD_PICOS_PER_MICRO;
+}
+
+export function usdMicrosToPicos(micros: bigint): bigint {
+  return micros * USD_PICOS_PER_MICRO;
+}
+
+export function usdPicosToNanos(picos: bigint): bigint {
+  return picos / USD_PICOS_PER_NANO;
+}
+
+/**
+ * Mirror collector fee mapping: ceil(fee_wei * eth_usd / 1e6), min 1 when fee_wei > 0.
+ * ethUsd is the ETH/USD spot (e.g. 3500).
+ */
+export function feeWeiToUsdPicos(feeWei: bigint, ethUsd: number): bigint {
+  if (feeWei <= 0n || !(ethUsd > 0) || !Number.isFinite(ethUsd)) {
+    return 0n;
+  }
+  const raw = (Number(feeWei) * ethUsd) / 1e6;
+  const picos = BigInt(Math.ceil(raw));
+  return picos < 1n ? 1n : picos;
 }
 
 type EnvLike = Record<string, string | undefined>;
@@ -41,6 +78,22 @@ export function getNetworkFeeNanosCutoverAt(env: EnvLike = process.env): Date {
     }
   }
   return new Date("2026-07-10T00:00:00.000Z");
+}
+
+/**
+ * Hard cutover: `network_fee_usd_picos` becomes the only fee meter written/read
+ * for new usage. Pre-cutover history stays on micros|nanos. Override with
+ * OPENMETER_NETWORK_FEE_PICOS_CUTOVER_AT (ISO-8601).
+ */
+export function getNetworkFeePicosCutoverAt(env: EnvLike = process.env): Date {
+  const raw = env.OPENMETER_NETWORK_FEE_PICOS_CUTOVER_AT?.trim();
+  if (raw) {
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return new Date("2026-07-11T00:00:00.000Z");
 }
 
 /** Fixed date to stop dual-emitting legacy micros fields from the collector. */

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -2,7 +2,6 @@ import type { OpenMeter } from "@openmeter/sdk";
 import {
   CREATE_SIGNED_TICKET_EVENT_TYPE,
   getHostedOpenMeterUrl,
-  NETWORK_FEE_USD_NANOS_METER,
   NETWORK_FEE_USD_PICOS_METER,
   SIGNED_TICKET_COUNT_METER,
   SIGNED_TICKET_EVENT_SOURCE,
@@ -183,20 +182,6 @@ export const OPENMETER_METER_DEFINITIONS = [
     eventType: CREATE_SIGNED_TICKET_EVENT_TYPE,
     aggregation: "SUM" as const,
     valueProperty: "$.network_fee_usd_picos",
-    groupBy: {
-      client_id: "$.client_id",
-      external_user_id: "$.external_user_id",
-      pipeline: "$.pipeline",
-      model_id: "$.model_id",
-    },
-  },
-  {
-    slug: NETWORK_FEE_USD_NANOS_METER,
-    description:
-      "Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — historical meter before picos hard cutover",
-    eventType: CREATE_SIGNED_TICKET_EVENT_TYPE,
-    aggregation: "SUM" as const,
-    valueProperty: "$.network_fee_usd_nanos",
     groupBy: {
       client_id: "$.client_id",
       external_user_id: "$.external_user_id",

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -3,10 +3,11 @@ import {
   CREATE_SIGNED_TICKET_EVENT_TYPE,
   getHostedOpenMeterUrl,
   NETWORK_FEE_USD_NANOS_METER,
+  NETWORK_FEE_USD_PICOS_METER,
   SIGNED_TICKET_COUNT_METER,
   SIGNED_TICKET_EVENT_SOURCE,
-  usdMicrosToNanos,
-  usdNanosToMicros,
+  usdMicrosToPicos,
+  usdPicosToMicros,
 } from "./constants";
 import { buildOpenMeterCustomerKey } from "./customer-key";
 import { ensureOpenMeterCustomer } from "./customers";
@@ -37,8 +38,8 @@ export async function grantTrialCredits(input: {
     input.customerKey,
     input.featureKey,
     {
-      // OpenMeter meter is USD nanos; app grants stay in micros.
-      amount: Number(usdMicrosToNanos(input.amountUsdMicros)),
+      // OpenMeter meter is USD picos; app grants stay in micros.
+      amount: Number(usdMicrosToPicos(input.amountUsdMicros)),
       priority: 1,
       effectiveAt: new Date(),
       expiration: { duration: "YEAR", count: 1 },
@@ -102,16 +103,16 @@ export async function getTrialCreditBalance(input: {
 
   const balance = Math.max(
     0,
-    Number(usdNanosToMicros(BigInt(Math.floor(value.balance ?? 0)))),
+    Number(usdPicosToMicros(BigInt(Math.floor(value.balance ?? 0)))),
   );
   const usage = Math.max(
     0,
-    Number(usdNanosToMicros(BigInt(Math.floor(value.usage ?? 0)))),
+    Number(usdPicosToMicros(BigInt(Math.floor(value.usage ?? 0)))),
   );
   const granted = Math.max(
     0,
     Number(
-      usdNanosToMicros(
+      usdPicosToMicros(
         BigInt(Math.floor(value.totalAvailableGrantAmount ?? (value.balance ?? 0) + (value.usage ?? 0))),
       ),
     ),
@@ -158,8 +159,8 @@ export async function ingestSignedTicketEvent(input: {
       usage_subject: usageSubject,
       usage_subject_type: "external_user_id",
       external_user_id: usageSubject,
-      network_fee_usd_nanos: Number(
-        usdMicrosToNanos(BigInt(input.event.networkFeeUsdMicros || "0")),
+      network_fee_usd_picos: Number(
+        usdMicrosToPicos(BigInt(input.event.networkFeeUsdMicros || "0")),
       ),
       fee_wei: input.event.feeWei,
       pixels: input.event.pixels,
@@ -176,9 +177,23 @@ export async function ingestSignedTicketEvent(input: {
 
 export const OPENMETER_METER_DEFINITIONS = [
   {
+    slug: NETWORK_FEE_USD_PICOS_METER,
+    description:
+      "Livepeer signed-ticket network fee (USD picos; 1 USD = 1e12) — SUM of collector network_fee_usd_picos; grouped by client, user, pipeline, model",
+    eventType: CREATE_SIGNED_TICKET_EVENT_TYPE,
+    aggregation: "SUM" as const,
+    valueProperty: "$.network_fee_usd_picos",
+    groupBy: {
+      client_id: "$.client_id",
+      external_user_id: "$.external_user_id",
+      pipeline: "$.pipeline",
+      model_id: "$.model_id",
+    },
+  },
+  {
     slug: NETWORK_FEE_USD_NANOS_METER,
     description:
-      "Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — SUM of collector network_fee_usd_nanos; grouped by client, user, pipeline, model",
+      "Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — historical meter before picos hard cutover",
     eventType: CREATE_SIGNED_TICKET_EVENT_TYPE,
     aggregation: "SUM" as const,
     valueProperty: "$.network_fee_usd_nanos",
@@ -207,5 +222,6 @@ export {
   DEFAULT_TRIAL_FEATURE_KEY,
   NETWORK_FEE_USD_MICROS_METER,
   NETWORK_FEE_USD_NANOS_METER,
+  NETWORK_FEE_USD_PICOS_METER,
   SIGNED_TICKET_COUNT_METER,
 } from "./constants";

--- a/src/lib/openmeter/konnect-catalog.ts
+++ b/src/lib/openmeter/konnect-catalog.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_TRIAL_FEATURE_KEY,
   getHostedOpenMeterUrl,
   NETWORK_FEE_USD_NANOS_METER,
+  NETWORK_FEE_USD_PICOS_METER,
   normalizeKonnectMeteringUrl,
   SIGNED_TICKET_COUNT_METER,
 } from "./constants";
@@ -25,10 +26,25 @@ type KonnectFeature = {
 
 const KONNECT_METER_DEFINITIONS = [
   {
+    key: NETWORK_FEE_USD_PICOS_METER,
+    name: "Network fee (USD picos)",
+    description:
+      "Livepeer signed-ticket network fee (USD picos; 1 USD = 1e12) — sum of collector network_fee_usd_picos",
+    event_type: CREATE_SIGNED_TICKET_EVENT_TYPE,
+    aggregation: "sum" as const,
+    value_property: "$.network_fee_usd_picos",
+    dimensions: {
+      client_id: "$.client_id",
+      external_user_id: "$.external_user_id",
+      pipeline: "$.pipeline",
+      model_id: "$.model_id",
+    },
+  },
+  {
     key: NETWORK_FEE_USD_NANOS_METER,
     name: "Network fee (USD nanos)",
     description:
-      "Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — sum of collector network_fee_usd_nanos",
+      "Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — historical meter before picos hard cutover",
     event_type: CREATE_SIGNED_TICKET_EVENT_TYPE,
     aggregation: "sum" as const,
     value_property: "$.network_fee_usd_nanos",
@@ -151,7 +167,7 @@ export async function ensureKonnectTenantCatalog(
 
   if (
     konnectCatalogEnsured &&
-    konnectMeterIdByKeyCache?.has(NETWORK_FEE_USD_NANOS_METER) &&
+    konnectMeterIdByKeyCache?.has(NETWORK_FEE_USD_PICOS_METER) &&
     konnectMeterIdByKeyCache.has(SIGNED_TICKET_COUNT_METER)
   ) {
     return;
@@ -173,10 +189,10 @@ export async function ensureKonnectTenantCatalog(
   cacheKonnectMeters(existingMeters);
 
   const networkFeeMeter = existingMeters.find(
-    (meter) => meter.key === NETWORK_FEE_USD_NANOS_METER,
+    (meter) => meter.key === NETWORK_FEE_USD_PICOS_METER,
   );
   if (!networkFeeMeter) {
-    throw new Error(`Konnect meter missing: ${NETWORK_FEE_USD_NANOS_METER}`);
+    throw new Error(`Konnect meter missing: ${NETWORK_FEE_USD_PICOS_METER}`);
   }
 
   const features = await konnectAdminFetch<KonnectPage<KonnectFeature>>("/features");

--- a/src/lib/openmeter/konnect-catalog.ts
+++ b/src/lib/openmeter/konnect-catalog.ts
@@ -22,7 +22,11 @@ type KonnectMeter = {
 type KonnectFeature = {
   id: string;
   key: string;
+  meter?: { id?: string };
 };
+
+/** Meters that must not remain active: they reject ingest when their valueProperty is absent. */
+const DEPRECATED_NETWORK_FEE_METER_KEYS = [NETWORK_FEE_USD_NANOS_METER] as const;
 
 const KONNECT_METER_DEFINITIONS = [
   {
@@ -33,21 +37,6 @@ const KONNECT_METER_DEFINITIONS = [
     event_type: CREATE_SIGNED_TICKET_EVENT_TYPE,
     aggregation: "sum" as const,
     value_property: "$.network_fee_usd_picos",
-    dimensions: {
-      client_id: "$.client_id",
-      external_user_id: "$.external_user_id",
-      pipeline: "$.pipeline",
-      model_id: "$.model_id",
-    },
-  },
-  {
-    key: NETWORK_FEE_USD_NANOS_METER,
-    name: "Network fee (USD nanos)",
-    description:
-      "Livepeer signed-ticket network fee (USD nanos; 1 USD = 1e9) — historical meter before picos hard cutover",
-    event_type: CREATE_SIGNED_TICKET_EVENT_TYPE,
-    aggregation: "sum" as const,
-    value_property: "$.network_fee_usd_nanos",
     dimensions: {
       client_id: "$.client_id",
       external_user_id: "$.external_user_id",
@@ -174,6 +163,18 @@ export async function ensureKonnectTenantCatalog(
   }
 
   let existingMeters = await listKonnectMeters();
+
+  for (const deprecatedKey of DEPRECATED_NETWORK_FEE_METER_KEYS) {
+    const deprecated = existingMeters.find((meter) => meter.key === deprecatedKey);
+    if (!deprecated) {
+      continue;
+    }
+    // Active SUM meters reject ingest when their valueProperty is missing from events.
+    // Hard cutover stops emitting nanos — delete the meter so ingest can proceed.
+    await konnectAdminFetch<unknown>(`/meters/${encodeURIComponent(deprecated.id)}`, {
+      method: "DELETE",
+    });
+  }
 
   for (const meter of KONNECT_METER_DEFINITIONS) {
     if (existingMeters.some((item) => item.key === meter.key)) {

--- a/src/lib/openmeter/konnect-plan-body.ts
+++ b/src/lib/openmeter/konnect-plan-body.ts
@@ -1,5 +1,5 @@
 /** Convert SDK camelCase keys to Konnect snake_case (recursive). */
-import { usdMicrosToNanos } from "./constants";
+import { usdMicrosToPicos } from "./constants";
 
 export function camelToSnakeKey(key: string): string {
   return key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
@@ -99,7 +99,7 @@ export function buildKonnectUsageRateCard(input: {
   featureId: string;
   unitAmount: string;
   billingCadence?: string;
-  /** Free usage units (USD micros in app; converted to meter nanos below). */
+  /** Free usage units (USD micros in app; converted to meter picos below). */
   includedMicros?: number;
 }): Record<string, unknown> {
   const card: Record<string, unknown> = {
@@ -115,7 +115,7 @@ export function buildKonnectUsageRateCard(input: {
 
   if (input.includedMicros != null && input.includedMicros > 0) {
     card.discounts = {
-      usage: String(usdMicrosToNanos(BigInt(input.includedMicros))),
+      usage: String(usdMicrosToPicos(BigInt(input.includedMicros))),
     };
   }
 

--- a/src/lib/openmeter/konnect-routes.test.ts
+++ b/src/lib/openmeter/konnect-routes.test.ts
@@ -199,7 +199,7 @@ test("buildKonnectUsageRateCard applies included usage discounts", () => {
     unitAmount: "0.000001",
     includedMicros: 5_000_000,
   });
-  assert.deepEqual(card.discounts, { usage: "5000000000" });
+  assert.deepEqual(card.discounts, { usage: "5000000000000" });
 });
 
 test("buildKonnectUsageRateCard omits discounts when includedMicros is absent", () => {

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -12,20 +12,27 @@ import {
 } from "@/lib/oidc/mint-user-signer-token";
 import { buildOpenMeterUsageResponse } from "@/lib/usage/query-openmeter";
 import {
+  getNetworkFeeMicrosEmitDeprecateAfter,
+  getNetworkFeeNanosCutoverAt,
+  getNetworkFeePicosCutoverAt,
+  NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER,
+  NETWORK_FEE_USD_MICROS_METER,
+  NETWORK_FEE_USD_NANOS_METER,
+  NETWORK_FEE_USD_PICOS_METER,
+  feeWeiToUsdPicos,
+  usdMicrosToPicos,
+  usdPicosToMicros,
+} from "@/lib/openmeter/constants";
+import {
   aggregateDailyRequestCounts,
   aggregateDailyPipelineModelRows,
   aggregatePipelineModelRows,
   aggregateUserPipelineModelRows,
   dateKeyFromMeterWindow,
   splitMeterQueryAtCutover,
+  splitNetworkFeeMeterQueryWindows,
 } from "@/lib/openmeter/usage-read";
-import {
-  getNetworkFeeMicrosEmitDeprecateAfter,
-  getNetworkFeeNanosCutoverAt,
-  NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER,
-  NETWORK_FEE_USD_MICROS_METER,
-  NETWORK_FEE_USD_NANOS_METER,
-} from "@/lib/openmeter/constants";
+import { resolveNetworkFeeMeterSlug } from "@/lib/openmeter/client-factory";
 import {
   isOpenMeterSubscriptionActive,
   verifyOpenMeterSubscriptionId,
@@ -627,7 +634,7 @@ test("mapPymthousePlanToOpenMeterCreate maps Starter plan with network_spend ent
   assert.equal(
     (usage.entitlementTemplate as { issueAfterReset?: number } | undefined)
       ?.issueAfterReset,
-    5_000_000_000,
+    5_000_000_000_000,
   );
 });
 
@@ -728,7 +735,16 @@ test("verifyOpenMeterPlanId returns null when remote plan missing", async () => 
 test("NETWORK_FEE_USD_MICROS_METER keeps the legacy slug for historical reads", () => {
   assert.equal(NETWORK_FEE_USD_MICROS_METER, "network_fee_usd_micros");
   assert.equal(NETWORK_FEE_USD_NANOS_METER, "network_fee_usd_nanos");
+  assert.equal(NETWORK_FEE_USD_PICOS_METER, "network_fee_usd_picos");
   assert.notEqual(NETWORK_FEE_USD_MICROS_METER, NETWORK_FEE_USD_NANOS_METER);
+  assert.notEqual(NETWORK_FEE_USD_NANOS_METER, NETWORK_FEE_USD_PICOS_METER);
+});
+
+test("resolveNetworkFeeMeterSlug maps legacy micros/nanos onto picos", () => {
+  assert.equal(resolveNetworkFeeMeterSlug(null), NETWORK_FEE_USD_PICOS_METER);
+  assert.equal(resolveNetworkFeeMeterSlug("network_fee_usd_micros"), NETWORK_FEE_USD_PICOS_METER);
+  assert.equal(resolveNetworkFeeMeterSlug("network_fee_usd_nanos"), NETWORK_FEE_USD_PICOS_METER);
+  assert.equal(resolveNetworkFeeMeterSlug("network_fee_usd_picos"), NETWORK_FEE_USD_PICOS_METER);
 });
 
 test("getNetworkFeeNanosCutoverAt defaults to 2026-07-10 and honors env override", () => {
@@ -739,6 +755,30 @@ test("getNetworkFeeNanosCutoverAt defaults to 2026-07-10 and honors env override
     }).toISOString(),
     "2026-07-11T12:00:00.000Z",
   );
+});
+
+test("getNetworkFeePicosCutoverAt defaults to 2026-07-11 and honors env override", () => {
+  assert.equal(getNetworkFeePicosCutoverAt({}).toISOString(), "2026-07-11T00:00:00.000Z");
+  assert.equal(
+    getNetworkFeePicosCutoverAt({
+      OPENMETER_NETWORK_FEE_PICOS_CUTOVER_AT: "2026-07-12T00:00:00.000Z",
+    }).toISOString(),
+    "2026-07-12T00:00:00.000Z",
+  );
+});
+
+test("feeWeiToUsdPicos ceils and never meters fee_wei>0 as free", () => {
+  // 300 wei * $3500 / 1e6 = 1.05 → ceil 2 picos
+  assert.equal(feeWeiToUsdPicos(300n, 3500), 2n);
+  // Sub-pico dust still meters as 1
+  assert.equal(feeWeiToUsdPicos(1n, 1), 1n);
+  assert.equal(feeWeiToUsdPicos(0n, 3500), 0n);
+});
+
+test("usdMicrosToPicos / usdPicosToMicros round-trip truncating", () => {
+  assert.equal(usdMicrosToPicos(5_000_000n), 5_000_000_000_000n);
+  assert.equal(usdPicosToMicros(5_000_000_000_000n), 5_000_000n);
+  assert.equal(usdPicosToMicros(999_999n), 0n);
 });
 
 test("NETWORK_FEE_MICROS_EMIT_DEPRECATE_AFTER is fixed at 2026-09-10", () => {
@@ -769,6 +809,41 @@ test("splitMeterQueryAtCutover isolates legacy micros and current nanos windows"
   assert.equal((legacy.from as Date).toISOString(), "2026-06-01T00:00:00.000Z");
   assert.equal((current.from as Date).toISOString(), cutover.toISOString());
   assert.equal((current.to as Date).toISOString(), "2026-08-01T00:00:00.000Z");
+});
+
+test("splitNetworkFeeMeterQueryWindows hard-cuts to picos; micros|nanos only pre-cutover", () => {
+  const nanosCutover = new Date("2026-07-10T00:00:00.000Z");
+  const picosCutover = new Date("2026-07-11T00:00:00.000Z");
+  const { micros, nanos, picos } = splitNetworkFeeMeterQueryWindows(
+    {
+      from: new Date("2026-06-01T00:00:00.000Z"),
+      to: new Date("2026-08-01T00:00:00.000Z"),
+    },
+    nanosCutover,
+    picosCutover,
+  );
+  assert.ok(micros);
+  assert.ok(nanos);
+  assert.ok(picos);
+  assert.equal((micros.to as Date).toISOString(), nanosCutover.toISOString());
+  assert.equal((nanos.from as Date).toISOString(), nanosCutover.toISOString());
+  assert.equal((nanos.to as Date).toISOString(), picosCutover.toISOString());
+  assert.equal((picos.from as Date).toISOString(), picosCutover.toISOString());
+  assert.equal((picos.to as Date).toISOString(), "2026-08-01T00:00:00.000Z");
+});
+
+test("splitNetworkFeeMeterQueryWindows returns only picos after picos cutover", () => {
+  const { micros, nanos, picos } = splitNetworkFeeMeterQueryWindows(
+    {
+      from: new Date("2026-07-11T00:00:00.000Z"),
+      to: new Date("2026-08-01T00:00:00.000Z"),
+    },
+    new Date("2026-07-10T00:00:00.000Z"),
+    new Date("2026-07-11T00:00:00.000Z"),
+  );
+  assert.equal(micros, null);
+  assert.equal(nanos, null);
+  assert.ok(picos);
 });
 
 test("splitMeterQueryAtCutover returns only legacy when range ends at cutover", () => {

--- a/src/lib/openmeter/plans-sync.ts
+++ b/src/lib/openmeter/plans-sync.ts
@@ -2,7 +2,7 @@ import type { OpenMeter } from "@openmeter/sdk";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db/index";
 import { planCapabilityBundles, plans } from "@/db/schema";
-import { getHostedOpenMeterUrl, DEFAULT_TRIAL_FEATURE_KEY, NETWORK_FEE_USD_NANOS_METER, usdMicrosToNanos } from "./constants";
+import { getHostedOpenMeterUrl, DEFAULT_TRIAL_FEATURE_KEY, NETWORK_FEE_USD_PICOS_METER, usdMicrosToPicos } from "./constants";
 import {
   ensureKonnectTenantCatalog,
   findKonnectFeatureIdByKey,
@@ -120,8 +120,8 @@ function buildUsageRateCard(input: {
         ? {
             type: "metered",
             isSoftLimit: false,
-            // Meter is USD nanos; plan allowance is stored in micros.
-            issueAfterReset: Number(usdMicrosToNanos(BigInt(input.includedMicros))),
+            // Meter is USD picos; plan allowance is stored in micros.
+            issueAfterReset: Number(usdMicrosToPicos(BigInt(input.includedMicros))),
             issueAfterResetPriority: 1,
           }
         : undefined,
@@ -312,7 +312,7 @@ export async function mapPymthousePlanToOpenMeterCreate(input: {
       metadata: {
         pymthouse_client_id: input.clientId,
         pymthouse_plan_id: plan.id,
-        meter_slug: NETWORK_FEE_USD_NANOS_METER,
+        meter_slug: NETWORK_FEE_USD_PICOS_METER,
       },
     };
   }
@@ -333,7 +333,7 @@ export async function mapPymthousePlanToOpenMeterCreate(input: {
     metadata: {
       pymthouse_client_id: input.clientId,
       pymthouse_plan_id: plan.id,
-      meter_slug: NETWORK_FEE_USD_NANOS_METER,
+      meter_slug: NETWORK_FEE_USD_PICOS_METER,
     },
   };
 }

--- a/src/lib/openmeter/usage-read.ts
+++ b/src/lib/openmeter/usage-read.ts
@@ -5,12 +5,15 @@ import { resolveOpenMeterMeterClientId } from "@/lib/openmeter/meter-client-id";
 import { buildOpenMeterCustomerKey } from "@/lib/openmeter/customer-key";
 import {
   getNetworkFeeNanosCutoverAt,
+  getNetworkFeePicosCutoverAt,
   NETWORK_FEE_USD_MICROS_METER,
   NETWORK_FEE_USD_NANOS_METER,
+  NETWORK_FEE_USD_PICOS_METER,
   openMeterUsesLiveNetworkInTests,
   requireOpenMeterForUsageReads,
   SIGNED_TICKET_COUNT_METER,
   usdNanosToMicros,
+  usdPicosToMicros,
 } from "@/lib/openmeter/constants";
 import type { MeterQueryRow, OpenMeter } from "@openmeter/sdk";
 
@@ -38,8 +41,8 @@ function asQueryDate(value: unknown): Date | null {
 }
 
 /**
- * Split a meter query at the nanos cutover so legacy micros and current nanos
- * windows do not overlap (avoids double-count while collector dual-emits).
+ * Split a meter query at a single cutover so legacy and current windows do not
+ * overlap (avoids double-count while collector dual-emits).
  */
 export function splitMeterQueryAtCutover(
   query: Record<string, unknown>,
@@ -70,13 +73,47 @@ export function splitMeterQueryAtCutover(
   return { legacy, current };
 }
 
+/**
+ * Hard picos cutover for fee queries.
+ *
+ * - Before `picosCutover`: historical micros|nanos (nested at `nanosCutover`)
+ * - From `picosCutover`: picos only (collector no longer writes nanos)
+ */
+export function splitNetworkFeeMeterQueryWindows(
+  query: Record<string, unknown>,
+  nanosCutover: Date = getNetworkFeeNanosCutoverAt(),
+  picosCutover: Date = getNetworkFeePicosCutoverAt(),
+): {
+  micros: Record<string, unknown> | null;
+  nanos: Record<string, unknown> | null;
+  picos: Record<string, unknown> | null;
+} {
+  const { legacy: prePicos, current: picos } = splitMeterQueryAtCutover(
+    query,
+    picosCutover,
+  );
+  if (!prePicos) {
+    return { micros: null, nanos: null, picos };
+  }
+  const { legacy: micros, current: nanos } = splitMeterQueryAtCutover(
+    prePicos,
+    nanosCutover,
+  );
+  return { micros, nanos, picos };
+}
+
 function mapRowsToFeeMicros(
   rows: MeterQueryRow[],
-  unit: "micros" | "nanos",
+  unit: "micros" | "nanos" | "picos",
 ): MeterQueryRow[] {
   return rows.map((row) => {
     const raw = feeMicrosFromMeterValue(row.value);
-    const micros = unit === "nanos" ? usdNanosToMicros(raw) : raw;
+    let micros = raw;
+    if (unit === "nanos") {
+      micros = usdNanosToMicros(raw);
+    } else if (unit === "picos") {
+      micros = usdPicosToMicros(raw);
+    }
     return { ...row, value: Number(micros) };
   });
 }
@@ -103,7 +140,11 @@ async function queryMeterRowsSafe(
     const result = await client.meters.query(meterSlug, query);
     return result.data || [];
   } catch (err) {
-    if (meterSlug === NETWORK_FEE_USD_MICROS_METER && isMeterNotFoundError(err)) {
+    if (
+      (meterSlug === NETWORK_FEE_USD_MICROS_METER ||
+        meterSlug === NETWORK_FEE_USD_PICOS_METER) &&
+      isMeterNotFoundError(err)
+    ) {
       return [];
     }
     throw err;
@@ -111,28 +152,38 @@ async function queryMeterRowsSafe(
 }
 
 /**
- * Query network-fee usage as USD micros, merging legacy micros (pre-cutover)
- * with nanos (post-cutover) without double-counting the dual-emit window.
+ * Query network-fee usage as USD micros.
+ * Hard cutover: micros|nanos history before picos cutover; picos after.
  */
 export async function queryNetworkFeeMeterRowsAsMicros(
   client: OpenMeter,
   query: Record<string, unknown>,
-  cutover: Date = getNetworkFeeNanosCutoverAt(),
+  nanosCutover: Date = getNetworkFeeNanosCutoverAt(),
+  picosCutover: Date = getNetworkFeePicosCutoverAt(),
 ): Promise<MeterQueryRow[]> {
-  const { legacy, current } = splitMeterQueryAtCutover(query, cutover);
-  const [legacyRows, currentRows] = await Promise.all([
-    legacy
-      ? queryMeterRowsSafe(client, NETWORK_FEE_USD_MICROS_METER, legacy).then((rows) =>
+  const { micros, nanos, picos } = splitNetworkFeeMeterQueryWindows(
+    query,
+    nanosCutover,
+    picosCutover,
+  );
+  const [microsRows, nanosRows, picosRows] = await Promise.all([
+    micros
+      ? queryMeterRowsSafe(client, NETWORK_FEE_USD_MICROS_METER, micros).then((rows) =>
           mapRowsToFeeMicros(rows, "micros"),
         )
       : Promise.resolve([] as MeterQueryRow[]),
-    current
-      ? queryMeterRowsSafe(client, NETWORK_FEE_USD_NANOS_METER, current).then((rows) =>
+    nanos
+      ? queryMeterRowsSafe(client, NETWORK_FEE_USD_NANOS_METER, nanos).then((rows) =>
           mapRowsToFeeMicros(rows, "nanos"),
         )
       : Promise.resolve([] as MeterQueryRow[]),
+    picos
+      ? queryMeterRowsSafe(client, NETWORK_FEE_USD_PICOS_METER, picos).then((rows) =>
+          mapRowsToFeeMicros(rows, "picos"),
+        )
+      : Promise.resolve([] as MeterQueryRow[]),
   ]);
-  return [...legacyRows, ...currentRows];
+  return [...microsRows, ...nanosRows, ...picosRows];
 }
 
 export type OpenMeterUsageRow = {

--- a/src/lib/openmeter/usage-read.ts
+++ b/src/lib/openmeter/usage-read.ts
@@ -142,6 +142,7 @@ async function queryMeterRowsSafe(
   } catch (err) {
     if (
       (meterSlug === NETWORK_FEE_USD_MICROS_METER ||
+        meterSlug === NETWORK_FEE_USD_NANOS_METER ||
         meterSlug === NETWORK_FEE_USD_PICOS_METER) &&
       isMeterNotFoundError(err)
     ) {


### PR DESCRIPTION
## Summary
- Make `network_fee_usd_picos` (1 USD = 1e12) the authoritative fee meter so sub-nano BYOC dust never meters as free (`ceil` + min 1 when `fee_wei > 0`).
- Hard cutover from nanos: collector emits picos (+ legacy micros until 2026-09-10); usage reads micros|nanos before cutover and picos after.
- Point plans/entitlements/features at the picos meter with allowances scaled micros → picos (`× 1e6`); add `formatUsdPicos` for sub-micro display.

## Test plan
- [ ] Unit: `node --import tsx --test src/lib/format-usd.test.ts src/lib/openmeter/openmeter.test.ts` (picos conversion + hard-cutover window split)
- [ ] Rebuild/recreate local `openmeter-collector` and confirm events include `network_fee_usd_picos` (no `network_fee_usd_nanos`)
- [ ] Run `scripts/openmeter-bootstrap.ts` (or Konnect catalog self-heal) so the picos meter + `network_spend` feature exist
- [ ] Submit a tiny-fee BYOC/ffmpeg job and confirm OpenMeter shows non-zero picos usage / entitlement burn
- [ ] Dashboard usage for a range spanning the cutover still aggregates without double-count