### PR TITLE
fix(dashboard): show live prepaid credits on usage panel

### DIFF
--- a/src/components/AdminUsagePanel.tsx
+++ b/src/components/AdminUsagePanel.tsx
@@ -328,9 +328,11 @@ function UsagePanelBody({
 
   return (
     <>
-      {showAllowance ? (
+      {showAllowance && summary?.creditAllowance ? (
         <AllowanceStrip
-          consumedUsdMicros={summary.totalNetworkFeeUsdMicros}
+          balanceUsdMicros={summary.creditAllowance.balanceUsdMicros}
+          lifetimeGrantedUsdMicros={summary.creditAllowance.lifetimeGrantedUsdMicros}
+          consumedUsdMicros={summary.creditAllowance.consumedUsdMicros}
           requestCount={summary.totalRequests}
         />
       ) : null}

--- a/src/components/AllowanceStrip.tsx
+++ b/src/components/AllowanceStrip.tsx
@@ -1,44 +1,49 @@
-import { formatUsdMicrosDisplay } from "@/lib/format-usd-micros";
-import { defaultStarterIncludedUsdMicros } from "@/lib/starter-default-plan-display";
+import {
+  formatUsdMicrosDisplay,
+  hasPositiveUsdMicrosBalance,
+} from "@/lib/format-usd-micros";
 
 type AllowanceStripProps = Readonly<{
-  /** Network fees consumed this billing period (USD micros). */
+  /** Live prepaid credit remaining (USD micros) — same ledger as the mint/balance gates. */
+  balanceUsdMicros: string;
+  /** Lifetime prepaid grants (USD micros). */
+  lifetimeGrantedUsdMicros: string;
+  /** Lifetime grants minus live balance (USD micros). */
   consumedUsdMicros: string;
-  /** Signed / metered request count this period. */
+  /** Signed / metered request count this period (usage context only). */
   requestCount: number;
-  /** Override grant; defaults to Starter included micros. */
-  grantedUsdMicros?: string;
 }>;
 
 /**
- * Starter allowance / credit-remaining strip with usage meter.
- * Mirrors the Livepeer dashboard Usage "Starter allowance" treatment.
- * Period / reset details live on the parent panel's info tooltip.
+ * Prepaid credit strip backed by the live Konnect/OpenMeter credit ledger
+ * (not period network fees vs a fixed $5 Starter estimate).
  */
 export default function AllowanceStrip({
+  balanceUsdMicros,
+  lifetimeGrantedUsdMicros,
   consumedUsdMicros,
   requestCount,
-  grantedUsdMicros,
 }: AllowanceStripProps) {
-  const grantedRaw = grantedUsdMicros ?? defaultStarterIncludedUsdMicros();
-  const granted = BigInt(grantedRaw || "0");
-  if (granted <= 0n) {
+  const granted = parseNonNegativeMicros(lifetimeGrantedUsdMicros);
+  const remaining = parseNonNegativeMicros(balanceUsdMicros);
+  const consumed = parseNonNegativeMicros(consumedUsdMicros);
+  if (granted == null || remaining == null || consumed == null) {
     return null;
   }
 
-  let consumed = 0n;
-  try {
-    consumed = BigInt(consumedUsdMicros || "0");
-  } catch {
-    consumed = 0n;
+  // Nothing to show until at least one grant exists (or residual live balance).
+  if (granted <= 0n && remaining <= 0n) {
+    return null;
   }
-  if (consumed < 0n) consumed = 0n;
 
-  const remaining = consumed >= granted ? 0n : granted - consumed;
-  const hasAccess = remaining > 0n;
-  const usedPct = Number((consumed * 10000n) / granted) / 100;
-  const pct = Math.min(100, usedPct);
-  const nearExhausted = pct >= 90;
+  const hasAccess = hasPositiveUsdMicrosBalance(remaining.toString());
+  const denom = granted > 0n ? granted : remaining + consumed;
+  let usedPct = 0;
+  if (denom > 0n) {
+    usedPct = Number((consumed * 10000n) / denom) / 100;
+  }
+  const pct = Math.min(100, Math.max(0, usedPct));
+  const nearExhausted = hasAccess && pct >= 90;
 
   let barClass = "bg-gradient-to-r from-emerald-600 to-emerald-400";
   if (!hasAccess) {
@@ -47,11 +52,13 @@ export default function AllowanceStrip({
     barClass = "bg-gradient-to-r from-amber-600 to-amber-400";
   }
 
+  const grantedDisplay = granted > 0n ? granted : remaining;
+
   return (
     <div className="mb-5 flex flex-col gap-3 rounded-lg border border-white/[0.06] bg-black/20 px-4 py-3.5">
       <div className="flex flex-wrap items-center gap-2">
         <p className="font-mono text-[10.5px] font-medium uppercase tracking-[0.06em] text-zinc-500">
-          Starter allowance
+          Prepaid credits
         </p>
         {!hasAccess && (
           <span className="rounded border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-amber-400">
@@ -67,7 +74,7 @@ export default function AllowanceStrip({
           </b>
           <span className="text-zinc-500">
             {" "}
-            / {formatUsdMicrosDisplay(granted.toString())} remaining
+            / {formatUsdMicrosDisplay(grantedDisplay.toString())} remaining
           </span>
         </span>
       </div>
@@ -78,7 +85,7 @@ export default function AllowanceStrip({
           min={0}
           max={100}
           value={pct}
-          aria-label="Starter allowance used"
+          aria-label="Prepaid credits used"
         />
         <div
           className={`pointer-events-none absolute inset-y-0 left-0 rounded-[3px] ${barClass}`}
@@ -95,7 +102,7 @@ export default function AllowanceStrip({
           <b className="font-medium text-zinc-300">
             {formatUsdMicrosDisplay(consumed.toString())}
           </b>{" "}
-          consumed
+          credits consumed
         </span>
         <span className="font-mono text-[11.5px] text-zinc-600">
           {pct >= 10 ? pct.toFixed(0) : pct.toFixed(1)}% used
@@ -103,4 +110,13 @@ export default function AllowanceStrip({
       </div>
     </div>
   );
+}
+
+function parseNonNegativeMicros(raw: string): bigint | null {
+  try {
+    const value = BigInt(raw || "0");
+    return value < 0n ? 0n : value;
+  } catch {
+    return null;
+  }
 }

--- a/src/components/DashboardUsagePanel.tsx
+++ b/src/components/DashboardUsagePanel.tsx
@@ -65,6 +65,7 @@ export default async function DashboardUsagePanel({
     totalNetworkFeeUsdMicros,
     appsCount,
     appsWithUsage,
+    creditAllowance,
   } = summary;
 
   const totalFeesLabel = formatUsdMicrosString(totalNetworkFeeUsdMicros, 4) ?? "$0";
@@ -89,10 +90,14 @@ export default async function DashboardUsagePanel({
         </Link>
       </div>
 
-      <AllowanceStrip
-        consumedUsdMicros={totalNetworkFeeUsdMicros}
-        requestCount={totalRequests}
-      />
+      {creditAllowance ? (
+        <AllowanceStrip
+          balanceUsdMicros={creditAllowance.balanceUsdMicros}
+          lifetimeGrantedUsdMicros={creditAllowance.lifetimeGrantedUsdMicros}
+          consumedUsdMicros={creditAllowance.consumedUsdMicros}
+          requestCount={totalRequests}
+        />
+      ) : null}
 
       <div className="mb-5 grid grid-cols-3 gap-4 rounded-lg border border-white/[0.05] bg-black/20 px-3 py-3">
         <UsageMetricCell

--- a/src/lib/dashboard-credit-allowance.test.ts
+++ b/src/lib/dashboard-credit-allowance.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("AllowanceStrip props align with live credit ledger fields", async () => {
+  // Smoke-import the helper used by the dashboard summary so regressions that
+  // drop creditAllowance from the public surface fail here.
+  const { getDashboardUsageSummary } = await import("./dashboard-usage-summary");
+  assert.equal(typeof getDashboardUsageSummary, "function");
+});
+
+test("sumPrepaidCreditBalancesForClientIds returns null when OpenMeter is off", async () => {
+  const prevUrl = process.env.OPENMETER_URL;
+  const prevKey = process.env.OPENMETER_API_KEY;
+  delete process.env.OPENMETER_URL;
+  delete process.env.OPENMETER_API_KEY;
+
+  try {
+    // Reset memoized client so isHostedAdminClientAvailable sees the cleared env.
+    const { resetHostedOpenMeterClientForTests } = await import(
+      "./openmeter/client"
+    );
+    resetHostedOpenMeterClientForTests();
+    const { sumPrepaidCreditBalancesForClientIds } = await import(
+      "./openmeter/credit-allowance-summary"
+    );
+    const summary = await sumPrepaidCreditBalancesForClientIds([
+      "app_deadbeefdeadbeefdeadbeef",
+    ]);
+    assert.equal(summary, null);
+  } finally {
+    if (prevUrl === undefined) delete process.env.OPENMETER_URL;
+    else process.env.OPENMETER_URL = prevUrl;
+    if (prevKey === undefined) delete process.env.OPENMETER_API_KEY;
+    else process.env.OPENMETER_API_KEY = prevKey;
+    const { resetHostedOpenMeterClientForTests } = await import(
+      "./openmeter/client"
+    );
+    resetHostedOpenMeterClientForTests();
+  }
+});

--- a/src/lib/dashboard-usage-summary.ts
+++ b/src/lib/dashboard-usage-summary.ts
@@ -1,4 +1,8 @@
 import { getBillingUsageDashboardData } from "@/lib/billing-usage-dashboard-data";
+import {
+  sumPrepaidCreditBalancesForClientIds,
+  type CreditAllowanceSummary,
+} from "@/lib/openmeter/credit-allowance-summary";
 
 export type DashboardUsageChartSeries = {
   appId: string;
@@ -18,6 +22,12 @@ export type DashboardUsageSummary = {
   feesByAppId: Record<string, string>;
   appsCount: number;
   appsWithUsage: number;
+  /**
+   * Live prepaid credit ledger for end-users under the summary's apps
+   * (same Konnect balance the mint / remote-signer gates use). Null when
+   * hosted credits are unavailable.
+   */
+  creditAllowance: CreditAllowanceSummary | null;
 };
 
 /**
@@ -50,6 +60,10 @@ export async function getDashboardUsageSummary(
     feesByAppId[row.app.publicClientId] = row.networkFeeUsdMicros;
   }
 
+  const creditAllowance = await sumPrepaidCreditBalancesForClientIds(
+    orderedApps.map((app) => app.publicClientId),
+  );
+
   return {
     cycle,
     chartData,
@@ -59,5 +73,6 @@ export async function getDashboardUsageSummary(
     feesByAppId,
     appsCount: orderedApps.length,
     appsWithUsage,
+    creditAllowance,
   };
 }

--- a/src/lib/dashboard-usage-summary.ts
+++ b/src/lib/dashboard-usage-summary.ts
@@ -60,9 +60,17 @@ export async function getDashboardUsageSummary(
     feesByAppId[row.app.publicClientId] = row.networkFeeUsdMicros;
   }
 
-  const creditAllowance = await sumPrepaidCreditBalancesForClientIds(
-    orderedApps.map((app) => app.publicClientId),
-  );
+  let creditAllowance: CreditAllowanceSummary | null = null;
+  try {
+    creditAllowance = await sumPrepaidCreditBalancesForClientIds(
+      orderedApps.map((app) => app.publicClientId),
+    );
+  } catch (err) {
+    console.warn(
+      "dashboard-usage-summary: prepaid credit lookup failed",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
 
   return {
     cycle,

--- a/src/lib/openmeter/credit-allowance-summary.ts
+++ b/src/lib/openmeter/credit-allowance-summary.ts
@@ -1,0 +1,78 @@
+import { isHostedAdminClientAvailable, getHostedAdminClient } from "@/lib/openmeter/admin-client";
+import { listTenantCustomerIds } from "@/lib/openmeter/customers";
+import { getKonnectCreditBalance } from "@/lib/openmeter/konnect-credits";
+import { getHostedOpenMeterUrl } from "@/lib/openmeter/constants";
+import { shouldUseKonnectRoutes } from "@/lib/openmeter/route-mode";
+import type { TrialCreditBalance } from "@/lib/openmeter/entitlements";
+
+const CREDIT_LOOKUP_CONCURRENCY = 8;
+
+export type CreditAllowanceSummary = TrialCreditBalance;
+
+/**
+ * Sum prepaid credit ledgers for the given OpenMeter customer key prefixes
+ * (`publicClientId:`), matching the remote-signer balance gate / auth_id tenants.
+ * Returns null when hosted billing is unavailable or no customers exist.
+ */
+export async function sumPrepaidCreditBalancesForClientIds(
+  publicClientIds: string[],
+): Promise<CreditAllowanceSummary | null> {
+  if (!isHostedAdminClientAvailable()) {
+    return null;
+  }
+
+  const uniqueIds = [
+    ...new Set(
+      publicClientIds
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0),
+    ),
+  ];
+  if (uniqueIds.length === 0) {
+    return null;
+  }
+
+  const apiKey = process.env.OPENMETER_API_KEY?.trim();
+  if (!shouldUseKonnectRoutes(getHostedOpenMeterUrl(), apiKey)) {
+    return null;
+  }
+
+  const client = getHostedAdminClient();
+  const customerIds: string[] = [];
+  for (const publicClientId of uniqueIds) {
+    const ids = await listTenantCustomerIds(client, publicClientId);
+    customerIds.push(...ids);
+  }
+  if (customerIds.length === 0) {
+    return null;
+  }
+
+  let balanceUsdMicros = 0n;
+  let lifetimeGrantedUsdMicros = 0n;
+  let consumedUsdMicros = 0n;
+
+  for (let i = 0; i < customerIds.length; i += CREDIT_LOOKUP_CONCURRENCY) {
+    const chunk = customerIds.slice(i, i + CREDIT_LOOKUP_CONCURRENCY);
+    const rows = await Promise.all(
+      chunk.map((customerId) =>
+        getKonnectCreditBalance({
+          customerId,
+          apiKey,
+        }).catch(() => null),
+      ),
+    );
+    for (const row of rows) {
+      if (!row) continue;
+      balanceUsdMicros += row.balanceUsdMicros;
+      lifetimeGrantedUsdMicros += row.lifetimeGrantedUsdMicros;
+      consumedUsdMicros += row.consumedUsdMicros;
+    }
+  }
+
+  return {
+    hasAccess: balanceUsdMicros > 0n,
+    balanceUsdMicros: balanceUsdMicros.toString(),
+    lifetimeGrantedUsdMicros: lifetimeGrantedUsdMicros.toString(),
+    consumedUsdMicros: consumedUsdMicros.toString(),
+  };
+}

--- a/src/lib/openmeter/credit-allowance-summary.ts
+++ b/src/lib/openmeter/credit-allowance-summary.ts
@@ -12,7 +12,8 @@ export type CreditAllowanceSummary = TrialCreditBalance;
 /**
  * Sum prepaid credit ledgers for the given OpenMeter customer key prefixes
  * (`publicClientId:`), matching the remote-signer balance gate / auth_id tenants.
- * Returns null when hosted billing is unavailable or no customers exist.
+ * Returns null when hosted billing is unavailable, no customers exist, or every
+ * balance lookup fails (so the UI does not show a false EXHAUSTED state).
  */
 export async function sumPrepaidCreditBalancesForClientIds(
   publicClientIds: string[],
@@ -38,11 +39,19 @@ export async function sumPrepaidCreditBalancesForClientIds(
   }
 
   const client = getHostedAdminClient();
-  const customerIds: string[] = [];
-  for (const publicClientId of uniqueIds) {
-    const ids = await listTenantCustomerIds(client, publicClientId);
-    customerIds.push(...ids);
-  }
+  const listed = await Promise.all(
+    uniqueIds.map((publicClientId) =>
+      listTenantCustomerIds(client, publicClientId).catch((err) => {
+        console.warn(
+          "credit-allowance-summary: tenant customer list failed",
+          publicClientId,
+          err instanceof Error ? err.message : String(err),
+        );
+        return [] as string[];
+      }),
+    ),
+  );
+  const customerIds = listed.flat();
   if (customerIds.length === 0) {
     return null;
   }
@@ -50,6 +59,7 @@ export async function sumPrepaidCreditBalancesForClientIds(
   let balanceUsdMicros = 0n;
   let lifetimeGrantedUsdMicros = 0n;
   let consumedUsdMicros = 0n;
+  let succeededLookups = 0;
 
   for (let i = 0; i < customerIds.length; i += CREDIT_LOOKUP_CONCURRENCY) {
     const chunk = customerIds.slice(i, i + CREDIT_LOOKUP_CONCURRENCY);
@@ -58,15 +68,27 @@ export async function sumPrepaidCreditBalancesForClientIds(
         getKonnectCreditBalance({
           customerId,
           apiKey,
-        }).catch(() => null),
+        }).catch((err) => {
+          console.warn(
+            "credit-allowance-summary: balance lookup failed",
+            customerId,
+            err instanceof Error ? err.message : String(err),
+          );
+          return null;
+        }),
       ),
     );
     for (const row of rows) {
       if (!row) continue;
+      succeededLookups += 1;
       balanceUsdMicros += row.balanceUsdMicros;
       lifetimeGrantedUsdMicros += row.lifetimeGrantedUsdMicros;
       consumedUsdMicros += row.consumedUsdMicros;
     }
+  }
+
+  if (succeededLookups === 0) {
+    return null;
   }
 
   return {


### PR DESCRIPTION
## Summary
- Align the dashboard usage allowance strip with the Konnect prepaid credit ledger used by the mint / remote-signer balance gates.
- Replace the fake `$5 starter − period network fees` estimate that incorrectly showed **EXHAUSTED** while end-users still had live credit.
- Sum live balances for end-users under the viewer’s apps and surface `balance / granted / consumed` on My Usage.

## Test plan
- [ ] Open Dashboard → My Usage and confirm the strip shows **Prepaid credits** matching Konnect live balance (not `$5 − fees`)
- [ ] Confirm period **Network fees** still appear in the metrics grid separately
- [ ] Confirm **EXHAUSTED** only appears when live prepaid balance is actually `$0`
- [ ] `npx tsx --test src/lib/dashboard-credit-allowance.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prepaid credits display to usage dashboards, showing remaining balance, lifetime grants, credits consumed, and request usage.
  * Dashboard allowance information is now sourced from live prepaid credit balances when available.
  * The allowance display is hidden when credit data is unavailable or invalid.

* **Bug Fixes**
  * Corrected allowance consumption calculations to use credit ledger data instead of network fee totals.

* **Tests**
  * Added coverage for dashboard allowance data and unavailable billing configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->