### PR TITLE
perf(signer): reduce first-request latency in remote signer webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,18 @@ ETH_USD_PRICE=3500
 # OIDC_JWKS_URI=http://localhost:3001/api/v1/oidc/jwks
 # OIDC_EXCHANGE_M2M_CLIENT_ID=
 # OIDC_EXCHANGE_M2M_CLIENT_SECRET=
+# Remote-signer balance gate tuning:
+# SIGNER_BALANCE_CACHE_TTL_SECONDS (default 20, 0 disables) — short-lived
+#   in-memory cache + request coalescing for spendable-balance lookups, so
+#   concurrent webhook calls for the same identity share one OpenMeter/Neon
+#   fan-out.
+# SIGNER_BALANCE_REAUTH_TTL_SECONDS (default 60) — caps how long go-livepeer
+#   caches a successful authorization before re-checking balance. Raising it
+#   (e.g. 120–300) cuts webhook traffic and first-request latency pressure, but
+#   widens the window in which an exhausted balance can keep spending; the
+#   worst-case overspend is roughly (spend rate x TTL).
+# SIGNER_BALANCE_CACHE_TTL_SECONDS=20
+# SIGNER_BALANCE_REAUTH_TTL_SECONDS=60
 # ---------- OpenMeter (usage metering + trial credits) ----------
 # Local: docker compose -f docker-compose.openmeter.yml up -d && npm run openmeter:bootstrap
 # Hosted Konnect/OpenMeter (production): OPENMETER_URL=https://{region}.api.konghq.com/v3/openmeter

--- a/src/app/webhooks/remote-signer/route.ts
+++ b/src/app/webhooks/remote-signer/route.ts
@@ -1,14 +1,28 @@
+import type { RemoteSignerWebhookConfig } from "@pymthouse/clearinghouse-identity-webhook/protocol";
 import { handleAuthorize } from "@pymthouse/clearinghouse-identity-webhook/protocol";
 import { buildRemoteSignerWebhookConfig } from "@/lib/oidc/remote-signer-webhook-config";
+import { timeSignerWebhookPhase } from "@/lib/oidc/signer-webhook-metrics";
+
+/**
+ * Built once per process (issue #248): retaining the config keeps the OIDC
+ * verifier's JWKS keyset, composite token-exchange cache, and balance-check
+ * cache warm across invocations instead of rebuilding them per request.
+ */
+let cachedConfig: RemoteSignerWebhookConfig | null = null;
+
+function getWebhookConfig(): RemoteSignerWebhookConfig {
+  cachedConfig ??= buildRemoteSignerWebhookConfig();
+  return cachedConfig;
+}
 
 export async function POST(request: Request): Promise<Response> {
-  const webhookSecret = process.env.WEBHOOK_SECRET?.trim() || "";
-  if (!webhookSecret) {
+  const config = getWebhookConfig();
+  if (!config.webhookSecret) {
     return Response.json(
       { status: 500, reason: "server misconfiguration" },
       { status: 500 },
     );
   }
 
-  return handleAuthorize(request, buildRemoteSignerWebhookConfig());
+  return timeSignerWebhookPhase("total", () => handleAuthorize(request, config));
 }

--- a/src/lib/oidc/local-signer-jwks.test.ts
+++ b/src/lib/oidc/local-signer-jwks.test.ts
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as jose from "jose";
+import { createLocalSignerJwksResolver } from "@/lib/oidc/local-signer-jwks";
+
+const ISSUER = "https://pymthouse.com/api/v1/oidc";
+
+async function makeSigningKey(kid: string) {
+  const { publicKey, privateKey } = await jose.generateKeyPair("RS256");
+  const jwk = await jose.exportJWK(publicKey);
+  jwk.kid = kid;
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+  return { jwk, privateKey };
+}
+
+async function signToken(privateKey: jose.CryptoKey, kid: string) {
+  return new jose.SignJWT({ scope: "sign:job" })
+    .setProtectedHeader({ alg: "RS256", kid })
+    .setIssuer(ISSUER)
+    .setAudience(ISSUER)
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(privateKey);
+}
+
+test("local signer JWKS resolver verifies tokens and caches the keyset", async () => {
+  const key = await makeSigningKey("kid-1");
+  let loads = 0;
+  const resolver = createLocalSignerJwksResolver({
+    loadJwks: async () => {
+      loads += 1;
+      return { keys: [key.jwk] };
+    },
+  });
+
+  const token = await signToken(key.privateKey, "kid-1");
+  for (let i = 0; i < 3; i += 1) {
+    const { payload } = await jose.jwtVerify(token, resolver, {
+      issuer: ISSUER,
+      audience: ISSUER,
+    });
+    assert.equal(payload.iss, ISSUER);
+  }
+  assert.equal(loads, 1);
+});
+
+test("local signer JWKS resolver coalesces concurrent initial loads", async () => {
+  const key = await makeSigningKey("kid-1");
+  let loads = 0;
+  const resolver = createLocalSignerJwksResolver({
+    loadJwks: async () => {
+      loads += 1;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return { keys: [key.jwk] };
+    },
+  });
+
+  const token = await signToken(key.privateKey, "kid-1");
+  await Promise.all(
+    Array.from({ length: 5 }, () =>
+      jose.jwtVerify(token, resolver, { issuer: ISSUER, audience: ISSUER }),
+    ),
+  );
+  assert.equal(loads, 1);
+});
+
+test("local signer JWKS resolver reloads after rotation to an unknown kid", async () => {
+  const oldKey = await makeSigningKey("kid-old");
+  const newKey = await makeSigningKey("kid-new");
+  let keys = [oldKey.jwk];
+  let loads = 0;
+  let nowMs = 0;
+  const resolver = createLocalSignerJwksResolver({
+    loadJwks: async () => {
+      loads += 1;
+      return { keys };
+    },
+    now: () => nowMs,
+  });
+
+  const oldToken = await signToken(oldKey.privateKey, "kid-old");
+  await jose.jwtVerify(oldToken, resolver, { issuer: ISSUER, audience: ISSUER });
+  assert.equal(loads, 1);
+
+  keys = [oldKey.jwk, newKey.jwk];
+  nowMs += 60_000; // past the forced-refresh floor, within the TTL
+  const newToken = await signToken(newKey.privateKey, "kid-new");
+  const { protectedHeader } = await jose.jwtVerify(newToken, resolver, {
+    issuer: ISSUER,
+    audience: ISSUER,
+  });
+  assert.equal(protectedHeader.kid, "kid-new");
+  assert.equal(loads, 2);
+});
+
+test("local signer JWKS resolver does not hammer reloads for unknown kids", async () => {
+  const key = await makeSigningKey("kid-1");
+  const rogue = await makeSigningKey("kid-rogue");
+  let loads = 0;
+  const resolver = createLocalSignerJwksResolver({
+    loadJwks: async () => {
+      loads += 1;
+      return { keys: [key.jwk] };
+    },
+  });
+
+  const good = await signToken(key.privateKey, "kid-1");
+  await jose.jwtVerify(good, resolver, { issuer: ISSUER, audience: ISSUER });
+
+  const bad = await signToken(rogue.privateKey, "kid-rogue");
+  await assert.rejects(
+    jose.jwtVerify(bad, resolver, { issuer: ISSUER, audience: ISSUER }),
+    jose.errors.JWKSNoMatchingKey,
+  );
+  // Keyset was just loaded, so the unknown kid must not trigger another load.
+  assert.equal(loads, 1);
+});

--- a/src/lib/oidc/local-signer-jwks.ts
+++ b/src/lib/oidc/local-signer-jwks.ts
@@ -1,0 +1,74 @@
+import * as jose from "jose";
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+/** Floor between forced refreshes on unknown `kid`, so bad tokens cannot hammer the DB. */
+const MIN_REFRESH_INTERVAL_MS = 10 * 1000;
+
+export type LocalJwksResolverOptions = {
+  /** JWKS loader; defaults to the DB-backed {@link import("./jwks").getPublicJWKS}. */
+  loadJwks?: () => Promise<jose.JSONWebKeySet>;
+  /** How long a loaded keyset is reused before reloading. */
+  ttlMs?: number;
+  /** Clock override for tests. */
+  now?: () => number;
+};
+
+async function loadPublicJwksFromDb(): Promise<jose.JSONWebKeySet> {
+  const { getPublicJWKS } = await import("@/lib/oidc/jwks");
+  return getPublicJWKS();
+}
+
+/**
+ * jose key resolver backed by this deployment's own signing keys (DB), so the
+ * remote-signer webhook never performs OIDC discovery / JWKS HTTP requests
+ * against itself. The keyset is cached per process and refreshed when it
+ * expires or when a token references an unknown `kid` (key rotation).
+ */
+export function createLocalSignerJwksResolver(
+  options: LocalJwksResolverOptions = {},
+): jose.JWTVerifyGetKey {
+  const loadJwks = options.loadJwks ?? loadPublicJwksFromDb;
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const now = options.now ?? Date.now;
+
+  let keyset: jose.JWTVerifyGetKey | null = null;
+  let loadedAtMs = 0;
+  let inflight: Promise<jose.JWTVerifyGetKey> | null = null;
+
+  async function refresh(): Promise<jose.JWTVerifyGetKey> {
+    inflight ??= loadJwks()
+      .then((jwks) => {
+        keyset = jose.createLocalJWKSet(jwks);
+        loadedAtMs = now();
+        return keyset;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+    return inflight;
+  }
+
+  async function currentKeyset(): Promise<jose.JWTVerifyGetKey> {
+    if (keyset && now() - loadedAtMs < ttlMs) {
+      return keyset;
+    }
+    return refresh();
+  }
+
+  return async (protectedHeader, token) => {
+    const resolver = await currentKeyset();
+    try {
+      return await resolver(protectedHeader, token);
+    } catch (err) {
+      const staleForMs = now() - loadedAtMs;
+      if (
+        err instanceof jose.errors.JWKSNoMatchingKey &&
+        staleForMs >= MIN_REFRESH_INTERVAL_MS
+      ) {
+        const refreshed = await refresh();
+        return refreshed(protectedHeader, token);
+      }
+      throw err;
+    }
+  };
+}

--- a/src/lib/oidc/local-signer-jwks.ts
+++ b/src/lib/oidc/local-signer-jwks.ts
@@ -3,6 +3,8 @@ import * as jose from "jose";
 const DEFAULT_TTL_MS = 5 * 60 * 1000;
 /** Floor between forced refreshes on unknown `kid`, so bad tokens cannot hammer the DB. */
 const MIN_REFRESH_INTERVAL_MS = 10 * 1000;
+/** Bound DB JWKS loads so a hung Neon query fails the verify path instead of stalling it. */
+const DEFAULT_LOAD_TIMEOUT_MS = 5_000;
 
 export type LocalJwksResolverOptions = {
   /** JWKS loader; defaults to the DB-backed {@link import("./jwks").getPublicJWKS}. */
@@ -13,9 +15,33 @@ export type LocalJwksResolverOptions = {
   now?: () => number;
 };
 
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 async function loadPublicJwksFromDb(): Promise<jose.JSONWebKeySet> {
   const { getPublicJWKS } = await import("@/lib/oidc/jwks");
-  return getPublicJWKS();
+  return withTimeout(
+    getPublicJWKS(),
+    DEFAULT_LOAD_TIMEOUT_MS,
+    "local JWKS load timed out",
+  );
 }
 
 /**

--- a/src/lib/oidc/remote-signer-webhook-config.ts
+++ b/src/lib/oidc/remote-signer-webhook-config.ts
@@ -1,12 +1,17 @@
 import type { RemoteSignerWebhookConfig } from "@pymthouse/clearinghouse-identity-webhook/protocol";
-import { createEndUserVerifierFromEnv } from "@pymthouse/clearinghouse-identity-webhook/verifiers";
+import {
+  createEndUserVerifierFromEnv,
+  createOidcVerifier,
+} from "@pymthouse/clearinghouse-identity-webhook/verifiers";
 import {
   OIDC_MOUNT_PATH,
   ensureHttpsForProduction,
   getIssuer,
   getPublicOrigin,
 } from "@/lib/oidc/issuer-urls";
+import { createLocalSignerJwksResolver } from "@/lib/oidc/local-signer-jwks";
 import { buildSignerBalanceCheck } from "@/lib/oidc/signer-balance-gate";
+import { timeSignerWebhookPhase } from "@/lib/oidc/signer-webhook-metrics";
 import { buildOwnerCustomerKey } from "@/lib/openmeter/customer-key";
 import { trimTrailingSlashes } from "@/lib/openapi/string-utils";
 
@@ -114,6 +119,90 @@ export function resolveIdentityWebhookEnv(env: EnvSource): Record<string, string
   return next;
 }
 
+/** App origin serving this webhook, matching the env source used for issuer resolution. */
+function resolveAppOrigin(source: EnvSource, original: EnvSource): string {
+  const fromEnv = trimEnv(source, "NEXTAUTH_URL");
+  if (fromEnv) {
+    return trimTrailingSlashes(ensureHttpsForProduction(fromEnv));
+  }
+  return original === process.env ? getPublicOrigin() : "";
+}
+
+/** True when the JWT issuer is served by this deployment (self-issued tokens). */
+function isSelfIssuedJwtIssuer(jwtIssuer: string, appOrigin: string): boolean {
+  if (!jwtIssuer || !appOrigin) {
+    return false;
+  }
+  try {
+    return new URL(jwtIssuer).origin === new URL(appOrigin).origin;
+  } catch {
+    return false;
+  }
+}
+
+/** fetch wrapper that logs composite token-exchange latency per request. */
+function createTimedExchangeFetch(): typeof fetch {
+  return (input, init) =>
+    timeSignerWebhookPhase("token_exchange", () => fetch(input, init));
+}
+
+function parseRequiredScopes(source: EnvSource): string[] {
+  return trimEnv(source, "OIDC_REQUIRED_SCOPES").split(/[\s,]+/).filter(Boolean);
+}
+
+/**
+ * The identity-webhook package bundles its own jose whose JWK type differs
+ * nominally (kty required vs optional) from the app's jose. The resolver is
+ * runtime-compatible, so bridge the two declaration trees with a direct cast.
+ */
+type OidcVerifierJwks = NonNullable<Parameters<typeof createOidcVerifier>[0]["jwks"]>;
+
+/**
+ * Build the end-user verifier. For self-issued OIDC tokens (the normal
+ * PymtHouse deployment) the verifier is constructed directly with a local
+ * DB-backed JWKS resolver, so warm invocations never perform OIDC discovery
+ * or JWKS HTTP requests back to this same host. An explicit OIDC_JWKS_URI or
+ * an external issuer falls back to the package's env-driven verifier.
+ */
+function buildEndUserVerifier(
+  source: Record<string, string | undefined>,
+  original: EnvSource,
+): EndUserVerifier {
+  const jwtIssuer = trimEnv(source, "OIDC_ISSUER");
+  const selfIssued =
+    source.IDENTITY_AUTH_MODE === "oidc" &&
+    !trimEnv(source, "OIDC_JWKS_URI") &&
+    isSelfIssuedJwtIssuer(jwtIssuer, resolveAppOrigin(source, original));
+
+  if (!selfIssued) {
+    return createEndUserVerifierFromEnv(source);
+  }
+
+  return createOidcVerifier({
+    jwtIssuer,
+    jwtAudience: trimEnv(source, "OIDC_AUDIENCE") || jwtIssuer,
+    jwks: createLocalSignerJwksResolver() as OidcVerifierJwks,
+    issuer: trimEnv(source, "IDENTITY_ISSUER") || jwtIssuer,
+    clientClaim: trimEnv(source, "OIDC_CLIENT_CLAIM") || undefined,
+    subjectClaim: trimEnv(source, "OIDC_SUBJECT_CLAIM") || undefined,
+    subjectTypeValue: trimEnv(source, "OIDC_SUBJECT_TYPE") || undefined,
+    requiredScopes: parseRequiredScopes(source),
+    tokenExchangeBaseUrl: trimEnv(source, "OIDC_TOKEN_EXCHANGE_BASE_URL") || undefined,
+    exchangeM2mClientId: trimEnv(source, "OIDC_EXCHANGE_M2M_CLIENT_ID") || undefined,
+    exchangeM2mClientSecret:
+      trimEnv(source, "OIDC_EXCHANGE_M2M_CLIENT_SECRET") || undefined,
+    fetchImpl: createTimedExchangeFetch(),
+  });
+}
+
+function withPhaseTiming(verifier: EndUserVerifier): EndUserVerifier {
+  return {
+    ...verifier,
+    verify: (input) =>
+      timeSignerWebhookPhase("end_user_verify", () => verifier.verify(input)),
+  };
+}
+
 /**
  * Build the remote-signer webhook config. Issuer / claim / exchange defaults are
  * applied in {@link resolveIdentityWebhookEnv}; only NEXTAUTH_URL is required
@@ -122,15 +211,19 @@ export function resolveIdentityWebhookEnv(env: EnvSource): Record<string, string
 export function buildRemoteSignerWebhookConfig(
   env?: NodeJS.ProcessEnv | Record<string, string | undefined>,
 ): RemoteSignerWebhookConfig {
-  const source = resolveIdentityWebhookEnv(env ?? process.env);
+  const original = env ?? process.env;
+  const source = resolveIdentityWebhookEnv(original);
   const config: RemoteSignerWebhookConfig = {
     webhookSecret: source.WEBHOOK_SECRET?.trim() || "",
-    endUserAuth: withOwnerBillingUsageSubject(createEndUserVerifierFromEnv(source)),
+    endUserAuth: withPhaseTiming(
+      withOwnerBillingUsageSubject(buildEndUserVerifier(source, original)),
+    ),
   };
 
   const checkBalance = buildSignerBalanceCheck();
   if (checkBalance) {
-    config.checkBalance = checkBalance;
+    config.checkBalance = (ctx) =>
+      timeSignerWebhookPhase("balance_check", async () => checkBalance(ctx));
   }
   return config;
 }

--- a/src/lib/oidc/signer-balance-gate.test.ts
+++ b/src/lib/oidc/signer-balance-gate.test.ts
@@ -87,3 +87,70 @@ test("spendable balance cache is disabled when ttl is zero", async () => {
   assert.equal(await cached(identity("user-1")), "7");
   assert.equal(calls, 2);
 });
+
+test("spendable balance cache stays bounded when every entry is inflight", async () => {
+  const maxEntries = 3;
+  let calls = 0;
+  let blockLookups = true;
+  const waiters: Array<() => void> = [];
+  const cached = createSpendableBalanceCache({
+    ttlSeconds: 60,
+    maxEntries,
+    getBalance: async (id) => {
+      calls += 1;
+      if (blockLookups) {
+        await new Promise<void>((resolve) => {
+          waiters.push(resolve);
+        });
+      }
+      return id.usage_subject;
+    },
+  });
+
+  const pending = [
+    cached(identity("user-0")),
+    cached(identity("user-1")),
+    cached(identity("user-2")),
+    cached(identity("user-3")),
+  ];
+  assert.equal(calls, 4);
+  assert.equal(waiters.length, 4);
+
+  for (const release of waiters) {
+    release();
+  }
+  await Promise.all(pending);
+
+  // Completions re-insert via setBounded; size stays at maxEntries, so the
+  // oldest identity from the burst is no longer cached.
+  blockLookups = false;
+  const callsAfterBurst = calls;
+  assert.equal(await cached(identity("user-1")), "user-1");
+  assert.equal(await cached(identity("user-2")), "user-2");
+  assert.equal(await cached(identity("user-3")), "user-3");
+  assert.equal(calls, callsAfterBurst);
+  assert.equal(await cached(identity("user-0")), "user-0");
+  assert.equal(calls, callsAfterBurst + 1);
+});
+
+test("spendable balance cache evicts oldest resolved entries at capacity", async () => {
+  let calls = 0;
+  const cached = createSpendableBalanceCache({
+    ttlSeconds: 60,
+    maxEntries: 2,
+    getBalance: async (id) => {
+      calls += 1;
+      return id.usage_subject;
+    },
+  });
+
+  assert.equal(await cached(identity("x")), "x");
+  assert.equal(await cached(identity("y")), "y");
+  assert.equal(await cached(identity("z")), "z"); // evicts x
+  assert.equal(calls, 3);
+  assert.equal(await cached(identity("y")), "y");
+  assert.equal(await cached(identity("z")), "z");
+  assert.equal(calls, 3);
+  assert.equal(await cached(identity("x")), "x");
+  assert.equal(calls, 4);
+});

--- a/src/lib/oidc/signer-balance-gate.test.ts
+++ b/src/lib/oidc/signer-balance-gate.test.ts
@@ -133,6 +133,38 @@ test("spendable balance cache stays bounded when every entry is inflight", async
   assert.equal(calls, callsAfterBurst + 1);
 });
 
+test("spendable balance cache repeats a lookup evicted while inflight", async () => {
+  let calls = 0;
+  const waiters: Array<() => void> = [];
+  const cached = createSpendableBalanceCache({
+    ttlSeconds: 60,
+    maxEntries: 1,
+    getBalance: async (id) => {
+      calls += 1;
+      await new Promise<void>((resolve) => {
+        waiters.push(resolve);
+      });
+      return id.usage_subject;
+    },
+  });
+
+  const first = cached(identity("user-1"));
+  const second = cached(identity("user-2"));
+  const repeatedFirst = cached(identity("user-1"));
+
+  assert.equal(calls, 3);
+  assert.equal(waiters.length, 3);
+
+  for (const release of waiters) {
+    release();
+  }
+  assert.deepEqual(await Promise.all([first, second, repeatedFirst]), [
+    "user-1",
+    "user-2",
+    "user-1",
+  ]);
+});
+
 test("spendable balance cache evicts oldest resolved entries at capacity", async () => {
   let calls = 0;
   const cached = createSpendableBalanceCache({

--- a/src/lib/oidc/signer-balance-gate.test.ts
+++ b/src/lib/oidc/signer-balance-gate.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { UsageIdentity } from "@pymthouse/clearinghouse-identity-webhook/protocol";
+import { createSpendableBalanceCache } from "@/lib/oidc/signer-balance-gate";
+
+function identity(subject: string): UsageIdentity {
+  return {
+    issuer: "https://pymthouse.com/api/v1/oidc",
+    client_id: "app_3b386c81a1db1169fd2c3986",
+    usage_subject: subject,
+    usage_subject_type: "external_user_id",
+  };
+}
+
+test("spendable balance cache serves repeat lookups within the TTL", async () => {
+  let calls = 0;
+  let nowMs = 0;
+  const cached = createSpendableBalanceCache({
+    ttlSeconds: 20,
+    getBalance: async () => {
+      calls += 1;
+      return "1000000";
+    },
+    now: () => nowMs,
+  });
+
+  assert.equal(await cached(identity("user-1")), "1000000");
+  nowMs += 5_000;
+  assert.equal(await cached(identity("user-1")), "1000000");
+  assert.equal(calls, 1);
+
+  nowMs += 20_000;
+  assert.equal(await cached(identity("user-1")), "1000000");
+  assert.equal(calls, 2);
+});
+
+test("spendable balance cache coalesces concurrent lookups per identity", async () => {
+  let calls = 0;
+  const cached = createSpendableBalanceCache({
+    ttlSeconds: 20,
+    getBalance: async (id) => {
+      calls += 1;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return id.usage_subject === "user-1" ? "111" : "222";
+    },
+  });
+
+  const results = await Promise.all([
+    cached(identity("user-1")),
+    cached(identity("user-1")),
+    cached(identity("user-2")),
+  ]);
+
+  assert.deepEqual(results, ["111", "111", "222"]);
+  assert.equal(calls, 2);
+});
+
+test("spendable balance cache does not cache failures", async () => {
+  let calls = 0;
+  const cached = createSpendableBalanceCache({
+    ttlSeconds: 20,
+    getBalance: async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("openmeter unavailable");
+      }
+      return "42";
+    },
+  });
+
+  await assert.rejects(cached(identity("user-1")), /openmeter unavailable/);
+  assert.equal(await cached(identity("user-1")), "42");
+  assert.equal(calls, 2);
+});
+
+test("spendable balance cache is disabled when ttl is zero", async () => {
+  let calls = 0;
+  const cached = createSpendableBalanceCache({
+    ttlSeconds: 0,
+    getBalance: async () => {
+      calls += 1;
+      return "7";
+    },
+  });
+
+  assert.equal(await cached(identity("user-1")), "7");
+  assert.equal(await cached(identity("user-1")), "7");
+  assert.equal(calls, 2);
+});

--- a/src/lib/oidc/signer-balance-gate.ts
+++ b/src/lib/oidc/signer-balance-gate.ts
@@ -46,9 +46,12 @@ export function createSpendableBalanceCache(options: {
   ttlSeconds: number;
   getBalance: (identity: UsageIdentity) => Promise<string | null>;
   now?: () => number;
+  /** Override for tests; production uses {@link BALANCE_CACHE_MAX_ENTRIES}. */
+  maxEntries?: number;
 }): (identity: UsageIdentity) => Promise<string | null> {
   const { ttlSeconds, getBalance } = options;
   const now = options.now ?? Date.now;
+  const maxEntries = options.maxEntries ?? BALANCE_CACHE_MAX_ENTRIES;
 
   if (ttlSeconds <= 0) {
     return getBalance;
@@ -56,18 +59,19 @@ export function createSpendableBalanceCache(options: {
 
   const entries = new Map<string, BalanceCacheEntry>();
 
-  function evictIfFull(): void {
-    if (entries.size < BALANCE_CACHE_MAX_ENTRIES) {
-      return;
+  /** Insert/update while keeping `entries.size <= maxEntries` (evicts oldest first). */
+  function setBounded(key: string, entry: BalanceCacheEntry): void {
+    if (entries.has(key)) {
+      entries.delete(key);
     }
-    for (const [key, entry] of entries) {
-      if (entries.size < BALANCE_CACHE_MAX_ENTRIES) {
+    while (entries.size >= maxEntries) {
+      const oldestKey = entries.keys().next().value;
+      if (oldestKey === undefined) {
         break;
       }
-      if (!entry.inflight) {
-        entries.delete(key);
-      }
+      entries.delete(oldestKey);
     }
+    entries.set(key, entry);
   }
 
   return (identity) => {
@@ -85,7 +89,7 @@ export function createSpendableBalanceCache(options: {
 
     const inflight = getBalance(identity).then(
       (value) => {
-        entries.set(key, { expiresAtMs: now() + ttlSeconds * 1000, value });
+        setBounded(key, { expiresAtMs: now() + ttlSeconds * 1000, value });
         return value;
       },
       (err) => {
@@ -94,8 +98,7 @@ export function createSpendableBalanceCache(options: {
       },
     );
 
-    evictIfFull();
-    entries.set(key, { expiresAtMs: now() + ttlSeconds * 1000, inflight });
+    setBounded(key, { expiresAtMs: now() + ttlSeconds * 1000, inflight });
     return inflight;
   };
 }

--- a/src/lib/oidc/signer-balance-gate.ts
+++ b/src/lib/oidc/signer-balance-gate.ts
@@ -7,17 +7,97 @@ import { isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
 import { getSpendableUsdMicros } from "@/lib/openmeter/spendable-allowance";
 
 const DEFAULT_REAUTH_TTL_SECONDS = 60;
+const DEFAULT_BALANCE_CACHE_TTL_SECONDS = 20;
+const BALANCE_CACHE_MAX_ENTRIES = 1000;
 
-function resolveReauthTtlSeconds(): number {
-  const raw = process.env.SIGNER_BALANCE_REAUTH_TTL_SECONDS?.trim();
+function resolvePositiveSecondsEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
   if (!raw) {
-    return DEFAULT_REAUTH_TTL_SECONDS;
+    return fallback;
   }
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return DEFAULT_REAUTH_TTL_SECONDS;
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
   }
   return parsed;
+}
+
+function resolveReauthTtlSeconds(): number {
+  const ttl = resolvePositiveSecondsEnv(
+    "SIGNER_BALANCE_REAUTH_TTL_SECONDS",
+    DEFAULT_REAUTH_TTL_SECONDS,
+  );
+  return ttl > 0 ? ttl : DEFAULT_REAUTH_TTL_SECONDS;
+}
+
+type BalanceCacheEntry = {
+  expiresAtMs: number;
+  value?: string | null;
+  inflight?: Promise<string | null>;
+};
+
+/**
+ * Short-lived keyed cache with singleflight for spendable-balance lookups
+ * (issue #248). Concurrent webhook calls for the same identity share one
+ * OpenMeter/Neon fan-out, and repeat calls within the TTL are served from
+ * memory. Failed lookups are never cached, so transient errors retry.
+ */
+export function createSpendableBalanceCache(options: {
+  ttlSeconds: number;
+  getBalance: (identity: UsageIdentity) => Promise<string | null>;
+  now?: () => number;
+}): (identity: UsageIdentity) => Promise<string | null> {
+  const { ttlSeconds, getBalance } = options;
+  const now = options.now ?? Date.now;
+
+  if (ttlSeconds <= 0) {
+    return getBalance;
+  }
+
+  const entries = new Map<string, BalanceCacheEntry>();
+
+  function evictIfFull(): void {
+    if (entries.size < BALANCE_CACHE_MAX_ENTRIES) {
+      return;
+    }
+    for (const [key, entry] of entries) {
+      if (entries.size < BALANCE_CACHE_MAX_ENTRIES) {
+        break;
+      }
+      if (!entry.inflight) {
+        entries.delete(key);
+      }
+    }
+  }
+
+  return (identity) => {
+    const key = `${identity.client_id}\u0000${identity.usage_subject}`;
+    const existing = entries.get(key);
+    if (existing) {
+      if (existing.inflight) {
+        return existing.inflight;
+      }
+      if (existing.expiresAtMs > now()) {
+        return Promise.resolve(existing.value ?? null);
+      }
+      entries.delete(key);
+    }
+
+    const inflight = getBalance(identity).then(
+      (value) => {
+        entries.set(key, { expiresAtMs: now() + ttlSeconds * 1000, value });
+        return value;
+      },
+      (err) => {
+        entries.delete(key);
+        throw err;
+      },
+    );
+
+    evictIfFull();
+    entries.set(key, { expiresAtMs: now() + ttlSeconds * 1000, inflight });
+    return inflight;
+  };
 }
 
 /**
@@ -42,8 +122,15 @@ export function buildSignerBalanceCheck(): BalanceCheck | undefined {
   if (!isHostedAdminClientAvailable()) {
     return undefined;
   }
+  const cachedBalance = createSpendableBalanceCache({
+    ttlSeconds: resolvePositiveSecondsEnv(
+      "SIGNER_BALANCE_CACHE_TTL_SECONDS",
+      DEFAULT_BALANCE_CACHE_TTL_SECONDS,
+    ),
+    getBalance: readIdentityBalanceUsdMicros,
+  });
   return createBalanceGate({
-    getBalanceUsdMicros: (identity) => readIdentityBalanceUsdMicros(identity),
+    getBalanceUsdMicros: (identity) => cachedBalance(identity),
     reauthTtlSeconds: resolveReauthTtlSeconds(),
     failClosed: true,
     onError: (err) => {

--- a/src/lib/oidc/signer-webhook-metrics.ts
+++ b/src/lib/oidc/signer-webhook-metrics.ts
@@ -1,0 +1,38 @@
+/**
+ * Phase-level latency logging for the remote-signer webhook (issue #248).
+ * One structured line per phase so cold/warm latency is observable per
+ * invocation: end-user verification, composite token exchange, balance
+ * lookup, and total webhook duration.
+ */
+
+export type SignerWebhookPhase =
+  | "end_user_verify"
+  | "token_exchange"
+  | "balance_check"
+  | "total";
+
+export function logSignerWebhookPhase(
+  phase: SignerWebhookPhase,
+  durationMs: number,
+  ok: boolean,
+): void {
+  console.info(
+    `[remote-signer] phase=${phase} duration_ms=${Math.round(durationMs)} ok=${ok}`,
+  );
+}
+
+/** Run `fn`, log its duration under `phase`, and re-throw failures unchanged. */
+export async function timeSignerWebhookPhase<T>(
+  phase: SignerWebhookPhase,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+  try {
+    const result = await fn();
+    logSignerWebhookPhase(phase, performance.now() - startedAt, true);
+    return result;
+  } catch (err) {
+    logSignerWebhookPhase(phase, performance.now() - startedAt, false);
+    throw err;
+  }
+}

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -1,4 +1,5 @@
 import type { OpenMeter } from "@openmeter/sdk";
+import type { ResolvedBillingIdentity } from "@/lib/openmeter/billing-identity";
 import {
   CREATE_SIGNED_TICKET_EVENT_TYPE,
   getHostedOpenMeterUrl,
@@ -68,6 +69,8 @@ export async function getTrialCreditBalance(input: {
   clientId: string;
   externalUserId: string;
   featureKey?: string;
+  /** Pre-resolved billing identity — avoids a duplicate DB lookup when the caller already has it. */
+  identity?: ResolvedBillingIdentity;
 }): Promise<TrialCreditBalance | null> {
   const client = getHostedTrialOpenMeterClient();
   if (!client) {
@@ -77,10 +80,12 @@ export async function getTrialCreditBalance(input: {
   const { resolveOpenMeterBillingIdentity } = await import(
     "@/lib/openmeter/billing-identity"
   );
-  const identity = await resolveOpenMeterBillingIdentity({
-    clientId: input.clientId,
-    externalUserId: input.externalUserId,
-  });
+  const identity =
+    input.identity ??
+    (await resolveOpenMeterBillingIdentity({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+    }));
   const customerKey = identity.customerKey;
   const featureKey =
     input.featureKey || (await getTrialFeatureKeyForApp(identity.developerAppId));

--- a/src/lib/openmeter/spendable-allowance.ts
+++ b/src/lib/openmeter/spendable-allowance.ts
@@ -7,7 +7,10 @@ import {
   getHostedAdminClient,
   isHostedAdminClientAvailable,
 } from "@/lib/openmeter/admin-client";
-import { resolveOpenMeterBillingIdentity } from "@/lib/openmeter/billing-identity";
+import {
+  resolveOpenMeterBillingIdentity,
+  type ResolvedBillingIdentity,
+} from "@/lib/openmeter/billing-identity";
 import { NETWORK_FEE_USD_MICROS_METER } from "@/lib/openmeter/constants";
 import { buildOwnerMeterSubjects } from "@/lib/openmeter/customer-key";
 import {
@@ -82,15 +85,19 @@ async function querySubjectsUsedUsdMicros(
 export async function getRemainingPlanDiscountUsdMicros(input: {
   clientId: string;
   externalUserId: string;
+  /** Pre-resolved billing identity — avoids a duplicate DB lookup when the caller already has it. */
+  identity?: ResolvedBillingIdentity;
 }): Promise<bigint> {
   if (!isHostedAdminClientAvailable()) {
     return 0n;
   }
 
-  const identity = await resolveOpenMeterBillingIdentity({
-    clientId: input.clientId,
-    externalUserId: input.externalUserId,
-  });
+  const identity =
+    input.identity ??
+    (await resolveOpenMeterBillingIdentity({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+    }));
 
   const subscription = await getPrimaryOpenMeterSubscriptionForAppUser({
     clientId: identity.publicClientId,
@@ -170,12 +177,20 @@ export async function getSpendableUsdMicros(input: {
     return null;
   }
 
+  // Resolve the billing identity once and share it across both lookups so the
+  // webhook balance gate performs a single Neon identity round-trip (#248).
+  const identity = await resolveOpenMeterBillingIdentity({
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+  });
+
   const [credits, discountRemaining] = await Promise.all([
     getTrialCreditBalance({
       clientId: input.clientId,
       externalUserId: input.externalUserId,
+      identity,
     }),
-    getRemainingPlanDiscountUsdMicros(input),
+    getRemainingPlanDiscountUsdMicros({ ...input, identity }),
   ]);
 
   const creditMicros = BigInt(credits?.balanceUsdMicros ?? "0");


### PR DESCRIPTION
Closes #248

## Summary

- **Module-scope webhook config**: `POST /webhooks/remote-signer` now builds the config/OIDC verifier once per process instead of per request, so the JWKS keyset, composite token-exchange cache, and balance cache stay warm across invocations.
- **No more OIDC self-HTTP**: when the JWT issuer is this deployment (the normal case), tokens are verified against a local, DB-backed JWKS resolver (`src/lib/oidc/local-signer-jwks.ts`) with a 5-minute cache and rotation-aware refresh on unknown `kid`. An explicit `OIDC_JWKS_URI` or an external issuer keeps the previous env-driven path.
- **Phase-level latency metrics**: each invocation logs structured `[remote-signer] phase=… duration_ms=… ok=…` lines for `end_user_verify`, `token_exchange` (composite keys), `balance_check`, and `total`, so cold vs. warm latency is observable per phase.
- **Balance-check cache + singleflight**: spendable-balance lookups are coalesced per identity and cached for `SIGNER_BALANCE_CACHE_TTL_SECONDS` (default 20s, 0 disables). Failures are never cached, and the gate still fails closed.
- **Deduped identity resolution**: `getSpendableUsdMicros()` resolves the OpenMeter billing identity once and shares it with the credits and plan-discount lookups, removing duplicate Neon round-trips per check.
- **TTL tradeoff documented**: `.env.example` now documents `SIGNER_BALANCE_REAUTH_TTL_SECONDS` (raising to 120–300s cuts webhook traffic; worst-case overspend ≈ spend rate × TTL) alongside the new cache TTL.

Out of scope (coordinated caller changes tracked in the issue): go-livepeer configurable webhook timeout, livepeer-python-gateway `/generate-live-payment` timeout alignment, and removing the nested composite-key token exchange (lives in `@pymthouse/clearinghouse-identity-webhook`).

## Test plan

- [x] `npm test` — 362/362 passing, including new suites for the local JWKS resolver (cache, coalescing, rotation refresh, refresh-floor) and the balance cache (TTL, singleflight, no failure caching, disable via 0)
- [x] `tsc --noEmit` clean on `src/` and `eslint` clean on all touched files
- [ ] After deploy: confirm warm invocations log no discovery/JWKS fetches and `phase=total` p99 fits the caller timeout budget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for self-issued OIDC tokens during remote-signer authentication.
  * Introduced local signing-key (JWKS) verification with caching and automatic refresh after rotation.
  * Added configurable spendable-balance caching with concurrent request coalescing, bounded capacity, and optional disabling via TTL.
  * Streamlined entitlement/allowance calculations by reusing resolved billing identity when available.

* **Improvements**
  * Added remote-signer webhook timing metrics for end-user verification, token exchange, balance checks, and total processing.
  * Documented new balance-cache and re-authorization tuning settings in the environment example.

* **Tests**
  * Added coverage for JWKS loading/refresh and balance-cache TTL, coalescing, and eviction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->