### PR TITLE
feat(collector): emit eth_usd_price on signed-ticket CloudEvents

### DIFF
--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -4,7 +4,8 @@
 # sequence blocks until
 # warm succeeds; collector never reads Kafka until cache is populated). Refreshed on
 # PRICE_ORACLE_REFRESH; refresh errors keep the last cached value. Runtime events read
-# from cache only (no static default).
+# from cache only (no static default). Each egress CloudEvent includes data.eth_usd_price
+# (the cached rate used for that event’s Wei → USD micros conversion).
 #
 # Oracle JSON (any one shape):
 #   {"price": 3456.78}
@@ -147,6 +148,7 @@ pipeline:
               "model_id": if $data.model_id != "" && $data.model_id != null { $data.model_id } else { "unknown" },
               "pixels": $data.pixels.string().or("0"),
               "fee_wei": $data.computed_fee.or("0"),
+              "eth_usd_price": $eth_usd.string(),
               "gateway_request_id": $data.request_id,
             }
           }

--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -355,6 +355,7 @@ Direct signing uses `@pymthouse/builder-sdk/signer/server` — mint a user JWT v
    - `data.client_id` = tenant (developer app OAuth `client_id`)
    - `data.usage_subject` = end user (OIDC `sub` analog)
    - `data.auth_id` retained for compatibility; `data.external_user_id` mirrors `usage_subject` for existing meter `groupBy`
+   - `data.eth_usd_price` = ETH/USD oracle rate used for that event’s Wei → USD micros conversion
 
 Retail pricing comes from **OpenMeter plans/rate cards** synced when plans are published (`POST`/`PUT …/plans`), not from bps markup on network cost at sign time.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The OpenMeter collector already fetches and caches ETH/USD to convert `computed_fee` (wei) into `network_fee_usd_micros`, but that rate was not included on egress CloudEvents.

This change adds `data.eth_usd_price` to each `create_signed_ticket` event so the exact oracle rate used for conversion is auditable in OpenMeter/Konnect.

## Changes

- **`deploy/openmeter-collector/collector.yaml`** — emit `eth_usd_price` (string) from the cached oracle value already used for the Wei → USD micros formula
- **`docs/builder-api.md`** — document the new CloudEvent field

No new OpenMeter meter is required; this is event metadata (same category as `fee_wei`). The TypeScript ingest helper (`SignedTicketOpenMeterEvent` / `ingestSignedTicketEvent`) already accepts `ethUsdPrice`.

## Verification

- Confirmed `$eth_usd` is already loaded from cache before mapping and is the same value used in `ceil(fee_wei * eth_usd / 1e12)`
- Field name matches existing contract in `src/lib/openmeter/entitlements.ts` and BPP forbidden-fields list

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26991789-2a50-4966-8965-99e9246b1303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26991789-2a50-4966-8965-99e9246b1303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Egress event payloads now include the ETH/USD conversion rate used to calculate network fees.

* **Documentation**
  * Updated collector and builder API documentation to describe the new `data.eth_usd_price` event field and its role in fee conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->