### PR TITLE
Assign staging domain to each deployed branch

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,7 +2,8 @@ name: Deploy staging
 
 # Auto-deploys on push to any branch except `main`, or manually deploys a chosen branch.
 # Vercel (pymthouse project, Preview environment): every feature branch push creates a
-# prebuilt Preview deployment and re-aliases staging.pymthouse.com onto it.
+# prebuilt Preview deployment, assigns staging.pymthouse.com to that branch, and
+# re-aliases the domain onto the new deployment.
 # Railway preview stack: only on push to `staging` (or manual dispatch with branch=staging).
 #
 # Git-triggered Vercel builds are disabled repo-wide (`vercel.json` deploymentEnabled=false)
@@ -102,10 +103,12 @@ jobs:
       - name: Build
         run: vercel build --token="$VERCEL_TOKEN"
 
-      - name: Deploy and alias staging
+      - name: Deploy, assign branch, and alias staging
         run: |
           set -euo pipefail
           url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          STAGING_GIT_BRANCH="$DEPLOY_BRANCH" bash scripts/assign-staging-domain-branch.sh
           vercel alias set "$url" staging.pymthouse.com --token="$VERCEL_TOKEN"
           echo "Deployment URL: $url"
+          echo "Staging branch: $DEPLOY_BRANCH"
           echo "Staging alias: https://staging.pymthouse.com"

--- a/scripts/assign-staging-domain-branch.sh
+++ b/scripts/assign-staging-domain-branch.sh
@@ -36,6 +36,23 @@ http_status="$(curl -sS -o "$response_file" -w '%{http_code}' -X PATCH "$api_url
   -H "Content-Type: application/json" \
   -d "$body")"
 response="$(<"$response_file")"
+
+if [[ "$http_status" == "404" ]] &&
+  jq -e '.error.code == "not_found" and .error.message == "Project Domain not found."' \
+    <<<"$response" >/dev/null 2>&1; then
+  echo "${STAGING_DOMAIN} is not a project domain yet; adding it with the branch assignment"
+  body="$(jq -n \
+    --arg name "$STAGING_DOMAIN" \
+    --arg branch "$STAGING_GIT_BRANCH" \
+    '{name: $name, gitBranch: $branch}')"
+  api_url="https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/domains?teamId=${VERCEL_ORG_ID}"
+  http_status="$(curl -sS -o "$response_file" -w '%{http_code}' -X POST "$api_url" \
+    -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body")"
+  response="$(<"$response_file")"
+fi
+
 rm -f "$response_file"
 
 if (( http_status < 200 || http_status >= 300 )); then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- assign `staging.pymthouse.com` to the pushed branch during the Vercel staging deployment
- keep the explicit deployment alias so the current prebuilt deployment is immediately served
- report the selected staging branch in workflow output

## Testing
- `actionlint .github/workflows/deploy-staging.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcfb03b8-c7be-4ca3-ba75-f28a774c89e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcfb03b8-c7be-4ca3-ba75-f28a774c89e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

