### PR TITLE
Keep wire subject simple; map owner wallet only in billing

### DIFF
--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -14,9 +14,10 @@
 #
 # Identity (go-livepeer Kafka wire -> normalized CloudEvent egress):
 # - Upstream auth_id stays client_id:usage_subject (webhook -> go-livepeer state -> Kafka).
-# - Collector parses auth_id once (first-colon split).
-# - App owners mint with usage_subject = owner:{users.id}; OpenMeter subject is that
-#   owner key (shared wallet). End-users keep subject = compound auth_id.
+# - Collector parses auth_id once (first-colon split) for data.client_id / data.usage_subject.
+# - CloudEvent subject is always the full compound auth_id (app_…:platformUserId).
+# - App-owner prepaid/Starter wallet is Konnect customer owner:{users.id}, linked via
+#   usageAttribution.subjectKeys (not by rewriting CloudEvent subject).
 # - data.client_id / data.usage_subject always retain the parsed tenant + subject.
 
 
@@ -118,11 +119,12 @@ pipeline:
         let is_compound = $colon > 0 && $colon < $auth_id.length() - 1
         let client_id = if $is_compound { $auth_id.slice(0, $colon) } else { $auth_id }
         let usage_subject_parsed = if $is_compound { $auth_id.slice($colon + 1) } else { $auth_id }
-        # Shared owner wallet: subject = owner:{users.id} (not compound auth_id).
-        # Derive type from subject shape — do not trust Kafka usage_subject_type.
+        # Metering subject is always the full compound auth_id. Owner prepaid wallets
+        # are linked via Konnect usageAttribution.subjectKeys, not subject rewrite.
         let is_owner_subject = $usage_subject_parsed.index_of("owner:") == 0
         let usage_subject_type = if $is_owner_subject { "app_owner" } else { "external_user_id" }
-        let openmeter_subject = if $is_owner_subject { $usage_subject_parsed } else { $auth_id }
+        let openmeter_subject = $auth_id
+        let openmeter_customer_key = if $is_owner_subject { $usage_subject_parsed } else { $auth_id }
 
         let eth_usd = meta("eth_usd_price").number()
         root = if $eth_usd == null { throw("eth_usd price cache miss") }
@@ -154,7 +156,7 @@ pipeline:
               "pixels": $data.pixels.string().or("0"),
               "fee_wei": $data.computed_fee.or("0"),
               "auth_id": $auth_id,
-              "openmeter_customer_key": $openmeter_subject,
+              "openmeter_customer_key": $openmeter_customer_key,
               "eth_usd_price": $eth_usd.string(),
               "gateway_request_id": $data.request_id,
             }

--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -14,10 +14,11 @@
 #
 # Identity (go-livepeer Kafka wire -> normalized CloudEvent egress):
 # - Upstream auth_id stays client_id:usage_subject (webhook -> go-livepeer state -> Kafka).
-# - Collector parses auth_id once (first-colon split) for data.client_id / data.usage_subject.
-# - CloudEvent subject is always the full compound auth_id (app_…:platformUserId).
-# - App-owner prepaid/Starter wallet is Konnect customer owner:{users.id}, linked via
-#   usageAttribution.subjectKeys (not by rewriting CloudEvent subject).
+# - For app owners, webhook maps JWT sub (bare user id) to usage_subject owner:{users.id}
+#   so auth_id is app_…:owner:{id}; CloudEvent subject is that owner key (Konnect customer
+#   key) so prepaid/credit_then_invoice settles. Compound subjects cannot be multi-attributed
+#   onto an owner customer while a subscription is active (Konnect billing beta).
+# - End-users keep CloudEvent subject = full compound auth_id.
 # - data.client_id / data.usage_subject always retain the parsed tenant + subject.
 
 
@@ -119,12 +120,12 @@ pipeline:
         let is_compound = $colon > 0 && $colon < $auth_id.length() - 1
         let client_id = if $is_compound { $auth_id.slice(0, $colon) } else { $auth_id }
         let usage_subject_parsed = if $is_compound { $auth_id.slice($colon + 1) } else { $auth_id }
-        # Metering subject is always the full compound auth_id. Owner prepaid wallets
-        # are linked via Konnect usageAttribution.subjectKeys, not subject rewrite.
+        # Owner wallet: meter subject = owner:{users.id} (Konnect customer key).
+        # End-users: meter subject = full compound auth_id.
         let is_owner_subject = $usage_subject_parsed.index_of("owner:") == 0
         let usage_subject_type = if $is_owner_subject { "app_owner" } else { "external_user_id" }
-        let openmeter_subject = $auth_id
-        let openmeter_customer_key = if $is_owner_subject { $usage_subject_parsed } else { $auth_id }
+        let openmeter_subject = if $is_owner_subject { $usage_subject_parsed } else { $auth_id }
+        let openmeter_customer_key = $openmeter_subject
 
         let eth_usd = meta("eth_usd_price").number()
         root = if $eth_usd == null { throw("eth_usd price cache miss") }

--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -345,19 +345,20 @@ For RFC 8693 exchange after minting a user JWT, use `POST /api/v1/apps/{clientId
 
 Direct signing uses `@pymthouse/builder-sdk/signer/server` — mint a user JWT via Builder API OIDC, forward it to the remote signer DMZ, and sign there directly. The PymtHouse `/api/signer/*` signing proxy is **removed**; only `POST /api/signer/device/exchange` remains for device JWT mint. Use `GET /api/v1/apps/{clientId}/signer/routing` for the DMZ URL and webhook URL.
 
-**Identity:** go-livepeer calls `POST /webhooks/remote-signer` (configured via `-remoteSignerWebhookUrl`) to verify the end-user JWT. The webhook returns `auth_id` (`client_id:usage_subject`) for go-livepeer state persistence — this wire format is unchanged. App-owner JWTs use `usage_subject` / `external_user_id` = `owner:{users.id}` so `auth_id` looks like `app_…:owner:{users.id}`.
+**Identity:** go-livepeer calls `POST /webhooks/remote-signer` (configured via `-remoteSignerWebhookUrl`) to verify the end-user JWT. The webhook returns `auth_id` (`client_id:usage_subject`) for go-livepeer state persistence — this wire format is unchanged. App-owner JWTs use bare `usage_subject` / `external_user_id` / JWT `sub` = `{users.id}` (same shape as end-users), with `user_type: "app_owner"` as metadata only. Wire `auth_id` is therefore `app_…:{users.id}`.
 
 **Usage metering (signer-authoritative, async collector):**
 
 1. **Authoritative event:** go-livepeer remote signer emits `create_signed_ticket` events to Kafka (`livepeer-gateway-events`) with `computed_fee` and `auth_id` (`client_id:usage_subject`).
 2. **Collector ingest:** OpenMeter collector consumes Kafka, parses `auth_id` once (first-colon split), converts Wei to `network_fee_usd_micros` via `ceil(fee_wei * eth_usd / 1e12)` so sub-micro fees still count as at least 1 micro, and writes normalized CloudEvents to OpenMeter/Konnect:
-   - `subject` = compound `auth_id` for M2M end-users; **`owner:{users.id}`** when `usage_subject` starts with `owner:` (shared owner wallet)
+   - `subject` = full compound `auth_id` (`app_…:platformUserId`) for owners and end-users
    - `data.client_id` = tenant (developer app OAuth `client_id`)
-   - `data.usage_subject` = end user or `owner:{users.id}`
+   - `data.usage_subject` = bare platform user id (or end-user external id)
    - `data.auth_id` retained for compatibility; `data.external_user_id` mirrors `usage_subject` for existing meter `groupBy`
+   - `data.openmeter_customer_key` = billing wallet key (`owner:{users.id}` for owners; compound for end-users)
    - `data.eth_usd_price` = ETH/USD oracle rate used for that event’s Wei → USD micros conversion
 
-**Prepaid credits:** App owners share one Konnect customer (`owner:{users.id}`) across all owned apps. M2M end-users remain `app_…:external_user_id` (per app). Dashboard owner prepaid strip reads the shared owner wallet; per-app usage pages sum end-user wallets only.
+**Prepaid credits:** App owners share one Konnect customer (`owner:{users.id}`) across all owned apps. That customer’s `usageAttribution.subjectKeys` includes each owned-app compound key (`app_…:{ownerUserId}`) so prepaid/`credit_then_invoice` settles against the shared wallet when CloudEvents use compound subjects. M2M end-users remain `app_…:external_user_id` (per app). Dashboard owner prepaid strip reads the shared owner wallet; subscription/spendable usage aggregates compound subjects (with legacy `owner:` / `app_…:owner:…` dual-read during transition). Per-app usage pages sum end-user wallets only.
 
 Retail pricing comes from **OpenMeter plans/rate cards** synced when plans are published (`POST`/`PUT …/plans`), not from bps markup on network cost at sign time.
 

--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -345,20 +345,20 @@ For RFC 8693 exchange after minting a user JWT, use `POST /api/v1/apps/{clientId
 
 Direct signing uses `@pymthouse/builder-sdk/signer/server` — mint a user JWT via Builder API OIDC, forward it to the remote signer DMZ, and sign there directly. The PymtHouse `/api/signer/*` signing proxy is **removed**; only `POST /api/signer/device/exchange` remains for device JWT mint. Use `GET /api/v1/apps/{clientId}/signer/routing` for the DMZ URL and webhook URL.
 
-**Identity:** go-livepeer calls `POST /webhooks/remote-signer` (configured via `-remoteSignerWebhookUrl`) to verify the end-user JWT. The webhook returns `auth_id` (`client_id:usage_subject`) for go-livepeer state persistence — this wire format is unchanged. App-owner JWTs use bare `usage_subject` / `external_user_id` / JWT `sub` = `{users.id}` (same shape as end-users), with `user_type: "app_owner"` as metadata only. Wire `auth_id` is therefore `app_…:{users.id}`.
+**Identity:** go-livepeer calls `POST /webhooks/remote-signer` (configured via `-remoteSignerWebhookUrl`) to verify the end-user JWT. The webhook returns `auth_id` (`client_id:usage_subject`) for go-livepeer state persistence. App-owner JWTs keep bare `sub` / `external_user_id` = `{users.id}` with `user_type: "app_owner"`; the webhook maps that to `usage_subject` = `owner:{users.id}` so `auth_id` is `app_…:owner:{users.id}` for metering settlement.
 
 **Usage metering (signer-authoritative, async collector):**
 
 1. **Authoritative event:** go-livepeer remote signer emits `create_signed_ticket` events to Kafka (`livepeer-gateway-events`) with `computed_fee` and `auth_id` (`client_id:usage_subject`).
 2. **Collector ingest:** OpenMeter collector consumes Kafka, parses `auth_id` once (first-colon split), converts Wei to `network_fee_usd_micros` via `ceil(fee_wei * eth_usd / 1e12)` so sub-micro fees still count as at least 1 micro, and writes normalized CloudEvents to OpenMeter/Konnect:
-   - `subject` = full compound `auth_id` (`app_…:platformUserId`) for owners and end-users
+   - `subject` = compound `auth_id` for M2M end-users; **`owner:{users.id}`** when `usage_subject` starts with `owner:` (shared owner wallet / Konnect customer key)
    - `data.client_id` = tenant (developer app OAuth `client_id`)
-   - `data.usage_subject` = bare platform user id (or end-user external id)
+   - `data.usage_subject` = end user or `owner:{users.id}`
    - `data.auth_id` retained for compatibility; `data.external_user_id` mirrors `usage_subject` for existing meter `groupBy`
-   - `data.openmeter_customer_key` = billing wallet key (`owner:{users.id}` for owners; compound for end-users)
+   - `data.openmeter_customer_key` = billing wallet key
    - `data.eth_usd_price` = ETH/USD oracle rate used for that event’s Wei → USD micros conversion
 
-**Prepaid credits:** App owners share one Konnect customer (`owner:{users.id}`) across all owned apps. That customer’s `usageAttribution.subjectKeys` includes each owned-app compound key (`app_…:{ownerUserId}`) so prepaid/`credit_then_invoice` settles against the shared wallet when CloudEvents use compound subjects. M2M end-users remain `app_…:external_user_id` (per app). Dashboard owner prepaid strip reads the shared owner wallet; subscription/spendable usage aggregates compound subjects (with legacy `owner:` / `app_…:owner:…` dual-read during transition). Per-app usage pages sum end-user wallets only.
+**Prepaid credits:** App owners share one Konnect customer (`owner:{users.id}`) across all owned apps. Konnect billing beta clears multi-subject `usageAttribution` when a subscription is active, so owner CloudEvents must use `subject = owner:{id}` (customer key auto-attribution) rather than compound subjects alone. M2M end-users remain `app_…:external_user_id` (per app). Dashboard owner prepaid strip reads the shared owner wallet; subscription/spendable usage dual-reads compound and `owner:` subjects during transition. Per-app usage pages sum end-user wallets only.
 
 Retail pricing comes from **OpenMeter plans/rate cards** synced when plans are published (`POST`/`PUT …/plans`), not from bps markup on network cost at sign time.
 

--- a/docs/openmeter-entitlements-cutover.md
+++ b/docs/openmeter-entitlements-cutover.md
@@ -108,6 +108,9 @@ Renaming UI to “allowance” already matches how we talk about the current mod
 - Grants / entitlement reads: `src/lib/openmeter/entitlements.ts`, `konnect-credits.ts`
 - UI allowance meter: `src/components/AllowanceProgressBar.tsx`
 - Owner wallet cleanup: `scripts/openmeter-dedupe-owner-subscriptions.ts`
+- Restore Starter included usage (`discounts.usage`) + resubscribe:
+  `scripts/openmeter-fix-starter-allowance.ts`
+  (`npm run openmeter:fix-starter-allowance -- --owner-id <users.id> --apply`)
 
 ## Success criteria
 

--- a/docs/openmeter-railway.md
+++ b/docs/openmeter-railway.md
@@ -128,7 +128,7 @@ Bootstrap does **not** create per-app plans or grant credits. Those happen at ru
 1. **Plan sync** (`syncPlanToOpenMeter`) publishes Starter with `settlement_mode=credit_then_invoice` and a bare `network_spend` unit price (`0.000001` per USD micro). Rate cards must **not** include `discounts.usage`.
 2. **Customer keys:**
    - **M2M end-users:** `client_id:external_user_id` — one Konnect customer per (app, user). CloudEvent `subject` matches this compound key.
-   - **App owners:** billing wallet `owner:{users.id}` — one shared Konnect customer across all apps they own. Wire identity stays simple: JWT `sub` / `external_user_id` = bare `{users.id}`, and CloudEvent `subject` = compound `app_…:{users.id}`. The owner customer’s `usageAttribution.subjectKeys` includes those compound keys so prepaid credits settle on the shared wallet without rewriting the meter subject.
+   - **App owners:** billing wallet `owner:{users.id}` — one shared Konnect customer across all apps they own. JWT `sub` / `external_user_id` stay bare `{users.id}`; the remote-signer webhook maps owners to `usage_subject` = `owner:{users.id}` so CloudEvent `subject` is the customer key (required for Konnect settlement — multi-subject `usageAttribution` is cleared when a subscription is created).
 3. **Trial / top-up allowance** is `POST /customers/{id}/credits/grants` only (`OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS`, default `$5`). Owners are granted once on the shared wallet; end-users once per app customer. Prepaid burn-down is driven by billing charges under `credit_then_invoice`.
 
 Migrate existing per-app owner wallets with:

--- a/docs/openmeter-railway.md
+++ b/docs/openmeter-railway.md
@@ -127,8 +127,8 @@ Bootstrap does **not** create per-app plans or grant credits. Those happen at ru
 
 1. **Plan sync** (`syncPlanToOpenMeter`) publishes Starter with `settlement_mode=credit_then_invoice` and a bare `network_spend` unit price (`0.000001` per USD micro). Rate cards must **not** include `discounts.usage`.
 2. **Customer keys:**
-   - **M2M end-users:** `client_id:external_user_id` — one Konnect customer per (app, user).
-   - **App owners:** `owner:{users.id}` — one shared Konnect customer across all apps they own. Owner mint JWTs use `external_user_id` / `sub` = `owner:{users.id}`; the collector sets CloudEvent `subject` to that owner key while keeping `data.client_id` for per-app analytics.
+   - **M2M end-users:** `client_id:external_user_id` — one Konnect customer per (app, user). CloudEvent `subject` matches this compound key.
+   - **App owners:** billing wallet `owner:{users.id}` — one shared Konnect customer across all apps they own. Wire identity stays simple: JWT `sub` / `external_user_id` = bare `{users.id}`, and CloudEvent `subject` = compound `app_…:{users.id}`. The owner customer’s `usageAttribution.subjectKeys` includes those compound keys so prepaid credits settle on the shared wallet without rewriting the meter subject.
 3. **Trial / top-up allowance** is `POST /customers/{id}/credits/grants` only (`OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS`, default `$5`). Owners are granted once on the shared wallet; end-users once per app customer. Prepaid burn-down is driven by billing charges under `credit_then_invoice`.
 
 Migrate existing per-app owner wallets with:

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "openmeter:bootstrap": "npx tsx scripts/openmeter-bootstrap.ts",
     "openmeter:ensure-customer": "npx tsx scripts/openmeter-ensure-customer.ts",
     "openmeter:migrate-starter-prepaid": "npx tsx scripts/openmeter-migrate-starter-prepaid.ts",
+    "openmeter:fix-starter-allowance": "npx tsx scripts/openmeter-fix-starter-allowance.ts",
     "openmeter:dedupe-owner-subscriptions": "npx tsx scripts/openmeter-dedupe-owner-subscriptions.ts",
     "turnkey:create-webhook": "npx tsx scripts/turnkey-create-webhook.ts",
     "openmeter:railway:bootstrap": "bash scripts/openmeter-railway-bootstrap.sh",

--- a/scripts/lib/openmeter-konnect-migrate.ts
+++ b/scripts/lib/openmeter-konnect-migrate.ts
@@ -1,0 +1,181 @@
+/**
+ * Shared Konnect HTTP helpers for OpenMeter migration scripts.
+ * Keep scripts thin so Sonar does not flag duplicated migrate boilerplate.
+ */
+import {
+  getHostedOpenMeterUrl,
+  isKonnectMeteringUrl,
+  KONNECT_SETTLEMENT_MODE_CREDIT_THEN_INVOICE,
+  normalizeKonnectMeteringUrl,
+} from "../../src/lib/openmeter/constants";
+
+export type SubscriptionChangeTiming = "immediate" | "next_billing_cycle";
+
+export type KonnectPlan = {
+  id: string;
+  key: string;
+  name?: string;
+  status?: string;
+  version?: number;
+  settlement_mode?: string;
+  currency?: string;
+  billing_cadence?: string;
+  phases?: Array<{
+    key?: string;
+    name?: string;
+    rate_cards?: Array<Record<string, unknown>>;
+  }>;
+};
+
+export type KonnectSubscription = {
+  id: string;
+  status: string;
+  customer_id: string;
+  plan_id?: string;
+  settlement_mode?: string;
+};
+
+export function takeArgValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1]?.trim();
+  if (!value) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+export function parseSubscriptionTiming(value: string): SubscriptionChangeTiming {
+  if (value !== "immediate" && value !== "next_billing_cycle") {
+    throw new Error("--timing must be immediate or next_billing_cycle");
+  }
+  return value;
+}
+
+export function requireKonnectConfig(): { baseUrl: string; apiKey: string } {
+  const rawUrl = getHostedOpenMeterUrl();
+  const apiKey = process.env.OPENMETER_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("OPENMETER_API_KEY is required");
+  }
+  if (!isKonnectMeteringUrl(rawUrl, apiKey)) {
+    throw new Error(
+      `This migration targets Konnect only (got OPENMETER_URL=${rawUrl})`,
+    );
+  }
+  return {
+    baseUrl: normalizeKonnectMeteringUrl(rawUrl),
+    apiKey,
+  };
+}
+
+export async function konnectFetch<T>(
+  baseUrl: string,
+  apiKey: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  let parsed: unknown = null;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Konnect ${method} ${path} failed [${response.status}]: ${String(text).slice(0, 800)}`,
+    );
+  }
+  return parsed as T;
+}
+
+export function rateCardsHaveUsageDiscount(plan: KonnectPlan): boolean {
+  return readUsageDiscountMicros(plan) != null;
+}
+
+export function readUsageDiscountMicros(plan: KonnectPlan): string | null {
+  for (const phase of plan.phases ?? []) {
+    for (const card of phase.rate_cards ?? []) {
+      const discounts = card.discounts;
+      if (!discounts || typeof discounts !== "object") continue;
+      const usage = (discounts as { usage?: unknown }).usage;
+      if (typeof usage === "string" || typeof usage === "number") {
+        return String(usage);
+      }
+    }
+  }
+  return null;
+}
+
+export function isUsableAllowancePlan(plan: KonnectPlan): boolean {
+  return (
+    plan.status === "active" &&
+    rateCardsHaveUsageDiscount(plan) &&
+    plan.settlement_mode === KONNECT_SETTLEMENT_MODE_CREDIT_THEN_INVOICE
+  );
+}
+
+export async function getKonnectPlan(
+  baseUrl: string,
+  apiKey: string,
+  planId: string,
+): Promise<KonnectPlan> {
+  return konnectFetch<KonnectPlan>(baseUrl, apiKey, "GET", `/plans/${planId}`);
+}
+
+export async function listActiveKonnectSubscriptions(
+  baseUrl: string,
+  apiKey: string,
+): Promise<KonnectSubscription[]> {
+  const out: KonnectSubscription[] = [];
+  let page = 1;
+  for (;;) {
+    const body = await konnectFetch<{ data?: KonnectSubscription[] }>(
+      baseUrl,
+      apiKey,
+      "GET",
+      `/subscriptions?page=${page}&pageSize=100`,
+    );
+    const items = body.data ?? [];
+    for (const item of items) {
+      if (item.status === "active" || item.status === "scheduled") {
+        out.push(item);
+      }
+    }
+    if (items.length < 100) break;
+    page += 1;
+  }
+  return out;
+}
+
+export async function changeKonnectSubscription(input: {
+  baseUrl: string;
+  apiKey: string;
+  subscriptionId: string;
+  customerId: string;
+  planId: string;
+  timing: SubscriptionChangeTiming;
+}): Promise<{ current?: KonnectSubscription; next?: KonnectSubscription }> {
+  return konnectFetch(
+    input.baseUrl,
+    input.apiKey,
+    "POST",
+    `/subscriptions/${input.subscriptionId}/change`,
+    {
+      customer: { id: input.customerId },
+      plan: { id: input.planId },
+      timing: input.timing,
+    },
+  );
+}

--- a/scripts/openmeter-fix-starter-allowance.ts
+++ b/scripts/openmeter-fix-starter-allowance.ts
@@ -1,0 +1,723 @@
+/**
+ * Fix Starter included-usage allowance and resubscribe onto plan versions that
+ * carry Konnect rate-card `discounts.usage`.
+ *
+ * Context: prepaid-only Starter publishes (see openmeter-migrate-starter-prepaid)
+ * left some live subscriptions on plan versions with no included allowance.
+ * Mint/billing then see $0 spendable when prepaid credits are also empty.
+ *
+ * This script:
+ *   1. Ensures each Starter row has `includedUsdMicros` (env default if missing)
+ *   2. Syncs/publishes the plan to Konnect via syncPlanToOpenMeter
+ *   3. Verifies the published plan has `discounts.usage`
+ *   4. Moves subscriptions onto that plan version
+ *        - default: POST /subscriptions/{id}/change
+ *        - --owner-id: cancel active owner:{id} subs, then ensure Starter
+ *
+ * Usage:
+ *   # Preview all Starter apps
+ *   npx tsx scripts/openmeter-fix-starter-allowance.ts
+ *
+ *   # One owner wallet (recommended for Billing “no included usage”)
+ *   npx tsx scripts/openmeter-fix-starter-allowance.ts \
+ *     --owner-id 8112311f-634e-4602-984a-c8270da373e3
+ *
+ *   # Apply
+ *   npx tsx scripts/openmeter-fix-starter-allowance.ts \
+ *     --owner-id 8112311f-634e-4602-984a-c8270da373e3 --apply
+ *
+ *   # One app’s Starter + change all active subs on that plan key
+ *   npx tsx scripts/openmeter-fix-starter-allowance.ts \
+ *     --client-id app_xxx --apply
+ */
+import "./load-env-first";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { closeDb, db } from "../src/db/index";
+import { developerApps, oidcClients, plans } from "../src/db/schema";
+import {
+  getHostedAdminClient,
+  isHostedAdminClientAvailable,
+} from "../src/lib/openmeter/admin-client";
+import {
+  getHostedOpenMeterUrl,
+  isKonnectMeteringUrl,
+  KONNECT_SETTLEMENT_MODE_CREDIT_THEN_INVOICE,
+  normalizeKonnectMeteringUrl,
+} from "../src/lib/openmeter/constants";
+import { buildOwnerCustomerKey } from "../src/lib/openmeter/customer-key";
+import { ensureOpenMeterCustomer } from "../src/lib/openmeter/customers";
+import { buildOpenMeterPlanKey } from "../src/lib/openmeter/plan-naming";
+import { syncPlanToOpenMeter } from "../src/lib/openmeter/plans-sync";
+import { ensureStarterSubscriptionForAppUser } from "../src/lib/openmeter/starter-subscription";
+import {
+  isOpenMeterSubscriptionActive,
+  listOpenMeterSubscriptionsForCustomer,
+  type OpenMeterSubscriptionView,
+} from "../src/lib/openmeter/subscription-read";
+import { defaultStarterIncludedUsdMicros } from "../src/lib/starter-default-plan-display";
+
+type Timing = "immediate" | "next_billing_cycle";
+
+type Args = {
+  apply: boolean;
+  ownerId?: string;
+  clientId?: string;
+  timing: Timing;
+};
+
+type StarterRow = {
+  id: string;
+  clientId: string;
+  includedUsdMicros: string | null;
+  openmeterPlanId: string | null;
+  openmeterPlanVersion: number | null;
+};
+
+type OwnedApp = {
+  developerAppId: string;
+  publicClientId: string;
+  name: string;
+};
+
+type KonnectPlan = {
+  id: string;
+  key: string;
+  name?: string;
+  status?: string;
+  version?: number;
+  settlement_mode?: string;
+  phases?: Array<{
+    key?: string;
+    name?: string;
+    rate_cards?: Array<Record<string, unknown>>;
+  }>;
+};
+
+type KonnectSubscription = {
+  id: string;
+  status: string;
+  customer_id: string;
+  plan_id?: string;
+};
+
+function usage(): string {
+  return [
+    "openmeter-fix-starter-allowance",
+    "",
+    "Republish Starter with discounts.usage and move subscriptions onto it.",
+    "",
+    "Options:",
+    "  --dry-run                 Preview only (default)",
+    "  --apply                   Write DB + Konnect changes",
+    "  --owner-id <users.id>     Fix shared owner:{id} wallet (cancel + recreate)",
+    "  --client-id <app_id>      Limit to one app's Starter plan",
+    "  --timing immediate|next_billing_cycle",
+    "                            Cancel/change timing (default: immediate)",
+  ].join("\n");
+}
+
+function takeValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1]?.trim();
+  if (!value) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { apply: false, timing: "immediate" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    switch (token) {
+      case "--apply":
+        args.apply = true;
+        break;
+      case "--dry-run":
+        args.apply = false;
+        break;
+      case "--owner-id":
+        args.ownerId = takeValue(argv, i, token);
+        i += 1;
+        break;
+      case "--client-id":
+        args.clientId = takeValue(argv, i, token);
+        i += 1;
+        break;
+      case "--timing": {
+        const value = takeValue(argv, i, token);
+        if (value !== "immediate" && value !== "next_billing_cycle") {
+          throw new Error("--timing must be immediate|next_billing_cycle");
+        }
+        args.timing = value;
+        i += 1;
+        break;
+      }
+      case "--help":
+      case "-h":
+        console.log(usage());
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${token}\n\n${usage()}`);
+    }
+  }
+  return args;
+}
+
+function requireKonnectConfig(): { baseUrl: string; apiKey: string } {
+  const rawUrl = getHostedOpenMeterUrl();
+  const apiKey = process.env.OPENMETER_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("OPENMETER_API_KEY is required");
+  }
+  if (!isKonnectMeteringUrl(rawUrl, apiKey)) {
+    throw new Error(
+      `This migration targets Konnect only (got OPENMETER_URL=${rawUrl})`,
+    );
+  }
+  if (!isHostedAdminClientAvailable()) {
+    throw new Error("OpenMeter admin client is not available");
+  }
+  return {
+    baseUrl: normalizeKonnectMeteringUrl(rawUrl),
+    apiKey,
+  };
+}
+
+async function konnectFetch<T>(
+  baseUrl: string,
+  apiKey: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Konnect ${method} ${path} failed [${response.status}]: ${text.slice(0, 800)}`,
+    );
+  }
+  if (!text) {
+    return null as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return text as T;
+  }
+}
+
+function rateCardsHaveUsageDiscount(plan: KonnectPlan): boolean {
+  for (const phase of plan.phases ?? []) {
+    for (const card of phase.rate_cards ?? []) {
+      const discounts = card.discounts;
+      if (
+        discounts &&
+        typeof discounts === "object" &&
+        (discounts as { usage?: unknown }).usage != null
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function readUsageDiscountMicros(plan: KonnectPlan): string | null {
+  for (const phase of plan.phases ?? []) {
+    for (const card of phase.rate_cards ?? []) {
+      const discounts = card.discounts;
+      if (!discounts || typeof discounts !== "object") continue;
+      const usage = (discounts as { usage?: unknown }).usage;
+      if (usage == null) continue;
+      return String(usage);
+    }
+  }
+  return null;
+}
+
+function isUsableAllowancePlan(plan: KonnectPlan): boolean {
+  return (
+    plan.status === "active" &&
+    rateCardsHaveUsageDiscount(plan) &&
+    plan.settlement_mode === KONNECT_SETTLEMENT_MODE_CREDIT_THEN_INVOICE
+  );
+}
+
+async function getPlan(
+  baseUrl: string,
+  apiKey: string,
+  planId: string,
+): Promise<KonnectPlan> {
+  return konnectFetch<KonnectPlan>(baseUrl, apiKey, "GET", `/plans/${planId}`);
+}
+
+async function changeSubscription(input: {
+  baseUrl: string;
+  apiKey: string;
+  subscriptionId: string;
+  customerId: string;
+  planId: string;
+  timing: Timing;
+}): Promise<void> {
+  await konnectFetch(
+    input.baseUrl,
+    input.apiKey,
+    "POST",
+    `/subscriptions/${input.subscriptionId}/change`,
+    {
+      customer: { id: input.customerId },
+      plan: { id: input.planId },
+      timing: input.timing,
+    },
+  );
+}
+
+async function listActiveSubscriptions(
+  baseUrl: string,
+  apiKey: string,
+): Promise<KonnectSubscription[]> {
+  const out: KonnectSubscription[] = [];
+  let page = 1;
+  for (;;) {
+    const body = await konnectFetch<{ data?: KonnectSubscription[] }>(
+      baseUrl,
+      apiKey,
+      "GET",
+      `/subscriptions?page=${page}&pageSize=100`,
+    );
+    const items = body.data ?? [];
+    for (const item of items) {
+      if (item.status === "active" || item.status === "scheduled") {
+        out.push(item);
+      }
+    }
+    if (items.length < 100) break;
+    page += 1;
+  }
+  return out;
+}
+
+async function loadStarterRows(clientIds?: string[]): Promise<StarterRow[]> {
+  const conditions = [
+    eq(plans.isStarterDefault, true),
+    eq(plans.status, "active"),
+  ];
+  if (clientIds && clientIds.length > 0) {
+    conditions.push(inArray(plans.clientId, clientIds));
+  }
+  return db
+    .select({
+      id: plans.id,
+      clientId: plans.clientId,
+      includedUsdMicros: plans.includedUsdMicros,
+      openmeterPlanId: plans.openmeterPlanId,
+      openmeterPlanVersion: plans.openmeterPlanVersion,
+    })
+    .from(plans)
+    .where(and(...conditions));
+}
+
+async function listOwnedApps(ownerId: string): Promise<OwnedApp[]> {
+  const rows = await db
+    .select({
+      developerAppId: developerApps.id,
+      name: developerApps.name,
+      publicClientId: oidcClients.clientId,
+    })
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(developerApps.ownerId, ownerId));
+
+  return rows
+    .map((row) => ({
+      developerAppId: row.developerAppId,
+      name: row.name,
+      publicClientId: row.publicClientId?.trim() || row.developerAppId,
+    }))
+    .filter((row) => row.publicClientId.length > 0);
+}
+
+async function ensureIncludedUsdMicros(row: StarterRow, apply: boolean): Promise<StarterRow> {
+  const current = row.includedUsdMicros?.trim() || "";
+  if (/^\d+$/.test(current) && BigInt(current) > 0n) {
+    return row;
+  }
+  const next = defaultStarterIncludedUsdMicros();
+  console.log(
+    `  [db] ${row.clientId} starter ${row.id}: includedUsdMicros ` +
+      `${current || "(empty)"} -> ${next}`,
+  );
+  if (!apply) {
+    return { ...row, includedUsdMicros: next };
+  }
+  await db
+    .update(plans)
+    .set({
+      includedUsdMicros: next,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(plans.id, row.id));
+  return { ...row, includedUsdMicros: next };
+}
+
+async function syncStarterWithAllowance(input: {
+  baseUrl: string;
+  apiKey: string;
+  row: StarterRow;
+  apply: boolean;
+}): Promise<{ planKey: string; planId: string | null; discount: string | null }> {
+  const planKey = buildOpenMeterPlanKey(input.row.clientId, input.row.id);
+  const row = await ensureIncludedUsdMicros(input.row, input.apply);
+
+  if (!input.apply) {
+    let discount: string | null = null;
+    if (row.openmeterPlanId?.trim()) {
+      try {
+        const existing = await getPlan(
+          input.baseUrl,
+          input.apiKey,
+          row.openmeterPlanId.trim(),
+        );
+        discount = readUsageDiscountMicros(existing);
+        console.log(
+          `  [dry-run] ${row.clientId} key=${planKey} current=${existing.id} ` +
+            `v${existing.version ?? "?"} hasDiscount=${Boolean(discount)} ` +
+            `discount=${discount ?? "none"} — would sync+publish allowance plan`,
+        );
+      } catch {
+        console.log(
+          `  [dry-run] ${row.clientId} key=${planKey} — would sync+publish allowance plan`,
+        );
+      }
+    } else {
+      console.log(
+        `  [dry-run] ${row.clientId} key=${planKey} — would sync+publish allowance plan`,
+      );
+    }
+    return { planKey, planId: row.openmeterPlanId, discount };
+  }
+
+  const sync = await syncPlanToOpenMeter(row.id);
+  if (!sync.ok || !sync.openmeterPlanId) {
+    throw new Error(
+      `syncPlanToOpenMeter failed for ${row.clientId}/${row.id}: ${sync.error ?? "no plan id"}`,
+    );
+  }
+
+  const published = await getPlan(input.baseUrl, input.apiKey, sync.openmeterPlanId);
+  const discount = readUsageDiscountMicros(published);
+  if (!isUsableAllowancePlan(published)) {
+    throw new Error(
+      `Published Starter ${published.id} key=${planKey} still missing discounts.usage ` +
+        `(status=${published.status} settlement=${published.settlement_mode})`,
+    );
+  }
+
+  console.log(
+    `  [plan] ${row.clientId} -> ${published.id} v${published.version ?? "?"} ` +
+      `key=${planKey} discount=${discount} settlement=${published.settlement_mode}`,
+  );
+  return { planKey, planId: published.id, discount };
+}
+
+async function cancelSubscription(input: {
+  client: ReturnType<typeof getHostedAdminClient>;
+  subscriptionId: string;
+  timing: Timing;
+  dryRun: boolean;
+  label: string;
+}): Promise<void> {
+  if (input.dryRun) {
+    console.log(`  [dry-run] would cancel ${input.subscriptionId} (${input.label})`);
+    return;
+  }
+  await input.client.subscriptions.cancel(input.subscriptionId, {
+    timing: input.timing,
+  });
+  console.log(`  [cancel] ${input.subscriptionId} (${input.label})`);
+}
+
+async function fixOwnerWallet(input: {
+  baseUrl: string;
+  apiKey: string;
+  ownerId: string;
+  apply: boolean;
+  timing: Timing;
+}): Promise<void> {
+  const apps = await listOwnedApps(input.ownerId);
+  if (apps.length === 0) {
+    console.log(`[owner] ${input.ownerId}: no owned apps — nothing to do`);
+    return;
+  }
+
+  const ownerKey = buildOwnerCustomerKey(input.ownerId);
+  console.log(
+    `\n[owner] ${input.ownerId} key=${ownerKey} apps=${apps.length}`,
+  );
+  for (const app of apps) {
+    console.log(`  app ${app.publicClientId} (${app.name})`);
+  }
+
+  const starters = await loadStarterRows(apps.map((a) => a.developerAppId));
+  for (const row of starters) {
+    await syncStarterWithAllowance({
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey,
+      row,
+      apply: input.apply,
+    });
+  }
+
+  const client = getHostedAdminClient();
+  const customer = await ensureOpenMeterCustomer(
+    client,
+    ownerKey,
+    `Owner ${input.ownerId}`,
+  );
+
+  const active = (
+    await listOpenMeterSubscriptionsForCustomer(client, customer.id)
+  ).filter((sub) => isOpenMeterSubscriptionActive(sub.status));
+
+  for (const sub of active) {
+    console.log(
+      `  [owner-sub] id=${sub.id} status=${sub.status} planKey=${sub.planKey ?? "?"}`,
+    );
+  }
+
+  if (!input.apply) {
+    console.log(
+      `  [dry-run] would cancel ${active.length} sub(s) then ensure Starter via ${apps[0].publicClientId}`,
+    );
+    return;
+  }
+
+  for (const sub of active) {
+    await cancelSubscription({
+      client,
+      subscriptionId: sub.id,
+      timing: input.timing,
+      dryRun: false,
+      label: `owner wallet planKey=${sub.planKey ?? "?"}`,
+    });
+  }
+
+  const firstApp = apps[0];
+  const ensured = await ensureStarterSubscriptionForAppUser({
+    clientId: firstApp.developerAppId,
+    externalUserId: input.ownerId,
+  });
+  console.log(
+    `  [ok] starter ensured sub=${ensured.openmeterSubscriptionId} ` +
+      `created=${ensured.created} planId=${ensured.planId}`,
+  );
+
+  if (ensured.openmeterSubscriptionId) {
+    const refreshed = await listOpenMeterSubscriptionsForCustomer(
+      client,
+      customer.id,
+    );
+    const current = refreshed.find((s) => s.id === ensured.openmeterSubscriptionId);
+    const planId = current?.planId ?? null;
+    if (planId) {
+      const plan = await getPlan(input.baseUrl, input.apiKey, planId);
+      console.log(
+        `  [verify] sub plan=${plan.id} v${plan.version ?? "?"} ` +
+          `discount=${readUsageDiscountMicros(plan) ?? "MISSING"} ` +
+          `ok=${isUsableAllowancePlan(plan)}`,
+      );
+    }
+  }
+}
+
+async function changeSubsOntoAllowancePlans(input: {
+  baseUrl: string;
+  apiKey: string;
+  apply: boolean;
+  timing: Timing;
+  targetPlanIdByKey: Map<string, string>;
+  starterKeys: Set<string>;
+}): Promise<{ changed: number; skipped: number; errors: number }> {
+  const stats = { changed: 0, skipped: 0, errors: 0 };
+  const planCache = new Map<string, KonnectPlan>();
+  const subscriptions = await listActiveSubscriptions(input.baseUrl, input.apiKey);
+
+  for (const sub of subscriptions) {
+    if (!sub.plan_id) {
+      stats.skipped += 1;
+      continue;
+    }
+    let plan = planCache.get(sub.plan_id);
+    if (!plan) {
+      try {
+        plan = await getPlan(input.baseUrl, input.apiKey, sub.plan_id);
+        planCache.set(sub.plan_id, plan);
+      } catch (err) {
+        stats.errors += 1;
+        console.warn(
+          `  [warn] sub ${sub.id}: cannot read plan ${sub.plan_id}: ${
+            err instanceof Error ? err.message : err
+          }`,
+        );
+        continue;
+      }
+    }
+
+    const isStarterKey = input.starterKeys.has(plan.key);
+    if (!isStarterKey) {
+      continue;
+    }
+
+    const targetPlanId = input.targetPlanIdByKey.get(plan.key);
+    if (!targetPlanId) {
+      stats.skipped += 1;
+      continue;
+    }
+
+    // Already on the target allowance plan version.
+    if (sub.plan_id === targetPlanId && isUsableAllowancePlan(plan)) {
+      stats.skipped += 1;
+      continue;
+    }
+
+    // On some other allowance version of the same key — still move to canonical synced id.
+    const needsChange =
+      sub.plan_id !== targetPlanId || !rateCardsHaveUsageDiscount(plan);
+
+    if (!needsChange) {
+      stats.skipped += 1;
+      continue;
+    }
+
+    if (!input.apply) {
+      console.log(
+        `  [dry-run] would change sub ${sub.id} customer=${sub.customer_id} ` +
+          `${sub.plan_id} -> ${targetPlanId} (key=${plan.key}, hasDiscount=${rateCardsHaveUsageDiscount(plan)})`,
+      );
+      stats.changed += 1;
+      continue;
+    }
+
+    try {
+      await changeSubscription({
+        baseUrl: input.baseUrl,
+        apiKey: input.apiKey,
+        subscriptionId: sub.id,
+        customerId: sub.customer_id,
+        planId: targetPlanId,
+        timing: input.timing,
+      });
+      console.log(
+        `  [change] sub ${sub.id} ${sub.plan_id} -> ${targetPlanId} (key=${plan.key})`,
+      );
+      stats.changed += 1;
+    } catch (err) {
+      stats.errors += 1;
+      console.error(
+        `  [error] change sub ${sub.id}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  return stats;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const { baseUrl, apiKey } = requireKonnectConfig();
+
+  console.log(
+    `[fix-starter-allowance] mode=${args.apply ? "APPLY" : "DRY-RUN"} ` +
+      `timing=${args.timing} target=${baseUrl}`,
+  );
+  console.log(
+    `[fix-starter-allowance] default includedUsdMicros=${defaultStarterIncludedUsdMicros()}`,
+  );
+
+  if (args.ownerId) {
+    await fixOwnerWallet({
+      baseUrl,
+      apiKey,
+      ownerId: args.ownerId.trim(),
+      apply: args.apply,
+      timing: args.timing,
+    });
+    if (!args.apply) {
+      console.log("\n[fix-starter-allowance] re-run with --apply to execute");
+    }
+    return;
+  }
+
+  const starterRows = await loadStarterRows(
+    args.clientId ? [args.clientId.trim()] : undefined,
+  );
+  console.log(`[fix-starter-allowance] starter plans in DB: ${starterRows.length}`);
+
+  const targetPlanIdByKey = new Map<string, string>();
+  const starterKeys = new Set<string>();
+
+  for (const row of starterRows) {
+    const synced = await syncStarterWithAllowance({
+      baseUrl,
+      apiKey,
+      row,
+      apply: args.apply,
+    });
+    starterKeys.add(synced.planKey);
+    if (synced.planId && !synced.planId.startsWith("pending:")) {
+      targetPlanIdByKey.set(synced.planKey, synced.planId);
+    }
+  }
+
+  if (args.apply && targetPlanIdByKey.size === 0) {
+    throw new Error("No published Starter plan ids available after sync");
+  }
+
+  // In dry-run, still map current ids so subscription preview can run.
+  if (!args.apply) {
+    for (const row of starterRows) {
+      const key = buildOpenMeterPlanKey(row.clientId, row.id);
+      starterKeys.add(key);
+      if (row.openmeterPlanId?.trim()) {
+        targetPlanIdByKey.set(key, row.openmeterPlanId.trim());
+      }
+    }
+  }
+
+  const subStats = await changeSubsOntoAllowancePlans({
+    baseUrl,
+    apiKey,
+    apply: args.apply,
+    timing: args.timing,
+    targetPlanIdByKey,
+    starterKeys,
+  });
+
+  console.log(
+    `\n[fix-starter-allowance] done changed=${subStats.changed} ` +
+      `skipped=${subStats.skipped} errors=${subStats.errors}`,
+  );
+  if (!args.apply) {
+    console.log("[fix-starter-allowance] re-run with --apply to execute");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("[fix-starter-allowance] fatal:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/scripts/openmeter-fix-starter-allowance.ts
+++ b/scripts/openmeter-fix-starter-allowance.ts
@@ -2,33 +2,11 @@
  * Fix Starter included-usage allowance and resubscribe onto plan versions that
  * carry Konnect rate-card `discounts.usage`.
  *
- * Context: prepaid-only Starter publishes (see openmeter-migrate-starter-prepaid)
- * left some live subscriptions on plan versions with no included allowance.
- * Mint/billing then see $0 spendable when prepaid credits are also empty.
- *
- * This script:
- *   1. Ensures each Starter row has `includedUsdMicros` (env default if missing)
- *   2. Syncs/publishes the plan to Konnect via syncPlanToOpenMeter
- *   3. Verifies the published plan has `discounts.usage`
- *   4. Moves subscriptions onto that plan version
- *        - default: POST /subscriptions/{id}/change
- *        - --owner-id: cancel active owner:{id} subs, then ensure Starter
- *
  * Usage:
- *   # Preview all Starter apps
  *   npx tsx scripts/openmeter-fix-starter-allowance.ts
- *
- *   # One owner wallet (recommended for Billing “no included usage”)
- *   npx tsx scripts/openmeter-fix-starter-allowance.ts \
- *     --owner-id 8112311f-634e-4602-984a-c8270da373e3
- *
- *   # Apply
- *   npx tsx scripts/openmeter-fix-starter-allowance.ts \
- *     --owner-id 8112311f-634e-4602-984a-c8270da373e3 --apply
- *
- *   # One app’s Starter + change all active subs on that plan key
- *   npx tsx scripts/openmeter-fix-starter-allowance.ts \
- *     --client-id app_xxx --apply
+ *   npx tsx scripts/openmeter-fix-starter-allowance.ts --owner-id <users.id>
+ *   npx tsx scripts/openmeter-fix-starter-allowance.ts --owner-id <users.id> --apply
+ *   npx tsx scripts/openmeter-fix-starter-allowance.ts --client-id app_xxx --apply
  */
 import "./load-env-first";
 import { and, eq, inArray } from "drizzle-orm";
@@ -39,12 +17,6 @@ import {
   getHostedAdminClient,
   isHostedAdminClientAvailable,
 } from "../src/lib/openmeter/admin-client";
-import {
-  getHostedOpenMeterUrl,
-  isKonnectMeteringUrl,
-  KONNECT_SETTLEMENT_MODE_CREDIT_THEN_INVOICE,
-  normalizeKonnectMeteringUrl,
-} from "../src/lib/openmeter/constants";
 import { buildOwnerCustomerKey } from "../src/lib/openmeter/customer-key";
 import { ensureOpenMeterCustomer } from "../src/lib/openmeter/customers";
 import { buildOpenMeterPlanKey } from "../src/lib/openmeter/plan-naming";
@@ -53,17 +25,28 @@ import { ensureStarterSubscriptionForAppUser } from "../src/lib/openmeter/starte
 import {
   isOpenMeterSubscriptionActive,
   listOpenMeterSubscriptionsForCustomer,
-  type OpenMeterSubscriptionView,
 } from "../src/lib/openmeter/subscription-read";
 import { defaultStarterIncludedUsdMicros } from "../src/lib/starter-default-plan-display";
-
-type Timing = "immediate" | "next_billing_cycle";
+import {
+  changeKonnectSubscription,
+  getKonnectPlan,
+  isUsableAllowancePlan,
+  listActiveKonnectSubscriptions,
+  parseSubscriptionTiming,
+  rateCardsHaveUsageDiscount,
+  readUsageDiscountMicros,
+  requireKonnectConfig,
+  takeArgValue,
+  type KonnectPlan,
+  type KonnectSubscription,
+  type SubscriptionChangeTiming,
+} from "./lib/openmeter-konnect-migrate";
 
 type Args = {
   apply: boolean;
   ownerId?: string;
   clientId?: string;
-  timing: Timing;
+  timing: SubscriptionChangeTiming;
 };
 
 type StarterRow = {
@@ -71,34 +54,12 @@ type StarterRow = {
   clientId: string;
   includedUsdMicros: string | null;
   openmeterPlanId: string | null;
-  openmeterPlanVersion: number | null;
 };
 
 type OwnedApp = {
   developerAppId: string;
   publicClientId: string;
   name: string;
-};
-
-type KonnectPlan = {
-  id: string;
-  key: string;
-  name?: string;
-  status?: string;
-  version?: number;
-  settlement_mode?: string;
-  phases?: Array<{
-    key?: string;
-    name?: string;
-    rate_cards?: Array<Record<string, unknown>>;
-  }>;
-};
-
-type KonnectSubscription = {
-  id: string;
-  status: string;
-  customer_id: string;
-  plan_id?: string;
 };
 
 function usage(): string {
@@ -110,19 +71,10 @@ function usage(): string {
     "Options:",
     "  --dry-run                 Preview only (default)",
     "  --apply                   Write DB + Konnect changes",
-    "  --owner-id <users.id>     Fix shared owner:{id} wallet (cancel + recreate)",
+    "  --owner-id <users.id>     Fix owner:{id} wallet (cancel + recreate)",
     "  --client-id <app_id>      Limit to one app's Starter plan",
     "  --timing immediate|next_billing_cycle",
-    "                            Cancel/change timing (default: immediate)",
   ].join("\n");
-}
-
-function takeValue(argv: string[], index: number, flag: string): string {
-  const value = argv[index + 1]?.trim();
-  if (!value) {
-    throw new Error(`${flag} requires a value`);
-  }
-  return value;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -137,22 +89,17 @@ function parseArgs(argv: string[]): Args {
         args.apply = false;
         break;
       case "--owner-id":
-        args.ownerId = takeValue(argv, i, token);
+        args.ownerId = takeArgValue(argv, i, token);
         i += 1;
         break;
       case "--client-id":
-        args.clientId = takeValue(argv, i, token);
+        args.clientId = takeArgValue(argv, i, token);
         i += 1;
         break;
-      case "--timing": {
-        const value = takeValue(argv, i, token);
-        if (value !== "immediate" && value !== "next_billing_cycle") {
-          throw new Error("--timing must be immediate|next_billing_cycle");
-        }
-        args.timing = value;
+      case "--timing":
+        args.timing = parseSubscriptionTiming(takeArgValue(argv, i, token));
         i += 1;
         break;
-      }
       case "--help":
       case "-h":
         console.log(usage());
@@ -163,149 +110,6 @@ function parseArgs(argv: string[]): Args {
     }
   }
   return args;
-}
-
-function requireKonnectConfig(): { baseUrl: string; apiKey: string } {
-  const rawUrl = getHostedOpenMeterUrl();
-  const apiKey = process.env.OPENMETER_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error("OPENMETER_API_KEY is required");
-  }
-  if (!isKonnectMeteringUrl(rawUrl, apiKey)) {
-    throw new Error(
-      `This migration targets Konnect only (got OPENMETER_URL=${rawUrl})`,
-    );
-  }
-  if (!isHostedAdminClientAvailable()) {
-    throw new Error("OpenMeter admin client is not available");
-  }
-  return {
-    baseUrl: normalizeKonnectMeteringUrl(rawUrl),
-    apiKey,
-  };
-}
-
-async function konnectFetch<T>(
-  baseUrl: string,
-  apiKey: string,
-  method: string,
-  path: string,
-  body?: unknown,
-): Promise<T> {
-  const response = await fetch(`${baseUrl}${path}`, {
-    method,
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
-  const text = await response.text();
-  if (!response.ok) {
-    throw new Error(
-      `Konnect ${method} ${path} failed [${response.status}]: ${text.slice(0, 800)}`,
-    );
-  }
-  if (!text) {
-    return null as T;
-  }
-  try {
-    return JSON.parse(text) as T;
-  } catch {
-    return text as T;
-  }
-}
-
-function rateCardsHaveUsageDiscount(plan: KonnectPlan): boolean {
-  for (const phase of plan.phases ?? []) {
-    for (const card of phase.rate_cards ?? []) {
-      const discounts = card.discounts;
-      if (
-        discounts &&
-        typeof discounts === "object" &&
-        (discounts as { usage?: unknown }).usage != null
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-function readUsageDiscountMicros(plan: KonnectPlan): string | null {
-  for (const phase of plan.phases ?? []) {
-    for (const card of phase.rate_cards ?? []) {
-      const discounts = card.discounts;
-      if (!discounts || typeof discounts !== "object") continue;
-      const usage = (discounts as { usage?: unknown }).usage;
-      if (usage == null) continue;
-      return String(usage);
-    }
-  }
-  return null;
-}
-
-function isUsableAllowancePlan(plan: KonnectPlan): boolean {
-  return (
-    plan.status === "active" &&
-    rateCardsHaveUsageDiscount(plan) &&
-    plan.settlement_mode === KONNECT_SETTLEMENT_MODE_CREDIT_THEN_INVOICE
-  );
-}
-
-async function getPlan(
-  baseUrl: string,
-  apiKey: string,
-  planId: string,
-): Promise<KonnectPlan> {
-  return konnectFetch<KonnectPlan>(baseUrl, apiKey, "GET", `/plans/${planId}`);
-}
-
-async function changeSubscription(input: {
-  baseUrl: string;
-  apiKey: string;
-  subscriptionId: string;
-  customerId: string;
-  planId: string;
-  timing: Timing;
-}): Promise<void> {
-  await konnectFetch(
-    input.baseUrl,
-    input.apiKey,
-    "POST",
-    `/subscriptions/${input.subscriptionId}/change`,
-    {
-      customer: { id: input.customerId },
-      plan: { id: input.planId },
-      timing: input.timing,
-    },
-  );
-}
-
-async function listActiveSubscriptions(
-  baseUrl: string,
-  apiKey: string,
-): Promise<KonnectSubscription[]> {
-  const out: KonnectSubscription[] = [];
-  let page = 1;
-  for (;;) {
-    const body = await konnectFetch<{ data?: KonnectSubscription[] }>(
-      baseUrl,
-      apiKey,
-      "GET",
-      `/subscriptions?page=${page}&pageSize=100`,
-    );
-    const items = body.data ?? [];
-    for (const item of items) {
-      if (item.status === "active" || item.status === "scheduled") {
-        out.push(item);
-      }
-    }
-    if (items.length < 100) break;
-    page += 1;
-  }
-  return out;
 }
 
 async function loadStarterRows(clientIds?: string[]): Promise<StarterRow[]> {
@@ -322,7 +126,6 @@ async function loadStarterRows(clientIds?: string[]): Promise<StarterRow[]> {
       clientId: plans.clientId,
       includedUsdMicros: plans.includedUsdMicros,
       openmeterPlanId: plans.openmeterPlanId,
-      openmeterPlanVersion: plans.openmeterPlanVersion,
     })
     .from(plans)
     .where(and(...conditions));
@@ -348,15 +151,17 @@ async function listOwnedApps(ownerId: string): Promise<OwnedApp[]> {
     .filter((row) => row.publicClientId.length > 0);
 }
 
-async function ensureIncludedUsdMicros(row: StarterRow, apply: boolean): Promise<StarterRow> {
+async function ensureIncludedUsdMicros(
+  row: StarterRow,
+  apply: boolean,
+): Promise<StarterRow> {
   const current = row.includedUsdMicros?.trim() || "";
   if (/^\d+$/.test(current) && BigInt(current) > 0n) {
     return row;
   }
   const next = defaultStarterIncludedUsdMicros();
   console.log(
-    `  [db] ${row.clientId} starter ${row.id}: includedUsdMicros ` +
-      `${current || "(empty)"} -> ${next}`,
+    `  [db] ${row.clientId}: includedUsdMicros ${current || "(empty)"} -> ${next}`,
   );
   if (!apply) {
     return { ...row, includedUsdMicros: next };
@@ -371,41 +176,40 @@ async function ensureIncludedUsdMicros(row: StarterRow, apply: boolean): Promise
   return { ...row, includedUsdMicros: next };
 }
 
+async function logCurrentPlanDiscount(
+  baseUrl: string,
+  apiKey: string,
+  row: StarterRow,
+  planKey: string,
+): Promise<void> {
+  if (!row.openmeterPlanId?.trim()) {
+    console.log(`  [dry-run] ${row.clientId} key=${planKey} — would sync allowance plan`);
+    return;
+  }
+  try {
+    const existing = await getKonnectPlan(baseUrl, apiKey, row.openmeterPlanId.trim());
+    const discount = readUsageDiscountMicros(existing);
+    console.log(
+      `  [dry-run] ${row.clientId} key=${planKey} hasDiscount=${Boolean(discount)} ` +
+        `— would sync+publish allowance plan`,
+    );
+  } catch {
+    console.log(`  [dry-run] ${row.clientId} key=${planKey} — would sync allowance plan`);
+  }
+}
+
 async function syncStarterWithAllowance(input: {
   baseUrl: string;
   apiKey: string;
   row: StarterRow;
   apply: boolean;
-}): Promise<{ planKey: string; planId: string | null; discount: string | null }> {
+}): Promise<{ planKey: string; planId: string | null }> {
   const planKey = buildOpenMeterPlanKey(input.row.clientId, input.row.id);
   const row = await ensureIncludedUsdMicros(input.row, input.apply);
 
   if (!input.apply) {
-    let discount: string | null = null;
-    if (row.openmeterPlanId?.trim()) {
-      try {
-        const existing = await getPlan(
-          input.baseUrl,
-          input.apiKey,
-          row.openmeterPlanId.trim(),
-        );
-        discount = readUsageDiscountMicros(existing);
-        console.log(
-          `  [dry-run] ${row.clientId} key=${planKey} current=${existing.id} ` +
-            `v${existing.version ?? "?"} hasDiscount=${Boolean(discount)} ` +
-            `discount=${discount ?? "none"} — would sync+publish allowance plan`,
-        );
-      } catch {
-        console.log(
-          `  [dry-run] ${row.clientId} key=${planKey} — would sync+publish allowance plan`,
-        );
-      }
-    } else {
-      console.log(
-        `  [dry-run] ${row.clientId} key=${planKey} — would sync+publish allowance plan`,
-      );
-    }
-    return { planKey, planId: row.openmeterPlanId, discount };
+    await logCurrentPlanDiscount(input.baseUrl, input.apiKey, row, planKey);
+    return { planKey, planId: row.openmeterPlanId };
   }
 
   const sync = await syncPlanToOpenMeter(row.id);
@@ -415,37 +219,67 @@ async function syncStarterWithAllowance(input: {
     );
   }
 
-  const published = await getPlan(input.baseUrl, input.apiKey, sync.openmeterPlanId);
-  const discount = readUsageDiscountMicros(published);
+  const published = await getKonnectPlan(input.baseUrl, input.apiKey, sync.openmeterPlanId);
   if (!isUsableAllowancePlan(published)) {
     throw new Error(
-      `Published Starter ${published.id} key=${planKey} still missing discounts.usage ` +
-        `(status=${published.status} settlement=${published.settlement_mode})`,
+      `Published Starter ${published.id} key=${planKey} missing discounts.usage`,
     );
   }
 
   console.log(
     `  [plan] ${row.clientId} -> ${published.id} v${published.version ?? "?"} ` +
-      `key=${planKey} discount=${discount} settlement=${published.settlement_mode}`,
+      `discount=${readUsageDiscountMicros(published)}`,
   );
-  return { planKey, planId: published.id, discount };
+  return { planKey, planId: published.id };
 }
 
-async function cancelSubscription(input: {
-  client: ReturnType<typeof getHostedAdminClient>;
-  subscriptionId: string;
-  timing: Timing;
-  dryRun: boolean;
-  label: string;
-}): Promise<void> {
-  if (input.dryRun) {
-    console.log(`  [dry-run] would cancel ${input.subscriptionId} (${input.label})`);
-    return;
+async function cancelOwnerSubs(input: {
+  apply: boolean;
+  timing: SubscriptionChangeTiming;
+  ownerId: string;
+  customerId: string;
+}): Promise<number> {
+  const client = getHostedAdminClient();
+  const active = (
+    await listOpenMeterSubscriptionsForCustomer(client, input.customerId)
+  ).filter((sub) => isOpenMeterSubscriptionActive(sub.status));
+
+  for (const sub of active) {
+    console.log(
+      `  [owner-sub] id=${sub.id} status=${sub.status} planKey=${sub.planKey ?? "?"}`,
+    );
   }
-  await input.client.subscriptions.cancel(input.subscriptionId, {
-    timing: input.timing,
-  });
-  console.log(`  [cancel] ${input.subscriptionId} (${input.label})`);
+
+  if (!input.apply) {
+    return active.length;
+  }
+
+  for (const sub of active) {
+    await client.subscriptions.cancel(sub.id, { timing: input.timing });
+    console.log(`  [cancel] ${sub.id}`);
+  }
+  return active.length;
+}
+
+async function verifyEnsuredStarter(input: {
+  baseUrl: string;
+  apiKey: string;
+  customerId: string;
+  subscriptionId: string | null;
+}): Promise<void> {
+  if (!input.subscriptionId) return;
+  const client = getHostedAdminClient();
+  const refreshed = await listOpenMeterSubscriptionsForCustomer(
+    client,
+    input.customerId,
+  );
+  const current = refreshed.find((s) => s.id === input.subscriptionId);
+  if (!current?.planId) return;
+  const plan = await getKonnectPlan(input.baseUrl, input.apiKey, current.planId);
+  console.log(
+    `  [verify] allowance ok=${isUsableAllowancePlan(plan)} ` +
+      `hasDiscount=${Boolean(readUsageDiscountMicros(plan))}`,
+  );
 }
 
 async function fixOwnerWallet(input: {
@@ -453,7 +287,7 @@ async function fixOwnerWallet(input: {
   apiKey: string;
   ownerId: string;
   apply: boolean;
-  timing: Timing;
+  timing: SubscriptionChangeTiming;
 }): Promise<void> {
   const apps = await listOwnedApps(input.ownerId);
   if (apps.length === 0) {
@@ -462,12 +296,7 @@ async function fixOwnerWallet(input: {
   }
 
   const ownerKey = buildOwnerCustomerKey(input.ownerId);
-  console.log(
-    `\n[owner] ${input.ownerId} key=${ownerKey} apps=${apps.length}`,
-  );
-  for (const app of apps) {
-    console.log(`  app ${app.publicClientId} (${app.name})`);
-  }
+  console.log(`\n[owner] ${input.ownerId} key=${ownerKey} apps=${apps.length}`);
 
   const starters = await loadStarterRows(apps.map((a) => a.developerAppId));
   for (const row of starters) {
@@ -479,6 +308,10 @@ async function fixOwnerWallet(input: {
     });
   }
 
+  if (!isHostedAdminClientAvailable()) {
+    throw new Error("OpenMeter admin client is not available");
+  }
+
   const client = getHostedAdminClient();
   const customer = await ensureOpenMeterCustomer(
     client,
@@ -486,58 +319,100 @@ async function fixOwnerWallet(input: {
     `Owner ${input.ownerId}`,
   );
 
-  const active = (
-    await listOpenMeterSubscriptionsForCustomer(client, customer.id)
-  ).filter((sub) => isOpenMeterSubscriptionActive(sub.status));
-
-  for (const sub of active) {
-    console.log(
-      `  [owner-sub] id=${sub.id} status=${sub.status} planKey=${sub.planKey ?? "?"}`,
-    );
-  }
+  const cancelCount = await cancelOwnerSubs({
+    apply: input.apply,
+    timing: input.timing,
+    ownerId: input.ownerId,
+    customerId: customer.id,
+  });
 
   if (!input.apply) {
     console.log(
-      `  [dry-run] would cancel ${active.length} sub(s) then ensure Starter via ${apps[0].publicClientId}`,
+      `  [dry-run] would cancel ${cancelCount} sub(s) then ensure Starter via ${apps[0].publicClientId}`,
     );
     return;
   }
 
-  for (const sub of active) {
-    await cancelSubscription({
-      client,
-      subscriptionId: sub.id,
-      timing: input.timing,
-      dryRun: false,
-      label: `owner wallet planKey=${sub.planKey ?? "?"}`,
-    });
-  }
-
-  const firstApp = apps[0];
   const ensured = await ensureStarterSubscriptionForAppUser({
-    clientId: firstApp.developerAppId,
+    clientId: apps[0].developerAppId,
     externalUserId: input.ownerId,
   });
   console.log(
-    `  [ok] starter ensured sub=${ensured.openmeterSubscriptionId} ` +
-      `created=${ensured.created} planId=${ensured.planId}`,
+    `  [ok] starter ensured created=${ensured.created} planId=${ensured.planId}`,
   );
+  await verifyEnsuredStarter({
+    baseUrl: input.baseUrl,
+    apiKey: input.apiKey,
+    customerId: customer.id,
+    subscriptionId: ensured.openmeterSubscriptionId,
+  });
+}
 
-  if (ensured.openmeterSubscriptionId) {
-    const refreshed = await listOpenMeterSubscriptionsForCustomer(
-      client,
-      customer.id,
+function subscriptionNeedsAllowanceChange(input: {
+  sub: KonnectSubscription;
+  plan: KonnectPlan;
+  targetPlanId: string;
+}): boolean {
+  if (input.sub.plan_id === input.targetPlanId && isUsableAllowancePlan(input.plan)) {
+    return false;
+  }
+  return (
+    input.sub.plan_id !== input.targetPlanId || !rateCardsHaveUsageDiscount(input.plan)
+  );
+}
+
+async function loadPlanCached(
+  cache: Map<string, KonnectPlan>,
+  baseUrl: string,
+  apiKey: string,
+  planId: string,
+): Promise<KonnectPlan | null> {
+  const cached = cache.get(planId);
+  if (cached) return cached;
+  try {
+    const plan = await getKonnectPlan(baseUrl, apiKey, planId);
+    cache.set(planId, plan);
+    return plan;
+  } catch {
+    return null;
+  }
+}
+
+async function changeOneSub(input: {
+  baseUrl: string;
+  apiKey: string;
+  apply: boolean;
+  timing: SubscriptionChangeTiming;
+  sub: KonnectSubscription;
+  plan: KonnectPlan;
+  targetPlanId: string;
+}): Promise<"changed" | "skipped" | "error"> {
+  if (!subscriptionNeedsAllowanceChange(input)) {
+    return "skipped";
+  }
+  if (!input.apply) {
+    console.log(
+      `  [dry-run] would change sub ${input.sub.id} -> target plan ` +
+        `(hasDiscount=${rateCardsHaveUsageDiscount(input.plan)})`,
     );
-    const current = refreshed.find((s) => s.id === ensured.openmeterSubscriptionId);
-    const planId = current?.planId ?? null;
-    if (planId) {
-      const plan = await getPlan(input.baseUrl, input.apiKey, planId);
-      console.log(
-        `  [verify] sub plan=${plan.id} v${plan.version ?? "?"} ` +
-          `discount=${readUsageDiscountMicros(plan) ?? "MISSING"} ` +
-          `ok=${isUsableAllowancePlan(plan)}`,
-      );
-    }
+    return "changed";
+  }
+  try {
+    await changeKonnectSubscription({
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey,
+      subscriptionId: input.sub.id,
+      customerId: input.sub.customer_id,
+      planId: input.targetPlanId,
+      timing: input.timing,
+    });
+    console.log(`  [change] sub ${input.sub.id} -> ${input.targetPlanId}`);
+    return "changed";
+  } catch (err) {
+    console.error(
+      `  [error] change sub ${input.sub.id}: ${err instanceof Error ? err.message : "failed"}`,
+    );
+    return "error";
   }
 }
 
@@ -545,92 +420,96 @@ async function changeSubsOntoAllowancePlans(input: {
   baseUrl: string;
   apiKey: string;
   apply: boolean;
-  timing: Timing;
+  timing: SubscriptionChangeTiming;
   targetPlanIdByKey: Map<string, string>;
   starterKeys: Set<string>;
 }): Promise<{ changed: number; skipped: number; errors: number }> {
   const stats = { changed: 0, skipped: 0, errors: 0 };
   const planCache = new Map<string, KonnectPlan>();
-  const subscriptions = await listActiveSubscriptions(input.baseUrl, input.apiKey);
+  const subscriptions = await listActiveKonnectSubscriptions(
+    input.baseUrl,
+    input.apiKey,
+  );
 
   for (const sub of subscriptions) {
     if (!sub.plan_id) {
       stats.skipped += 1;
       continue;
     }
-    let plan = planCache.get(sub.plan_id);
+    const plan = await loadPlanCached(
+      planCache,
+      input.baseUrl,
+      input.apiKey,
+      sub.plan_id,
+    );
     if (!plan) {
-      try {
-        plan = await getPlan(input.baseUrl, input.apiKey, sub.plan_id);
-        planCache.set(sub.plan_id, plan);
-      } catch (err) {
-        stats.errors += 1;
-        console.warn(
-          `  [warn] sub ${sub.id}: cannot read plan ${sub.plan_id}: ${
-            err instanceof Error ? err.message : err
-          }`,
-        );
-        continue;
-      }
-    }
-
-    const isStarterKey = input.starterKeys.has(plan.key);
-    if (!isStarterKey) {
+      stats.errors += 1;
       continue;
     }
-
+    if (!input.starterKeys.has(plan.key)) {
+      continue;
+    }
     const targetPlanId = input.targetPlanIdByKey.get(plan.key);
     if (!targetPlanId) {
       stats.skipped += 1;
       continue;
     }
-
-    // Already on the target allowance plan version.
-    if (sub.plan_id === targetPlanId && isUsableAllowancePlan(plan)) {
-      stats.skipped += 1;
-      continue;
-    }
-
-    // On some other allowance version of the same key — still move to canonical synced id.
-    const needsChange =
-      sub.plan_id !== targetPlanId || !rateCardsHaveUsageDiscount(plan);
-
-    if (!needsChange) {
-      stats.skipped += 1;
-      continue;
-    }
-
-    if (!input.apply) {
-      console.log(
-        `  [dry-run] would change sub ${sub.id} customer=${sub.customer_id} ` +
-          `${sub.plan_id} -> ${targetPlanId} (key=${plan.key}, hasDiscount=${rateCardsHaveUsageDiscount(plan)})`,
-      );
-      stats.changed += 1;
-      continue;
-    }
-
-    try {
-      await changeSubscription({
-        baseUrl: input.baseUrl,
-        apiKey: input.apiKey,
-        subscriptionId: sub.id,
-        customerId: sub.customer_id,
-        planId: targetPlanId,
-        timing: input.timing,
-      });
-      console.log(
-        `  [change] sub ${sub.id} ${sub.plan_id} -> ${targetPlanId} (key=${plan.key})`,
-      );
-      stats.changed += 1;
-    } catch (err) {
-      stats.errors += 1;
-      console.error(
-        `  [error] change sub ${sub.id}: ${err instanceof Error ? err.message : err}`,
-      );
-    }
+    const result = await changeOneSub({
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey,
+      apply: input.apply,
+      timing: input.timing,
+      sub,
+      plan,
+      targetPlanId,
+    });
+    stats[result === "changed" ? "changed" : result === "error" ? "errors" : "skipped"] += 1;
   }
 
   return stats;
+}
+
+async function syncAllStarters(input: {
+  baseUrl: string;
+  apiKey: string;
+  apply: boolean;
+  clientId?: string;
+}): Promise<{
+  targetPlanIdByKey: Map<string, string>;
+  starterKeys: Set<string>;
+}> {
+  const starterRows = await loadStarterRows(
+    input.clientId ? [input.clientId.trim()] : undefined,
+  );
+  console.log(`[fix-starter-allowance] starter plans in DB: ${starterRows.length}`);
+
+  const targetPlanIdByKey = new Map<string, string>();
+  const starterKeys = new Set<string>();
+
+  for (const row of starterRows) {
+    const synced = await syncStarterWithAllowance({
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey,
+      row,
+      apply: input.apply,
+    });
+    starterKeys.add(synced.planKey);
+    if (synced.planId) {
+      targetPlanIdByKey.set(synced.planKey, synced.planId);
+    }
+  }
+
+  if (!input.apply) {
+    for (const row of starterRows) {
+      const key = buildOpenMeterPlanKey(row.clientId, row.id);
+      starterKeys.add(key);
+      if (row.openmeterPlanId?.trim()) {
+        targetPlanIdByKey.set(key, row.openmeterPlanId.trim());
+      }
+    }
+  }
+
+  return { targetPlanIdByKey, starterKeys };
 }
 
 async function main(): Promise<void> {
@@ -638,8 +517,7 @@ async function main(): Promise<void> {
   const { baseUrl, apiKey } = requireKonnectConfig();
 
   console.log(
-    `[fix-starter-allowance] mode=${args.apply ? "APPLY" : "DRY-RUN"} ` +
-      `timing=${args.timing} target=${baseUrl}`,
+    `[fix-starter-allowance] mode=${args.apply ? "APPLY" : "DRY-RUN"} timing=${args.timing}`,
   );
   console.log(
     `[fix-starter-allowance] default includedUsdMicros=${defaultStarterIncludedUsdMicros()}`,
@@ -659,40 +537,15 @@ async function main(): Promise<void> {
     return;
   }
 
-  const starterRows = await loadStarterRows(
-    args.clientId ? [args.clientId.trim()] : undefined,
-  );
-  console.log(`[fix-starter-allowance] starter plans in DB: ${starterRows.length}`);
-
-  const targetPlanIdByKey = new Map<string, string>();
-  const starterKeys = new Set<string>();
-
-  for (const row of starterRows) {
-    const synced = await syncStarterWithAllowance({
-      baseUrl,
-      apiKey,
-      row,
-      apply: args.apply,
-    });
-    starterKeys.add(synced.planKey);
-    if (synced.planId && !synced.planId.startsWith("pending:")) {
-      targetPlanIdByKey.set(synced.planKey, synced.planId);
-    }
-  }
+  const { targetPlanIdByKey, starterKeys } = await syncAllStarters({
+    baseUrl,
+    apiKey,
+    apply: args.apply,
+    clientId: args.clientId,
+  });
 
   if (args.apply && targetPlanIdByKey.size === 0) {
     throw new Error("No published Starter plan ids available after sync");
-  }
-
-  // In dry-run, still map current ids so subscription preview can run.
-  if (!args.apply) {
-    for (const row of starterRows) {
-      const key = buildOpenMeterPlanKey(row.clientId, row.id);
-      starterKeys.add(key);
-      if (row.openmeterPlanId?.trim()) {
-        targetPlanIdByKey.set(key, row.openmeterPlanId.trim());
-      }
-    }
   }
 
   const subStats = await changeSubsOntoAllowancePlans({
@@ -715,7 +568,7 @@ async function main(): Promise<void> {
 
 main()
   .catch((err) => {
-    console.error("[fix-starter-allowance] fatal:", err);
+    console.error("[fix-starter-allowance] fatal:", err instanceof Error ? err.message : err);
     process.exitCode = 1;
   })
   .finally(async () => {

--- a/scripts/openmeter-migrate-starter-prepaid.ts
+++ b/scripts/openmeter-migrate-starter-prepaid.ts
@@ -21,43 +21,27 @@ import "./load-env-first";
 import { and, eq } from "drizzle-orm";
 import { closeDb, db } from "../src/db/index";
 import { plans } from "../src/db/schema";
-import {
-  getHostedOpenMeterUrl,
-  isKonnectMeteringUrl,
-  KONNECT_SETTLEMENT_MODE_CREDIT_THEN_INVOICE,
-  normalizeKonnectMeteringUrl,
-} from "../src/lib/openmeter/constants";
+import { KONNECT_SETTLEMENT_MODE_CREDIT_THEN_INVOICE } from "../src/lib/openmeter/constants";
 import { buildOpenMeterPlanKey } from "../src/lib/openmeter/plan-naming";
 import { syncPlanToOpenMeter } from "../src/lib/openmeter/plans-sync";
+import {
+  changeKonnectSubscription,
+  getKonnectPlan,
+  konnectFetch,
+  listActiveKonnectSubscriptions,
+  parseSubscriptionTiming,
+  rateCardsHaveUsageDiscount,
+  requireKonnectConfig,
+  takeArgValue,
+  type KonnectPlan,
+  type KonnectSubscription,
+  type SubscriptionChangeTiming,
+} from "./lib/openmeter-konnect-migrate";
 
 type Args = {
   apply: boolean;
   clientId?: string;
-  timing: "immediate" | "next_billing_cycle";
-};
-
-type KonnectPlan = {
-  id: string;
-  key: string;
-  name?: string;
-  status?: string;
-  version?: number;
-  settlement_mode?: string;
-  currency?: string;
-  billing_cadence?: string;
-  phases?: Array<{
-    key?: string;
-    name?: string;
-    rate_cards?: Array<Record<string, unknown>>;
-  }>;
-};
-
-type KonnectSubscription = {
-  id: string;
-  status: string;
-  customer_id: string;
-  plan_id?: string;
-  settlement_mode?: string;
+  timing: SubscriptionChangeTiming;
 };
 
 type StarterRow = {
@@ -97,14 +81,6 @@ function usage(): string {
   ].join("\n");
 }
 
-function takeValue(argv: string[], index: number, flag: string): string {
-  const value = argv[index + 1]?.trim();
-  if (!value) {
-    throw new Error(`${flag} requires a value`);
-  }
-  return value;
-}
-
 function parseArgs(argv: string[]): Args {
   const args: Args = { apply: false, timing: "immediate" };
 
@@ -118,18 +94,13 @@ function parseArgs(argv: string[]): Args {
         args.apply = false;
         break;
       case "--client-id":
-        args.clientId = takeValue(argv, i, token);
+        args.clientId = takeArgValue(argv, i, token);
         i += 1;
         break;
-      case "--timing": {
-        const value = takeValue(argv, i, token);
-        if (value !== "immediate" && value !== "next_billing_cycle") {
-          throw new Error("--timing must be immediate or next_billing_cycle");
-        }
-        args.timing = value;
+      case "--timing":
+        args.timing = parseSubscriptionTiming(takeArgValue(argv, i, token));
         i += 1;
         break;
-      }
       case "--help":
       case "-h":
         console.log(usage());
@@ -141,72 +112,6 @@ function parseArgs(argv: string[]): Args {
   }
 
   return args;
-}
-
-function requireKonnectConfig(): { baseUrl: string; apiKey: string } {
-  const rawUrl = getHostedOpenMeterUrl();
-  const apiKey = process.env.OPENMETER_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error("OPENMETER_API_KEY is required");
-  }
-  if (!isKonnectMeteringUrl(rawUrl, apiKey)) {
-    throw new Error(
-      `This migration targets Konnect only (got OPENMETER_URL=${rawUrl})`,
-    );
-  }
-  return {
-    baseUrl: normalizeKonnectMeteringUrl(rawUrl),
-    apiKey,
-  };
-}
-
-async function konnectFetch<T>(
-  baseUrl: string,
-  apiKey: string,
-  method: string,
-  path: string,
-  body?: unknown,
-): Promise<T> {
-  const response = await fetch(`${baseUrl}${path}`, {
-    method,
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
-  const text = await response.text();
-  let parsed: unknown = null;
-  if (text) {
-    try {
-      parsed = JSON.parse(text);
-    } catch {
-      parsed = text;
-    }
-  }
-  if (!response.ok) {
-    throw new Error(
-      `Konnect ${method} ${path} failed [${response.status}]: ${text.slice(0, 800)}`,
-    );
-  }
-  return parsed as T;
-}
-
-function rateCardsHaveUsageDiscount(plan: KonnectPlan): boolean {
-  for (const phase of plan.phases ?? []) {
-    for (const card of phase.rate_cards ?? []) {
-      const discounts = card.discounts;
-      if (
-        discounts &&
-        typeof discounts === "object" &&
-        (discounts as { usage?: unknown }).usage != null
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
 }
 
 function stripUsageDiscountsFromPhases(
@@ -234,39 +139,12 @@ function isUsablePrepaidPlan(plan: KonnectPlan): boolean {
   return plan.status === "active" && !planNeedsPrepaidRepublish(plan);
 }
 
-async function listActiveSubscriptions(
-  baseUrl: string,
-  apiKey: string,
-): Promise<KonnectSubscription[]> {
-  const out: KonnectSubscription[] = [];
-  let page = 1;
-  for (;;) {
-    const body = await konnectFetch<{ data?: KonnectSubscription[] }>(
-      baseUrl,
-      apiKey,
-      "GET",
-      `/subscriptions?page=${page}&pageSize=100`,
-    );
-    const items = body.data ?? [];
-    for (const item of items) {
-      if (item.status === "active" || item.status === "scheduled") {
-        out.push(item);
-      }
-    }
-    if (items.length < 100) {
-      break;
-    }
-    page += 1;
-  }
-  return out;
-}
-
 async function getPlan(
   baseUrl: string,
   apiKey: string,
   planId: string,
 ): Promise<KonnectPlan> {
-  return konnectFetch<KonnectPlan>(baseUrl, apiKey, "GET", `/plans/${planId}`);
+  return getKonnectPlan(baseUrl, apiKey, planId);
 }
 
 async function publishPrepaidPlanVersion(
@@ -297,18 +175,8 @@ async function changeSubscription(input: {
   customerId: string;
   planId: string;
   timing: Args["timing"];
-}): Promise<{ current: KonnectSubscription; next: KonnectSubscription }> {
-  return konnectFetch(
-    input.baseUrl,
-    input.apiKey,
-    "POST",
-    `/subscriptions/${input.subscriptionId}/change`,
-    {
-      customer: { id: input.customerId },
-      plan: { id: input.planId },
-      timing: input.timing,
-    },
-  );
+}): Promise<{ current?: KonnectSubscription; next?: KonnectSubscription }> {
+  return changeKonnectSubscription(input);
 }
 
 async function loadStarterRows(clientId?: string): Promise<StarterRow[]> {
@@ -591,7 +459,7 @@ async function migrateOneSubscription(input: {
     });
     stats.changed += 1;
     console.log(
-      `[changed] ${sub.id} -> ${result.next.id} plan=${result.next.plan_id} customer=${sub.customer_id}`,
+      `[changed] ${sub.id} -> ${result.next?.id ?? targetPlanId} plan=${result.next?.plan_id ?? targetPlanId} customer=${sub.customer_id}`,
     );
   } catch (err) {
     stats.errors += 1;
@@ -629,7 +497,7 @@ async function main() {
     });
   }
 
-  const subscriptions = await listActiveSubscriptions(baseUrl, apiKey);
+  const subscriptions = await listActiveKonnectSubscriptions(baseUrl, apiKey);
   const clientStarterKeys = new Set(
     starterRows.map((row) => buildOpenMeterPlanKey(row.clientId, row.id)),
   );

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { signOut, useSession } from "next-auth/react";
 import { useEffect, useMemo, useState } from "react";
+import CopyIdButton from "@/components/apps/CopyIdButton";
 import SidebarCreditPreview from "@/components/SidebarCreditPreview";
 
 interface NavItem {
@@ -110,7 +111,10 @@ export default function DashboardLayout({
     });
   };
 
-  const userRole = (session?.user as Record<string, unknown> | undefined)?.role as string | undefined;
+  const sessionUser = session?.user as Record<string, unknown> | undefined;
+  const userRole = sessionUser?.role as string | undefined;
+  const userId =
+    typeof sessionUser?.id === "string" ? sessionUser.id.trim() : "";
 
   const navItems = useMemo(
     () =>
@@ -331,10 +335,26 @@ export default function DashboardLayout({
                 <p className="text-sm font-medium truncate">
                   {session.user.name}
                 </p>
-                <div className="flex items-center gap-1.5 mt-0.5">
-                  <p className="text-xs text-zinc-500 truncate">
+                {session.user.email ? (
+                  <p className="mt-0.5 text-xs text-zinc-500 truncate">
                     {session.user.email}
                   </p>
+                ) : null}
+                <div className="flex items-center gap-1.5 mt-0.5">
+                  {userId ? (
+                    <>
+                      <p
+                        className="min-w-0 truncate font-mono text-[11px] text-zinc-500"
+                        title={userId}
+                      >
+                        {userId}
+                      </p>
+                      <CopyIdButton
+                        value={userId}
+                        label="Copy user id"
+                      />
+                    </>
+                  ) : null}
                   {userRole && (
                     <span
                       className={`shrink-0 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${roleBadgeClassName(userRole)}`}

--- a/src/components/OwnerBillingView.tsx
+++ b/src/components/OwnerBillingView.tsx
@@ -5,7 +5,21 @@ import AllowanceStrip from "@/components/AllowanceStrip";
 import DashboardLayout from "@/components/DashboardLayout";
 import { formatBillingPeriod } from "@/lib/billing-format";
 import { formatUsdMicrosDisplay, formatUsdMicrosString } from "@/lib/format-usd-micros";
+import type { CreditAllowanceSummary } from "@/lib/openmeter/credit-allowance-summary";
 import type { OwnerBillingPayload } from "@/lib/owner-billing-data";
+
+function hasDisplayablePrepaidCredit(
+  allowance: CreditAllowanceSummary | null | undefined,
+): boolean {
+  if (!allowance) return false;
+  try {
+    const remaining = BigInt(allowance.balanceUsdMicros || "0");
+    const granted = BigInt(allowance.lifetimeGrantedUsdMicros || "0");
+    return remaining > 0n || granted > 0n;
+  } catch {
+    return false;
+  }
+}
 
 function SubscriptionCard({
   row,
@@ -113,7 +127,7 @@ export default function OwnerBillingView({
               Lifetime wallet shared across apps you own. Separate from per-cycle plan
               allowances below.
             </p>
-            {data.creditAllowance ? (
+            {hasDisplayablePrepaidCredit(data.creditAllowance) && data.creditAllowance ? (
               <AllowanceStrip
                 balanceUsdMicros={data.creditAllowance.balanceUsdMicros}
                 lifetimeGrantedUsdMicros={data.creditAllowance.lifetimeGrantedUsdMicros}

--- a/src/components/OwnerBillingView.tsx
+++ b/src/components/OwnerBillingView.tsx
@@ -141,7 +141,7 @@ export default function OwnerBillingView({
             ) : (
               <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-5 text-sm text-zinc-500">
                 No prepaid credit balance. Starter included usage comes from your plan
-                allowance; credits appear here after a manual top-up or overage settlement.
+                allowance; credits appear here after a payment is received.
               </div>
             )}
           </section>

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -202,13 +202,12 @@ export async function mintSignerJwtForExternalUser(input: {
     clientId: input.publicClientId,
     externalUserId,
   });
-  // App owners mint/sign as owner:{users.id} so auth_id / OpenMeter subject share one wallet.
+  // Wire JWT/sub stays the bare platform user id. Owner billing wallet is
+  // owner:{users.id} via resolveOpenMeterBillingIdentity / Konnect attribution.
   const provisionExternalUserId = identity.isOwner
     ? (identity.ownerUserId as string)
     : externalUserId;
-  const jwtExternalUserId = identity.isOwner
-    ? identity.customerKey
-    : externalUserId;
+  const jwtExternalUserId = provisionExternalUserId;
 
   let allowance: TrialCreditBalance | null;
   try {

--- a/src/lib/oidc/remote-signer-webhook-config.ts
+++ b/src/lib/oidc/remote-signer-webhook-config.ts
@@ -52,8 +52,6 @@ function withOwnerBillingUsageSubject(verifier: EndUserVerifier): EndUserVerifie
   };
 }
 
-type EnvSource = NodeJS.ProcessEnv | Record<string, string | undefined>;
-
 function trimEnv(env: EnvSource, name: string): string {
   const value = env[name];
   return typeof value === "string" ? value.trim() : "";

--- a/src/lib/oidc/remote-signer-webhook-config.ts
+++ b/src/lib/oidc/remote-signer-webhook-config.ts
@@ -7,7 +7,50 @@ import {
   getPublicOrigin,
 } from "@/lib/oidc/issuer-urls";
 import { buildSignerBalanceCheck } from "@/lib/oidc/signer-balance-gate";
+import { buildOwnerCustomerKey } from "@/lib/openmeter/customer-key";
 import { trimTrailingSlashes } from "@/lib/openapi/string-utils";
+
+type EnvSource = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+type EndUserVerifier = RemoteSignerWebhookConfig["endUserAuth"];
+
+/**
+ * Map owner JWTs (bare platform user id + user_type=app_owner) onto webhook
+ * usage_subject owner:{id} so go-livepeer auth_id / CloudEvent settlement use
+ * the shared Konnect customer key. JWT claims stay bare for clients.
+ */
+function withOwnerBillingUsageSubject(verifier: EndUserVerifier): EndUserVerifier {
+  return {
+    ...verifier,
+    verify: async (input) => {
+      const result = await verifier.verify(input);
+      const raw = result.raw as Record<string, unknown> | undefined;
+      const userType =
+        typeof raw?.user_type === "string" ? raw.user_type.trim() : "";
+      if (userType !== "app_owner") {
+        return result;
+      }
+      const bareId = result.identity.usage_subject.trim();
+      if (!bareId || bareId.startsWith("owner:")) {
+        return {
+          ...result,
+          identity: {
+            ...result.identity,
+            usage_subject_type: "app_owner",
+          },
+        };
+      }
+      return {
+        ...result,
+        identity: {
+          ...result.identity,
+          usage_subject: buildOwnerCustomerKey(bareId),
+          usage_subject_type: "app_owner",
+        },
+      };
+    },
+  };
+}
 
 type EnvSource = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
@@ -84,7 +127,7 @@ export function buildRemoteSignerWebhookConfig(
   const source = resolveIdentityWebhookEnv(env ?? process.env);
   const config: RemoteSignerWebhookConfig = {
     webhookSecret: source.WEBHOOK_SECRET?.trim() || "",
-    endUserAuth: createEndUserVerifierFromEnv(source),
+    endUserAuth: withOwnerBillingUsageSubject(createEndUserVerifierFromEnv(source)),
   };
 
   const checkBalance = buildSignerBalanceCheck();

--- a/src/lib/openmeter/billing-identity.ts
+++ b/src/lib/openmeter/billing-identity.ts
@@ -11,7 +11,11 @@ import {
 } from "@/lib/openmeter/customer-key";
 
 export type ResolvedBillingIdentity = {
-  /** OpenMeter customer key / preferred CloudEvent subject for credits. */
+  /**
+   * Konnect customer key for credits/Starter (`owner:{users.id}` for owners;
+   * compound `app_…:externalUserId` for end-users). Metering wire subject is
+   * always compound — linked via usageAttribution.subjectKeys for owners.
+   */
   customerKey: string;
   isOwner: boolean;
   /** Platform users.id when isOwner. */

--- a/src/lib/openmeter/credit-allowance-summary.ts
+++ b/src/lib/openmeter/credit-allowance-summary.ts
@@ -242,6 +242,11 @@ export async function getOwnerPrepaidCreditBalance(
     if (!balance) {
       return null;
     }
+    // Treat an all-zero ledger as "no prepaid wallet" so UI empty-states render
+    // instead of a blank AllowanceStrip (which hides when granted+remaining are 0).
+    if (balance.balanceUsdMicros <= 0n && balance.lifetimeGrantedUsdMicros <= 0n) {
+      return null;
+    }
     return {
       hasAccess: balance.balanceUsdMicros > 0n,
       balanceUsdMicros: balance.balanceUsdMicros.toString(),

--- a/src/lib/openmeter/customer-key.ts
+++ b/src/lib/openmeter/customer-key.ts
@@ -43,6 +43,28 @@ export function parseOwnerCustomerKey(key: string): string | null {
 }
 
 /**
+ * Meter subjects for shared-owner usage reads: compound wire keys plus
+ * transitional owner: / app_…:owner:… subjects.
+ */
+export function buildOwnerMeterSubjects(
+  ownerUserId: string,
+  publicClientIds: string[],
+): string[] {
+  const trimmedOwnerId = ownerUserId.trim();
+  const ownerKey = buildOwnerCustomerKey(trimmedOwnerId);
+  const subjects = [ownerKey];
+  for (const clientId of publicClientIds) {
+    const trimmedClientId = clientId.trim();
+    if (!trimmedClientId) continue;
+    subjects.push(
+      buildOpenMeterCustomerKey(trimmedClientId, trimmedOwnerId),
+      buildOpenMeterCustomerKey(trimmedClientId, ownerKey),
+    );
+  }
+  return [...new Set(subjects)];
+}
+
+/**
  * Normalize platform user ids from mint/device subjects:
  * `owner:{id}`, `user:{id}`, or bare `{id}` → `{id}`.
  */

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -66,7 +66,7 @@ export async function ensureOwnerCustomerWireSubjects(
   return customer;
 }
 
-async function listOwnedPublicClientIds(ownerUserId: string): Promise<string[]> {
+export async function listOwnedPublicClientIds(ownerUserId: string): Promise<string[]> {
   const rows = await db
     .select({
       publicClientId: oidcClients.clientId,

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -23,6 +23,14 @@ type OpenMeterCustomerRecord = {
   usageAttribution?: { subjectKeys?: string[] };
 };
 
+function isActiveSubscriptionSubjectKeyError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    /cannot change subject keys/i.test(message) &&
+    /active subscriptions/i.test(message)
+  );
+}
+
 async function ensureCustomerUsageAttribution(
   client: OpenMeter,
   customer: OpenMeterCustomerRecord,
@@ -35,15 +43,30 @@ async function ensureCustomerUsageAttribution(
   }
 
   const nextKeys = [...new Set([...subjectKeys, ...requiredSubjectKeys])];
-  await client.customers.update(customer.id, {
-    name: customer.name?.trim() || customer.key || requiredSubjectKeys[0],
-    usageAttribution: { subjectKeys: nextKeys },
-  });
+  try {
+    await client.customers.update(customer.id, {
+      name: customer.name?.trim() || customer.key || requiredSubjectKeys[0],
+      usageAttribution: { subjectKeys: nextKeys },
+    });
+  } catch (err) {
+    // Konnect rejects subject-key changes while a subscription is active.
+    // Owner settlement uses CloudEvent subject = owner:{id} (customer key),
+    // so mint/provision must not fail closed on this.
+    if (isActiveSubscriptionSubjectKeyError(err)) {
+      console.warn(
+        "openmeter: skip subject key update (active subscription)",
+        customer.key ?? customer.id,
+        missing.join(","),
+      );
+      return;
+    }
+    throw err;
+  }
 }
 
 /**
- * Link compound wire subjects (`app_…:{ownerUserId}`) onto the shared owner
- * Konnect customer so prepaid/credit_then_invoice settles against owner:{id}.
+ * Ensure the shared owner Konnect customer exists. Compound wire subjects are
+ * best-effort — Konnect blocks subject-key changes with active subscriptions.
  */
 export async function ensureOwnerCustomerWireSubjects(
   client: OpenMeter,

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -1,4 +1,12 @@
+import { eq } from "drizzle-orm";
 import type { OpenMeter } from "@openmeter/sdk";
+
+import { db } from "@/db/index";
+import { developerApps, oidcClients } from "@/db/schema";
+import {
+  buildOpenMeterCustomerKey,
+  buildOwnerCustomerKey,
+} from "@/lib/openmeter/customer-key";
 import { getHostedOpenMeterUrl } from "./constants";
 import { isOpenMeterUlid } from "./konnect-routes";
 import { shouldUseKonnectRoutes } from "./route-mode";
@@ -18,18 +26,63 @@ type OpenMeterCustomerRecord = {
 async function ensureCustomerUsageAttribution(
   client: OpenMeter,
   customer: OpenMeterCustomerRecord,
-  customerKey: string,
+  requiredSubjectKeys: string[],
 ): Promise<void> {
   const subjectKeys = customer.usageAttribution?.subjectKeys ?? [];
-  if (subjectKeys.includes(customerKey)) {
+  const missing = requiredSubjectKeys.filter((key) => !subjectKeys.includes(key));
+  if (missing.length === 0) {
     return;
   }
 
-  const nextKeys = [...new Set([...subjectKeys, customerKey])];
+  const nextKeys = [...new Set([...subjectKeys, ...requiredSubjectKeys])];
   await client.customers.update(customer.id, {
-    name: customer.name?.trim() || customerKey,
+    name: customer.name?.trim() || customer.key || requiredSubjectKeys[0],
     usageAttribution: { subjectKeys: nextKeys },
   });
+}
+
+/**
+ * Link compound wire subjects (`app_…:{ownerUserId}`) onto the shared owner
+ * Konnect customer so prepaid/credit_then_invoice settles against owner:{id}.
+ */
+export async function ensureOwnerCustomerWireSubjects(
+  client: OpenMeter,
+  ownerUserId: string,
+  publicClientIds: string[],
+): Promise<OpenMeterCustomerIdentity> {
+  const trimmedOwnerId = ownerUserId.trim();
+  const ownerKey = buildOwnerCustomerKey(trimmedOwnerId);
+  const wireKeys = publicClientIds
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+    .map((clientId) => buildOpenMeterCustomerKey(clientId, trimmedOwnerId));
+  const requiredKeys = [...new Set([ownerKey, ...wireKeys])];
+
+  const customer = await ensureOpenMeterCustomer(client, ownerKey);
+  const existing = await findOpenMeterCustomerByKey(client, ownerKey);
+  if (existing?.id) {
+    await ensureCustomerUsageAttribution(client, existing, requiredKeys);
+  }
+  return customer;
+}
+
+async function listOwnedPublicClientIds(ownerUserId: string): Promise<string[]> {
+  const rows = await db
+    .select({
+      publicClientId: oidcClients.clientId,
+      developerAppId: developerApps.id,
+    })
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(developerApps.ownerId, ownerUserId.trim()));
+
+  return [
+    ...new Set(
+      rows
+        .map((row) => row.publicClientId?.trim() || row.developerAppId)
+        .filter((id): id is string => Boolean(id?.trim())),
+    ),
+  ];
 }
 
 async function findOpenMeterCustomerByKey(
@@ -58,7 +111,7 @@ export async function ensureOpenMeterCustomer(
 ): Promise<OpenMeterCustomerIdentity> {
   const existing = await findOpenMeterCustomerByKey(client, customerKey);
   if (existing?.id) {
-    await ensureCustomerUsageAttribution(client, existing, customerKey);
+    await ensureCustomerUsageAttribution(client, existing, [customerKey]);
     return { id: existing.id, key: customerKey };
   }
 
@@ -75,7 +128,7 @@ export async function ensureOpenMeterCustomer(
   } catch (err) {
     const raced = await findOpenMeterCustomerByKey(client, customerKey);
     if (raced?.id) {
-      await ensureCustomerUsageAttribution(client, raced, customerKey);
+      await ensureCustomerUsageAttribution(client, raced, [customerKey]);
       return { id: raced.id, key: customerKey };
     }
     throw err;
@@ -95,6 +148,17 @@ export async function ensureOpenMeterCustomerForAppUser(input: {
     clientId: input.clientId,
     externalUserId: input.externalUserId,
   });
+  if (identity.isOwner && identity.ownerUserId) {
+    const ownedClientIds = await listOwnedPublicClientIds(identity.ownerUserId);
+    const publicClientIds = [
+      ...new Set([identity.publicClientId, ...ownedClientIds]),
+    ];
+    return ensureOwnerCustomerWireSubjects(
+      input.client,
+      identity.ownerUserId,
+      publicClientIds,
+    );
+  }
   return ensureOpenMeterCustomer(
     input.client,
     identity.customerKey,

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -172,22 +172,25 @@ export async function ingestSignedTicketEvent(input: {
     clientId: input.event.clientId,
     externalUserId: usageSubject,
   });
-  // Wire subject is always compound app_…:platformUserId. Billing wallet key
-  // (owner:{id} for app owners) is metadata only via openmeter_customer_key.
+  // Wire auth_id stays compound app_…:platformUserId for analytics.
+  // CloudEvent subject must be the Konnect customer key for owners
+  // (owner:{id}) — Konnect billing beta clears multi-subject attribution
+  // when a subscription is created, so compound subjects cannot settle.
   const platformUserId = identity.isOwner
     ? (identity.ownerUserId as string)
     : usageSubject;
-  const wireSubject = buildOpenMeterCustomerKey(
+  const wireAuthId = buildOpenMeterCustomerKey(
     identity.publicClientId,
     platformUserId,
   );
+  const meterSubject = identity.customerKey;
 
   await input.client.events.ingest({
     specversion: "1.0",
     type: CREATE_SIGNED_TICKET_EVENT_TYPE,
     id: input.event.requestId,
     source: SIGNED_TICKET_EVENT_SOURCE,
-    subject: wireSubject,
+    subject: meterSubject,
     data: {
       client_id: identity.publicClientId,
       usage_subject: platformUserId,
@@ -202,7 +205,7 @@ export async function ingestSignedTicketEvent(input: {
       eth_usd_price: input.event.ethUsdPrice,
       eth_usd_round_id: input.event.ethUsdRoundId,
       eth_usd_observed_at: input.event.ethUsdObservedAt,
-      auth_id: wireSubject,
+      auth_id: wireAuthId,
       openmeter_customer_key: identity.customerKey,
     },
   });

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -172,12 +172,14 @@ export async function ingestSignedTicketEvent(input: {
     clientId: input.event.clientId,
     externalUserId: usageSubject,
   });
-  // Owners: subject = owner:{users.id} (shared wallet). End-users: app_…:external_id.
-  // Wire auth_id for go-livepeer stays compound; OpenMeter subject follows customer key.
-  const subject = identity.customerKey;
-  const legacyAuthId = buildOpenMeterCustomerKey(
+  // Wire subject is always compound app_…:platformUserId. Billing wallet key
+  // (owner:{id} for app owners) is metadata only via openmeter_customer_key.
+  const platformUserId = identity.isOwner
+    ? (identity.ownerUserId as string)
+    : usageSubject;
+  const wireSubject = buildOpenMeterCustomerKey(
     identity.publicClientId,
-    usageSubject,
+    platformUserId,
   );
 
   await input.client.events.ingest({
@@ -185,12 +187,12 @@ export async function ingestSignedTicketEvent(input: {
     type: CREATE_SIGNED_TICKET_EVENT_TYPE,
     id: input.event.requestId,
     source: SIGNED_TICKET_EVENT_SOURCE,
-    subject,
+    subject: wireSubject,
     data: {
       client_id: identity.publicClientId,
-      usage_subject: usageSubject,
+      usage_subject: platformUserId,
       usage_subject_type: identity.isOwner ? "app_owner" : "external_user_id",
-      external_user_id: usageSubject,
+      external_user_id: platformUserId,
       network_fee_usd_micros: Number(input.event.networkFeeUsdMicros),
       fee_wei: input.event.feeWei,
       pixels: input.event.pixels,
@@ -200,8 +202,8 @@ export async function ingestSignedTicketEvent(input: {
       eth_usd_price: input.event.ethUsdPrice,
       eth_usd_round_id: input.event.ethUsdRoundId,
       eth_usd_observed_at: input.event.ethUsdObservedAt,
-      auth_id: legacyAuthId,
-      openmeter_customer_key: subject,
+      auth_id: wireSubject,
+      openmeter_customer_key: identity.customerKey,
     },
   });
 }

--- a/src/lib/openmeter/konnect-routes.test.ts
+++ b/src/lib/openmeter/konnect-routes.test.ts
@@ -145,6 +145,23 @@ test("rewriteKonnectRequestBody rewrites plan PUT bodies", () => {
   assert.ok(Array.isArray(rewritten.phases[0]?.rate_cards));
 });
 
+test("rewriteKonnectRequestBody maps customer usageAttribution to snake_case", () => {
+  const rewritten = rewriteKonnectRequestBody(
+    "/v3/openmeter/api/v1/customers/cust_1",
+    "PUT",
+    {
+      name: "owner:uuid-1",
+      usageAttribution: { subjectKeys: ["owner:uuid-1", "app_1:uuid-1"] },
+    },
+  );
+  assert.deepEqual(rewritten, {
+    name: "owner:uuid-1",
+    usage_attribution: {
+      subject_keys: ["owner:uuid-1", "app_1:uuid-1"],
+    },
+  });
+});
+
 test("rewriteKonnectRequestBody maps customerId to nested customer for subscription create", () => {
   const rewritten = rewriteKonnectRequestBody(
     "/v3/openmeter/api/v1/subscriptions",

--- a/src/lib/openmeter/konnect-routes.ts
+++ b/src/lib/openmeter/konnect-routes.ts
@@ -1,4 +1,4 @@
-import { rewriteKonnectPlanRequestBody } from "./konnect-plan-body";
+import { deepCamelToSnake, rewriteKonnectPlanRequestBody } from "./konnect-plan-body";
 
 /**
  * Maps @openmeter/sdk paths (self-hosted /api/v1|v2) to Konnect Metering & Billing v3 paths.
@@ -281,6 +281,36 @@ function rewriteKonnectSubscriptionCreateBody(body: unknown): unknown {
   return next;
 }
 
+function isKonnectCustomerMutation(pathname: string, method: string): boolean {
+  const normalizedPath = rewriteKonnectPathname(pathname, method);
+  const verb = method.toUpperCase();
+  if (verb !== "POST" && verb !== "PUT" && verb !== "PATCH") {
+    return false;
+  }
+  // /customers or /customers/{id} — not nested entitlement/credit routes.
+  return /\/customers(?:\/[^/]+)?$/.test(normalizedPath);
+}
+
+function normalizeKonnectCustomerRecord(record: unknown): unknown {
+  if (!record || typeof record !== "object") {
+    return record;
+  }
+  const item = { ...(record as Record<string, unknown>) };
+  const attribution =
+    item.usage_attribution ?? item.usageAttribution;
+  if (attribution && typeof attribution === "object") {
+    const attr = attribution as Record<string, unknown>;
+    const subjectKeys = attr.subject_keys ?? attr.subjectKeys;
+    item.usageAttribution = {
+      subjectKeys: Array.isArray(subjectKeys)
+        ? subjectKeys.filter((key): key is string => typeof key === "string")
+        : [],
+    };
+    delete item.usage_attribution;
+  }
+  return item;
+}
+
 /** Normalize SDK JSON bodies to Konnect v3 request shapes. */
 export function rewriteKonnectRequestBody(
   pathname: string,
@@ -292,6 +322,10 @@ export function rewriteKonnectRequestBody(
 
   if (isKonnectPlanMutation(pathname, method)) {
     return rewriteKonnectPlanRequestBody(body);
+  }
+
+  if (isKonnectCustomerMutation(pathname, method)) {
+    return deepCamelToSnake(body);
   }
 
   if (verb === "POST" && normalizedPath.endsWith("/subscriptions")) {
@@ -328,7 +362,7 @@ export function normalizeKonnectListResponse(body: unknown): unknown {
     !("items" in body)
   ) {
     const data = ((body as Record<string, unknown>).data as unknown[]).map(
-      normalizeKonnectSubscriptionRecord,
+      (item) => normalizeKonnectCustomerRecord(normalizeKonnectSubscriptionRecord(item)),
     );
     return { ...(body as Record<string, unknown>), items: data, data };
   }
@@ -346,6 +380,14 @@ export function normalizeKonnectResponseBody(body: unknown): unknown {
     ("plan_id" in listed || "planId" in listed || "plan" in listed)
   ) {
     return normalizeKonnectSubscriptionRecord(listed);
+  }
+  if (
+    listed &&
+    typeof listed === "object" &&
+    "id" in listed &&
+    ("key" in listed || "usage_attribution" in listed || "usageAttribution" in listed)
+  ) {
+    return normalizeKonnectCustomerRecord(listed);
   }
   return listed;
 }

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import type { OpenMeter } from "@openmeter/sdk";
 
 import { buildOpenMeterCustomerKey, parseOpenMeterCustomerKey } from "./customer-key";
-import { ensureOpenMeterCustomer } from "./customers";
+import { ensureOpenMeterCustomer, ensureOwnerCustomerWireSubjects } from "./customers";
 import { listTenantInvoices } from "./invoices";
 import { mapPymthousePlanToOpenMeterCreate } from "./plans-sync";
 import {
@@ -403,6 +403,42 @@ test("ensureOpenMeterCustomer creates customer when missing", async () => {
 
   const identity = await ensureOpenMeterCustomer(openMeterTestClient(client), "app_1:user-2");
   assert.deepEqual(identity, { id: "om-new", key: "app_1:user-2" });
+});
+
+test("ensureOwnerCustomerWireSubjects adds compound app keys to owner customer", async () => {
+  let updatedSubjectKeys: string[] | undefined;
+  const ownerKey = "owner:uuid-1";
+  const client = {
+    customers: {
+      get: async (key: string) => ({
+        id: "om-owner-1",
+        key,
+        name: key,
+        usageAttribution: { subjectKeys: [ownerKey] },
+      }),
+      update: async (
+        _id: string,
+        input: { usageAttribution: { subjectKeys: string[] } },
+      ) => {
+        updatedSubjectKeys = input.usageAttribution.subjectKeys;
+        return { id: "om-owner-1", key: ownerKey };
+      },
+      create: async () => {
+        throw new Error("should not create");
+      },
+    },
+  };
+
+  const identity = await ensureOwnerCustomerWireSubjects(
+    openMeterTestClient(client),
+    "uuid-1",
+    ["app_aaa", "app_bbb"],
+  );
+  assert.deepEqual(identity, { id: "om-owner-1", key: ownerKey });
+  assert.deepEqual(
+    [...(updatedSubjectKeys ?? [])].sort(),
+    ["app_aaa:uuid-1", "app_bbb:uuid-1", ownerKey].sort(),
+  );
 });
 
 test("listTenantInvoices scopes billing.invoices.list to tenant customer ids", async () => {

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -441,6 +441,33 @@ test("ensureOwnerCustomerWireSubjects adds compound app keys to owner customer",
   );
 });
 
+test("ensureOpenMeterCustomer soft-fails subject update when subscription is active", async () => {
+  const client = {
+    customers: {
+      get: async (key: string) => ({
+        id: "om-owner-1",
+        key,
+        name: key,
+        usageAttribution: { subjectKeys: [] },
+      }),
+      update: async () => {
+        throw new Error(
+          "Request failed (https://us.api.konghq.com/v3/openmeter/customers/x) [400]: validation error: cannot change subject keys for customer with active subscriptions",
+        );
+      },
+      create: async () => {
+        throw new Error("should not create");
+      },
+    },
+  };
+
+  const identity = await ensureOpenMeterCustomer(
+    openMeterTestClient(client),
+    "owner:uuid-1",
+  );
+  assert.deepEqual(identity, { id: "om-owner-1", key: "owner:uuid-1" });
+});
+
 test("listTenantInvoices scopes billing.invoices.list to tenant customer ids", async () => {
   const listedCustomers: string[][] = [];
   const client = {

--- a/src/lib/openmeter/signed-ticket-events.test.ts
+++ b/src/lib/openmeter/signed-ticket-events.test.ts
@@ -82,6 +82,54 @@ test("eventMatchesViewerSubjects keeps only viewer subjects", () => {
   );
 });
 
+test("eventMatchesViewerSubjects matches owner wallet CE subjects", () => {
+  const ownerId = "2e51154b-d296-4015-990c-02d5f16ecf1e";
+  const subjects = new Set([ownerId, `owner:${ownerId}`]);
+  const ownerEvent = {
+    event: {
+      id: "evt-owner-1",
+      type: CREATE_SIGNED_TICKET_EVENT_TYPE,
+      subject: `owner:${ownerId}`,
+      time: "2026-07-11T12:00:00.000Z",
+      data: {
+        client_id: "app_abc",
+        external_user_id: `owner:${ownerId}`,
+        usage_subject: `owner:${ownerId}`,
+        gateway_request_id: "req-owner-1",
+        pipeline: "text-to-image",
+        model_id: "sdxl",
+        network_fee_usd_micros: "1500",
+      },
+    },
+  };
+  assert.equal(eventMatchesViewerSubjects(ownerEvent, subjects), true);
+  assert.equal(
+    eventMatchesViewerSubjects(ownerEvent, subjects, "app_abc"),
+    true,
+  );
+  assert.equal(
+    eventMatchesViewerSubjects(ownerEvent, new Set(["someone-else"])),
+    false,
+  );
+  assert.equal(eventClientId(ownerEvent), "app_abc");
+  assert.equal(eventUsageSubject(ownerEvent), `owner:${ownerId}`);
+});
+
+test("eventClientId ignores owner: CloudEvent subject prefix", () => {
+  const ownerId = "uuid-owner-1";
+  const bare = {
+    event: {
+      id: "evt-3",
+      type: CREATE_SIGNED_TICKET_EVENT_TYPE,
+      subject: `owner:${ownerId}`,
+      time: "2026-07-11T12:00:00.000Z",
+      data: {},
+    },
+  };
+  assert.equal(eventClientId(bare), null);
+  assert.equal(eventUsageSubject(bare), `owner:${ownerId}`);
+});
+
 test("eventMatchesViewerSubjects enforces clientId filter", () => {
   const subjects = new Set(["user-123"]);
   assert.equal(

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -436,52 +436,61 @@ function compoundQueriesForSubject(
   return [subject];
 }
 
+function addQueries(target: Set<string>, keys: Iterable<string>): void {
+  for (const key of keys) {
+    target.add(key);
+  }
+}
+
+function addOwnerSubjectQueries(
+  queries: Set<string>,
+  ownerKey: string,
+  clientIds: ReadonlySet<string> | null,
+): void {
+  const ownerUserId = parseOwnerCustomerKey(ownerKey);
+  if (!ownerUserId) return;
+  queries.add(ownerKey);
+  queries.add(ownerUserId);
+  if (clientIds && clientIds.size > 0) {
+    addQueries(queries, buildOwnerMeterSubjects(ownerUserId, [...clientIds]));
+    return;
+  }
+  addQueries(queries, compoundQueriesForSubject(ownerUserId, null));
+}
+
+function addPlatformSubjectQueries(
+  queries: Set<string>,
+  subject: string,
+  clientIds: ReadonlySet<string> | null,
+): void {
+  const normalized = normalizePlatformUserId(subject);
+  queries.add(subject);
+  queries.add(normalized);
+  queries.add(buildOwnerCustomerKey(normalized));
+  if (clientIds && clientIds.size > 0) {
+    addQueries(queries, buildOwnerMeterSubjects(normalized, [...clientIds]));
+    for (const clientId of clientIds) {
+      queries.add(buildOpenMeterCustomerKey(clientId, subject));
+    }
+    return;
+  }
+  addQueries(queries, compoundQueriesForSubject(subject, null));
+}
+
 function buildSubjectQueries(
   subjects: ReadonlySet<string>,
   clientIds: ReadonlySet<string> | null,
 ): string[] {
   const queries = new Set<string>();
-  const clientIdList =
-    clientIds && clientIds.size > 0 ? [...clientIds] : ([] as string[]);
-
   for (const subject of subjects) {
     const trimmed = subject.trim();
     if (!trimmed) continue;
-    // Always include the raw key (owner:{id} is the live CE subject for owners).
-    queries.add(trimmed);
-
     if (isOwnerCustomerKey(trimmed)) {
-      const ownerUserId = parseOwnerCustomerKey(trimmed);
-      if (ownerUserId && clientIdList.length > 0) {
-        for (const key of buildOwnerMeterSubjects(ownerUserId, clientIdList)) {
-          queries.add(key);
-        }
-      } else if (ownerUserId) {
-        queries.add(ownerUserId);
-        for (const key of compoundQueriesForSubject(ownerUserId, clientIds)) {
-          queries.add(key);
-        }
-      }
+      addOwnerSubjectQueries(queries, trimmed, clientIds);
       continue;
     }
-
-    const normalized = normalizePlatformUserId(trimmed);
-    queries.add(normalized);
-    queries.add(buildOwnerCustomerKey(normalized));
-    if (clientIdList.length > 0) {
-      for (const key of buildOwnerMeterSubjects(normalized, clientIdList)) {
-        queries.add(key);
-      }
-      for (const clientId of clientIdList) {
-        queries.add(buildOpenMeterCustomerKey(clientId, trimmed));
-      }
-    } else {
-      for (const key of compoundQueriesForSubject(trimmed, null)) {
-        queries.add(key);
-      }
-    }
+    addPlatformSubjectQueries(queries, trimmed, clientIds);
   }
-
   return [...queries];
 }
 

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -13,7 +13,9 @@ import { getHostedOpenMeterClient } from "@/lib/openmeter/client";
 import {
   buildOpenMeterCustomerKey,
   buildOwnerCustomerKey,
+  buildOwnerMeterSubjects,
   isOwnerCustomerKey,
+  normalizePlatformUserId,
   parseOpenMeterCustomerKey,
   parseOwnerCustomerKey,
 } from "@/lib/openmeter/customer-key";
@@ -177,18 +179,47 @@ export function eventUsageSubject(event: IngestedEventLike): string | null {
   if (fromData) {
     return fromData;
   }
-  const parsed = parseOpenMeterCustomerKey(event.event?.subject?.trim() || "");
+  const subject = event.event?.subject?.trim() || "";
+  if (isOwnerCustomerKey(subject)) {
+    return subject;
+  }
+  const parsed = parseOpenMeterCustomerKey(subject);
   return parsed?.externalUserId ?? null;
 }
 
 export function eventClientId(event: IngestedEventLike): string | null {
   const data = event.event?.data ?? {};
   const fromData = stringField(data, "client_id");
-  if (fromData) {
+  if (fromData && fromData !== "owner") {
     return fromData;
   }
-  const parsed = parseOpenMeterCustomerKey(event.event?.subject?.trim() || "");
-  return parsed?.clientId ?? null;
+  const subject = event.event?.subject?.trim() || "";
+  // Owner wallet events use CE subject owner:{id}; client lives in data only.
+  if (isOwnerCustomerKey(subject)) {
+    return null;
+  }
+  const parsed = parseOpenMeterCustomerKey(subject);
+  if (!parsed || parsed.clientId === "owner") {
+    return null;
+  }
+  return parsed.clientId;
+}
+
+/** Expand bare / owner: / user: forms so list filters match subscription meters. */
+export function expandViewerSubjectMatchKeys(
+  subjects: ReadonlySet<string>,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const raw of subjects) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    keys.add(trimmed);
+    const normalized = normalizePlatformUserId(trimmed);
+    keys.add(normalized);
+    keys.add(buildOwnerCustomerKey(normalized));
+    keys.add(`user:${normalized}`);
+  }
+  return keys;
 }
 
 export function eventMatchesViewerSubjects(
@@ -202,8 +233,17 @@ export function eventMatchesViewerSubjects(
   if (event.event.type && event.event.type !== CREATE_SIGNED_TICKET_EVENT_TYPE) {
     return false;
   }
+  const matchKeys = expandViewerSubjectMatchKeys(subjects);
   const usageSubject = eventUsageSubject(event);
-  if (!usageSubject || !subjects.has(usageSubject)) {
+  const ceSubject = event.event.subject?.trim() || "";
+  const candidates = [usageSubject, ceSubject].filter(
+    (value): value is string => Boolean(value),
+  );
+  const subjectMatched = candidates.some(
+    (value) =>
+      matchKeys.has(value) || matchKeys.has(normalizePlatformUserId(value)),
+  );
+  if (!subjectMatched) {
     return false;
   }
   if (clientIdOrIds == null) {
@@ -400,20 +440,49 @@ function buildSubjectQueries(
   subjects: ReadonlySet<string>,
   clientIds: ReadonlySet<string> | null,
 ): string[] {
-  const queries: string[] = [];
+  const queries = new Set<string>();
+  const clientIdList =
+    clientIds && clientIds.size > 0 ? [...clientIds] : ([] as string[]);
+
   for (const subject of subjects) {
-    if (isOwnerCustomerKey(subject)) {
-      const ownerUserId = parseOwnerCustomerKey(subject);
-      // Primary: compound wire subjects. Legacy: bare owner:{id} events.
-      if (ownerUserId) {
-        queries.push(...compoundQueriesForSubject(ownerUserId, clientIds));
+    const trimmed = subject.trim();
+    if (!trimmed) continue;
+    // Always include the raw key (owner:{id} is the live CE subject for owners).
+    queries.add(trimmed);
+
+    if (isOwnerCustomerKey(trimmed)) {
+      const ownerUserId = parseOwnerCustomerKey(trimmed);
+      if (ownerUserId && clientIdList.length > 0) {
+        for (const key of buildOwnerMeterSubjects(ownerUserId, clientIdList)) {
+          queries.add(key);
+        }
+      } else if (ownerUserId) {
+        queries.add(ownerUserId);
+        for (const key of compoundQueriesForSubject(ownerUserId, clientIds)) {
+          queries.add(key);
+        }
       }
-      queries.push(subject);
       continue;
     }
-    queries.push(...compoundQueriesForSubject(subject, clientIds));
+
+    const normalized = normalizePlatformUserId(trimmed);
+    queries.add(normalized);
+    queries.add(buildOwnerCustomerKey(normalized));
+    if (clientIdList.length > 0) {
+      for (const key of buildOwnerMeterSubjects(normalized, clientIdList)) {
+        queries.add(key);
+      }
+      for (const clientId of clientIdList) {
+        queries.add(buildOpenMeterCustomerKey(clientId, trimmed));
+      }
+    } else {
+      for (const key of compoundQueriesForSubject(trimmed, null)) {
+        queries.add(key);
+      }
+    }
   }
-  return queries;
+
+  return [...queries];
 }
 
 async function loadAppNames(clientIds: string[]): Promise<Map<string, string>> {

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -15,6 +15,7 @@ import {
   buildOwnerCustomerKey,
   isOwnerCustomerKey,
   parseOpenMeterCustomerKey,
+  parseOwnerCustomerKey,
 } from "@/lib/openmeter/customer-key";
 
 const DEFAULT_PAGE_SIZE = 25;
@@ -382,6 +383,19 @@ function normalizeClientIdFilter(
   return new Set(ids);
 }
 
+function compoundQueriesForSubject(
+  subject: string,
+  clientIds: ReadonlySet<string> | null,
+): string[] {
+  if (clientIds && clientIds.size > 0) {
+    return [...clientIds].map((clientId) =>
+      buildOpenMeterCustomerKey(clientId, subject),
+    );
+  }
+  // Partial subject match: compound auth_id ends with :external_user_id
+  return [subject];
+}
+
 function buildSubjectQueries(
   subjects: ReadonlySet<string>,
   clientIds: ReadonlySet<string> | null,
@@ -389,18 +403,15 @@ function buildSubjectQueries(
   const queries: string[] = [];
   for (const subject of subjects) {
     if (isOwnerCustomerKey(subject)) {
-      // Owner wallet events use subject = owner:{users.id} (not compound).
+      const ownerUserId = parseOwnerCustomerKey(subject);
+      // Primary: compound wire subjects. Legacy: bare owner:{id} events.
+      if (ownerUserId) {
+        queries.push(...compoundQueriesForSubject(ownerUserId, clientIds));
+      }
       queries.push(subject);
       continue;
     }
-    if (clientIds && clientIds.size > 0) {
-      for (const clientId of clientIds) {
-        queries.push(buildOpenMeterCustomerKey(clientId, subject));
-      }
-    } else {
-      // Partial subject match: compound auth_id ends with :external_user_id
-      queries.push(subject);
-    }
+    queries.push(...compoundQueriesForSubject(subject, clientIds));
   }
   return queries;
 }

--- a/src/lib/openmeter/spendable-allowance.ts
+++ b/src/lib/openmeter/spendable-allowance.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 
 import { db } from "@/db/index";
-import { plans } from "@/db/schema";
+import { developerApps, oidcClients, plans } from "@/db/schema";
 import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
 import {
   getHostedAdminClient,
@@ -9,7 +9,14 @@ import {
 } from "@/lib/openmeter/admin-client";
 import { resolveOpenMeterBillingIdentity } from "@/lib/openmeter/billing-identity";
 import { NETWORK_FEE_USD_MICROS_METER } from "@/lib/openmeter/constants";
-import { ensureOpenMeterCustomer } from "@/lib/openmeter/customers";
+import {
+  buildOpenMeterCustomerKey,
+  buildOwnerCustomerKey,
+} from "@/lib/openmeter/customer-key";
+import {
+  ensureOpenMeterCustomer,
+  ensureOpenMeterCustomerForAppUser,
+} from "@/lib/openmeter/customers";
 import { getTrialCreditBalance } from "@/lib/openmeter/entitlements";
 import { defaultStarterIncludedUsdMicros } from "@/lib/starter-default-plan-display";
 import {
@@ -40,12 +47,16 @@ export function includedDiscountUsdMicrosForPlan(
   return null;
 }
 
-async function querySubjectUsedUsdMicros(
-  subject: string,
+async function querySubjectsUsedUsdMicros(
+  subjects: string[],
   start: string,
   end: string,
 ): Promise<bigint> {
   if (!isHostedAdminClientAvailable()) {
+    return 0n;
+  }
+  const unique = [...new Set(subjects.map((s) => s.trim()).filter(Boolean))];
+  if (unique.length === 0) {
     return 0n;
   }
   const client = getHostedAdminClient();
@@ -54,7 +65,7 @@ async function querySubjectUsedUsdMicros(
       windowSize: "MONTH",
       from: new Date(start),
       to: new Date(end),
-      subject: [subject],
+      subject: unique,
     });
     let used = 0n;
     for (const row of result.data || []) {
@@ -64,6 +75,41 @@ async function querySubjectUsedUsdMicros(
   } catch {
     return 0n;
   }
+}
+
+async function listOwnedPublicClientIds(ownerUserId: string): Promise<string[]> {
+  const rows = await db
+    .select({
+      publicClientId: oidcClients.clientId,
+      developerAppId: developerApps.id,
+    })
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(developerApps.ownerId, ownerUserId.trim()));
+
+  return [
+    ...new Set(
+      rows
+        .map((row) => row.publicClientId?.trim() || row.developerAppId)
+        .filter((id): id is string => Boolean(id?.trim())),
+    ),
+  ];
+}
+
+/** Compound wire subjects (+ transitional) for owner discount burn measurement. */
+function buildOwnerUsageSubjects(
+  ownerUserId: string,
+  publicClientIds: string[],
+): string[] {
+  const ownerKey = buildOwnerCustomerKey(ownerUserId);
+  const subjects = [ownerKey];
+  for (const clientId of publicClientIds) {
+    subjects.push(
+      buildOpenMeterCustomerKey(clientId, ownerUserId),
+      buildOpenMeterCustomerKey(clientId, ownerKey),
+    );
+  }
+  return [...new Set(subjects)];
 }
 
 /**
@@ -117,10 +163,31 @@ export async function getRemainingPlanDiscountUsdMicros(input: {
     return 0n;
   }
 
-  await ensureOpenMeterCustomer(getHostedAdminClient(), identity.customerKey);
+  const client = getHostedAdminClient();
+  if (identity.isOwner && identity.ownerUserId) {
+    await ensureOpenMeterCustomerForAppUser({
+      client,
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+    });
+  } else {
+    await ensureOpenMeterCustomer(client, identity.customerKey);
+  }
+
   const cycle = calendarMonthBoundsUtc(new Date());
-  const used = await querySubjectUsedUsdMicros(
-    identity.customerKey,
+  const usageSubjects =
+    identity.isOwner && identity.ownerUserId
+      ? buildOwnerUsageSubjects(
+          identity.ownerUserId,
+          [
+            identity.publicClientId,
+            ...(await listOwnedPublicClientIds(identity.ownerUserId)),
+          ],
+        )
+      : [identity.customerKey];
+
+  const used = await querySubjectsUsedUsdMicros(
+    usageSubjects,
     cycle.start,
     cycle.end,
   );

--- a/src/lib/openmeter/spendable-allowance.ts
+++ b/src/lib/openmeter/spendable-allowance.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 
 import { db } from "@/db/index";
-import { developerApps, oidcClients, plans } from "@/db/schema";
+import { plans } from "@/db/schema";
 import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
 import {
   getHostedAdminClient,
@@ -9,13 +9,11 @@ import {
 } from "@/lib/openmeter/admin-client";
 import { resolveOpenMeterBillingIdentity } from "@/lib/openmeter/billing-identity";
 import { NETWORK_FEE_USD_MICROS_METER } from "@/lib/openmeter/constants";
-import {
-  buildOpenMeterCustomerKey,
-  buildOwnerCustomerKey,
-} from "@/lib/openmeter/customer-key";
+import { buildOwnerMeterSubjects } from "@/lib/openmeter/customer-key";
 import {
   ensureOpenMeterCustomer,
   ensureOpenMeterCustomerForAppUser,
+  listOwnedPublicClientIds,
 } from "@/lib/openmeter/customers";
 import { getTrialCreditBalance } from "@/lib/openmeter/entitlements";
 import { defaultStarterIncludedUsdMicros } from "@/lib/starter-default-plan-display";
@@ -75,41 +73,6 @@ async function querySubjectsUsedUsdMicros(
   } catch {
     return 0n;
   }
-}
-
-async function listOwnedPublicClientIds(ownerUserId: string): Promise<string[]> {
-  const rows = await db
-    .select({
-      publicClientId: oidcClients.clientId,
-      developerAppId: developerApps.id,
-    })
-    .from(developerApps)
-    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
-    .where(eq(developerApps.ownerId, ownerUserId.trim()));
-
-  return [
-    ...new Set(
-      rows
-        .map((row) => row.publicClientId?.trim() || row.developerAppId)
-        .filter((id): id is string => Boolean(id?.trim())),
-    ),
-  ];
-}
-
-/** Compound wire subjects (+ transitional) for owner discount burn measurement. */
-function buildOwnerUsageSubjects(
-  ownerUserId: string,
-  publicClientIds: string[],
-): string[] {
-  const ownerKey = buildOwnerCustomerKey(ownerUserId);
-  const subjects = [ownerKey];
-  for (const clientId of publicClientIds) {
-    subjects.push(
-      buildOpenMeterCustomerKey(clientId, ownerUserId),
-      buildOpenMeterCustomerKey(clientId, ownerKey),
-    );
-  }
-  return [...new Set(subjects)];
 }
 
 /**
@@ -177,7 +140,7 @@ export async function getRemainingPlanDiscountUsdMicros(input: {
   const cycle = calendarMonthBoundsUtc(new Date());
   const usageSubjects =
     identity.isOwner && identity.ownerUserId
-      ? buildOwnerUsageSubjects(
+      ? buildOwnerMeterSubjects(
           identity.ownerUserId,
           [
             identity.publicClientId,

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -5,7 +5,7 @@ import { plans } from "@/db/schema";
 import { getOrCreateStarterPlan } from "@/lib/starter-default-plan";
 import { applyFreeBillingProfileToCustomer } from "./billing-profiles";
 import { getHostedAdminClient, isHostedAdminClientAvailable } from "./admin-client";
-import { ensureOpenMeterCustomer } from "./customers";
+import { ensureOpenMeterCustomer, ensureOpenMeterCustomerForAppUser } from "./customers";
 import {
   isOpenMeterConflictError,
   isOpenMeterPlanNotFoundError,
@@ -264,10 +264,13 @@ export async function ensureStarterSubscriptionForAppUser(input: {
   }
 
   const client = getHostedAdminClient();
-  const customer = await ensureOpenMeterCustomer(
-    client,
-    identity.customerKey,
-  );
+  const customer = identity.isOwner
+    ? await ensureOpenMeterCustomerForAppUser({
+        client,
+        clientId: input.clientId,
+        externalUserId: input.externalUserId,
+      })
+    : await ensureOpenMeterCustomer(client, identity.customerKey);
   // Starter trial subscriptions always use the sandbox billing profile so Konnect
   // does not require Stripe customer data, even when the app has Stripe Connect.
   await applyFreeBillingProfileToCustomer({

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -178,15 +178,20 @@ async function resolveDiscountUsdMicros(input: {
 
 async function querySubjectCycleUsage(input: {
   client: OpenMeter;
-  subject: string;
+  subjects: string[];
   start: string;
   end: string;
 }): Promise<{ usedUsdMicros: bigint; requestCount: number }> {
+  const subjects = [...new Set(input.subjects.map((s) => s.trim()).filter(Boolean))];
+  if (subjects.length === 0) {
+    return { usedUsdMicros: 0n, requestCount: 0 };
+  }
+
   const baseQuery = {
     windowSize: "MONTH" as const,
     from: new Date(input.start),
     to: new Date(input.end),
-    subject: [input.subject],
+    subject: subjects,
   };
 
   try {
@@ -212,11 +217,27 @@ async function querySubjectCycleUsage(input: {
   } catch (err) {
     console.warn(
       "owner-billing: meter query failed",
-      input.subject,
+      subjects.join(","),
       err instanceof Error ? err.message : String(err),
     );
     return { usedUsdMicros: 0n, requestCount: 0 };
   }
+}
+
+/** Wire + transitional subjects for shared-owner subscription usage. */
+function buildOwnerWalletUsageSubjects(
+  ownerUserId: string,
+  ownedApps: OwnedApp[],
+): string[] {
+  const ownerKey = buildOwnerCustomerKey(ownerUserId);
+  const subjects = [ownerKey];
+  for (const app of ownedApps) {
+    subjects.push(
+      buildOpenMeterCustomerKey(app.publicClientId, ownerUserId),
+      buildOpenMeterCustomerKey(app.publicClientId, ownerKey),
+    );
+  }
+  return [...new Set(subjects)];
 }
 
 async function listOwnedApps(ownerUserId: string): Promise<OwnedApp[]> {
@@ -305,6 +326,8 @@ async function mapSubscriptionRow(input: {
   subscription: OpenMeterSubscriptionView;
   candidate: CustomerCandidate;
   cycle: { start: string; end: string };
+  ownerUserId: string;
+  ownedApps: OwnedApp[];
 }): Promise<OwnerBillingSubscriptionRow> {
   const localPlanId = input.candidate.appPublicClientId
     ? await resolveLocalPlanIdFromOpenMeterSubscription(
@@ -342,9 +365,14 @@ async function mapSubscriptionRow(input: {
     isStarterDefault,
   });
 
+  const isSharedOwnerWallet = input.candidate.appPublicClientId == null;
+  const usageSubjects = isSharedOwnerWallet
+    ? buildOwnerWalletUsageSubjects(input.ownerUserId, input.ownedApps)
+    : [input.candidate.customerKey];
+
   const usage = await querySubjectCycleUsage({
     client: input.client,
-    subject: input.candidate.customerKey,
+    subjects: usageSubjects,
     start: input.cycle.start,
     end: input.cycle.end,
   });
@@ -467,6 +495,8 @@ export async function listOwnerActiveSubscriptions(
           subscription,
           candidate,
           cycle,
+          ownerUserId: trimmed,
+          ownedApps,
         }),
       );
     }

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -22,6 +22,7 @@ import {
 import {
   buildOpenMeterCustomerKey,
   buildOwnerCustomerKey,
+  buildOwnerMeterSubjects,
 } from "@/lib/openmeter/customer-key";
 import { ensureOpenMeterCustomer } from "@/lib/openmeter/customers";
 import {
@@ -229,15 +230,10 @@ function buildOwnerWalletUsageSubjects(
   ownerUserId: string,
   ownedApps: OwnedApp[],
 ): string[] {
-  const ownerKey = buildOwnerCustomerKey(ownerUserId);
-  const subjects = [ownerKey];
-  for (const app of ownedApps) {
-    subjects.push(
-      buildOpenMeterCustomerKey(app.publicClientId, ownerUserId),
-      buildOpenMeterCustomerKey(app.publicClientId, ownerKey),
-    );
-  }
-  return [...new Set(subjects)];
+  return buildOwnerMeterSubjects(
+    ownerUserId,
+    ownedApps.map((app) => app.publicClientId),
+  );
 }
 
 async function listOwnedApps(ownerUserId: string): Promise<OwnedApp[]> {


### PR DESCRIPTION
## Summary
- Keep JWT/`auth_id`/CloudEvent wire identity as the normal end-user shape (`sub` = bare `{platformUserId}`, meter subject = compound `app_…:{platformUserId}`).
- Keep the shared owner prepaid/Starter wallet on Konnect customer `owner:{users.id}`, and link compound subjects via `usageAttribution.subjectKeys`.
- Aggregate owner subscription/spendable usage across compound (+ transitional) subjects so billing UI no longer under-counts when events are not on `subject=[owner:…]`.

## Test plan
- [ ] Mint/exchange an owner API key JWT and confirm `sub` / `external_user_id` are bare user id (not `owner:…`) and `user_type` is `app_owner`
- [ ] Confirm signed-ticket CloudEvents use compound `subject` / `auth_id`, with `openmeter_customer_key` still `owner:{id}` on the direct ingest path
- [ ] Confirm owner Konnect customer `usageAttribution.subjectKeys` includes `owner:{id}` and each owned `app_…:{ownerUserId}` after mint/Starter ensure
- [ ] Owner Billing page: Active Subscription usage matches request history for compound-subject traffic
- [ ] Historical events under `owner:` / `app_…:owner:…` still appear via dual-read
- [ ] Redeploy/restart OpenMeter collector with updated `collector.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Billing & Usage**
  - Improved prepaid-credit, Starter plan, and discount usage tracking for shared-owner wallets and multiple owned applications.
  - Refined signed-ticket event ingestion to use consistent “platform” identity for `usage_subject`/`external_user_id` and updated `auth_id`/customer key wiring.
  - Expanded owner-related subject matching and Konnect customer usage-attribution normalization.

- **Documentation**
  - Updated signer minting and collector mapping guidance to clarify owner vs end-user attribution and subject key behavior.

- **UI**
  - Added “copy user ID” support and conditional email/user ID rendering in the dashboard layout and improved prepaid-credit display gating.

- **Automation / Tests**
  - Added `openmeter:fix-starter-allowance` script and improved coverage for owner-subject handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->