### PR TITLE
Add end-user signed ticket request history on Usage

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -366,6 +366,20 @@ Aggregated request and fee usage for a developer application — read-only, tena
 
 Totals and `groupBy=user` / `groupBy=pipeline_model` read from OpenMeter meters (`network_fee_usd_micros`, `signed_ticket_count`). The `network_fee_usd_micros` meter SUMs fees per `(client_id, external_user_id)` where `external_user_id` equals collector-emitted `usage_subject`. **`OPENMETER_URL` is required** — responses include `"source": "openmeter"`. Allowance balance is never read from Postgres.
 
+### Session request history (Usage dashboard)
+
+**Endpoint:** `GET /api/v1/me/usage/requests`
+
+Session-authenticated (NextAuth). Lists OpenMeter `create_signed_ticket` CloudEvents for the **signed-in viewer’s own usage subject(s)** only — newest first. This is not a Builder/M2M API for listing all end users of an app.
+
+| Query | Description |
+| --- | --- |
+| `cursor` | Opaque pagination cursor from a prior response |
+| `limit` | Page size (default 25, max 50) |
+| `clientId` | Optional public OIDC `app_…` id to restrict to one app (used by `/apps/{id}/usage`) |
+
+Do **not** pass `externalUserId` — the server derives subjects from the session (`users.id` plus `app_users.external_user_id` rows matching the session email). Responses include `items`, `nextCursor`, and `openMeterConfigured`.
+
 **Balance (subscription allowance):** `GET /api/v1/apps/{clientId}/usage/balance?externalUserId=...` returns prepaid credit balance (`balanceUsdMicros`, `hasAccess`, etc.). On Konnect this is `GET /credits/balance` (`live`); on self-hosted OpenMeter it is the entitlement grant balance.
 
 **Starter plan (per app):** Each app has a seeded **Starter** plan (`isStarterDefault`) separate from **Network Price** (discovery-only, not synced to OpenMeter). Starter syncs to OpenMeter/Konnect with a `network_spend` rate card for settlement (`credit_then_invoice`). On Konnect, included trial allowance is a prepaid grant via `POST /customers/{id}/credits/grants` (amount from `OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS`, default `$5`), not `rate_cards.discounts.usage`. New end users are auto-subscribed to Starter and granted credits when provisioned (`POST /users`, signer mint, Kafka collector ingest / `openmeter-ensure-customer`) if they have no credit balance yet.

--- a/src/app/api/v1/me/usage/requests/route.ts
+++ b/src/app/api/v1/me/usage/requests/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/next-auth-options";
+import { listViewerSignedTicketRequests } from "@/lib/openmeter/signed-ticket-events";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const sessionUser = session?.user as Record<string, unknown> | undefined;
+  const userId = typeof sessionUser?.id === "string" ? sessionUser.id : undefined;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  const clientId = params.get("clientId")?.trim() || undefined;
+  const cursor = params.get("cursor")?.trim() || undefined;
+  const limitRaw = params.get("limit");
+  const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+
+  // Never accept externalUserId — viewers may only see their own subjects.
+  if (params.has("externalUserId") || params.has("external_user_id")) {
+    return NextResponse.json(
+      { error: "externalUserId is not allowed; requests are scoped to the signed-in user" },
+      { status: 400 },
+    );
+  }
+
+  const result = await listViewerSignedTicketRequests({
+    userId,
+    clientId,
+    cursor,
+    limit: Number.isFinite(limit) ? limit : undefined,
+  });
+
+  return NextResponse.json({
+    items: result.items,
+    nextCursor: result.nextCursor,
+    openMeterConfigured: result.openMeterConfigured,
+  });
+}

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import UsageLineChart from "@/components/UsageLineChart";
+import SignedTicketRequestHistory from "@/components/SignedTicketRequestHistory";
 import {
   AppUsageSection,
   BillingDashboardHeader,
@@ -134,6 +135,10 @@ export default async function BillingUsageDashboard({
           ))}
         </div>
       )}
+
+      <SignedTicketRequestHistory
+        clientId={scope === "single" ? orderedApps[0]?.publicClientId : null}
+      />
     </DashboardLayout>
   );
 }

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { formatUsdMicrosString } from "@/lib/format-usd-micros";
+import type { SignedTicketRequestRow } from "@/lib/openmeter/signed-ticket-events";
+
+type RequestsResponse = {
+  items: SignedTicketRequestRow[];
+  nextCursor: string | null;
+  openMeterConfigured: boolean;
+  error?: string;
+};
+
+function formatRequestTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function shortenId(value: string, keep = 10): string {
+  if (value.length <= keep * 2 + 1) {
+    return value;
+  }
+  return `${value.slice(0, keep)}…${value.slice(-6)}`;
+}
+
+export default function SignedTicketRequestHistory({
+  clientId,
+}: Readonly<{
+  /** Public OIDC client_id when scoped to a single app. */
+  clientId?: string | null;
+}>) {
+  const [items, setItems] = useState<SignedTicketRequestRow[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [openMeterConfigured, setOpenMeterConfigured] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPage = useCallback(
+    async (cursor: string | null, append: boolean) => {
+      const params = new URLSearchParams();
+      params.set("limit", "25");
+      if (cursor) {
+        params.set("cursor", cursor);
+      }
+      if (clientId?.trim()) {
+        params.set("clientId", clientId.trim());
+      }
+
+      const res = await fetch(`/api/v1/me/usage/requests?${params.toString()}`, {
+        method: "GET",
+        credentials: "same-origin",
+      });
+      const body = (await res.json().catch(() => null)) as RequestsResponse | null;
+      if (!res.ok) {
+        throw new Error(body?.error || `Request failed (${res.status})`);
+      }
+      if (!body) {
+        throw new Error("Empty response");
+      }
+
+      setOpenMeterConfigured(body.openMeterConfigured !== false);
+      setNextCursor(body.nextCursor);
+      setItems((prev) => (append ? [...prev, ...body.items] : body.items));
+    },
+    [clientId],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setItems([]);
+    setNextCursor(null);
+
+    fetchPage(null, false)
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load requests");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchPage]);
+
+  async function onLoadMore() {
+    if (!nextCursor || loadingMore) {
+      return;
+    }
+    setLoadingMore(true);
+    setError(null);
+    try {
+      await fetchPage(nextCursor, true);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load more");
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
+  return (
+    <section className="mt-8 sm:mt-10 rounded-xl border border-zinc-800 bg-zinc-900/30 p-4 sm:p-5">
+      <div className="mb-4">
+        <h2 className="text-sm font-semibold text-zinc-200">Your signed ticket requests</h2>
+        <p className="text-xs text-zinc-500 mt-1">
+          Only requests billed to your usage identity, newest first.
+        </p>
+      </div>
+
+      {!openMeterConfigured ? (
+        <p className="text-sm text-zinc-500 py-6 text-center">
+          OpenMeter is not configured, so per-request history is unavailable.
+        </p>
+      ) : null}
+
+      {openMeterConfigured && loading ? (
+        <div className="animate-pulse space-y-3 py-2">
+          {["a", "b", "c"].map((key) => (
+            <div key={key} className="h-10 rounded-lg bg-zinc-800/80" />
+          ))}
+        </div>
+      ) : null}
+
+      {openMeterConfigured && !loading && error ? (
+        <p className="text-sm text-rose-400 py-4 text-center">{error}</p>
+      ) : null}
+
+      {openMeterConfigured && !loading && !error && items.length === 0 ? (
+        <p className="text-sm text-zinc-500 py-6 text-center">
+          No signed ticket requests for your usage identity in this billing cycle.
+        </p>
+      ) : null}
+
+      {openMeterConfigured && !loading && items.length > 0 ? (
+        <>
+          <div className="overflow-x-auto -mx-1">
+            <table className="w-full min-w-[640px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 text-xs uppercase tracking-wider text-zinc-500">
+                  <th className="px-2 py-2 font-medium">Time</th>
+                  <th className="px-2 py-2 font-medium">App</th>
+                  <th className="px-2 py-2 font-medium">Request ID</th>
+                  <th className="px-2 py-2 font-medium">Pipeline / Model</th>
+                  <th className="px-2 py-2 font-medium text-right">Network fee</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((row) => {
+                  const feeLabel =
+                    formatUsdMicrosString(row.networkFeeUsdMicros, 4) ?? "$0";
+                  const pipelineLabel =
+                    row.modelId && row.modelId !== "unknown"
+                      ? `${row.pipeline} / ${row.modelId}`
+                      : row.pipeline;
+                  return (
+                    <tr
+                      key={row.eventId}
+                      className="border-b border-zinc-800/60 last:border-0"
+                    >
+                      <td className="px-2 py-3 text-zinc-300 whitespace-nowrap align-top">
+                        {formatRequestTime(row.time)}
+                      </td>
+                      <td className="px-2 py-3 text-zinc-300 align-top">
+                        <div className="truncate max-w-[10rem]" title={row.appName || row.clientId}>
+                          {row.appName || row.clientId}
+                        </div>
+                      </td>
+                      <td className="px-2 py-3 font-mono text-xs text-zinc-400 align-top">
+                        <span title={row.gatewayRequestId}>
+                          {shortenId(row.gatewayRequestId)}
+                        </span>
+                      </td>
+                      <td
+                        className="px-2 py-3 text-zinc-400 align-top truncate max-w-[14rem]"
+                        title={pipelineLabel}
+                      >
+                        {pipelineLabel}
+                      </td>
+                      <td
+                        className="px-2 py-3 text-right font-mono text-emerald-400/90 align-top whitespace-nowrap"
+                        title={feeLabel}
+                      >
+                        {feeLabel}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {nextCursor ? (
+            <div className="mt-4 flex justify-center">
+              <button
+                type="button"
+                onClick={() => void onLoadMore()}
+                disabled={loadingMore}
+                className="px-4 py-2 rounded-lg text-xs font-semibold bg-zinc-800 text-zinc-200 hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/lib/openmeter/signed-ticket-events.test.ts
+++ b/src/lib/openmeter/signed-ticket-events.test.ts
@@ -1,0 +1,173 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { CREATE_SIGNED_TICKET_EVENT_TYPE } from "./constants";
+import {
+  coerceIngestedEvent,
+  coerceIngestedEvents,
+  eventClientId,
+  eventMatchesViewerSubjects,
+  eventUsageSubject,
+  normalizeSignedTicketEvent,
+} from "./signed-ticket-events";
+
+function sampleEvent(overrides?: {
+  subject?: string;
+  type?: string;
+  data?: Record<string, unknown>;
+  id?: string;
+  time?: string;
+}) {
+  return {
+    event: {
+      id: overrides?.id ?? "evt-1",
+      type: overrides?.type ?? CREATE_SIGNED_TICKET_EVENT_TYPE,
+      subject: overrides?.subject ?? "app_abc:user-123",
+      time: overrides?.time ?? "2026-07-11T12:00:00.000Z",
+      data: {
+        client_id: "app_abc",
+        external_user_id: "user-123",
+        usage_subject: "user-123",
+        gateway_request_id: "req-1",
+        pipeline: "text-to-image",
+        model_id: "sdxl",
+        network_fee_usd_micros: "1500",
+        fee_wei: "100",
+        pixels: "64",
+        ...(overrides?.data ?? {}),
+      },
+    },
+    ingestedAt: "2026-07-11T12:00:01.000Z",
+  };
+}
+
+test("eventUsageSubject prefers data.external_user_id", () => {
+  const ev = sampleEvent({
+    subject: "app_abc:other",
+    data: { external_user_id: "from-data", usage_subject: "from-usage" },
+  });
+  assert.equal(eventUsageSubject(ev), "from-data");
+});
+
+test("eventUsageSubject falls back to subject suffix", () => {
+  const ev = sampleEvent({
+    data: { external_user_id: "", usage_subject: "" },
+  });
+  // clear empty strings from data by rebuilding
+  const bare = {
+    event: {
+      id: "evt-2",
+      type: CREATE_SIGNED_TICKET_EVENT_TYPE,
+      subject: "app_xyz:subj-9",
+      time: "2026-07-11T12:00:00.000Z",
+      data: {},
+    },
+  };
+  assert.equal(eventUsageSubject(bare), "subj-9");
+  assert.equal(eventClientId(bare), "app_xyz");
+});
+
+test("eventMatchesViewerSubjects keeps only viewer subjects", () => {
+  const subjects = new Set(["user-123"]);
+  assert.equal(eventMatchesViewerSubjects(sampleEvent(), subjects), true);
+  assert.equal(
+    eventMatchesViewerSubjects(
+      sampleEvent({
+        subject: "app_abc:other-user",
+        data: { external_user_id: "other-user", usage_subject: "other-user" },
+      }),
+      subjects,
+    ),
+    false,
+  );
+});
+
+test("eventMatchesViewerSubjects enforces clientId filter", () => {
+  const subjects = new Set(["user-123"]);
+  assert.equal(
+    eventMatchesViewerSubjects(sampleEvent(), subjects, "app_abc"),
+    true,
+  );
+  assert.equal(
+    eventMatchesViewerSubjects(sampleEvent(), subjects, "app_other"),
+    false,
+  );
+});
+
+test("eventMatchesViewerSubjects rejects non signed-ticket types", () => {
+  assert.equal(
+    eventMatchesViewerSubjects(
+      sampleEvent({ type: "other.event" }),
+      new Set(["user-123"]),
+    ),
+    false,
+  );
+});
+
+test("normalizeSignedTicketEvent maps CloudEvent fields", () => {
+  const row = normalizeSignedTicketEvent(
+    sampleEvent(),
+    new Map([["app_abc", "Demo App"]]),
+  );
+  assert.ok(row);
+  assert.equal(row?.appName, "Demo App");
+  assert.equal(row?.clientId, "app_abc");
+  assert.equal(row?.externalUserId, "user-123");
+  assert.equal(row?.gatewayRequestId, "req-1");
+  assert.equal(row?.pipeline, "text-to-image");
+  assert.equal(row?.modelId, "sdxl");
+  assert.equal(row?.networkFeeUsdMicros, "1500");
+  assert.equal(row?.feeWei, "100");
+  assert.equal(row?.pixels, "64");
+  assert.equal(row?.time, "2026-07-11T12:00:00.000Z");
+});
+
+test("coerceIngestedEvent accepts wrapped IngestedEvent", () => {
+  const coerced = coerceIngestedEvent(sampleEvent());
+  assert.ok(coerced);
+  assert.equal(coerced?.event.type, CREATE_SIGNED_TICKET_EVENT_TYPE);
+});
+
+test("coerceIngestedEvent accepts flat CloudEvent", () => {
+  const coerced = coerceIngestedEvent({
+    id: "flat-1",
+    type: CREATE_SIGNED_TICKET_EVENT_TYPE,
+    subject: "app_abc:user-123",
+    time: "2026-07-11T12:00:00.000Z",
+    data: { client_id: "app_abc", external_user_id: "user-123" },
+    ingested_at: "2026-07-11T12:00:01.000Z",
+  });
+  assert.ok(coerced);
+  assert.equal(coerced?.event.id, "flat-1");
+  assert.equal(coerced?.event.subject, "app_abc:user-123");
+  assert.equal(eventUsageSubject(coerced!), "user-123");
+  assert.equal(
+    eventMatchesViewerSubjects(coerced!, new Set(["user-123"])),
+    true,
+  );
+});
+
+test("coerceIngestedEvent skips undefined and empty objects", () => {
+  assert.equal(coerceIngestedEvent(undefined), null);
+  assert.equal(coerceIngestedEvent(null), null);
+  assert.equal(coerceIngestedEvent({}), null);
+  assert.equal(coerceIngestedEvent({ ingestedAt: "2026-01-01" }), null);
+});
+
+test("coerceIngestedEvents unwraps items/data envelopes and drops junk", () => {
+  const rows = coerceIngestedEvents({
+    items: [
+      undefined,
+      sampleEvent(),
+      {
+        id: "flat-2",
+        type: CREATE_SIGNED_TICKET_EVENT_TYPE,
+        subject: "app_abc:user-123",
+        data: { external_user_id: "user-123" },
+      },
+    ],
+  });
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0]?.event.id, "evt-1");
+  assert.equal(rows[1]?.event.id, "flat-2");
+});

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -1,0 +1,453 @@
+import { eq, inArray, sql } from "drizzle-orm";
+import type { OpenMeter } from "@openmeter/sdk";
+
+import { db } from "@/db/index";
+import { appUsers, developerApps, oidcClients, users } from "@/db/schema";
+import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
+import {
+  CREATE_SIGNED_TICKET_EVENT_TYPE,
+  isOpenMeterEnabled,
+  requireOpenMeterForUsageReads,
+} from "@/lib/openmeter/constants";
+import { getHostedOpenMeterClient } from "@/lib/openmeter/client";
+import {
+  buildOpenMeterCustomerKey,
+  parseOpenMeterCustomerKey,
+} from "@/lib/openmeter/customer-key";
+
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 50;
+const LIST_FETCH_LIMIT = 100;
+
+export type SignedTicketRequestRow = {
+  time: string;
+  clientId: string;
+  appName?: string;
+  externalUserId: string;
+  gatewayRequestId: string;
+  pipeline: string;
+  modelId: string;
+  networkFeeUsdMicros: string;
+  feeWei?: string;
+  pixels?: string;
+  eventId: string;
+};
+
+export type ListViewerSignedTicketRequestsInput = {
+  userId: string;
+  /** Public OIDC client_id (app_…), not developer_apps.id. */
+  clientId?: string | null;
+  cursor?: string | null;
+  limit?: number;
+  from?: string;
+  to?: string;
+};
+
+export type ListViewerSignedTicketRequestsResult = {
+  items: SignedTicketRequestRow[];
+  nextCursor: string | null;
+  openMeterConfigured: boolean;
+};
+
+type CloudEventLike = {
+  id?: string;
+  type?: string;
+  subject?: string;
+  time?: Date | string | null;
+  data?: Record<string, unknown> | null;
+};
+
+type IngestedEventLike = {
+  event: CloudEventLike;
+  ingestedAt?: Date | string;
+};
+
+type OffsetCursor = { offset: number };
+
+/** Normalize SDK / Konnect list payloads into IngestedEvent-shaped rows. */
+export function coerceIngestedEvent(raw: unknown): IngestedEventLike | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const row = raw as Record<string, unknown>;
+
+  // Standard IngestedEvent: { event, ingestedAt }
+  if (row.event && typeof row.event === "object") {
+    const event = row.event as CloudEventLike;
+    const ingestedAt =
+      (row.ingestedAt as Date | string | undefined) ??
+      (row.ingested_at as Date | string | undefined);
+    return { event, ingestedAt };
+  }
+
+  // Flat CloudEvent (Konnect sometimes returns the event body directly).
+  if (
+    typeof row.type === "string" ||
+    typeof row.subject === "string" ||
+    typeof row.id === "string"
+  ) {
+    return {
+      event: {
+        id: typeof row.id === "string" ? row.id : undefined,
+        type: typeof row.type === "string" ? row.type : undefined,
+        subject: typeof row.subject === "string" ? row.subject : undefined,
+        time: (row.time as Date | string | null | undefined) ?? null,
+        data:
+          row.data && typeof row.data === "object"
+            ? (row.data as Record<string, unknown>)
+            : null,
+      },
+      ingestedAt:
+        (row.ingestedAt as Date | string | undefined) ??
+        (row.ingested_at as Date | string | undefined),
+    };
+  }
+
+  return null;
+}
+
+export function coerceIngestedEvents(raw: unknown): IngestedEventLike[] {
+  if (!Array.isArray(raw)) {
+    if (raw && typeof raw === "object") {
+      const obj = raw as Record<string, unknown>;
+      if (Array.isArray(obj.items)) {
+        return coerceIngestedEvents(obj.items);
+      }
+      if (Array.isArray(obj.data)) {
+        return coerceIngestedEvents(obj.data);
+      }
+    }
+    return [];
+  }
+  const out: IngestedEventLike[] = [];
+  for (const item of raw) {
+    const coerced = coerceIngestedEvent(item);
+    if (coerced) {
+      out.push(coerced);
+    }
+  }
+  return out;
+}
+
+export async function resolveViewerUsageSubjects(userId: string): Promise<Set<string>> {
+  const subjects = new Set<string>();
+  const trimmedUserId = userId.trim();
+  if (!trimmedUserId) {
+    return subjects;
+  }
+  subjects.add(trimmedUserId);
+
+  const userRows = await db
+    .select({ email: users.email })
+    .from(users)
+    .where(eq(users.id, trimmedUserId))
+    .limit(1);
+  const email = userRows[0]?.email?.trim().toLowerCase();
+  if (!email) {
+    return subjects;
+  }
+
+  const matched = await db
+    .select({ externalUserId: appUsers.externalUserId })
+    .from(appUsers)
+    .where(sql`lower(${appUsers.email}) = ${email}`);
+  for (const row of matched) {
+    const ext = row.externalUserId?.trim();
+    if (ext) {
+      subjects.add(ext);
+    }
+  }
+
+  return subjects;
+}
+
+export function eventUsageSubject(event: IngestedEventLike): string | null {
+  const data = event.event?.data ?? {};
+  const fromData =
+    stringField(data, "external_user_id") || stringField(data, "usage_subject");
+  if (fromData) {
+    return fromData;
+  }
+  const parsed = parseOpenMeterCustomerKey(event.event?.subject?.trim() || "");
+  return parsed?.externalUserId ?? null;
+}
+
+export function eventClientId(event: IngestedEventLike): string | null {
+  const data = event.event?.data ?? {};
+  const fromData = stringField(data, "client_id");
+  if (fromData) {
+    return fromData;
+  }
+  const parsed = parseOpenMeterCustomerKey(event.event?.subject?.trim() || "");
+  return parsed?.clientId ?? null;
+}
+
+export function eventMatchesViewerSubjects(
+  event: IngestedEventLike,
+  subjects: ReadonlySet<string>,
+  clientId?: string | null,
+): boolean {
+  if (!event?.event) {
+    return false;
+  }
+  if (event.event.type && event.event.type !== CREATE_SIGNED_TICKET_EVENT_TYPE) {
+    return false;
+  }
+  const usageSubject = eventUsageSubject(event);
+  if (!usageSubject || !subjects.has(usageSubject)) {
+    return false;
+  }
+  if (clientId?.trim()) {
+    const eventClient = eventClientId(event);
+    if (!eventClient || eventClient !== clientId.trim()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function normalizeSignedTicketEvent(
+  event: IngestedEventLike,
+  appNameByClientId?: ReadonlyMap<string, string>,
+): SignedTicketRequestRow | null {
+  if (!event?.event) {
+    return null;
+  }
+  const clientId = eventClientId(event);
+  const externalUserId = eventUsageSubject(event);
+  if (!clientId || !externalUserId) {
+    return null;
+  }
+  const data = event.event.data ?? {};
+  const time = toIsoTime(event.event.time) || toIsoTime(event.ingestedAt) || new Date(0).toISOString();
+  const gatewayRequestId =
+    stringField(data, "gateway_request_id") ||
+    event.event.id?.trim() ||
+    `${clientId}:${time}`;
+  const networkFeeUsdMicros = microsField(data, "network_fee_usd_micros") || "0";
+  return {
+    time,
+    clientId,
+    appName: appNameByClientId?.get(clientId),
+    externalUserId,
+    gatewayRequestId,
+    pipeline: stringField(data, "pipeline") || "unknown",
+    modelId: stringField(data, "model_id") || "unknown",
+    networkFeeUsdMicros,
+    feeWei: stringField(data, "fee_wei") || undefined,
+    pixels: stringField(data, "pixels") || undefined,
+    eventId: event.event.id?.trim() || gatewayRequestId,
+  };
+}
+
+export async function listViewerSignedTicketRequests(
+  input: ListViewerSignedTicketRequestsInput,
+): Promise<ListViewerSignedTicketRequestsResult> {
+  if (!requireOpenMeterForUsageReads() || !isOpenMeterEnabled()) {
+    return { items: [], nextCursor: null, openMeterConfigured: false };
+  }
+
+  const client = getHostedOpenMeterClient();
+  if (!client) {
+    return { items: [], nextCursor: null, openMeterConfigured: false };
+  }
+
+  const subjects = await resolveViewerUsageSubjects(input.userId);
+  if (subjects.size === 0) {
+    return { items: [], nextCursor: null, openMeterConfigured: true };
+  }
+
+  const cycle = calendarMonthBoundsUtc(new Date());
+  const from = input.from?.trim() || cycle.start;
+  const to = input.to?.trim() || cycle.end;
+  const limit = clampLimit(input.limit);
+  const offset = decodeOffsetCursor(input.cursor);
+  const clientIdFilter = input.clientId?.trim() || null;
+
+  const rawEvents = await fetchSignedTicketEvents({
+    client,
+    subjects,
+    clientId: clientIdFilter,
+    from,
+    to,
+  });
+
+  const matching = rawEvents.filter((ev) =>
+    eventMatchesViewerSubjects(ev, subjects, clientIdFilter),
+  );
+
+  const appNames = await loadAppNames(
+    matching.map((ev) => eventClientId(ev)).filter((id): id is string => Boolean(id)),
+  );
+
+  const rows = matching
+    .map((ev) => normalizeSignedTicketEvent(ev, appNames))
+    .filter((row): row is SignedTicketRequestRow => row != null);
+
+  rows.sort((a, b) => {
+    const byTime = b.time.localeCompare(a.time);
+    if (byTime !== 0) return byTime;
+    return b.eventId.localeCompare(a.eventId);
+  });
+
+  // Dedupe by event id / gateway request id (fan-out can overlap).
+  const seen = new Set<string>();
+  const deduped: SignedTicketRequestRow[] = [];
+  for (const row of rows) {
+    const key = row.eventId || row.gatewayRequestId;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(row);
+  }
+
+  const page = deduped.slice(offset, offset + limit);
+  const nextOffset = offset + page.length;
+  const nextCursor =
+    nextOffset < deduped.length ? encodeOffsetCursor({ offset: nextOffset }) : null;
+
+  return {
+    items: page,
+    nextCursor,
+    openMeterConfigured: true,
+  };
+}
+
+async function fetchSignedTicketEvents(input: {
+  client: OpenMeter;
+  subjects: ReadonlySet<string>;
+  clientId: string | null;
+  from: string;
+  to: string;
+}): Promise<IngestedEventLike[]> {
+  const subjectQueries = buildSubjectQueries(input.subjects, input.clientId);
+  const batches = await Promise.all(
+    subjectQueries.map(async (subject) => {
+      try {
+        const listed = await input.client.events.list({
+          subject,
+          from: input.from,
+          to: input.to,
+          limit: LIST_FETCH_LIMIT,
+        });
+        return coerceIngestedEvents(listed);
+      } catch {
+        // listV2 fallback when list is unavailable (some Konnect deployments).
+        try {
+          const listedV2 = await input.client.events.listV2({
+            limit: LIST_FETCH_LIMIT,
+            filter: JSON.stringify({
+              type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
+              subject: { contains: subject },
+            }),
+          });
+          return coerceIngestedEvents(listedV2?.items ?? listedV2);
+        } catch {
+          return [];
+        }
+      }
+    }),
+  );
+  return batches.flat();
+}
+
+function buildSubjectQueries(
+  subjects: ReadonlySet<string>,
+  clientId: string | null,
+): string[] {
+  const queries: string[] = [];
+  for (const subject of subjects) {
+    if (clientId) {
+      queries.push(buildOpenMeterCustomerKey(clientId, subject));
+    } else {
+      // Partial subject match: compound auth_id ends with :external_user_id
+      queries.push(subject);
+    }
+  }
+  return queries;
+}
+
+async function loadAppNames(clientIds: string[]): Promise<Map<string, string>> {
+  const unique = [...new Set(clientIds.map((id) => id.trim()).filter(Boolean))];
+  const map = new Map<string, string>();
+  if (unique.length === 0) {
+    return map;
+  }
+
+  const rows = await db
+    .select({
+      publicClientId: oidcClients.clientId,
+      name: developerApps.name,
+    })
+    .from(oidcClients)
+    .innerJoin(developerApps, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(inArray(oidcClients.clientId, unique));
+
+  for (const row of rows) {
+    const id = row.publicClientId?.trim();
+    if (id) {
+      map.set(id, row.name);
+    }
+  }
+  return map;
+}
+
+function stringField(data: Record<string, unknown>, key: string): string | null {
+  const value = data[key];
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function microsField(data: Record<string, unknown>, key: string): string | null {
+  const value = data[key];
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(Math.trunc(value));
+  }
+  return null;
+}
+
+function toIsoTime(value: Date | string | null | undefined): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? trimmed : parsed.toISOString();
+}
+
+function clampLimit(limit?: number): number {
+  if (limit == null || !Number.isFinite(limit)) {
+    return DEFAULT_PAGE_SIZE;
+  }
+  return Math.min(MAX_PAGE_SIZE, Math.max(1, Math.trunc(limit)));
+}
+
+function encodeOffsetCursor(cursor: OffsetCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function decodeOffsetCursor(raw?: string | null): number {
+  if (!raw?.trim()) {
+    return 0;
+  }
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(raw.trim(), "base64url").toString("utf8"),
+    ) as OffsetCursor;
+    if (typeof parsed.offset === "number" && Number.isFinite(parsed.offset) && parsed.offset >= 0) {
+      return Math.trunc(parsed.offset);
+    }
+  } catch {
+    // ignore malformed cursors
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Adds a **Your signed ticket requests** section on `/billing` and `/apps/[id]/usage` (newest first), scoped to the signed-in user’s usage subjects only
- New session API `GET /api/v1/me/usage/requests` reads OpenMeter ingested events (coerces Konnect/flat CloudEvent shapes)
- Keeps existing usage aggregates/charts unchanged

## Test plan
- [x] Unit tests for event coerce/filter/normalize (`signed-ticket-events.test.ts`)
- [ ] Sign in → open `/billing` → request history loads without 500
- [ ] Confirm only your own usage-subject tickets appear
- [ ] On `/apps/{id}/usage`, history is filtered to that app’s `clientId`
- [ ] Load more pagination works when more than one page exists