### PR TITLE
fix(billing): show plan allowances as $5.00 dollar controls

### DIFF
--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -25,6 +25,13 @@ import {
   CUSTOM_PLAN_NAME_MAX_LENGTH,
   validateCustomPlanName,
 } from "@/lib/openmeter/plan-naming";
+import {
+  formatUsdMicrosDisplay,
+  normalizeUsdCentsDisplay,
+  sanitizeUsdCentsInput,
+  usdCentsDisplayToMicros,
+  usdMicrosToCentsDisplay,
+} from "@/lib/format-usd-micros";
 
 // ── Types & utilities ─────────────────────────────────────────────────────────
 
@@ -91,8 +98,6 @@ interface PlanDraft {
   capabilityMarkupByKey: Record<string, string>;
 }
 
-const USD_MICROS = 1_000_000;
-
 const PLAN_TYPES = [
   { value: "free", label: "Free" },
   { value: "subscription", label: "Subscription" },
@@ -122,15 +127,55 @@ async function readFetchJson(res: Response): Promise<{
 
 function usdMicrosToDisplay(micros: string | null | undefined): string {
   if (!micros) return "";
-  const n = parseInt(micros, 10);
-  if (isNaN(n)) return "";
-  return (n / USD_MICROS).toFixed(2);
+  return usdMicrosToCentsDisplay(micros);
 }
 
 function displayToUsdMicros(display: string): string | null {
-  const n = parseFloat(display);
-  if (!isFinite(n) || n < 0) return null;
-  return Math.round(n * USD_MICROS).toString();
+  return usdCentsDisplayToMicros(display);
+}
+
+function DollarCentsInput({
+  id,
+  value,
+  onChange,
+  disabled,
+  placeholder = "5.00",
+  "aria-label": ariaLabel,
+}: Readonly<{
+  id?: string;
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  "aria-label"?: string;
+}>) {
+  return (
+    <div
+      className={`flex items-center rounded-lg border border-zinc-700 bg-zinc-800/50 focus-within:border-sky-500/40 focus-within:ring-1 focus-within:ring-sky-500/20 ${
+        disabled ? "opacity-50" : ""
+      }`}
+    >
+      <span className="pl-3 text-sm text-zinc-500 select-none" aria-hidden="true">
+        $
+      </span>
+      <input
+        id={id}
+        type="text"
+        inputMode="decimal"
+        autoComplete="off"
+        value={value}
+        onChange={(e) => onChange(sanitizeUsdCentsInput(e.target.value))}
+        onBlur={() => {
+          if (value.trim() === "") return;
+          onChange(normalizeUsdCentsDisplay(value));
+        }}
+        placeholder={placeholder}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        className="w-full bg-transparent px-2 py-2 text-sm tabular-nums text-zinc-100 placeholder:text-zinc-600 focus:outline-none disabled:cursor-not-allowed"
+      />
+    </div>
+  );
 }
 
 function catalogLiteFrom(catalog: PipelineCatalogEntry[]): CatalogLite[] {
@@ -655,18 +700,15 @@ function PlanDraftForm({
           </div>
           <div>
           <label htmlFor={`${idPrefix}-included`} className="block text-xs text-zinc-500 mb-1">
-            Included usage allowance (USD)
+            Included usage allowance
           </label>
-          <input
+          <DollarCentsInput
             id={`${idPrefix}-included`}
-            type="number"
-            min="0"
-            step="0.01"
             value={draft.includedUsdDisplay}
-            onChange={(e) => onChange({ ...draft, includedUsdDisplay: e.target.value })}
-            placeholder="e.g. 10.00"
+            onChange={(includedUsdDisplay) => onChange({ ...draft, includedUsdDisplay })}
+            placeholder="10.00"
             disabled={!canEdit}
-            className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-100 disabled:opacity-50"
+            aria-label="Included usage allowance in dollars"
           />
           </div>
         </>
@@ -1149,23 +1191,25 @@ function StarterPlanCard({
   onSaved: () => void | Promise<void>;
 }>) {
   const [expanded, setExpanded] = useState(false);
-  const [includedUsdMicros, setIncludedUsdMicros] = useState(plan.includedUsdMicros ?? "5000000");
+  const [includedUsdDisplay, setIncludedUsdDisplay] = useState(() =>
+    usdMicrosToCentsDisplay(plan.includedUsdMicros ?? "5000000"),
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const syncFailure = planSyncFailureMessage(plan);
 
   useEffect(() => {
     if (expanded) {
-      setIncludedUsdMicros(plan.includedUsdMicros ?? "5000000");
+      setIncludedUsdDisplay(usdMicrosToCentsDisplay(plan.includedUsdMicros ?? "5000000"));
       setError(null);
     }
   }, [expanded, plan.includedUsdMicros]);
 
   const save = async () => {
     if (!canEdit) return;
-    const trimmed = includedUsdMicros.trim();
-    if (!/^\d+$/.test(trimmed)) {
-      setError("Allowance must be a non-negative whole number (USD micros)");
+    const micros = usdCentsDisplayToMicros(includedUsdDisplay);
+    if (micros == null) {
+      setError("Allowance must be a valid dollar amount (e.g. 5.00)");
       return;
     }
     setSaving(true);
@@ -1174,7 +1218,7 @@ function StarterPlanCard({
       const res = await fetch(`/api/v1/apps/${appId}/starter-plan`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ includedUsdMicros: trimmed }),
+        body: JSON.stringify({ includedUsdMicros: micros }),
       });
       const data = await readFetchJson(res);
       if (!data.ok) {
@@ -1234,7 +1278,7 @@ function StarterPlanCard({
           </p>
           {!expanded && plan.includedUsdMicros && (
             <p className="text-sm text-sky-300/90 mt-2">
-              ${usdMicrosToDisplay(plan.includedUsdMicros)} USD included per billing period
+              {formatUsdMicrosDisplay(plan.includedUsdMicros)} included per billing period
             </p>
           )}
           {syncFailure && (
@@ -1256,20 +1300,18 @@ function StarterPlanCard({
 
       {expanded && (
         <div className="relative z-10 space-y-3 border-t border-zinc-800 pt-3">
-          <label className="block text-sm text-zinc-300">
-            Included usage allowance (USD micros){" "}
-            <input
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              value={includedUsdMicros}
-              onChange={(e) => setIncludedUsdMicros(e.target.value)}
-              className="mt-1 w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-zinc-100 font-mono text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+          <div>
+            <label htmlFor="starter-included-usd" className="block text-sm text-zinc-300 mb-1">
+              Included usage allowance
+            </label>
+            <DollarCentsInput
+              id="starter-included-usd"
+              value={includedUsdDisplay}
+              onChange={setIncludedUsdDisplay}
+              disabled={!canEdit}
+              aria-label="Included usage allowance in dollars"
             />
-          </label>
-          <p className="text-xs text-zinc-500">
-            Display: ${usdMicrosToDisplay(includedUsdMicros || "0")} USD · 1,000,000 micros = $1
-          </p>
+          </div>
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
@@ -1410,7 +1452,7 @@ function CustomPlanCard({
           )}
           {plan.includedUsdMicros && (
             <p className="text-xs text-emerald-400/80 mt-1">
-              Includes ${usdMicrosToDisplay(plan.includedUsdMicros)} USD usage
+              Includes {formatUsdMicrosDisplay(plan.includedUsdMicros)} usage
             </p>
           )}
           {plan.type !== "free" && !plan.isNetworkDefault && syncFailure && (

--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -172,7 +172,7 @@ function DollarCentsInput({
         placeholder={placeholder}
         disabled={disabled}
         aria-label={ariaLabel}
-        className="w-full bg-transparent px-2 py-2 text-sm tabular-nums text-zinc-100 placeholder:text-zinc-600 focus:outline-none disabled:cursor-not-allowed"
+        className="w-full bg-transparent px-2 py-2 text-sm tabular-nums text-zinc-100 placeholder:text-zinc-600 focus:outline-hidden disabled:cursor-not-allowed"
       />
     </div>
   );

--- a/src/lib/format-usd-micros.test.ts
+++ b/src/lib/format-usd-micros.test.ts
@@ -4,7 +4,11 @@ import {
   formatUsdMicrosDisplay,
   formatUsdMicrosString,
   hasPositiveUsdMicrosBalance,
+  normalizeUsdCentsDisplay,
   parseUsdMicrosString,
+  sanitizeUsdCentsInput,
+  usdCentsDisplayToMicros,
+  usdMicrosToCentsDisplay,
 } from "./format-usd-micros";
 
 test("formatUsdMicrosString shows sub-$0.0001 fees as a floor label", () => {
@@ -34,4 +38,25 @@ test("formatUsdMicrosDisplay uses fixed $0.00 cents for allowance UI", () => {
   assert.equal(formatUsdMicrosDisplay("0"), "$0.00");
   assert.equal(formatUsdMicrosDisplay("5250000"), "$5.25");
   assert.equal(formatUsdMicrosDisplay("15"), "$0.00");
+});
+
+test("sanitizeUsdCentsInput keeps only dollars and cents", () => {
+  assert.equal(sanitizeUsdCentsInput("$5.00"), "5.00");
+  assert.equal(sanitizeUsdCentsInput("5.999"), "5.99");
+  assert.equal(sanitizeUsdCentsInput("12.3.4"), "12.34");
+  assert.equal(sanitizeUsdCentsInput("abc"), "");
+});
+
+test("usd micros ↔ cents display round-trips at cent precision", () => {
+  assert.equal(usdMicrosToCentsDisplay("5000000"), "5.00");
+  assert.equal(usdMicrosToCentsDisplay("5250000"), "5.25");
+  assert.equal(usdCentsDisplayToMicros("5"), "5000000");
+  assert.equal(usdCentsDisplayToMicros("5.5"), "5500000");
+  assert.equal(usdCentsDisplayToMicros("5.00"), "5000000");
+  assert.equal(usdCentsDisplayToMicros("5."), "5000000");
+  assert.equal(usdCentsDisplayToMicros(""), null);
+  assert.equal(usdCentsDisplayToMicros("5.999"), null);
+  assert.equal(normalizeUsdCentsDisplay("5"), "5.00");
+  assert.equal(normalizeUsdCentsDisplay("5.5"), "5.50");
+  assert.equal(normalizeUsdCentsDisplay("5."), "5.00");
 });

--- a/src/lib/format-usd-micros.ts
+++ b/src/lib/format-usd-micros.ts
@@ -111,10 +111,10 @@ const USD_MICROS_PER_CENT = 10_000n;
  * fraction digits (cents). Strips currency symbols and extra punctuation.
  */
 export function sanitizeUsdCentsInput(raw: string): string {
-  let s = raw.replace(/[^\d.]/g, "");
+  let s = raw.replaceAll(/[^\d.]/g, "");
   const dot = s.indexOf(".");
   if (dot !== -1) {
-    s = `${s.slice(0, dot + 1)}${s.slice(dot + 1).replace(/\./g, "").slice(0, 2)}`;
+    s = `${s.slice(0, dot + 1)}${s.slice(dot + 1).replaceAll(/\./g, "").slice(0, 2)}`;
   }
   return s;
 }
@@ -124,7 +124,7 @@ export function sanitizeUsdCentsInput(raw: string): string {
  * (e.g. `"5000000"` → `"5.00"`). Truncates sub-cent remainders.
  */
 export function usdMicrosToCentsDisplay(microsStr: string | null | undefined): string {
-  return formatUsdMicrosDisplay(microsStr).replace("$", "");
+  return formatUsdMicrosDisplay(microsStr).replaceAll("$", "");
 }
 
 /**

--- a/src/lib/format-usd-micros.ts
+++ b/src/lib/format-usd-micros.ts
@@ -114,7 +114,7 @@ export function sanitizeUsdCentsInput(raw: string): string {
   let s = raw.replaceAll(/[^\d.]/g, "");
   const dot = s.indexOf(".");
   if (dot !== -1) {
-    s = `${s.slice(0, dot + 1)}${s.slice(dot + 1).replaceAll(/\./g, "").slice(0, 2)}`;
+    s = `${s.slice(0, dot + 1)}${s.slice(dot + 1).replaceAll(".", "").slice(0, 2)}`;
   }
   return s;
 }

--- a/src/lib/format-usd-micros.ts
+++ b/src/lib/format-usd-micros.ts
@@ -102,3 +102,55 @@ export function formatUsdMicrosDisplay(microsStr: string | undefined | null): st
     return "$0.00";
   }
 }
+
+/** 1 cent = 10_000 USD micros. */
+const USD_MICROS_PER_CENT = 10_000n;
+
+/**
+ * Sanitize typed USD amount input to non-negative dollars with at most 2
+ * fraction digits (cents). Strips currency symbols and extra punctuation.
+ */
+export function sanitizeUsdCentsInput(raw: string): string {
+  let s = raw.replace(/[^\d.]/g, "");
+  const dot = s.indexOf(".");
+  if (dot !== -1) {
+    s = `${s.slice(0, dot + 1)}${s.slice(dot + 1).replace(/\./g, "").slice(0, 2)}`;
+  }
+  return s;
+}
+
+/**
+ * Convert USD micros to a cents-limited amount string for dollar inputs
+ * (e.g. `"5000000"` → `"5.00"`). Truncates sub-cent remainders.
+ */
+export function usdMicrosToCentsDisplay(microsStr: string | null | undefined): string {
+  return formatUsdMicrosDisplay(microsStr).replace("$", "");
+}
+
+/**
+ * Parse a cents-limited dollar amount (`"5"`, `"5.5"`, `"5.00"`) to an integer
+ * USD micros string. Returns null for empty/invalid input. Storage stays in
+ * micros; the UI never exposes more than cents.
+ */
+export function usdCentsDisplayToMicros(display: string): string | null {
+  const t = display.trim().replace(/\.$/, "");
+  if (!t || !/^\d+(\.\d{1,2})?$/.test(t)) return null;
+  try {
+    const [wholePart, fracPart = ""] = t.split(".");
+    const whole = BigInt(wholePart);
+    const cents = BigInt((fracPart + "00").slice(0, 2));
+    return (whole * USD_MICROS_PER_DOLLAR + cents * USD_MICROS_PER_CENT).toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize a typed dollar amount to fixed cents (`"5"` → `"5.00"`).
+ * Returns the original trimmed string when it is not yet a complete amount.
+ */
+export function normalizeUsdCentsDisplay(display: string): string {
+  const micros = usdCentsDisplayToMicros(display);
+  if (micros == null) return display.trim();
+  return usdMicrosToCentsDisplay(micros);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates plan included-usage allowance fields to use a cents-limited dollar formatter control (e.g. `$5.00`) instead of exposing USD micros or sub-cent precision in the UI.

## Changes
- Add shared helpers to sanitize/parse/normalize dollar cents input and convert to/from micros
- Replace the Starter plan raw micros input with a `$`-prefixed dollar control
- Use the same control for custom subscription included usage allowance
- Continue saving `includedUsdMicros` as integer micros strings (storage precision unchanged; UI capped at cents)

## Testing
- `node --import ./src/test-env.ts --import tsx --test --test-force-exit src/lib/format-usd-micros.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58ff0443-c4b9-479b-b918-0e2d79f6309d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58ff0443-c4b9-479b-b918-0e2d79f6309d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer dollar-and-cents inputs for plan usage allowances.
  * Inputs now sanitize invalid characters, limit values to two decimal places, and normalize amounts when editing is complete.
  * Plan allowances consistently display in readable dollar-and-cents formatting across plan cards and billing periods.

* **Bug Fixes**
  * Improved validation and error handling for incomplete, malformed, or invalid allowance amounts.
  * Preserved cent-level accuracy when saving and displaying usage allowances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->