### PR TITLE
feat(auth): embedded Turnkey Wallet Kit login + OAuth callback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,13 @@ BILLING_STABLE_FEATURE_KEYS=true
 # From Turnkey dashboard → Wallet Kit / Auth Proxy
 NEXT_PUBLIC_ORGANIZATION_ID=
 NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID=
+# OAuth return URL for Google/Discord/etc (must match Turnkey Auth Proxy + provider consoles).
+# Local: http://localhost:3001/auth/callback
+# Prod:  https://pymthouse.com/auth/callback
+# NEXT_PUBLIC_OAUTH_REDIRECT_URI=http://localhost:3001/auth/callback
+# Optional Terms / Privacy links shown under the auth panel (kit hardcodes Turnkey URLs).
+# NEXT_PUBLIC_TERMS_URL=https://www.turnkey.com/legal/terms
+# NEXT_PUBLIC_PRIVACY_URL=https://www.turnkey.com/legal/privacy
 # Optional: comma-separated organization UUIDs allowed for session JWTs (defense in depth)
 # TURNKEY_ALLOWED_ORGANIZATION_IDS=
 

--- a/.env.vercel.template
+++ b/.env.vercel.template
@@ -72,6 +72,11 @@ GITHUB_CLIENT_SECRET=
 NEXT_PUBLIC_ORGANIZATION_ID=
 NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID=
 # From: https://app.turnkey.com/ → Wallet Kit / Auth Proxy (public IDs, browser-safe)
+# OAuth return URL — must match Turnkey Auth Proxy + Google/Discord redirect URIs exactly.
+# NEXT_PUBLIC_OAUTH_REDIRECT_URI=https://pymthouse.com/auth/callback
+# Optional legal links under the auth panel (overrides Turnkey defaults):
+# NEXT_PUBLIC_TERMS_URL=https://example.com/terms
+# NEXT_PUBLIC_PRIVACY_URL=https://example.com/privacy
 # Optional: TURNKEY_ALLOWED_ORGANIZATION_IDS=uuid1,uuid2
 
 # ========================================

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,10 @@
 import type { NextConfig } from "next";
+import path from "node:path";
+
+const turnkeyAuthComponent = path.join(
+  process.cwd(),
+  "node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.mjs",
+);
 
 const nextConfig: NextConfig = {
   serverExternalPackages: [
@@ -9,6 +15,13 @@ const nextConfig: NextConfig = {
     "@pymthouse/clearinghouse-identity-webhook",
   ],
   webpack: (config, { isServer }) => {
+    config.resolve = config.resolve ?? {};
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      // AuthComponent is unpublished; pin the ESM build so it shares
+      // ClientContext with TurnkeyProvider (CJS deep import breaks the context).
+      "@turnkey/react-wallet-kit/auth-component": turnkeyAuthComponent,
+    };
     if (isServer) {
       const prev = config.externals;
       let externalsList: unknown[] = [];

--- a/public/pymthouse-mark.svg
+++ b/public/pymthouse-mark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="280" height="48" viewBox="0 0 280 48" fill="none" role="img" aria-label="pymthouse">
+  <text
+    x="0"
+    y="34"
+    font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif"
+    font-size="32"
+    font-weight="700"
+    letter-spacing="-0.04em"
+  >
+    <tspan fill="#34d399">pymt</tspan><tspan fill="#fafafa">house</tspan>
+  </text>
+</svg>

--- a/src/app/auth/callback/oauth-callback-client.tsx
+++ b/src/app/auth/callback/oauth-callback-client.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import {
+  AuthState,
+  ClientState,
+  useTurnkey,
+} from "@turnkey/react-wallet-kit";
+import { useSession } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import {
+  bridgeTurnkeySessionToNextAuth,
+  safeCallbackUrl,
+} from "@/lib/turnkey-nextauth-bridge";
+
+/**
+ * Minimal OAuth return surface for Turnkey.
+ * Does NOT clear leftover Turnkey sessions (that would race the OAuth return).
+ * Popup flows may briefly paint this before the parent closes the window;
+ * full-page redirects (mobile) complete the NextAuth bridge here.
+ */
+export function OAuthCallbackClient() {
+  const {
+    authState,
+    clientState,
+    getSession,
+    refreshWallets,
+    refreshUser,
+    user,
+    wallets,
+  } = useTurnkey();
+  const { status: nextAuthStatus } = useSession();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
+
+  const [error, setError] = useState<string | null>(null);
+  const bridging = useRef(false);
+
+  useEffect(() => {
+    if (nextAuthStatus === "authenticated") {
+      router.replace(callbackUrl);
+    }
+  }, [nextAuthStatus, router, callbackUrl]);
+
+  useEffect(() => {
+    if (bridging.current) return;
+    if (nextAuthStatus !== "unauthenticated") return;
+    if (authState !== AuthState.Authenticated) return;
+    if (clientState !== ClientState.Ready) return;
+
+    bridging.current = true;
+    setError(null);
+
+    void (async () => {
+      try {
+        const result = await bridgeTurnkeySessionToNextAuth({
+          getSession: () => getSession(),
+          refreshUser,
+          refreshWallets,
+          wallets,
+          user,
+        });
+        if (result.ok) {
+          router.replace(callbackUrl);
+          return;
+        }
+        setError(result.error);
+        bridging.current = false;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Authentication failed");
+        bridging.current = false;
+      }
+    })();
+  }, [
+    authState,
+    clientState,
+    nextAuthStatus,
+    getSession,
+    refreshUser,
+    refreshWallets,
+    wallets,
+    user,
+    router,
+    callbackUrl,
+  ]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-950 px-6">
+      <p className="text-2xl font-bold tracking-tight mb-6">
+        <span className="text-emerald-400">pymt</span>house
+      </p>
+      {error ? (
+        <div className="w-full max-w-sm space-y-3 text-center">
+          <p className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+            {error}
+          </p>
+          <a
+            href="/login"
+            className="inline-block text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+          >
+            Back to sign in
+          </a>
+        </div>
+      ) : (
+        <p className="text-sm text-zinc-400 animate-pulse">
+          Completing sign-in…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/auth/callback/oauth-callback-client.tsx
+++ b/src/app/auth/callback/oauth-callback-client.tsx
@@ -50,9 +50,8 @@ export function OAuthCallbackClient() {
     if (clientState !== ClientState.Ready) return;
 
     bridging.current = true;
-    setError(null);
 
-    void (async () => {
+    (async () => {
       try {
         const result = await bridgeTurnkeySessionToNextAuth({
           getSession: () => getSession(),
@@ -71,7 +70,9 @@ export function OAuthCallbackClient() {
         setError(err instanceof Error ? err.message : "Authentication failed");
         bridging.current = false;
       }
-    })();
+    })().catch(() => {
+      bridging.current = false;
+    });
   }, [
     authState,
     clientState,

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react";
+import { OAuthCallbackClient } from "./oauth-callback-client";
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-950 px-6">
+          <p className="text-2xl font-bold tracking-tight mb-6">
+            <span className="text-emerald-400">pymt</span>house
+          </p>
+          <p className="text-sm text-zinc-400 animate-pulse">
+            Completing sign-in…
+          </p>
+        </div>
+      }
+    >
+      <OAuthCallbackClient />
+    </Suspense>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,11 +17,11 @@ const metadataBase = (() => {
 })();
 
 export const metadata: Metadata = {
-  title: "pymthouse - Identity & Payment Infrastructure",
+  title: "pymthouse - Platform Builder API for Livepeer Applications",
   description: siteDescription,
   metadataBase,
   openGraph: {
-    title: "pymthouse - Identity & Payment Infrastructure",
+    title: "pymthouse - Platform Builder API for Livepeer Applications",
     description: siteDescription,
     siteName: "pymthouse",
     type: "website",
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "pymthouse - Identity & Payment Infrastructure",
+    title: "pymthouse - Platform Builder API for Livepeer Applications",
     description: siteDescription,
   },
 };

--- a/src/app/login/admin/admin-login-form.tsx
+++ b/src/app/login/admin/admin-login-form.tsx
@@ -22,11 +22,13 @@ export function AdminLoginForm() {
   const accessDenied =
     authError === "AccessDenied" ||
     (typeof authError === "string" && authError.includes("AccessDenied"));
-  const oauthCallbackMessage = accessDenied
-    ? "OAuth sign-in was denied. Admin accounts must use a bearer token from npm run bootstrap."
-    : authError
-      ? "Sign-in failed. Please try again."
-      : null;
+  let oauthCallbackMessage: string | null = null;
+  if (accessDenied) {
+    oauthCallbackMessage =
+      "OAuth sign-in was denied. Admin accounts must use a bearer token from npm run bootstrap.";
+  } else if (authError) {
+    oauthCallbackMessage = "Sign-in failed. Please try again.";
+  }
 
   useEffect(() => {
     if (status === "authenticated" && session) {

--- a/src/app/login/admin/admin-login-form.tsx
+++ b/src/app/login/admin/admin-login-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signIn, useSession } from "next-auth/react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { MarketingFooter } from "@/components/MarketingFooter";
@@ -85,7 +86,12 @@ export function AdminLoginForm() {
       <div className="w-full max-w-sm">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold tracking-tight">
-            <span className="text-emerald-400">pymt</span>house
+            <Link
+              href="/"
+              className="inline-block hover:opacity-90 transition-opacity"
+            >
+              <span className="text-emerald-400">pymt</span>house
+            </Link>
           </h1>
           <p className="text-zinc-500 mt-2 text-sm">Admin sign-in</p>
         </div>

--- a/src/app/login/admin/admin-login-form.tsx
+++ b/src/app/login/admin/admin-login-form.tsx
@@ -41,9 +41,9 @@ export function AdminLoginForm() {
     e.preventDefault();
     // Prefer FormData so browser autofill (which often skips React onChange)
     // still submits the value painted in the password field.
+    const rawToken = new FormData(e.currentTarget).get("token");
     const formToken =
-      String(new FormData(e.currentTarget).get("token") ?? "").trim() ||
-      token.trim();
+      (typeof rawToken === "string" ? rawToken : "").trim() || token.trim();
     if (!formToken) {
       setError("Enter a bearer token to sign in.");
       return;

--- a/src/app/login/admin/admin-login-form.tsx
+++ b/src/app/login/admin/admin-login-form.tsx
@@ -38,13 +38,21 @@ export function AdminLoginForm() {
 
   async function handleTokenLogin(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!token.trim()) return;
+    // Prefer FormData so browser autofill (which often skips React onChange)
+    // still submits the value painted in the password field.
+    const formToken =
+      String(new FormData(e.currentTarget).get("token") ?? "").trim() ||
+      token.trim();
+    if (!formToken) {
+      setError("Enter a bearer token to sign in.");
+      return;
+    }
 
     setLoading(true);
     setError(null);
 
     const result = await signIn("token", {
-      token: token.trim(),
+      token: formToken,
       redirect: false,
     });
 
@@ -93,10 +101,16 @@ export function AdminLoginForm() {
           <form onSubmit={handleTokenLogin} className="space-y-3">
             <input
               type="password"
+              name="token"
+              autoComplete="current-password"
               value={token}
               onChange={(e) => {
                 setToken(e.target.value);
                 setError(null);
+              }}
+              onInput={(e) => {
+                // Some browsers surface autofill via input without a change event.
+                setToken(e.currentTarget.value);
               }}
               placeholder="pmth_..."
               className="w-full px-3 py-2.5 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-200 focus:outline-none focus:border-emerald-500/50 font-mono placeholder:font-sans placeholder:text-zinc-600"
@@ -113,7 +127,7 @@ export function AdminLoginForm() {
             )}
             <button
               type="submit"
-              disabled={loading || !token.trim()}
+              disabled={loading}
               className="w-full px-4 py-2.5 bg-zinc-700 text-zinc-200 rounded-lg text-sm font-medium hover:bg-zinc-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {loading ? "Signing in..." : "Sign in with Token"}

--- a/src/app/login/admin/admin-login-form.tsx
+++ b/src/app/login/admin/admin-login-form.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { signIn, useSession } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { MarketingFooter } from "@/components/MarketingFooter";
+
+export function AdminLoginForm() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [token, setToken] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const callbackUrl = searchParams.get("callbackUrl") || "/apps";
+  const safeCallbackUrl =
+    callbackUrl.startsWith("/") && !callbackUrl.startsWith("//")
+      ? callbackUrl
+      : "/apps";
+  const authError = searchParams.get("error");
+  const accessDenied =
+    authError === "AccessDenied" ||
+    (typeof authError === "string" && authError.includes("AccessDenied"));
+  const oauthCallbackMessage = accessDenied
+    ? "OAuth sign-in was denied. Admin accounts must use a bearer token from npm run bootstrap."
+    : authError
+      ? "Sign-in failed. Please try again."
+      : null;
+
+  useEffect(() => {
+    if (status === "authenticated" && session) {
+      router.push(safeCallbackUrl);
+    }
+  }, [session, status, router, safeCallbackUrl]);
+
+  async function handleTokenLogin(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!token.trim()) return;
+
+    setLoading(true);
+    setError(null);
+
+    const result = await signIn("token", {
+      token: token.trim(),
+      redirect: false,
+    });
+
+    if (result?.error) {
+      setError("Invalid token or insufficient permissions.");
+      setLoading(false);
+    } else if (result?.ok) {
+      router.push(safeCallbackUrl);
+    }
+  }
+
+  if (status === "authenticated") {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-zinc-950">
+        <div className="animate-pulse text-zinc-500">Redirecting...</div>
+      </div>
+    );
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-zinc-950">
+        <div className="animate-pulse text-zinc-500">Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-zinc-950">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold tracking-tight">
+            <span className="text-emerald-400">pymt</span>house
+          </h1>
+          <p className="text-zinc-500 mt-2 text-sm">Admin sign-in</p>
+        </div>
+
+        <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30 mb-4">
+          <h2 className="text-lg font-semibold text-zinc-200 mb-1">
+            Sign in with token
+          </h2>
+          <p className="text-sm text-zinc-500 mb-5">
+            Use a bearer token from{" "}
+            <code className="text-zinc-400">npm run bootstrap</code>.
+          </p>
+          <form onSubmit={handleTokenLogin} className="space-y-3">
+            <input
+              type="password"
+              value={token}
+              onChange={(e) => {
+                setToken(e.target.value);
+                setError(null);
+              }}
+              placeholder="pmth_..."
+              className="w-full px-3 py-2.5 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-200 focus:outline-none focus:border-emerald-500/50 font-mono placeholder:font-sans placeholder:text-zinc-600"
+            />
+            {error && (
+              <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+                {error}
+              </p>
+            )}
+            {oauthCallbackMessage && (
+              <p className="text-xs text-amber-300/90 bg-amber-500/10 border border-amber-500/25 rounded-lg px-3 py-2">
+                {oauthCallbackMessage}
+              </p>
+            )}
+            <button
+              type="submit"
+              disabled={loading || !token.trim()}
+              className="w-full px-4 py-2.5 bg-zinc-700 text-zinc-200 rounded-lg text-sm font-medium hover:bg-zinc-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "Signing in..." : "Sign in with Token"}
+            </button>
+          </form>
+        </div>
+
+        <p className="text-center text-xs text-zinc-600 mb-4">
+          <a
+            href="/login"
+            className="text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            ← Developer sign-in
+          </a>
+        </p>
+
+        <MarketingFooter className="mt-6" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/admin/page.tsx
+++ b/src/app/login/admin/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import { AdminLoginForm } from "./admin-login-form";
+
+export default function AdminLoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen bg-zinc-950">
+          <div className="animate-pulse text-zinc-500">Loading...</div>
+        </div>
+      }
+    >
+      <AdminLoginForm />
+    </Suspense>
+  );
+}

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -2,6 +2,7 @@
 
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { MarketingFooter } from "@/components/MarketingFooter";
@@ -126,7 +127,12 @@ export function LoginForm() {
           ) : (
             <>
               <h1 className="text-3xl font-bold tracking-tight">
-                <span className="text-emerald-400">pymt</span>house
+                <Link
+                  href="/"
+                  className="inline-block hover:opacity-90 transition-opacity"
+                >
+                  <span className="text-emerald-400">pymt</span>house
+                </Link>
               </h1>
               <p className="text-zinc-500 mt-2 text-sm">Log in or sign up</p>
             </>

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,18 +1,11 @@
 "use client";
 
 import { sanitizeUrl } from "@braintree/sanitize-url";
-import {
-  AuthState,
-  ClientState,
-  useTurnkey,
-} from "@turnkey/react-wallet-kit";
-import { signIn, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { MarketingFooter } from "@/components/MarketingFooter";
-
-/** Temporarily hide direct Google OAuth on the login page. Re-enable when ready. */
-const SHOW_GOOGLE_LOGIN = false;
+import { TurnkeyEmbeddedAuth } from "@/components/TurnkeyEmbeddedAuth";
 
 interface AppBranding {
   mode: "blackLabel" | "whiteLabel";
@@ -21,196 +14,16 @@ interface AppBranding {
   primaryColor: string;
 }
 
-function TurnkeyLoginButton({ primaryColor = "#10b981" }: { primaryColor?: string }) {
-  const turnkeyConfigured =
-    !!process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
-    !!process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim();
-
-  if (!turnkeyConfigured) {
-    return (
-      <p className="text-xs text-zinc-500 leading-relaxed">
-        Turnkey Wallet Kit is not configured. Set{" "}
-        <code className="text-zinc-400">NEXT_PUBLIC_ORGANIZATION_ID</code> and{" "}
-        <code className="text-zinc-400">NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID</code>{" "}
-        in your environment.
-      </p>
-    );
-  }
-
-  return <TurnkeyLoginButtonInner primaryColor={primaryColor} />;
-}
-
-function TurnkeyLoginButtonInner({ primaryColor = "#10b981" }: { primaryColor?: string }) {
-  const {
-    handleLogin,
-    authState,
-    clientState,
-    getSession,
-    refreshWallets,
-    refreshUser,
-    user,
-    wallets,
-    logout,
-  } = useTurnkey();
-  const { status: nextAuthStatus } = useSession();
-  const [bridging, setBridging] = useState(false);
-  const [bridgeRequested, setBridgeRequested] = useState(false);
-  const [handleLoginPending, setHandleLoginPending] = useState(false);
-  const [failed, setFailed] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const rawCallbackUrl = searchParams.get("callbackUrl") || "/dashboard";
-  const callbackUrl =
-    rawCallbackUrl.startsWith("/") && !rawCallbackUrl.startsWith("//")
-      ? rawCallbackUrl
-      : "/dashboard";
-
-  useEffect(() => {
-    if (
-      !bridgeRequested ||
-      authState !== AuthState.Authenticated ||
-      clientState !== ClientState.Ready ||
-      bridging ||
-      failed
-    ) {
-      return;
-    }
-
-    (async () => {
-      setBridging(true);
-      setError(null);
-      try {
-        await refreshUser();
-        await refreshWallets();
-        const session = await getSession();
-        if (!session?.token) {
-          setError("Could not get session token");
-          setFailed(true);
-          setBridgeRequested(false);
-          setBridging(false);
-          return;
-        }
-
-        const walletAddress = firstEvmAddressFromWallets(wallets);
-        const email = user?.userEmail?.trim() || undefined;
-        const name = user?.userName?.trim() || undefined;
-
-        const result = await signIn("turnkey-wallet", {
-          turnkeySessionJwt: session.token,
-          walletAddress: walletAddress || "",
-          email: email || "",
-          name: name || "",
-          redirect: false,
-        });
-
-        if (result?.error) {
-          setError("Authentication failed — check server logs");
-          setFailed(true);
-          setBridgeRequested(false);
-          setBridging(false);
-        } else if (result?.ok) {
-          setBridgeRequested(false);
-          router.push(callbackUrl);
-        }
-      } catch {
-        setError("Authentication failed");
-        setFailed(true);
-        setBridgeRequested(false);
-        setBridging(false);
-      }
-    })();
-  }, [
-    bridgeRequested,
-    authState,
-    clientState,
-    bridging,
-    failed,
-    getSession,
-    refreshUser,
-    refreshWallets,
-    router,
-    callbackUrl,
-    wallets,
-    user,
-  ]);
-
-  return (
-    <div>
-      <button
-        type="button"
-        onClick={() => {
-          setFailed(false);
-          setError(null);
-          void (async () => {
-            setHandleLoginPending(true);
-            try {
-              if (
-                nextAuthStatus === "unauthenticated" &&
-                authState === AuthState.Authenticated
-              ) {
-                await logout();
-              }
-              await handleLogin();
-              setBridgeRequested(true);
-            } catch {
-              setError("Authentication failed");
-              setFailed(true);
-              setBridgeRequested(false);
-            } finally {
-              setHandleLoginPending(false);
-            }
-          })();
-        }}
-        disabled={
-          bridging ||
-          handleLoginPending ||
-          clientState === ClientState.Loading
-        }
-        className="w-full px-4 py-3 text-white rounded-lg text-sm font-medium hover:opacity-90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        style={{ backgroundColor: primaryColor }}
-      >
-        {bridging || handleLoginPending
-          ? "Connecting..."
-          : "Sign In / Create Account"}
-      </button>
-      {error && (
-        <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 mt-3">
-          {error}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function firstEvmAddressFromWallets(
-  wallets: { accounts: { address: string }[] }[],
-): string | undefined {
-  for (const w of wallets) {
-    for (const a of w.accounts) {
-      const addr = a.address;
-      if (typeof addr === "string" && addr.startsWith("0x")) {
-        return addr;
-      }
-    }
-  }
-  return undefined;
-}
-
 export function LoginForm() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [token, setToken] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [adminSectionOpen, setAdminSectionOpen] = useState(false);
   const [branding, setBranding] = useState<AppBranding | null>(null);
-  const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
+  const callbackUrl = searchParams.get("callbackUrl") || "/apps";
   const safeCallbackUrl =
     callbackUrl.startsWith("/") && !callbackUrl.startsWith("//")
       ? callbackUrl
-      : "/dashboard";
+      : "/apps";
   const clientId = searchParams.get("client_id");
   const isAdmin = searchParams.get("admin") === "1";
   const isOidcFlow = callbackUrl.includes("/oidc/");
@@ -219,12 +32,19 @@ export function LoginForm() {
     authError === "AccessDenied" ||
     (typeof authError === "string" && authError.includes("AccessDenied"));
   const oauthCallbackMessage = accessDenied
-    ? isAdmin
-      ? "OAuth sign-in was denied. Admin accounts must use a bearer token from npm run bootstrap, not Google or GitHub."
-      : "Sign-in was denied. You can try again or use a different sign-in method."
+    ? "Sign-in was denied. You can try again or use a different sign-in method."
     : authError
       ? "Sign-in failed. Please try again."
       : null;
+
+  // Preserve legacy ?admin=1 links by sending them to the dedicated admin login.
+  useEffect(() => {
+    if (!isAdmin) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("admin");
+    const qs = params.toString();
+    router.replace(qs ? `/login/admin?${qs}` : "/login/admin");
+  }, [isAdmin, router, searchParams]);
 
   useEffect(() => {
     if (clientId && isOidcFlow) {
@@ -242,6 +62,12 @@ export function LoginForm() {
   const isWhiteLabel = branding?.mode === "whiteLabel";
   const primaryColor = branding?.primaryColor || "#10b981";
   const logoUrl = toSafeLogoUrl(branding?.logoUrl ?? null);
+  // Always brand outside the kit. AuthComponent logos are capped at max-w-32 /
+  // max-h-16 and Firefox often collapses the SVG <img> to a near-invisible box.
+  const authLogoUrl = null;
+  const authTitle = isWhiteLabel
+    ? branding?.displayName || "Sign in"
+    : "Log in or sign up";
 
   useEffect(() => {
     if (status === "authenticated" && session) {
@@ -249,31 +75,12 @@ export function LoginForm() {
     }
   }, [session, status, router, safeCallbackUrl]);
 
-  useEffect(() => {
-    if (!isAdmin) return;
-    queueMicrotask(() => {
-      setAdminSectionOpen(true);
-    });
-  }, [isAdmin]);
-
-  async function handleTokenLogin(e: React.FormEvent) {
-    e.preventDefault();
-    if (!token.trim()) return;
-
-    setLoading(true);
-    setError(null);
-
-    const result = await signIn("token", {
-      token: token.trim(),
-      redirect: false,
-    });
-
-    if (result?.error) {
-      setError("Invalid token or insufficient permissions.");
-      setLoading(false);
-    } else if (result?.ok) {
-      router.push(safeCallbackUrl);
-    }
+  if (isAdmin) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-zinc-950">
+        <div className="animate-pulse text-zinc-500">Redirecting...</div>
+      </div>
+    );
   }
 
   if (status === "authenticated") {
@@ -295,6 +102,11 @@ export function LoginForm() {
   return (
     <div className="flex items-center justify-center min-h-screen bg-zinc-950">
       <div className="w-full max-w-sm">
+        {/*
+          Hero wordmark above the panel (HTML text, not kit SVG-as-img).
+          Kit AuthComponent hard-caps logo at max-w-32 / max-h-16 — too small,
+          and Firefox can collapse the SVG <img> to an invisible/tiny box.
+        */}
         <div className="text-center mb-8">
           {isWhiteLabel && branding ? (
             <>
@@ -318,107 +130,22 @@ export function LoginForm() {
                 <span className="text-emerald-400">pymt</span>house
               </h1>
               <p className="text-zinc-500 mt-2 text-sm">
-                Identity & Payment Infrastructure
+                Platform Builder API for Livepeer Applications
               </p>
             </>
           )}
         </div>
 
         <div className="border border-zinc-800 rounded-xl p-6 bg-zinc-900/30 mb-4">
-          <h2 className="text-lg font-semibold text-zinc-200 mb-1">
-            {isWhiteLabel ? "Sign In" : "Developer Sign In"}
-          </h2>
-          <p className="text-sm text-zinc-500 mb-5">
-            Sign in with passkey, email OTP, wallet, or social (via Turnkey).
-          </p>
-          <TurnkeyLoginButton primaryColor={primaryColor} />
-          {!isAdmin && (
-            <div className="mt-5 pt-5 border-t border-zinc-800 space-y-3">
-              <p className="text-xs text-zinc-500 leading-relaxed">
-                For developer accounts only.
-              </p>
-              <div className="space-y-2">
-                {SHOW_GOOGLE_LOGIN ? (
-                  <button
-                    type="button"
-                    onClick={() =>
-                      signIn("google", { callbackUrl: safeCallbackUrl })
-                    }
-                    className="w-full flex items-center justify-center gap-3 px-4 py-2.5 border border-zinc-700 rounded-lg hover:bg-zinc-800/50 transition-colors text-sm font-medium text-zinc-300"
-                  >
-                    Google
-                  </button>
-                ) : null}
-                <button
-                  type="button"
-                  onClick={() =>
-                    signIn("github", { callbackUrl: safeCallbackUrl })
-                  }
-                  className="w-full flex items-center justify-center gap-3 px-4 py-2.5 border border-zinc-700 rounded-lg hover:bg-zinc-800/50 transition-colors text-sm font-medium text-zinc-300"
-                >
-                  GitHub
-                </button>
-              </div>
-            </div>
-          )}
+          <TurnkeyEmbeddedAuth
+            primaryColor={primaryColor}
+            logoUrl={authLogoUrl}
+            title={authTitle}
+          />
           {oauthCallbackMessage && (
             <p className="text-xs text-amber-300/90 bg-amber-500/10 border border-amber-500/25 rounded-lg px-3 py-2 mt-4">
               {oauthCallbackMessage}
             </p>
-          )}
-        </div>
-
-        <div className="border border-zinc-800 rounded-xl bg-zinc-900/30 mb-4">
-          <button
-            type="button"
-            onClick={() => setAdminSectionOpen(!adminSectionOpen)}
-            className="w-full px-6 py-4 flex items-center justify-between text-left"
-          >
-            <span className="text-xs text-zinc-500 uppercase tracking-wider">
-              Admin sign-in
-            </span>
-            <svg
-              className={`w-4 h-4 text-zinc-500 transition-transform ${adminSectionOpen ? "rotate-180" : ""}`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
-          </button>
-
-          {adminSectionOpen && (
-            <div className="px-6 pb-6 space-y-3">
-              <form onSubmit={handleTokenLogin} className="space-y-3">
-                <input
-                  type="password"
-                  value={token}
-                  onChange={(e) => {
-                    setToken(e.target.value);
-                    setError(null);
-                  }}
-                  placeholder="pmth_..."
-                  className="w-full px-3 py-2.5 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-200 focus:outline-none focus:border-emerald-500/50 font-mono placeholder:font-sans placeholder:text-zinc-600"
-                />
-                {error && (
-                  <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
-                    {error}
-                  </p>
-                )}
-                <button
-                  type="submit"
-                  disabled={loading || !token.trim()}
-                  className="w-full px-4 py-2.5 bg-zinc-700 text-zinc-200 rounded-lg text-sm font-medium hover:bg-zinc-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {loading ? "Signing in..." : "Sign in with Token"}
-                </button>
-              </form>
-            </div>
           )}
         </div>
 

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -64,10 +64,9 @@ export function LoginForm() {
   const logoUrl = toSafeLogoUrl(branding?.logoUrl ?? null);
   // Always brand outside the kit. AuthComponent logos are capped at max-w-32 /
   // max-h-16 and Firefox often collapses the SVG <img> to a near-invisible box.
+  // Brand outside the kit (AuthComponent only shows its title when a logo is set).
   const authLogoUrl = null;
-  const authTitle = isWhiteLabel
-    ? branding?.displayName || "Sign in"
-    : "Log in or sign up";
+  const authTitle = "Log in or sign up";
 
   useEffect(() => {
     if (status === "authenticated" && session) {
@@ -122,16 +121,14 @@ export function LoginForm() {
               <h1 className="text-3xl font-bold tracking-tight text-zinc-100">
                 {branding.displayName}
               </h1>
-              <p className="text-zinc-500 mt-2 text-sm">Sign in to continue</p>
+              <p className="text-zinc-500 mt-2 text-sm">Log in or sign up</p>
             </>
           ) : (
             <>
               <h1 className="text-3xl font-bold tracking-tight">
                 <span className="text-emerald-400">pymt</span>house
               </h1>
-              <p className="text-zinc-500 mt-2 text-sm">
-                Platform Builder API for Livepeer Applications
-              </p>
+              <p className="text-zinc-500 mt-2 text-sm">Log in or sign up</p>
             </>
           )}
         </div>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const alt = "pymthouse - Identity & Payment Infrastructure";
+export const alt = "pymthouse - Platform Builder API for Livepeer Applications";
 export const size = {
   width: 1200,
   height: 630,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -206,7 +206,7 @@ const STATS = [
 
 export default async function HomePage() {
   const session = await getServerSession(authOptions);
-  if (session) redirect("/dashboard");
+  if (session) redirect("/apps");
 
   const docsUrl = getDocsBaseUrl();
 

--- a/src/components/MarketingFooter.tsx
+++ b/src/components/MarketingFooter.tsx
@@ -33,10 +33,10 @@ export function MarketingFooter({ className = "" }: { className?: string }) {
           <p className="text-zinc-500 uppercase tracking-wider mb-2">Platform</p>
           <div className="space-y-1.5">
             <Link
-              href="/dashboard"
+              href="/apps"
               className="block text-zinc-400 hover:text-zinc-200 transition-colors"
             >
-              Dashboard
+              My Apps
             </Link>
           </div>
         </div>

--- a/src/components/TurnkeyEmbeddedAuth.tsx
+++ b/src/components/TurnkeyEmbeddedAuth.tsx
@@ -5,14 +5,10 @@ import {
   ClientState,
   useTurnkey,
 } from "@turnkey/react-wallet-kit";
-// AuthComponent is not in the package public exports; render it inline so auth
-// lives on the page instead of behind handleLogin()'s dismissible modal.
-// Import the CJS build path (with adjacent .d.ts) — importing `.mjs` fails
-// Next.js typecheck because TS does not associate that file with index.d.ts.
-import { AuthComponent } from "../../node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.js";
 import { useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { AuthComponent } from "@/lib/turnkey-auth-component";
 import {
   bridgeTurnkeySessionToNextAuth,
   safeCallbackUrl,

--- a/src/components/TurnkeyEmbeddedAuth.tsx
+++ b/src/components/TurnkeyEmbeddedAuth.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import {
+  AuthState,
+  ClientState,
+  useTurnkey,
+} from "@turnkey/react-wallet-kit";
+// AuthComponent is not in the package public exports; render it inline so auth
+// lives on the page instead of behind handleLogin()'s dismissible modal.
+import { AuthComponent } from "../../node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.mjs";
+import { useSession } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  bridgeTurnkeySessionToNextAuth,
+  safeCallbackUrl,
+} from "@/lib/turnkey-nextauth-bridge";
+
+const DEFAULT_AUTH_LOGO = "/pymthouse-mark.svg";
+const DEFAULT_TERMS_URL = "https://www.turnkey.com/legal/terms";
+const DEFAULT_PRIVACY_URL = "https://www.turnkey.com/legal/privacy";
+
+export function TurnkeyEmbeddedAuth({
+  primaryColor = "#10b981",
+  logoUrl,
+  title = "Log in or sign up",
+}: Readonly<{
+  primaryColor?: string;
+  /** Image URL shown inside the AuthComponent panel. */
+  logoUrl?: string | null;
+  title?: string;
+}>) {
+  const turnkeyConfigured =
+    !!process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
+    !!process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim();
+
+  if (!turnkeyConfigured) {
+    return (
+      <p className="text-xs text-zinc-500 leading-relaxed">
+        Turnkey Wallet Kit is not configured. Set{" "}
+        <code className="text-zinc-400">NEXT_PUBLIC_ORGANIZATION_ID</code> and{" "}
+        <code className="text-zinc-400">NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID</code>{" "}
+        in your environment.
+      </p>
+    );
+  }
+
+  return (
+    <TurnkeyEmbeddedAuthInner
+      primaryColor={primaryColor}
+      logoUrl={logoUrl}
+      title={title}
+    />
+  );
+}
+
+function TurnkeyEmbeddedAuthInner({
+  primaryColor,
+  logoUrl,
+  title,
+}: Readonly<{
+  primaryColor: string;
+  logoUrl?: string | null;
+  title: string;
+}>) {
+  const {
+    authState,
+    clientState,
+    getSession,
+    refreshWallets,
+    refreshUser,
+    user,
+    wallets,
+    logout,
+  } = useTurnkey();
+  const { status: nextAuthStatus } = useSession();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
+
+  const [bridging, setBridging] = useState(false);
+  const [bridgeRequested, setBridgeRequested] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // True once Turnkey has been Unauthenticated on this page — a later
+  // Authenticated state is a fresh login we should bridge to NextAuth.
+  const sawUnauthenticated = useRef(false);
+  // Only inspect the initial Turnkey session once (avoid logging out mid-bridge).
+  const initialSessionHandled = useRef(false);
+
+  // undefined → default pymthouse mark; null/"" → no interior logo (exterior branding).
+  const authLogo =
+    logoUrl === undefined
+      ? DEFAULT_AUTH_LOGO
+      : logoUrl?.trim() || undefined;
+  const termsUrl =
+    process.env.NEXT_PUBLIC_TERMS_URL?.trim() || DEFAULT_TERMS_URL;
+  const privacyUrl =
+    process.env.NEXT_PUBLIC_PRIVACY_URL?.trim() || DEFAULT_PRIVACY_URL;
+
+  useEffect(() => {
+    if (authState === AuthState.Unauthenticated) {
+      sawUnauthenticated.current = true;
+    }
+  }, [authState]);
+
+  // On first Ready tick: clear a leftover Turnkey session so the form is usable.
+  // Must not run again after a fresh OTP/passkey login or it races the bridge.
+  // Only on /login — never on /auth/callback.
+  useEffect(() => {
+    if (initialSessionHandled.current) return;
+    if (clientState !== ClientState.Ready) return;
+    if (nextAuthStatus === "loading") return;
+
+    initialSessionHandled.current = true;
+
+    if (
+      nextAuthStatus === "unauthenticated" &&
+      authState === AuthState.Authenticated
+    ) {
+      void logout().catch(() => {
+        // Ignore — AuthComponent can still proceed after a failed clear.
+      });
+      return;
+    }
+
+    if (authState === AuthState.Unauthenticated) {
+      sawUnauthenticated.current = true;
+    }
+  }, [authState, clientState, logout, nextAuthStatus]);
+
+  // Bridge after a fresh Turnkey authentication (user completed the form).
+  useEffect(() => {
+    if (authState !== AuthState.Authenticated) return;
+    if (nextAuthStatus !== "unauthenticated") return;
+    if (!sawUnauthenticated.current) return;
+    setFailed(false);
+    setError(null);
+    setBridgeRequested(true);
+  }, [authState, nextAuthStatus]);
+
+  useEffect(() => {
+    if (
+      !bridgeRequested ||
+      authState !== AuthState.Authenticated ||
+      clientState !== ClientState.Ready ||
+      bridging ||
+      failed
+    ) {
+      return;
+    }
+
+    (async () => {
+      setBridging(true);
+      setError(null);
+      try {
+        const result = await bridgeTurnkeySessionToNextAuth({
+          getSession: () => getSession(),
+          refreshUser,
+          refreshWallets,
+          wallets,
+          user,
+        });
+
+        if (!result.ok) {
+          setError(result.error);
+          setFailed(true);
+          setBridgeRequested(false);
+          setBridging(false);
+          return;
+        }
+
+        setBridgeRequested(false);
+        router.push(callbackUrl);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Authentication failed";
+        setError(message);
+        setFailed(true);
+        setBridgeRequested(false);
+        setBridging(false);
+      }
+    })();
+  }, [
+    bridgeRequested,
+    authState,
+    clientState,
+    bridging,
+    failed,
+    getSession,
+    refreshUser,
+    refreshWallets,
+    router,
+    callbackUrl,
+    wallets,
+    user,
+  ]);
+
+  if (clientState === ClientState.Loading) {
+    return (
+      <p className="text-sm text-zinc-500 animate-pulse text-center py-6">
+        Loading sign-in…
+      </p>
+    );
+  }
+
+  if (bridging) {
+    return (
+      <p className="text-sm text-zinc-400 text-center py-6">Connecting…</p>
+    );
+  }
+
+  return (
+    <div>
+      {/*
+        Turnkey Auth styles expect the kit's design tokens. OTP / wallet
+        sub-steps may still open Turnkey's modal stack; outside-click dismiss
+        is blocked by TurnkeyModalDismissGuard.
+        Kit hardcodes Terms/Privacy to turnkey.com — hide that footer and
+        render env-configurable links below.
+      */}
+      <div
+        className={
+          "dark tk-embedded-auth w-full overflow-hidden rounded-lg [&_.w-96]:!w-full [&_>div_>div:last-child]:hidden" +
+          // Kit defaults logo to max-w-32/max-h-16; force a readable header size.
+          // Also give no-logo spacer less empty top padding (kit uses mt-12).
+          (authLogo
+            ? " [&_img]:!max-w-[min(100%,14rem)] [&_img]:!max-h-12 [&_img]:!h-12 [&_img]:!w-auto [&_img]:!min-h-12"
+            : " [&_.mt-12]:!mt-2")
+        }
+        style={
+          {
+            ["--tk-primary"]: primaryColor,
+          } as CSSProperties
+        }
+      >
+        <AuthComponent
+          title={title}
+          {...(authLogo
+            ? {
+                logo: authLogo,
+                logoClassName:
+                  "!max-w-[min(100%,14rem)] !max-h-12 !h-12 !w-auto !min-h-12",
+              }
+            : {})}
+        />
+      </div>
+      <p className="text-xs text-zinc-500 mt-4 text-center leading-relaxed">
+        By continuing, you agree to our{" "}
+        <a
+          href={termsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
+        >
+          Terms of Service
+        </a>{" "}
+        &{" "}
+        <a
+          href={privacyUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
+        >
+          Privacy Policy
+        </a>
+        .
+      </p>
+      {error && (
+        <div className="mt-3 space-y-2">
+          <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+            {error}
+          </p>
+          {authState === AuthState.Authenticated && (
+            <button
+              type="button"
+              onClick={() => {
+                setFailed(false);
+                setError(null);
+                setBridgeRequested(true);
+              }}
+              className="w-full text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+            >
+              Try connecting again
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TurnkeyEmbeddedAuth.tsx
+++ b/src/components/TurnkeyEmbeddedAuth.tsx
@@ -7,7 +7,9 @@ import {
 } from "@turnkey/react-wallet-kit";
 // AuthComponent is not in the package public exports; render it inline so auth
 // lives on the page instead of behind handleLogin()'s dismissible modal.
-import { AuthComponent } from "../../node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.mjs";
+// Import the CJS build path (with adjacent .d.ts) — importing `.mjs` fails
+// Next.js typecheck because TS does not associate that file with index.d.ts.
+import { AuthComponent } from "../../node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.js";
 import { useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState, type CSSProperties } from "react";
@@ -79,7 +81,7 @@ function TurnkeyEmbeddedAuthInner({
   const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
 
   const [bridging, setBridging] = useState(false);
-  const [bridgeRequested, setBridgeRequested] = useState(false);
+  const [retryNonce, setRetryNonce] = useState(0);
   const [failed, setFailed] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // True once Turnkey has been Unauthenticated on this page — a later
@@ -87,6 +89,7 @@ function TurnkeyEmbeddedAuthInner({
   const sawUnauthenticated = useRef(false);
   // Only inspect the initial Turnkey session once (avoid logging out mid-bridge).
   const initialSessionHandled = useRef(false);
+  const bridgeInFlight = useRef(false);
 
   // undefined → default pymthouse mark; null/"" → no interior logo (exterior branding).
   const authLogo =
@@ -118,7 +121,7 @@ function TurnkeyEmbeddedAuthInner({
       nextAuthStatus === "unauthenticated" &&
       authState === AuthState.Authenticated
     ) {
-      void logout().catch(() => {
+      logout().catch(() => {
         // Ignore — AuthComponent can still proceed after a failed clear.
       });
       return;
@@ -134,21 +137,10 @@ function TurnkeyEmbeddedAuthInner({
     if (authState !== AuthState.Authenticated) return;
     if (nextAuthStatus !== "unauthenticated") return;
     if (!sawUnauthenticated.current) return;
-    setFailed(false);
-    setError(null);
-    setBridgeRequested(true);
-  }, [authState, nextAuthStatus]);
+    if (clientState !== ClientState.Ready) return;
+    if (failed || bridgeInFlight.current) return;
 
-  useEffect(() => {
-    if (
-      !bridgeRequested ||
-      authState !== AuthState.Authenticated ||
-      clientState !== ClientState.Ready ||
-      bridging ||
-      failed
-    ) {
-      return;
-    }
+    bridgeInFlight.current = true;
 
     (async () => {
       setBridging(true);
@@ -165,28 +157,31 @@ function TurnkeyEmbeddedAuthInner({
         if (!result.ok) {
           setError(result.error);
           setFailed(true);
-          setBridgeRequested(false);
           setBridging(false);
+          bridgeInFlight.current = false;
           return;
         }
 
-        setBridgeRequested(false);
         router.push(callbackUrl);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "Authentication failed";
         setError(message);
         setFailed(true);
-        setBridgeRequested(false);
         setBridging(false);
+        bridgeInFlight.current = false;
       }
-    })();
+    })().catch(() => {
+      setFailed(true);
+      setBridging(false);
+      bridgeInFlight.current = false;
+    });
   }, [
-    bridgeRequested,
     authState,
+    nextAuthStatus,
     clientState,
-    bridging,
     failed,
+    retryNonce,
     getSession,
     refreshUser,
     refreshWallets,
@@ -254,8 +249,8 @@ function TurnkeyEmbeddedAuthInner({
           className="font-medium text-zinc-400 hover:text-zinc-200 transition-colors"
         >
           Terms of Service
-        </a>{" "}
-        &{" "}
+        </a>
+        {" & "}
         <a
           href={privacyUrl}
           target="_blank"
@@ -277,7 +272,8 @@ function TurnkeyEmbeddedAuthInner({
               onClick={() => {
                 setFailed(false);
                 setError(null);
-                setBridgeRequested(true);
+                bridgeInFlight.current = false;
+                setRetryNonce((n) => n + 1);
               }}
               className="w-full text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
             >

--- a/src/components/TurnkeyEmbeddedAuth.tsx
+++ b/src/components/TurnkeyEmbeddedAuth.tsx
@@ -255,7 +255,7 @@ function TurnkeyEmbeddedAuthInner({
         >
           Privacy Policy
         </a>
-        .
+        {"."}
       </p>
       {error && (
         <div className="mt-3 space-y-2">

--- a/src/components/TurnkeyModalDismissGuard.tsx
+++ b/src/components/TurnkeyModalDismissGuard.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Turnkey's modal closes on backdrop mousedown. That discards in-progress OTP /
+ * wallet selection. Capture-phase stop keeps the X button working (it's a child)
+ * while preventing accidental dismiss when clicking outside.
+ */
+export function TurnkeyModalDismissGuard() {
+  useEffect(() => {
+    const onMouseDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (!target.classList.contains("tk-modal")) return;
+      event.stopImmediatePropagation();
+    };
+
+    document.addEventListener("mousedown", onMouseDown, true);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown, true);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/TurnkeyProvider.tsx
+++ b/src/components/TurnkeyProvider.tsx
@@ -47,16 +47,25 @@ function rejectionMessage(reason: unknown): string {
   }
 }
 
+/** Kit wrappers sometimes prefix the same failures ("Error completing OTP: …"). */
+const OTP_REJECTION_SUBSTRINGS = [
+  "Error completing OTP",
+  "Error resending OTP",
+  "Error initializing OTP",
+] as const;
+
 function isExpectedTurnkeyOtpRejection(reason: unknown): boolean {
   const message = rejectionMessage(reason);
-  return (
-    message.includes("Error completing OTP") ||
-    message.includes("Error resending OTP") ||
-    message.includes("Error initializing OTP") ||
-    message.includes("Failed to verify OTP") ||
-    message.includes("Failed to complete OTP") ||
-    message.includes("Failed to initialize OTP")
-  );
+  if (!message) return false;
+  if (EXPECTED_USER_TURNKEY_MESSAGES.has(message)) return true;
+  if (BENIGN_TURNKEY_MESSAGES.has(message)) return true;
+  for (const expected of EXPECTED_USER_TURNKEY_MESSAGES) {
+    if (message.includes(expected)) return true;
+  }
+  for (const benign of BENIGN_TURNKEY_MESSAGES) {
+    if (message.includes(benign)) return true;
+  }
+  return OTP_REJECTION_SUBSTRINGS.some((s) => message.includes(s));
 }
 
 function isQuietTurnkeyError(error: unknown): boolean {

--- a/src/components/TurnkeyProvider.tsx
+++ b/src/components/TurnkeyProvider.tsx
@@ -4,6 +4,8 @@ import {
   TurnkeyProvider as TurnkeyProviderBase,
   type TurnkeyProviderConfig,
 } from "@turnkey/react-wallet-kit";
+import { useEffect } from "react";
+import { TurnkeyModalDismissGuard } from "./TurnkeyModalDismissGuard";
 
 // Wallet Kit auto-calls fetchUser/fetchWallets on mount whenever it thinks
 // a session might exist. On /login (or after a stale/expired session) these
@@ -15,11 +17,74 @@ const BENIGN_TURNKEY_MESSAGES = new Set([
   "Failed to fetch user",
 ]);
 
+// OTP failures are expected user mistakes (wrong code, expired, etc.). The kit
+// already renders a friendly inline message ("Invalid OTP code" / "An error has
+// occurred"); console.error + rethrows only feed Next.js's dev overlay.
+const EXPECTED_USER_TURNKEY_MESSAGES = new Set([
+  "Failed to verify OTP",
+  "Failed to complete OTP",
+  "Failed to initialize OTP",
+  "Failed to login with OTP",
+  "Failed to sign up with OTP",
+]);
+
 const BENIGN_TURNKEY_CODES = new Set([
   "NO_SESSION_FOUND",
   "SESSION_EXPIRED",
   "CLIENT_NOT_INITIALIZED",
+  "INVALID_OTP_CODE",
 ]);
+
+/** Kit OTP UI catches, shows a friendly message, then rethrows → unhandledRejection. */
+function rejectionMessage(reason: unknown): string {
+  if (reason instanceof Error) return reason.message;
+  if (typeof reason === "string") return reason;
+  if (reason == null) return "";
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return "";
+  }
+}
+
+function isExpectedTurnkeyOtpRejection(reason: unknown): boolean {
+  const message = rejectionMessage(reason);
+  return (
+    message.includes("Error completing OTP") ||
+    message.includes("Error resending OTP") ||
+    message.includes("Error initializing OTP") ||
+    message.includes("Failed to verify OTP") ||
+    message.includes("Failed to complete OTP") ||
+    message.includes("Failed to initialize OTP")
+  );
+}
+
+function isQuietTurnkeyError(error: unknown): boolean {
+  const message = (error as { message?: string })?.message ?? "";
+  const code = (error as { code?: string })?.code ?? "";
+  return (
+    BENIGN_TURNKEY_MESSAGES.has(message) ||
+    EXPECTED_USER_TURNKEY_MESSAGES.has(message) ||
+    BENIGN_TURNKEY_CODES.has(code)
+  );
+}
+
+function TurnkeyExpectedErrorGuard() {
+  useEffect(() => {
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      if (!isExpectedTurnkeyOtpRejection(event.reason)) return;
+      event.preventDefault();
+      console.debug("Turnkey (expected OTP failure):", event.reason);
+    };
+
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+    return () => {
+      window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    };
+  }, []);
+
+  return null;
+}
 
 export default function TurnkeyProviderWrapper({
   children,
@@ -33,9 +98,24 @@ export default function TurnkeyProviderWrapper({
     return <>{children}</>;
   }
 
+  const oauthRedirectUri =
+    process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI?.trim() || undefined;
+
   const turnkeyConfig: TurnkeyProviderConfig = {
     organizationId,
     authProxyConfigId,
+    auth: oauthRedirectUri
+      ? {
+          oauthConfig: {
+            oauthRedirectUri,
+          },
+        }
+      : undefined,
+    ui: {
+      darkMode: true,
+      logoDark: "/pymthouse-mark.svg",
+      logoLight: "/pymthouse-mark.svg",
+    },
   };
 
   return (
@@ -43,19 +123,18 @@ export default function TurnkeyProviderWrapper({
       config={turnkeyConfig}
       callbacks={{
         onError: (error) => {
-          const message = (error as { message?: string })?.message ?? "";
-          const code = (error as { code?: string })?.code ?? "";
-          if (
-            BENIGN_TURNKEY_MESSAGES.has(message) ||
-            BENIGN_TURNKEY_CODES.has(code)
-          ) {
-            console.debug("Turnkey (benign):", code || message);
+          if (isQuietTurnkeyError(error)) {
+            const message = (error as { message?: string })?.message ?? "";
+            const code = (error as { code?: string })?.code ?? "";
+            console.debug("Turnkey (expected):", code || message);
             return;
           }
           console.error("Turnkey error:", error);
         },
       }}
     >
+      <TurnkeyModalDismissGuard />
+      <TurnkeyExpectedErrorGuard />
       {children}
     </TurnkeyProviderBase>
   );

--- a/src/lib/next-auth-options.ts
+++ b/src/lib/next-auth-options.ts
@@ -1,11 +1,8 @@
 import type { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
-import GoogleProvider from "next-auth/providers/google";
-import GitHubProvider from "next-auth/providers/github";
 import { db } from "@/db/index";
 import { users } from "@/db/schema";
-import { eq, and, sql } from "drizzle-orm";
-import { v4 as uuidv4 } from "uuid";
+import { eq, and } from "drizzle-orm";
 import { validateBearerToken, hasScope } from "@/lib/auth";
 import {
   findOrCreateDeveloperUser,
@@ -92,93 +89,15 @@ export const authOptions: NextAuthOptions = {
         };
       },
     }),
-
-    ...(process.env.GOOGLE_CLIENT_ID
-      ? [
-          GoogleProvider({
-            clientId: process.env.GOOGLE_CLIENT_ID!,
-            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-          }),
-        ]
-      : []),
-    ...(process.env.GITHUB_CLIENT_ID
-      ? [
-          GitHubProvider({
-            clientId: process.env.GITHUB_CLIENT_ID!,
-            clientSecret: process.env.GITHUB_CLIENT_SECRET!,
-          }),
-        ]
-      : []),
   ],
   callbacks: {
-    async signIn({ user, account }) {
+    async signIn({ account }) {
       if (!account) return false;
 
       if (account.provider === "token") return true;
-
       if (account.provider === "turnkey-wallet") return true;
 
-      if (!user.email) return false;
-
-      const provider = account.provider;
-      const subject = account.providerAccountId;
-
-      const existingRows = await db
-        .select()
-        .from(users)
-        .where(
-          and(
-            eq(users.oauthProvider, provider),
-            eq(users.oauthSubject, subject),
-          ),
-        )
-        .limit(1);
-      const existing = existingRows[0];
-
-      if (provider === "google" || provider === "github") {
-        if (existing && existing.role === "admin") {
-          return false;
-        }
-        if (existing) {
-          return true;
-        }
-        const normalizedEmail = user.email.trim().toLowerCase();
-        const adminByEmailRows = await db
-          .select()
-          .from(users)
-          .where(
-            and(
-              eq(users.role, "admin"),
-              sql`lower(${users.email}) = ${normalizedEmail}`,
-            ),
-          )
-          .limit(1);
-        if (adminByEmailRows[0]) {
-          return false;
-        }
-        await db.insert(users).values({
-          id: uuidv4(),
-          email: user.email,
-          name: user.name || null,
-          oauthProvider: provider,
-          oauthSubject: subject,
-          role: "developer",
-        });
-        return true;
-      }
-
-      if (!existing) {
-        await db.insert(users).values({
-          id: uuidv4(),
-          email: user.email,
-          name: user.name || null,
-          oauthProvider: provider,
-          oauthSubject: subject,
-          role: "developer",
-        });
-      }
-
-      return true;
+      return false;
     },
     async session({ session, token }) {
       if (session.user) {

--- a/src/lib/turnkey-auth-component.ts
+++ b/src/lib/turnkey-auth-component.ts
@@ -1,21 +1,8 @@
-import type { ComponentType } from "react";
-
-type AuthComponentProps = {
-  sessionKey?: string;
-  logo?: string;
-  logoClassName?: string;
-  title?: string;
-};
-
 /**
  * AuthComponent is not in @turnkey/react-wallet-kit's public exports.
- * Import the ESM (.mjs) build so it shares ClientContext with TurnkeyProvider
- * (also ESM). The CJS (.js) build uses a separate Hook.js module instance —
- * wrapping with TurnkeyProvider then crashes: "useTurnkey must be used within
- * TurnkeyProvider".
+ * Resolve the ESM (.mjs) build via a stable alias (see next.config.ts /
+ * tsconfig paths) so it shares ClientContext with TurnkeyProvider.
+ * The CJS (.js) build uses a separate Hook.js module instance and crashes:
+ * "useTurnkey must be used within TurnkeyProvider".
  */
-// @ts-expect-error -- deep .mjs path has no TS resolution via package exports
-import { AuthComponent as AuthComponentUntyped } from "../../node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.mjs"; // NOSONAR
-
-export const AuthComponent =
-  AuthComponentUntyped as ComponentType<AuthComponentProps>;
+export { AuthComponent } from "@turnkey/react-wallet-kit/auth-component";

--- a/src/lib/turnkey-auth-component.ts
+++ b/src/lib/turnkey-auth-component.ts
@@ -1,0 +1,21 @@
+import type { ComponentType } from "react";
+
+type AuthComponentProps = {
+  sessionKey?: string;
+  logo?: string;
+  logoClassName?: string;
+  title?: string;
+};
+
+/**
+ * AuthComponent is not in @turnkey/react-wallet-kit's public exports.
+ * Import the ESM (.mjs) build so it shares ClientContext with TurnkeyProvider
+ * (also ESM). The CJS (.js) build uses a separate Hook.js module instance —
+ * wrapping with TurnkeyProvider then crashes: "useTurnkey must be used within
+ * TurnkeyProvider".
+ */
+// @ts-expect-error -- deep .mjs path has no TS resolution via package exports
+import { AuthComponent as AuthComponentUntyped } from "../../node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.mjs";
+
+export const AuthComponent =
+  AuthComponentUntyped as ComponentType<AuthComponentProps>;

--- a/src/lib/turnkey-auth-component.ts
+++ b/src/lib/turnkey-auth-component.ts
@@ -15,7 +15,7 @@ type AuthComponentProps = {
  * TurnkeyProvider".
  */
 // @ts-expect-error -- deep .mjs path has no TS resolution via package exports
-import { AuthComponent as AuthComponentUntyped } from "../../node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.mjs";
+import { AuthComponent as AuthComponentUntyped } from "../../node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.mjs"; // NOSONAR
 
 export const AuthComponent =
   AuthComponentUntyped as ComponentType<AuthComponentProps>;

--- a/src/lib/turnkey-nextauth-bridge.test.ts
+++ b/src/lib/turnkey-nextauth-bridge.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  firstEvmAddressFromWallets,
+  safeCallbackUrl,
+} from "./turnkey-nextauth-bridge";
+
+test("safeCallbackUrl keeps same-origin relative paths", () => {
+  assert.equal(safeCallbackUrl("/apps"), "/apps");
+  assert.equal(safeCallbackUrl("/apps/settings?x=1"), "/apps/settings?x=1");
+  assert.equal(safeCallbackUrl("/auth/callback"), "/auth/callback");
+});
+
+test("safeCallbackUrl rejects open redirects and empty values", () => {
+  assert.equal(safeCallbackUrl(null), "/apps");
+  assert.equal(safeCallbackUrl(undefined), "/apps");
+  assert.equal(safeCallbackUrl(""), "/apps");
+  assert.equal(safeCallbackUrl("//evil.example"), "/apps");
+  assert.equal(safeCallbackUrl("https://evil.example"), "/apps");
+  assert.equal(safeCallbackUrl("evil.example"), "/apps");
+  assert.equal(safeCallbackUrl(null, "/login"), "/login");
+});
+
+test("firstEvmAddressFromWallets returns the first 0x account", () => {
+  assert.equal(firstEvmAddressFromWallets([]), undefined);
+  assert.equal(
+    firstEvmAddressFromWallets([{ accounts: [{ address: "solana1" }] }]),
+    undefined,
+  );
+  assert.equal(
+    firstEvmAddressFromWallets([
+      { accounts: [{ address: "solana1" }, { address: "0xabc" }] },
+      { accounts: [{ address: "0xdef" }] },
+    ]),
+    "0xabc",
+  );
+});

--- a/src/lib/turnkey-nextauth-bridge.ts
+++ b/src/lib/turnkey-nextauth-bridge.ts
@@ -1,0 +1,94 @@
+import { signIn } from "next-auth/react";
+
+type WalletAccount = {
+  address: string;
+};
+
+type WalletLike = {
+  accounts: WalletAccount[];
+};
+
+type TurnkeyUserLike = {
+  userEmail?: string | null;
+  userName?: string | null;
+} | null | undefined;
+
+export type TurnkeyBridgeSession = {
+  token?: string;
+} | null | undefined;
+
+export type TurnkeyNextAuthBridgeDeps = {
+  getSession: () => Promise<TurnkeyBridgeSession>;
+  refreshUser: () => Promise<unknown>;
+  refreshWallets: () => Promise<WalletLike[] | null | undefined>;
+  wallets: WalletLike[];
+  user: TurnkeyUserLike;
+};
+
+export function firstEvmAddressFromWallets(
+  wallets: WalletLike[],
+): string | undefined {
+  for (const w of wallets) {
+    for (const a of w.accounts) {
+      const addr = a.address;
+      if (typeof addr === "string" && addr.startsWith("0x")) {
+        return addr;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Exchange an authenticated Turnkey session for a NextAuth `turnkey-wallet` session.
+ * Callers must ensure Turnkey is Authenticated and the client is Ready.
+ */
+export async function bridgeTurnkeySessionToNextAuth(
+  deps: TurnkeyNextAuthBridgeDeps,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const {
+    getSession,
+    refreshUser,
+    refreshWallets,
+    wallets,
+    user,
+  } = deps;
+
+  await refreshUser();
+  const refreshedWallets = await refreshWallets();
+  const session = await getSession();
+  if (!session?.token) {
+    return { ok: false, error: "Could not get session token" };
+  }
+
+  const walletAddress = firstEvmAddressFromWallets(
+    refreshedWallets?.length ? refreshedWallets : wallets,
+  );
+  const email = user?.userEmail?.trim() || undefined;
+  const name = user?.userName?.trim() || undefined;
+
+  const result = await signIn("turnkey-wallet", {
+    turnkeySessionJwt: session.token,
+    walletAddress: walletAddress || "",
+    email: email || "",
+    name: name || "",
+    redirect: false,
+  });
+
+  if (result?.error) {
+    return { ok: false, error: `Authentication failed (${result.error})` };
+  }
+  if (result?.ok) {
+    return { ok: true };
+  }
+  return { ok: false, error: "Authentication failed — no session created" };
+}
+
+/** Safe relative callback path for post-login redirects. */
+export function safeCallbackUrl(
+  raw: string | null | undefined,
+  fallback = "/apps",
+): string {
+  if (!raw) return fallback;
+  return raw.startsWith("/") && !raw.startsWith("//") ? raw : fallback;
+}

--- a/src/lib/turnkey-nextauth-bridge.ts
+++ b/src/lib/turnkey-nextauth-bridge.ts
@@ -39,9 +39,27 @@ export function firstEvmAddressFromWallets(
   return undefined;
 }
 
+async function bestEffort<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.debug(`Turnkey bridge: ${label} failed (continuing):`, message);
+    return undefined;
+  }
+}
+
 /**
  * Exchange an authenticated Turnkey session for a NextAuth `turnkey-wallet` session.
  * Callers must ensure Turnkey is Authenticated and the client is Ready.
+ *
+ * The session JWT alone is enough for NextAuth (`user_id` in claims).
+ * `refreshUser` / `refreshWallets` are best-effort enrichment — they often throw
+ * "Failed to fetch user" right after OTP/OAuth on staging, and a SESSION_EXPIRED
+ * path can logout mid-bridge if we refresh before capturing the token.
  */
 export async function bridgeTurnkeySessionToNextAuth(
   deps: TurnkeyNextAuthBridgeDeps,
@@ -54,12 +72,16 @@ export async function bridgeTurnkeySessionToNextAuth(
     user,
   } = deps;
 
-  await refreshUser();
-  const refreshedWallets = await refreshWallets();
   const session = await getSession();
-  if (!session?.token) {
+  const sessionToken = session?.token?.trim();
+  if (!sessionToken) {
     return { ok: false, error: "Could not get session token" };
   }
+
+  await bestEffort("refreshUser", () => refreshUser());
+  const refreshedWallets = await bestEffort("refreshWallets", () =>
+    refreshWallets(),
+  );
 
   const walletAddress = firstEvmAddressFromWallets(
     refreshedWallets?.length ? refreshedWallets : wallets,
@@ -68,7 +90,7 @@ export async function bridgeTurnkeySessionToNextAuth(
   const name = user?.userName?.trim() || undefined;
 
   const result = await signIn("turnkey-wallet", {
-    turnkeySessionJwt: session.token,
+    turnkeySessionJwt: sessionToken,
     walletAddress: walletAddress || "",
     email: email || "",
     name: name || "",

--- a/src/types/turnkey-auth-component.d.ts
+++ b/src/types/turnkey-auth-component.d.ts
@@ -1,0 +1,12 @@
+declare module "@turnkey/react-wallet-kit/auth-component" {
+  import type { ComponentType } from "react";
+
+  export type AuthComponentProps = {
+    sessionKey?: string;
+    logo?: string;
+    logoClassName?: string;
+    title?: string;
+  };
+
+  export const AuthComponent: ComponentType<AuthComponentProps>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     "paths": {
       "@/*": [
         "./src/*"
+      ],
+      "@turnkey/react-wallet-kit/auth-component": [
+        "./node_modules/@turnkey/react-wallet-kit/dist/components/auth/index.mjs"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- Move developer and admin login onto the embedded Turnkey Wallet Kit (`TurnkeyEmbeddedAuth`) with OAuth callback handling at `/auth/callback`.
- Bridge Wallet Kit sessions into NextAuth via `turnkey-nextauth-bridge`, and remove NextAuth Google/GitHub providers.
- Document OAuth redirect / legal-link env vars and refresh login branding (mark, titles, footer).

Split from the nexus branch [`feat/balance-credit`](https://github.com/pymthouse/pymthouse/pull/237) (login/wallet slice only).

## Test plan
- [ ] Load `/login` with Turnkey env configured; complete email/OAuth login and land on the callback URL
- [ ] Confirm `/auth/callback` completes the NextAuth bridge and establishes a session
- [ ] Load `/login/admin` and verify admin kit login still works
- [ ] Confirm Google/GitHub NextAuth buttons are gone and Turnkey-only sign-in is enforced