### PR TITLE
fix(openmeter): Konnect events.list subject filter for signed-ticket history

### DIFF
--- a/src/lib/openmeter/konnect-routes.test.ts
+++ b/src/lib/openmeter/konnect-routes.test.ts
@@ -86,6 +86,42 @@ test("rewriteKonnectRequestUrl maps customer subscriptions to filtered list", ()
   assert.equal(rewritten.searchParams.get("page[size]"), "100");
 });
 
+test("rewriteKonnectRequestUrl maps events.list subject/limit/from/to to Konnect filters", () => {
+  const url = new URL(
+    "https://us.api.konghq.com/v3/openmeter/api/v1/events?subject=uuid-owner-1&limit=50&from=2026-07-01T00:00:00.000Z&to=2026-07-31T23:59:59.999Z",
+  );
+  const rewritten = rewriteKonnectRequestUrl(url, "GET");
+  assert.equal(rewritten.pathname, "/v3/openmeter/events");
+  assert.equal(rewritten.searchParams.get("filter[subject][eq]"), "uuid-owner-1");
+  assert.equal(rewritten.searchParams.get("page[size]"), "50");
+  assert.equal(
+    rewritten.searchParams.get("filter[time][gte]"),
+    "2026-07-01T00:00:00.000Z",
+  );
+  assert.equal(
+    rewritten.searchParams.get("filter[time][lte]"),
+    "2026-07-31T23:59:59.999Z",
+  );
+  assert.equal(rewritten.searchParams.get("subject"), null);
+  assert.equal(rewritten.searchParams.get("limit"), null);
+  assert.equal(rewritten.searchParams.get("from"), null);
+  assert.equal(rewritten.searchParams.get("to"), null);
+});
+
+test("rewriteKonnectRequestUrl maps multiple event subjects to oeq", () => {
+  const url = new URL("https://us.api.konghq.com/v3/openmeter/api/v1/events");
+  url.searchParams.append("subject", "uuid-1");
+  url.searchParams.append("subject", "owner:uuid-1");
+  url.searchParams.set("limit", "25");
+  const rewritten = rewriteKonnectRequestUrl(url, "GET");
+  assert.equal(
+    rewritten.searchParams.get("filter[subject][oeq]"),
+    "uuid-1,owner:uuid-1",
+  );
+  assert.equal(rewritten.searchParams.get("filter[subject][eq]"), null);
+  assert.equal(rewritten.searchParams.get("page[size]"), "25");
+});
+
 test("unwrapOpenMeterListResult accepts arrays and Konnect page envelopes", () => {
   assert.deepEqual(unwrapOpenMeterListResult([{ id: "1" }]), [{ id: "1" }]);
   assert.deepEqual(unwrapOpenMeterListResult({ data: [{ id: "2" }] }), [{ id: "2" }]);

--- a/src/lib/openmeter/konnect-routes.ts
+++ b/src/lib/openmeter/konnect-routes.ts
@@ -116,29 +116,60 @@ export function rewriteKonnectSearchParams(
   return params;
 }
 
-function rewriteKonnectEventsListParams(params: URLSearchParams): void {
-  const subjects = params
-    .getAll("subject")
+function takeTrimmedParamValues(
+  params: URLSearchParams,
+  key: string,
+): string[] {
+  const values = params
+    .getAll(key)
     .map((value) => value.trim())
     .filter((value) => value.length > 0);
-  params.delete("subject");
-  if (subjects.length === 1) {
-    params.set("filter[subject][eq]", subjects[0]);
-  } else if (subjects.length > 1) {
-    // Konnect supports comma-delimited exact match via oeq.
-    params.set("filter[subject][oeq]", subjects.join(","));
-  }
+  params.delete(key);
+  return values;
+}
 
-  const customerIds = params
-    .getAll("customerId")
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0);
-  params.delete("customerId");
-  if (customerIds.length === 1) {
-    params.set("filter[customer_id][eq]", customerIds[0]);
-  } else if (customerIds.length > 1) {
-    params.set("filter[customer_id][oeq]", customerIds.join(","));
+/** Map multi-value SDK params to Konnect filter[field][eq|oeq]. */
+function setKonnectEqOrOeqFilter(
+  params: URLSearchParams,
+  filterField: string,
+  values: string[],
+): void {
+  if (values.length === 1) {
+    params.set(`filter[${filterField}][eq]`, values[0]);
+    return;
   }
+  if (values.length > 1) {
+    // Konnect supports comma-delimited exact match via oeq.
+    params.set(`filter[${filterField}][oeq]`, values.join(","));
+  }
+}
+
+function moveParamToKonnectFilter(
+  params: URLSearchParams,
+  sourceKey: string,
+  filterKey: string,
+): void {
+  if (!params.has(sourceKey)) {
+    return;
+  }
+  const value = params.get(sourceKey)?.trim();
+  params.delete(sourceKey);
+  if (value) {
+    params.set(filterKey, value);
+  }
+}
+
+function rewriteKonnectEventsListParams(params: URLSearchParams): void {
+  setKonnectEqOrOeqFilter(
+    params,
+    "subject",
+    takeTrimmedParamValues(params, "subject"),
+  );
+  setKonnectEqOrOeqFilter(
+    params,
+    "customer_id",
+    takeTrimmedParamValues(params, "customerId"),
+  );
 
   if (params.has("limit")) {
     const limit = params.get("limit");
@@ -148,35 +179,10 @@ function rewriteKonnectEventsListParams(params: URLSearchParams): void {
     }
   }
 
-  if (params.has("from")) {
-    const from = params.get("from");
-    params.delete("from");
-    if (from?.trim()) {
-      params.set("filter[time][gte]", from.trim());
-    }
-  }
-  if (params.has("to")) {
-    const to = params.get("to");
-    params.delete("to");
-    if (to?.trim()) {
-      params.set("filter[time][lte]", to.trim());
-    }
-  }
-
-  if (params.has("ingestedAtFrom")) {
-    const from = params.get("ingestedAtFrom");
-    params.delete("ingestedAtFrom");
-    if (from?.trim()) {
-      params.set("filter[ingested_at][gte]", from.trim());
-    }
-  }
-  if (params.has("ingestedAtTo")) {
-    const to = params.get("ingestedAtTo");
-    params.delete("ingestedAtTo");
-    if (to?.trim()) {
-      params.set("filter[ingested_at][lte]", to.trim());
-    }
-  }
+  moveParamToKonnectFilter(params, "from", "filter[time][gte]");
+  moveParamToKonnectFilter(params, "to", "filter[time][lte]");
+  moveParamToKonnectFilter(params, "ingestedAtFrom", "filter[ingested_at][gte]");
+  moveParamToKonnectFilter(params, "ingestedAtTo", "filter[ingested_at][lte]");
 }
 
 export function rewriteKonnectRequestUrl(url: URL, method: string): URL {

--- a/src/lib/openmeter/konnect-routes.ts
+++ b/src/lib/openmeter/konnect-routes.ts
@@ -105,7 +105,78 @@ export function rewriteKonnectSearchParams(
     }
   }
 
+  // OpenMeter SDK events.list uses subject/limit/from/to; Konnect expects
+  // filter[subject][eq], page[size], and filter[time][gte|lte]. Without this,
+  // subject is ignored and the latest global events are returned — drowning out
+  // the viewer's own signed-ticket history under busy platform traffic.
+  if (method.toUpperCase() === "GET" && /\/events\/?$/.test(normalizedPath)) {
+    rewriteKonnectEventsListParams(params);
+  }
+
   return params;
+}
+
+function rewriteKonnectEventsListParams(params: URLSearchParams): void {
+  const subjects = params
+    .getAll("subject")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  params.delete("subject");
+  if (subjects.length === 1) {
+    params.set("filter[subject][eq]", subjects[0]);
+  } else if (subjects.length > 1) {
+    // Konnect supports comma-delimited exact match via oeq.
+    params.set("filter[subject][oeq]", subjects.join(","));
+  }
+
+  const customerIds = params
+    .getAll("customerId")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  params.delete("customerId");
+  if (customerIds.length === 1) {
+    params.set("filter[customer_id][eq]", customerIds[0]);
+  } else if (customerIds.length > 1) {
+    params.set("filter[customer_id][oeq]", customerIds.join(","));
+  }
+
+  if (params.has("limit")) {
+    const limit = params.get("limit");
+    params.delete("limit");
+    if (limit && !params.has("page[size]")) {
+      params.set("page[size]", limit);
+    }
+  }
+
+  if (params.has("from")) {
+    const from = params.get("from");
+    params.delete("from");
+    if (from?.trim()) {
+      params.set("filter[time][gte]", from.trim());
+    }
+  }
+  if (params.has("to")) {
+    const to = params.get("to");
+    params.delete("to");
+    if (to?.trim()) {
+      params.set("filter[time][lte]", to.trim());
+    }
+  }
+
+  if (params.has("ingestedAtFrom")) {
+    const from = params.get("ingestedAtFrom");
+    params.delete("ingestedAtFrom");
+    if (from?.trim()) {
+      params.set("filter[ingested_at][gte]", from.trim());
+    }
+  }
+  if (params.has("ingestedAtTo")) {
+    const to = params.get("ingestedAtTo");
+    params.delete("ingestedAtTo");
+    if (to?.trim()) {
+      params.set("filter[ingested_at][lte]", to.trim());
+    }
+  }
 }
 
 export function rewriteKonnectRequestUrl(url: URL, method: string): URL {


### PR DESCRIPTION
## Summary
- Map OpenMeter SDK `events.list` query params (`subject`, `limit`, `from`/`to`, `customerId`) to Konnect deepObject filters (`filter[subject][eq]`, `page[size]`, `filter[time][gte|lte]`, etc.).
- Without this, Konnect ignored `subject` and returned the latest global events, so “Your signed ticket requests” stayed empty for viewers (notably admin) under busy platform traffic.
- Adds unit coverage for single- and multi-subject rewrites.

## Test plan
- [x] `node --import tsx --test src/lib/openmeter/konnect-routes.test.ts`
- [x] Verified against production Konnect: `filter[subject][eq]=<admin user id>` returns that user’s `create_signed_ticket` events
- [ ] After deploy: open `/usage` as admin → “Your signed ticket requests” lists recent own requests