### PR TITLE
Default Get API Key display to Token instead of Bearer

### DIFF
--- a/src/components/apps/ApiKeyCredentialSwitcher.tsx
+++ b/src/components/apps/ApiKeyCredentialSwitcher.tsx
@@ -111,7 +111,7 @@ export default function ApiKeyCredentialSwitcher({
   apiKey: string;
   sdkToken?: string | null;
 }>): ReactNode {
-  const [format, setFormat] = useState<ApiKeyDisplayFormat>("bearer");
+  const [format, setFormat] = useState<ApiKeyDisplayFormat>("token");
   const hasToken = Boolean(sdkToken?.trim());
   const showToken = hasToken && format === "token";
   const value = showToken ? sdkToken!.trim() : apiKey;


### PR DESCRIPTION
## Summary
- When clicking **Get API Key**, the credential format slider now defaults to **Token** (Python SDK `--token`) instead of **Bearer**.

## Test plan
- [ ] Open an app and click **Get API Key**
- [ ] Confirm the Token option is selected by default and the base64 SDK token is shown
- [ ] Toggle to Bearer and confirm the raw API key still displays correctly
- [ ] If no `sdkToken` is present, confirm the slider is hidden and the raw key still shows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default credential display to use the token format when an SDK token is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->