### PR TITLE
Bump clearinghouse-identity-webhook to 0.4.2

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -69,7 +69,7 @@ Do not pass M2M client secrets as `subject_token` on the signer session exchange
 ### Implementation tasks
 
 - [x] Issue only `app_*_*` from key creation APIs (`formatCompositeApiKey`).
-- [x] Publish `@pymthouse/clearinghouse-identity-webhook` with the matching composite parser (`0.4.1`).
+- [x] Publish `@pymthouse/clearinghouse-identity-webhook` with the matching composite parser (`0.4.2`).
 - [ ] Update integrator docs / dashboard curl snippets when the package is deployed.
 
 ## Authentication

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",
         "@pymthouse/builder-sdk": "^0.5.0",
-        "@pymthouse/clearinghouse-identity-webhook": "^0.4.1",
+        "@pymthouse/clearinghouse-identity-webhook": "^0.4.2",
         "@tailwindcss/postcss": "^4.1.18",
         "@turnkey/crypto": "^2.10.0",
         "@turnkey/react-wallet-kit": "^1.11.1",
@@ -2260,9 +2260,9 @@
       }
     },
     "node_modules/@pymthouse/clearinghouse-identity-webhook": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pymthouse/clearinghouse-identity-webhook/-/clearinghouse-identity-webhook-0.4.1.tgz",
-      "integrity": "sha512-375KJ8EAtqrqj3qZDti/xm3XhvdZibF18NqefVi693RR05aDaX7wRdBB2x/rDgKqeZEJpPAYvUhD9qi+scHb7g==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@pymthouse/clearinghouse-identity-webhook/-/clearinghouse-identity-webhook-0.4.2.tgz",
+      "integrity": "sha512-yHavpaadKSJex8+wRjgO/lDcySAvgeB8xHVXUUtn1c+e1w2XSlq8HboDMGK/ehFjwU7/xs/ECXRSm3dKeKmxSQ==",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.9.6"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@braintree/sanitize-url": "^7.1.2",
     "@openmeter/sdk": "^1.0.0-beta.228",
     "@pymthouse/builder-sdk": "^0.5.0",
-    "@pymthouse/clearinghouse-identity-webhook": "^0.4.1",
+    "@pymthouse/clearinghouse-identity-webhook": "^0.4.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@turnkey/crypto": "^2.10.0",
     "@turnkey/react-wallet-kit": "^1.11.1",


### PR DESCRIPTION
## Summary
- Bump `@pymthouse/clearinghouse-identity-webhook` from `0.4.1` to `0.4.2`
- Update the Builder API docs checklist to reference the new package version

## Test plan
- [ ] Confirm `npm ci` / install resolves `@pymthouse/clearinghouse-identity-webhook@0.4.2`
- [ ] Smoke remote-signer webhook authorize path still imports protocol / verifiers / balance-gate from the package