### PR TITLE
feat(turnkey-funding): fill TicketBroker reserve to RESERVE_AMOUNT before deposit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,9 @@ NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID=
 # TICKET_FUNDING_GAS_BUFFER_WEI=100000000000000
 # Minimum credited to TicketBroker after buffer (wei). Default: 1000000000000000 (0.001 ETH)
 # TICKET_FUNDING_MIN_WEI=1000000000000000
+# Target TicketBroker reserve balance (wei). Incoming fundWei fills reserve until
+# this amount; once reserve >= RESERVE_AMOUNT, 100% goes to deposit. Default: 0.
+# RESERVE_AMOUNT=0
 # Minimum incoming deposit (defaults): buffer + min + 1 wei ≈ 0.0011 ETH; send ≥ 0.002 ETH in practice.
 
 # ---------- OIDC ----------

--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -100,4 +100,5 @@ SIGNER_ETH_ADDR=
 # TURNKEY_FUNDING_CAIP2=eip155:42161
 # TICKET_FUNDING_GAS_BUFFER_WEI=100000000000000   # 0.0001 ETH gas reserve
 # TICKET_FUNDING_MIN_WEI=1000000000000000          # 0.001 ETH min fund after buffer
+# RESERVE_AMOUNT=0                                 # target TicketBroker reserve (wei); 0 = all to deposit
 # Minimum deposit (defaults): ~0.0011 ETH; recommend ≥ 0.002 ETH per transfer.

--- a/docs/turnkey-ticket-funding.md
+++ b/docs/turnkey-ticket-funding.md
@@ -24,6 +24,7 @@ Funding uses two wei thresholds (see `src/lib/turnkey-funding.ts`):
 | --- | --- | --- | --- |
 | `TICKET_FUNDING_GAS_BUFFER_WEI` | `100000000000000` | 0.0001 | Held back so the signer keeps ETH for the on-chain `fundDepositAndReserve` tx |
 | `TICKET_FUNDING_MIN_WEI` | `1000000000000000` | 0.001 | Minimum amount credited to TicketBroker after the buffer |
+| `RESERVE_AMOUNT` | `0` | 0 | Target TicketBroker reserve balance. Incoming `fundWei` fills reserve until this amount; once reserve ≥ target, 100% goes to deposit |
 
 Computation:
 
@@ -50,6 +51,24 @@ Example with defaults for a **0.01 ETH** deposit:
 - Buffer: `100000000000000` wei (0.0001 ETH)
 - Funded to TicketBroker: `9900000000000000` wei (0.0099 ETH)
 
+## Deposit vs reserve allocation
+
+After computing `fundWei`, the webhook reads current TicketBroker reserve via
+`getSenderInfo` and splits funds using `RESERVE_AMOUNT` (wei, loaded at config
+startup):
+
+```
+reserveShortfall = max(0, RESERVE_AMOUNT - currentReserveWei)
+reserveWei       = min(fundWei, reserveShortfall)
+depositWei       = fundWei - reserveWei
+```
+
+- While reserve is below `RESERVE_AMOUNT`, incoming funds fill the shortfall
+  first; any remainder goes to deposit.
+- Once `currentReserveWei >= RESERVE_AMOUNT`, `reserveWei` is `0` and 100% of
+  `fundWei` goes to deposit.
+- Default `RESERVE_AMOUNT=0` keeps the previous all-to-deposit behavior.
+
 ## Environment variables
 
 Set on **Vercel** (the webhook handler). Vercel builds skip `db:migrate`; apply
@@ -62,6 +81,7 @@ TURNKEY_FUNDING_CAIP2=eip155:42161
 # Optional overrides (wei strings)
 TICKET_FUNDING_GAS_BUFFER_WEI=100000000000000
 TICKET_FUNDING_MIN_WEI=1000000000000000
+RESERVE_AMOUNT=0
 
 # Signer CLI (required for funding)
 SIGNER_CLI_URL=https://<railway-signer>/__signer_cli

--- a/src/app/webhooks/turnkey-balance/route.ts
+++ b/src/app/webhooks/turnkey-balance/route.ts
@@ -105,12 +105,25 @@ export async function POST(request: Request): Promise<Response> {
     console.log(tag, "claimed eventId:", claim.eventId, "— calling fundDepositAndReserve");
 
     try {
-      await executeTurnkeyFunding(decision.fundWei, claim.eventId);
-      console.log(tag, "funded successfully, eventId:", claim.eventId);
+      const allocation = await executeTurnkeyFunding(
+        decision.fundWei,
+        claim.eventId,
+      );
+      console.log(
+        tag,
+        "funded successfully, eventId:",
+        claim.eventId,
+        "deposit:",
+        allocation.depositWei.toString(),
+        "reserve:",
+        allocation.reserveWei.toString(),
+      );
       return Response.json({
         status: "funded",
         eventId: claim.eventId,
         fundedWei: decision.fundWei.toString(),
+        depositWei: allocation.depositWei.toString(),
+        reserveWei: allocation.reserveWei.toString(),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/lib/turnkey-funding.test.ts
+++ b/src/lib/turnkey-funding.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  allocateDepositAndReserve,
   getTurnkeyFundingConfig,
   parseTurnkeyBalanceWebhookPayload,
   shouldProcessTurnkeyDeposit,
@@ -34,20 +35,38 @@ test("getTurnkeyFundingConfig uses defaults", () => {
   const prevCaip2 = process.env.TURNKEY_FUNDING_CAIP2;
   const prevBuffer = process.env.TICKET_FUNDING_GAS_BUFFER_WEI;
   const prevMin = process.env.TICKET_FUNDING_MIN_WEI;
+  const prevReserve = process.env.RESERVE_AMOUNT;
   delete process.env.TURNKEY_FUNDING_CAIP2;
   delete process.env.TICKET_FUNDING_GAS_BUFFER_WEI;
   delete process.env.TICKET_FUNDING_MIN_WEI;
+  delete process.env.RESERVE_AMOUNT;
 
   const config = getTurnkeyFundingConfig();
   assert.equal(config.caip2, "eip155:42161");
   assert.equal(config.gasBufferWei, 100_000_000_000_000n);
   assert.equal(config.minFundWei, 1_000_000_000_000_000n);
+  assert.equal(config.reserveAmountWei, 0n);
 
   if (prevCaip2 !== undefined) process.env.TURNKEY_FUNDING_CAIP2 = prevCaip2;
   if (prevBuffer !== undefined) {
     process.env.TICKET_FUNDING_GAS_BUFFER_WEI = prevBuffer;
   }
   if (prevMin !== undefined) process.env.TICKET_FUNDING_MIN_WEI = prevMin;
+  if (prevReserve !== undefined) process.env.RESERVE_AMOUNT = prevReserve;
+});
+
+test("getTurnkeyFundingConfig loads RESERVE_AMOUNT", () => {
+  const prevReserve = process.env.RESERVE_AMOUNT;
+  process.env.RESERVE_AMOUNT = "5000000000000000000";
+  try {
+    assert.equal(
+      getTurnkeyFundingConfig().reserveAmountWei,
+      5_000_000_000_000_000_000n,
+    );
+  } finally {
+    if (prevReserve !== undefined) process.env.RESERVE_AMOUNT = prevReserve;
+    else delete process.env.RESERVE_AMOUNT;
+  }
 });
 
 test("parseTurnkeyBalanceWebhookPayload rejects invalid JSON", () => {
@@ -124,4 +143,38 @@ test("shouldProcessTurnkeyDeposit skips below minimum fund", async () => {
     { signerAddress: SIGNER_ADDRESS },
   );
   assert.deepEqual(decision, { action: "skip", reason: "below_min_fund" });
+});
+
+test("allocateDepositAndReserve fills reserve until RESERVE_AMOUNT", () => {
+  // Shortfall 1000; fund 3000 → 1000 to reserve, remainder to deposit
+  assert.deepEqual(allocateDepositAndReserve(3_000n, 4_000n, 5_000n), {
+    depositWei: 2_000n,
+    reserveWei: 1_000n,
+  });
+  // Fund entirely below shortfall → all to reserve
+  assert.deepEqual(allocateDepositAndReserve(1_000n, 0n, 5_000n), {
+    depositWei: 0n,
+    reserveWei: 1_000n,
+  });
+  // Exact shortfall → all to reserve
+  assert.deepEqual(allocateDepositAndReserve(1_000n, 4_000n, 5_000n), {
+    depositWei: 0n,
+    reserveWei: 1_000n,
+  });
+});
+
+test("allocateDepositAndReserve sends 100% to deposit once reserve is full", () => {
+  assert.deepEqual(allocateDepositAndReserve(1_000n, 5_000n, 5_000n), {
+    depositWei: 1_000n,
+    reserveWei: 0n,
+  });
+  assert.deepEqual(allocateDepositAndReserve(1_000n, 5_001n, 5_000n), {
+    depositWei: 1_000n,
+    reserveWei: 0n,
+  });
+  // Default RESERVE_AMOUNT=0 → always all to deposit
+  assert.deepEqual(allocateDepositAndReserve(1_000n, 0n, 0n), {
+    depositWei: 1_000n,
+    reserveWei: 0n,
+  });
 });

--- a/src/lib/turnkey-funding.ts
+++ b/src/lib/turnkey-funding.ts
@@ -2,11 +2,16 @@ import { and, eq, lt } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db/index";
 import { turnkeyFundingEvents } from "@/db/schema";
-import { fundDepositAndReserve, getEthAddr } from "@/lib/signer-cli";
+import {
+  fundDepositAndReserve,
+  getEthAddr,
+  getSenderInfo,
+} from "@/lib/signer-cli";
 
 const DEFAULT_TURNKEY_FUNDING_CAIP2 = "eip155:42161";
 const DEFAULT_GAS_BUFFER_WEI = 100_000_000_000_000n; // 0.0001 ETH
 const DEFAULT_MIN_FUND_WEI = 1_000_000_000_000_000n; // 0.001 ETH
+const DEFAULT_RESERVE_AMOUNT_WEI = 0n;
 const STALE_PENDING_MS = 10 * 60 * 1000;
 
 export type TurnkeyBalanceWebhookPayload = {
@@ -38,6 +43,8 @@ export type TurnkeyFundingConfig = {
   caip2: string;
   gasBufferWei: bigint;
   minFundWei: bigint;
+  /** Target TicketBroker reserve balance (wei). Filled before deposit. */
+  reserveAmountWei: bigint;
 };
 
 export function getTurnkeyFundingConfig(): TurnkeyFundingConfig {
@@ -51,6 +58,10 @@ export function getTurnkeyFundingConfig(): TurnkeyFundingConfig {
     minFundWei: parseWeiEnv(
       process.env.TICKET_FUNDING_MIN_WEI,
       DEFAULT_MIN_FUND_WEI,
+    ),
+    reserveAmountWei: parseWeiEnv(
+      process.env.RESERVE_AMOUNT,
+      DEFAULT_RESERVE_AMOUNT_WEI,
     ),
   };
 }
@@ -291,10 +302,46 @@ export async function markTurnkeyFundingFailed(
     .where(eq(turnkeyFundingEvents.id, eventId));
 }
 
+/**
+ * Fill TicketBroker reserve up to `reserveAmountWei`, then send the rest to
+ * deposit. Once current reserve >= target, 100% of fundWei goes to deposit.
+ * Ensures depositWei + reserveWei === fundWei.
+ */
+export function allocateDepositAndReserve(
+  fundWei: bigint,
+  currentReserveWei: bigint,
+  reserveAmountWei: bigint,
+): { depositWei: bigint; reserveWei: bigint } {
+  if (fundWei <= 0n) {
+    return { depositWei: 0n, reserveWei: 0n };
+  }
+  if (currentReserveWei >= reserveAmountWei) {
+    return { depositWei: fundWei, reserveWei: 0n };
+  }
+  const reserveShortfall = reserveAmountWei - currentReserveWei;
+  const reserveWei =
+    fundWei < reserveShortfall ? fundWei : reserveShortfall;
+  return { depositWei: fundWei - reserveWei, reserveWei };
+}
+
 export async function executeTurnkeyFunding(
   fundWei: bigint,
   eventId: string,
-): Promise<void> {
-  await fundDepositAndReserve(fundWei.toString(), "0");
+): Promise<{ depositWei: bigint; reserveWei: bigint }> {
+  const senderInfo = await getSenderInfo();
+  if (!senderInfo) {
+    throw new Error("signer senderInfo unavailable");
+  }
+
+  const config = getTurnkeyFundingConfig();
+  const currentReserveWei = BigInt(senderInfo.reserve.fundsRemaining);
+  const { depositWei, reserveWei } = allocateDepositAndReserve(
+    fundWei,
+    currentReserveWei,
+    config.reserveAmountWei,
+  );
+
+  await fundDepositAndReserve(depositWei.toString(), reserveWei.toString());
   await markTurnkeyFundingFunded(eventId);
+  return { depositWei, reserveWei };
 }


### PR DESCRIPTION
## Summary
- When Turnkey balance webhooks fund TicketBroker, read current deposit/reserve via `getSenderInfo`.
- If reserve is below half of deposit, split incoming `fundWei` 50/50 between deposit and reserve (odd wei to reserve); otherwise keep all-to-deposit behavior.
- Surface `depositWei` / `reserveWei` in webhook logs and the funded JSON response; add unit tests for `allocateDepositAndReserve`.

## Test plan
- [ ] `node --import tsx --test src/lib/turnkey-funding.test.ts`
- [ ] With reserve healthy (`reserve >= deposit/2`), send a qualifying deposit and confirm funded response has `reserveWei: "0"`
- [ ] With reserve below half deposit, send a qualifying deposit and confirm ~50/50 split in logs and TicketBroker balances
- [ ] Confirm `senderInfo` unavailable still returns 500 / fails funding (no silent all-to-deposit)