### PR TITLE
feat: add scripts for managing legacy usage tables and cleanup of test apps

### DIFF
--- a/.github/workflows/deploy-production-vercel.yml
+++ b/.github/workflows/deploy-production-vercel.yml
@@ -7,8 +7,13 @@ name: Deploy production (Vercel)
 # Enable with repository variable:
 #   VERCEL_PRODUCTION_AUTO_DEPLOY=true
 #
-# Required secret:
-#   VERCEL_TOKEN
+# Required secrets:
+#   VERCEL_TOKEN (repository)
+#   DATABASE_URL (environment `vercel / production`) — Neon production Postgres URL
+#   NEXTAUTH_SECRET, AUTH_TOKEN_PEPPER (environment `vercel / production`)
+#
+# DB migrations run in this workflow before the Vercel build. Vercel itself still
+# skips `db:prepare` when VERCEL=1 (see package.json prebuild).
 #
 # Recommended: disable native Git auto-builds on the pymthouse Vercel project
 # (Settings → Git → Ignored Build Step: exit 1) so only this workflow deploys prod.
@@ -63,6 +68,16 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Apply production DB migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "DATABASE_URL is required on GitHub environment 'vercel / production'." >&2
+            exit 1
+          fi
+          npm run db:migrate
 
       - name: Install Vercel CLI
         run: npm install -g vercel@latest

--- a/drizzle/0029_drop_legacy_usage_tables_repair.sql
+++ b/drizzle/0029_drop_legacy_usage_tables_repair.sql
@@ -1,0 +1,5 @@
+-- Repair: 0021_drop_legacy_usage_tables was skipped on some branches where
+-- later migrations already advanced drizzle.__drizzle_migrations.created_at.
+-- Idempotent; safe if tables are already gone.
+DROP TABLE IF EXISTS "usage_billing_events";
+DROP TABLE IF EXISTS "usage_records";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1778800000000,
       "tag": "0028_onramp_turnkey_organization",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1778900000000,
+      "tag": "0029_drop_legacy_usage_tables_repair",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bootstrap": "npx tsx scripts/bootstrap-admin.ts",
     "db:prepare": "npx tsx scripts/db-migrate.ts",
     "api-keys:hard-cutover": "npx tsx scripts/api-keys-hard-cutover.ts",
+    "cleanup:fixture-test-apps": "npx tsx scripts/cleanup-fixture-test-apps.ts",
     "oidc:seed": "npx tsx scripts/seed-oidc.ts",
     "openmeter:bootstrap": "npx tsx scripts/openmeter-bootstrap.ts",
     "openmeter:ensure-customer": "npx tsx scripts/openmeter-ensure-customer.ts",

--- a/scripts/check-legacy-usage-tables.ts
+++ b/scripts/check-legacy-usage-tables.ts
@@ -1,0 +1,60 @@
+/**
+ * One-shot: report and optionally drop legacy usage ledger tables.
+ *
+ *   npx tsx scripts/check-legacy-usage-tables.ts
+ *   npx tsx scripts/check-legacy-usage-tables.ts --drop
+ */
+import "./load-env-first";
+import postgres from "postgres";
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!databaseUrl) throw new Error("DATABASE_URL is required.");
+
+  const drop = process.argv.includes("--drop");
+  const sql = postgres(databaseUrl, { max: 1 });
+  try {
+    const host = databaseUrl.match(/@([^/]+)/)?.[1] ?? "?";
+    const [tables] = await sql<{
+      usage_records: string | null;
+      usage_billing_events: string | null;
+    }[]>`
+      SELECT to_regclass('public.usage_records')::text AS usage_records,
+             to_regclass('public.usage_billing_events')::text AS usage_billing_events
+    `;
+    const [counts] = await sql<{ matching: number }[]>`
+      SELECT COUNT(*)::int AS matching
+      FROM developer_apps
+      WHERE name ~ '^Test App [0-9a-f]{8}$'
+    `;
+    console.log({
+      host,
+      usage_records: tables.usage_records,
+      usage_billing_events: tables.usage_billing_events,
+      matching_test_apps: counts.matching,
+    });
+
+    if (!drop) {
+      console.log("Re-run with --drop to DROP TABLE IF EXISTS both legacy tables.");
+      return;
+    }
+
+    await sql`DROP TABLE IF EXISTS usage_billing_events`;
+    await sql`DROP TABLE IF EXISTS usage_records`;
+    const [after] = await sql<{
+      usage_records: string | null;
+      usage_billing_events: string | null;
+    }[]>`
+      SELECT to_regclass('public.usage_records')::text AS usage_records,
+             to_regclass('public.usage_billing_events')::text AS usage_billing_events
+    `;
+    console.log("Dropped. Now:", after);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-fixture-test-apps.ts
+++ b/scripts/cleanup-fixture-test-apps.ts
@@ -1,0 +1,128 @@
+/**
+ * Remove leaked test-fixture developer apps from a database.
+ *
+ * Matches only names like `Test App d6595404` (exactly "Test App " + 8 hex
+ * chars). Does not touch apps named plain "Test App" or other real apps.
+ *
+ * Also removes the fixture `user-test-*` owner rows (and any `app-user-*`
+ * users that belonged only to those apps) after the apps are deleted.
+ *
+ * Usage:
+ *   npx tsx scripts/cleanup-fixture-test-apps.ts --dry-run
+ *   npx tsx scripts/cleanup-fixture-test-apps.ts --execute
+ */
+
+import "./load-env-first";
+import { eq, inArray, sql } from "drizzle-orm";
+
+import { closeDb, db } from "../src/db/index";
+import { appUsers, developerApps, users } from "../src/db/schema";
+import { deleteDeveloperAppAndRelatedData } from "../src/lib/delete-developer-app";
+
+/** Same pattern as seedDeveloperAppWithClient: `Test App ${uuid.slice(0, 8)}`. */
+const FIXTURE_APP_NAME_RE = /^Test App [0-9a-f]{8}$/;
+
+function hasFlag(flag: string): boolean {
+  return process.argv.slice(2).includes(flag);
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required.");
+  }
+
+  const execute = hasFlag("--execute");
+  const dryRun = hasFlag("--dry-run") || !execute;
+
+  const allApps = await db
+    .select({
+      id: developerApps.id,
+      name: developerApps.name,
+      ownerId: developerApps.ownerId,
+      oidcClientId: developerApps.oidcClientId,
+      createdAt: developerApps.createdAt,
+    })
+    .from(developerApps)
+    .orderBy(developerApps.createdAt);
+
+  const targets = allApps.filter((app) => FIXTURE_APP_NAME_RE.test(app.name));
+
+  if (targets.length === 0) {
+    console.log("No developer apps match /^Test App [0-9a-f]{8}$/.");
+    return;
+  }
+
+  const targetIds = targets.map((app) => app.id);
+  const ownerIds = [...new Set(targets.map((app) => app.ownerId))];
+
+  const appUserRows = await db
+    .select({ id: appUsers.id, clientId: appUsers.clientId })
+    .from(appUsers)
+    .where(inArray(appUsers.clientId, targetIds));
+  const appUserIds = appUserRows.map((row) => row.id);
+
+  console.log(
+    `${dryRun ? "[dry-run]" : "[execute]"} ${targets.length} fixture app(s):`,
+  );
+  for (const app of targets) {
+    console.log(`  - ${app.name}  id=${app.id}  owner=${app.ownerId}  created=${app.createdAt}`);
+  }
+  console.log(`  owners to remove after apps: ${ownerIds.length}`);
+  console.log(`  app_users under those apps: ${appUserIds.length}`);
+
+  if (dryRun) {
+    console.log("Re-run with --execute to delete these apps and fixture users.");
+    return;
+  }
+
+  let deletedApps = 0;
+  for (const app of targets) {
+    await deleteDeveloperAppAndRelatedData(app.id, app.oidcClientId);
+    deletedApps += 1;
+    console.log(`  deleted app ${app.name} (${app.id})`);
+  }
+
+  // Fixture createAppUser() inserts matching users rows with the same id.
+  if (appUserIds.length > 0) {
+    const removedAppUsers = await db
+      .delete(users)
+      .where(inArray(users.id, appUserIds))
+      .returning({ id: users.id });
+    console.log(`  deleted ${removedAppUsers.length} app-user fixture user(s)`);
+  }
+
+  // Only remove owners that look like test fixtures and no longer own any app.
+  const fixtureOwners = ownerIds.filter((id) => id.startsWith("user-test-"));
+  let deletedOwners = 0;
+  for (const ownerId of fixtureOwners) {
+    const remaining = await db
+      .select({ id: developerApps.id })
+      .from(developerApps)
+      .where(eq(developerApps.ownerId, ownerId))
+      .limit(1);
+    if (remaining.length > 0) {
+      console.log(`  skip owner ${ownerId}: still owns other apps`);
+      continue;
+    }
+    await db.delete(users).where(eq(users.id, ownerId));
+    deletedOwners += 1;
+  }
+
+  const leftover = await db.execute<{ count: string }>(
+    sql`SELECT COUNT(*)::text AS count FROM developer_apps WHERE name ~ '^Test App [0-9a-f]{8}$'`,
+  );
+  console.log(
+    `[execute] Deleted ${deletedApps} app(s) and ${deletedOwners} fixture owner(s). ` +
+      `Matching apps remaining: ${leftover[0]?.count ?? "?"}.`,
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/src/lib/delete-developer-app.ts
+++ b/src/lib/delete-developer-app.ts
@@ -2,13 +2,19 @@ import { db } from "@/db/index";
 import {
   apiKeys,
   appAllowedDomains,
+  appBillingConfig,
+  appBillingOauthStates,
+  appBillingOracleConfig,
+  appOpenMeterConfig,
   appUsers,
   authAuditLog,
   developerApps,
+  discoveryProfileBundles,
   discoveryProfiles,
   endUsers,
   oidcClients,
   oidcPayloads,
+  onrampSessions,
   planCapabilityBundles,
   plans,
   providerAdmins,
@@ -17,6 +23,7 @@ import {
   streamSessions,
   subscriptions,
   transactions,
+  usageIngestReceipts,
 } from "@/db/schema";
 import { eq, inArray, or, sql } from "drizzle-orm";
 
@@ -103,10 +110,37 @@ export async function deleteDeveloperAppAndRelatedData(
     await tx.delete(sessions).where(eq(sessions.appId, appInternalId));
     await tx.delete(signerConfig).where(eq(signerConfig.clientId, appInternalId));
 
+    await tx.delete(usageIngestReceipts).where(eq(usageIngestReceipts.clientId, appInternalId));
+    await tx.delete(appOpenMeterConfig).where(eq(appOpenMeterConfig.clientId, appInternalId));
+    await tx.delete(appBillingConfig).where(eq(appBillingConfig.clientId, appInternalId));
+    await tx.delete(appBillingOauthStates).where(eq(appBillingOauthStates.clientId, appInternalId));
+    await tx.delete(appBillingOracleConfig).where(eq(appBillingOracleConfig.clientId, appInternalId));
+    await tx.delete(discoveryProfileBundles).where(eq(discoveryProfileBundles.clientId, appInternalId));
+    await tx.delete(onrampSessions).where(eq(onrampSessions.clientId, appInternalId));
+
+    // Legacy ledger tables dropped by 0021; still present on some DBs that skipped it.
+    await dropLegacyUsageRowsIfPresent(tx, appInternalId);
+
     await tx.delete(developerApps).where(eq(developerApps.id, appInternalId));
 
     for (const pk of oidcPkList) {
       await tx.delete(oidcClients).where(eq(oidcClients.id, pk));
     }
   });
+}
+
+async function dropLegacyUsageRowsIfPresent(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  appInternalId: string,
+): Promise<void> {
+  for (const table of ["usage_billing_events", "usage_records"] as const) {
+    const existsRows = await tx.execute<{ exists: boolean }>(
+      sql`SELECT to_regclass(${`public.${table}`}) IS NOT NULL AS exists`,
+    );
+    const row = existsRows[0] as { exists: boolean } | undefined;
+    if (!row?.exists) continue;
+    await tx.execute(
+      sql`DELETE FROM ${sql.identifier(table)} WHERE client_id = ${appInternalId}`,
+    );
+  }
 }


### PR DESCRIPTION
- Introduced `cleanup:fixture-test-apps` script to remove leaked test-fixture developer apps and associated users.
- Added `check-legacy-usage-tables` script to report and optionally drop legacy usage ledger tables.
- Created SQL migration `0029_drop_legacy_usage_tables_repair.sql` to safely drop legacy tables if they exist.
- Updated `deleteDeveloperAppAndRelatedData` function to handle additional related data deletions for legacy usage tables.