### PR TITLE
feat(signer): implement A/B signer version routing for apps

### DIFF
--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -91,9 +91,9 @@ SIGNER_ETH_ADDR=
 # pymthouse-signer-test (latest, newer go-livepeer build + BYOC per-cap pricing,
 # same signing identity). All apps use the stable signer by default; only apps
 # whose public OIDC client id (app_*) is listed in LATEST_SIGNER_APPS are routed
-# to the latest DMZ. Leaving PYMTHOUSE_SIGNER_LATEST_URL unset makes the allowlist
+# to the latest DMZ. Leaving SIGNER_LATEST_URL unset makes the allowlist
 # a safe no-op (opted-in apps fall back to stable).
-# PYMTHOUSE_SIGNER_LATEST_URL=https://<pymthouse-signer-test-production>.up.railway.app
+# SIGNER_LATEST_URL=https://<pymthouse-signer-test-production>.up.railway.app
 # LATEST_SIGNER_APPS=app_123,app_234
 # Turnkey balance webhook → TicketBroker auto-funding (Vercel only).
 # See docs/turnkey-ticket-funding.md for minimum deposit math and verification.

--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -85,6 +85,16 @@ SIGNER_ETH_ADDR=
 # Vercel (Next app, separate from Railway pymthouse service):
 # SIGNER_INTERNAL_URL=https://<pymthouse-production>.up.railway.app
 # SIGNER_CLI_URL=https://<pymthouse-production>.up.railway.app/__signer_cli
+#
+# A/B signer version selection (Vercel / Next app only). The Railway stack now
+# deploys two signer DMZs in production: pymthouse (stable) and
+# pymthouse-signer-test (latest, newer go-livepeer build + BYOC per-cap pricing,
+# same signing identity). All apps use the stable signer by default; only apps
+# whose public OIDC client id (app_*) is listed in LATEST_SIGNER_APPS are routed
+# to the latest DMZ. Leaving PYMTHOUSE_SIGNER_LATEST_URL unset makes the allowlist
+# a safe no-op (opted-in apps fall back to stable).
+# PYMTHOUSE_SIGNER_LATEST_URL=https://<pymthouse-signer-test-production>.up.railway.app
+# LATEST_SIGNER_APPS=app_123,app_234
 # Turnkey balance webhook → TicketBroker auto-funding (Vercel only).
 # See docs/turnkey-ticket-funding.md for minimum deposit math and verification.
 # TURNKEY_FUNDING_CAIP2=eip155:42161

--- a/config/railway/stack.json
+++ b/config/railway/stack.json
@@ -8,11 +8,10 @@
   "deployOrder": [
     "kafka",
     "openmeter-collector",
-    "pymthouse"
-  ],
-  "previewOnlyServices": [
+    "pymthouse",
     "pymthouse-signer-test"
   ],
+  "previewOnlyServices": [],
   "services": {
     "kafka": { "kind": "image" },
     "openmeter-collector": { "kind": "image" },
@@ -24,8 +23,8 @@
     "pymthouse-signer-test": {
       "kind": "repo",
       "manifest": "deploy/pymthouse-signer-test/railway.json",
-      "environments": ["preview"],
-      "description": "Preview-only A/B remote signer DMZ. Do not deploy to production. Same webhook/OIDC/Kafka as pymthouse preview; LIVEPEER_IMAGE pins a different go-livepeer build. Entrypoint defaults BYOC_PER_CAP_PRICING=on for this service name.",
+      "environments": ["preview", "production"],
+      "description": "A/B 'latest' remote signer DMZ, deployed in both preview and production. Same webhook/OIDC/Kafka and signing identity as pymthouse (the 'stable' signer); LIVEPEER_IMAGE pins a newer go-livepeer build. Entrypoint defaults BYOC_PER_CAP_PRICING=on for this service name. Apps opt in via LATEST_SIGNER_APPS on the Next app.",
       "livepeerImage": "livepeer/go-livepeer:sha-4214202f4458cda90bd030a0bbdddf7b3a1f52a5",
       "byocPerCapPricing": true
     }

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -276,6 +276,8 @@ In your Vercel project dashboard, go to "Settings" → "Environment Variables" a
 | `NEXTAUTH_SECRET` | Random secret (generate with `openssl rand -base64 32`) | `your-secret-here` |
 | `SIGNER_INTERNAL_URL` | Your deployed signer URL from Step 1 | `https://your-signer.up.railway.app` |
 | `SIGNER_CLI_URL` | Same as SIGNER_INTERNAL_URL (or separate if exposed) | `https://your-signer.up.railway.app` |
+| `PYMTHOUSE_SIGNER_LATEST_URL` | Optional; public URL of the `pymthouse-signer-test` (latest) DMZ. Unset ⇒ all apps use the stable signer | `https://your-signer-test.up.railway.app` |
+| `LATEST_SIGNER_APPS` | Optional; comma-separated public client ids (`app_*`) routed to the latest signer. Default: none (all apps use stable) | `app_123,app_234` |
 | `OPENMETER_URL` | Self-hosted OpenMeter on Railway (**separate project**) | `https://openmeter-xxxx.up.railway.app` |
 | `OPENMETER_API_KEY` | Optional; set if OpenMeter auth is enabled | (secret) |
 | `OPENMETER_TRIAL_FEATURE_KEY` | Trial entitlement feature | `network_spend` |

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -276,7 +276,7 @@ In your Vercel project dashboard, go to "Settings" → "Environment Variables" a
 | `NEXTAUTH_SECRET` | Random secret (generate with `openssl rand -base64 32`) | `your-secret-here` |
 | `SIGNER_INTERNAL_URL` | Your deployed signer URL from Step 1 | `https://your-signer.up.railway.app` |
 | `SIGNER_CLI_URL` | Same as SIGNER_INTERNAL_URL (or separate if exposed) | `https://your-signer.up.railway.app` |
-| `PYMTHOUSE_SIGNER_LATEST_URL` | Optional; public URL of the `pymthouse-signer-test` (latest) DMZ. Unset ⇒ all apps use the stable signer | `https://your-signer-test.up.railway.app` |
+| `SIGNER_LATEST_URL` | Optional; public URL of the `pymthouse-signer-test` (latest) DMZ. Unset ⇒ all apps use the stable signer | `https://your-signer-test.up.railway.app` |
 | `LATEST_SIGNER_APPS` | Optional; comma-separated public client ids (`app_*`) routed to the latest signer. Default: none (all apps use stable) | `app_123,app_234` |
 | `OPENMETER_URL` | Self-hosted OpenMeter on Railway (**separate project**) | `https://openmeter-xxxx.up.railway.app` |
 | `OPENMETER_API_KEY` | Optional; set if OpenMeter auth is enabled | (secret) |

--- a/scripts/lib/railway-auth.sh
+++ b/scripts/lib/railway-auth.sh
@@ -65,6 +65,23 @@ railway_is_preview_only_service() {
   jq -e --arg s "$service" '(.previewOnlyServices // []) | index($s) != null' "$stack" >/dev/null 2>&1
 }
 
+# True when a service should run in the given environment. A service with no
+# services.<name>.environments key runs everywhere (kafka, collector, pymthouse);
+# one with the key runs only in the listed environments (e.g. pymthouse-signer-test).
+railway_service_in_environment() {
+  local service="$1"
+  local env="$2"
+  local stack
+  stack="$(railway_stack_json)"
+  # No stack metadata or no jq: assume the service runs everywhere.
+  [[ -f "$stack" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -e --arg s "$service" --arg e "$env" '
+    (.services[$s].environments) as $envs
+    | ($envs == null) or ($envs | index($e) != null)
+  ' "$stack" >/dev/null 2>&1
+}
+
 # Print livepeerImage for a service from stack.json, or empty.
 railway_service_livepeer_image() {
   local service="$1"

--- a/scripts/railway-apply-stack-env.sh
+++ b/scripts/railway-apply-stack-env.sh
@@ -97,4 +97,11 @@ export REMOTE_SIGNER_WEBHOOK_URL
 export WEBHOOK_SECRET
 railway_apply_signer_env pymthouse "$PE_FLAGS"
 
+# A/B "latest" signer shares pymthouse's signing identity and DMZ env (same
+# Turnkey wallet / eth addr / webhook secret / OIDC / Kafka). Apply the same env
+# wherever stack.json says signer-test runs (preview + production).
+if railway_service_in_environment pymthouse-signer-test "$ENV"; then
+  railway_apply_signer_env pymthouse-signer-test "$PE_FLAGS"
+fi
+
 echo "Done. Run scripts/railway-deploy-stack.sh $ENV to deploy."

--- a/scripts/railway-deploy-stack.sh
+++ b/scripts/railway-deploy-stack.sh
@@ -32,8 +32,14 @@ echo "=== Railway stack deploy: $ENV ==="
 bash "$ROOT/scripts/railway-deploy-from-manifest.sh" kafka "$ENV" deploy/kafka
 bash "$ROOT/scripts/railway-deploy-from-manifest.sh" openmeter-collector "$ENV" deploy/openmeter-collector
 
-# Signer DMZ (service name: pymthouse)
+# Signer DMZ (service name: pymthouse) — the "stable" signer.
 bash "$ROOT/scripts/railway-deploy-signer.sh" pymthouse "$ENV"
+
+# A/B "latest" signer DMZ. Runs in the environments listed in stack.json
+# (preview + production); LIVEPEER_IMAGE is pinned to a newer go-livepeer build.
+if railway_service_in_environment pymthouse-signer-test "$ENV"; then
+  bash "$ROOT/scripts/railway-deploy-signer.sh" pymthouse-signer-test "$ENV"
+fi
 
 echo "=== Stack deploy triggered for $ENV ==="
 echo "After deploy, run a signed-ticket request and confirm collector events in OpenMeter."

--- a/src/app/api/signer/device/exchange/route.ts
+++ b/src/app/api/signer/device/exchange/route.ts
@@ -16,11 +16,17 @@ import { scopeStringFromPayload } from "@/lib/oidc/scope-string";
 async function mintFromDeviceToken(
   deviceToken: string,
   context: { scope?: string; clientId?: string },
+  onResolvedPublicClientId?: (publicClientId: string) => void,
 ) {
   try {
     const resolved = await resolveSubjectAccessToken(deviceToken, {
       expectedPublicClientId: context.clientId ?? undefined,
     });
+
+    // Report the token-verified public client id so the caller can pick the
+    // signer version (latest vs stable) for this app. Authoritative source is
+    // the subject token, not the client-supplied body clientId.
+    onResolvedPublicClientId?.(resolved.publicClientId);
 
     const scopeStr = scopeStringFromPayload(resolved.payload);
     if (!hasScope(scopeStr, "sign:job")) {
@@ -61,11 +67,17 @@ async function mintFromDeviceToken(
   }
 }
 
-const deviceExchangeHandler = createDeviceExchangeHandler({
-  mint: mintFromDeviceToken,
-  getSignerUrl: () => getClientSignerApiUrl(),
-});
-
 export async function POST(request: NextRequest) {
+  // Per-request handler: capture the token-resolved public client id during mint
+  // so the returned signer_url points at this app's signer version (latest vs
+  // stable). The SDK invokes getSignerUrl only after mint has awaited.
+  let signerAppClientId: string | undefined;
+  const deviceExchangeHandler = createDeviceExchangeHandler({
+    mint: (deviceToken, context) =>
+      mintFromDeviceToken(deviceToken, context, (publicClientId) => {
+        signerAppClientId = publicClientId;
+      }),
+    getSignerUrl: () => getClientSignerApiUrl(signerAppClientId),
+  });
   return deviceExchangeHandler(request);
 }

--- a/src/app/api/v1/apps/[id]/signer/routing/route.ts
+++ b/src/app/api/v1/apps/[id]/signer/routing/route.ts
@@ -16,7 +16,7 @@ export async function GET(
 
   const issuer = getIssuer();
   const origin = getPublicOrigin();
-  const signerApiUrl = getClientSignerApiUrl();
+  const signerApiUrl = getClientSignerApiUrl(clientId);
   const remoteDmzUrl = signerApiUrl;
   const identityMode = "webhook";
   const meteringMode: SignerRoutingConfig["meteringMode"] = "platform_ingest";

--- a/src/app/api/v1/apps/[id]/users/[externalUserId]/keys/route.ts
+++ b/src/app/api/v1/apps/[id]/users/[externalUserId]/keys/route.ts
@@ -16,6 +16,7 @@ import {
   revokeAppUserApiKey,
 } from "@/lib/app-api-keys";
 import { createLivepeerPythonSdkToken } from "@/lib/livepeer-python-sdk-token";
+import { getClientSignerApiUrl } from "@/lib/signer-proxy";
 
 async function canAccessUserKeys(request: NextRequest, clientId: string) {
   const app = await getProviderApp(clientId);
@@ -131,7 +132,10 @@ export async function POST(
     },
   });
 
-  const sdkToken = createLivepeerPythonSdkToken({ apiKey: created.apiKey });
+  const sdkToken = createLivepeerPythonSdkToken({
+    apiKey: created.apiKey,
+    signer: getClientSignerApiUrl(clientId),
+  });
 
   return NextResponse.json(
     {

--- a/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
@@ -164,6 +164,7 @@ test("handleAppScopedSignerTokenExchange rejects wrong grant_type", async () => 
 });
 
 test("handleAppScopedSignerTokenExchange mints signer session from API key subject", async () => {
+  let signerUrlAppId: string | undefined;
   const session = await handleAppScopedSignerTokenExchange(
     {
       publicClientId: PUBLIC_ID,
@@ -194,7 +195,10 @@ test("handleAppScopedSignerTokenExchange mints signer session from API key subje
         balanceUsdMicros: "1000000",
         lifetimeGrantedUsdMicros: "5000000",
       }),
-      getClientSignerApiUrl: () => "https://signer.example",
+      getClientSignerApiUrl: (appClientId) => {
+        signerUrlAppId = appClientId ?? undefined;
+        return "https://signer.example";
+      },
       getSignerDiscoveryUrl: () => "https://discovery.example/v1/discovery",
     },
   );
@@ -205,6 +209,9 @@ test("handleAppScopedSignerTokenExchange mints signer session from API key subje
   assert.equal(session.balanceUsdMicros, "1000000");
   assert.equal(session.signer_url, "https://signer.example");
   assert.equal(session.discovery_url, "https://discovery.example/v1/discovery");
+  // Signer version is selected per app: the subject's public client id must flow
+  // into getClientSignerApiUrl so LATEST_SIGNER_APPS routing applies.
+  assert.equal(signerUrlAppId, PUBLIC_ID);
 });
 
 test("handleAppScopedSignerTokenExchange mints from user JWT with sign:job scope", async () => {

--- a/src/lib/oidc/app-scoped-signer-token-exchange.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.ts
@@ -358,7 +358,7 @@ export async function handleAppScopedSignerTokenExchange(
     scope: minted.scope,
     balanceUsdMicros: minted.balanceUsdMicros,
     lifetimeGrantedUsdMicros: minted.lifetimeGrantedUsdMicros,
-    signer_url: deps.getClientSignerApiUrl(),
+    signer_url: deps.getClientSignerApiUrl(subject.publicClientId),
     discovery_url: deps.getSignerDiscoveryUrl(),
     issued_token_type: ISSUED_ACCESS_TOKEN_TYPE,
     correlation_id: input.correlationId,

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -108,6 +108,7 @@ async function loadPublicSignJobClient(appId: string) {
 
 function signerSessionFromMint(
   minted: Awaited<ReturnType<typeof mintSignerJwtForExternalUser>>,
+  publicClientId: string,
 ) {
   return buildSignerSessionEnvelope({
     access_token: minted.access_token,
@@ -115,7 +116,7 @@ function signerSessionFromMint(
     scope: minted.scope,
     balanceUsdMicros: minted.balanceUsdMicros,
     lifetimeGrantedUsdMicros: minted.lifetimeGrantedUsdMicros,
-    signer_url: getClientSignerApiUrl(),
+    signer_url: getClientSignerApiUrl(publicClientId),
     issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
   });
 }
@@ -314,7 +315,7 @@ export async function handleMintUserSignerToken(input: {
     developerAppId: row.appId,
     externalUserId,
   });
-  return signerSessionFromMint(minted);
+  return signerSessionFromMint(minted, publicClient.clientId);
 }
 
 export async function handleM2mOwnerSignJob(input: {
@@ -338,5 +339,5 @@ export async function handleM2mOwnerSignJob(input: {
     developerAppId: row.appId,
     externalUserId: row.ownerId,
   });
-  return signerSessionFromMint(minted);
+  return signerSessionFromMint(minted, publicClient.clientId);
 }

--- a/src/lib/signer-proxy.test.ts
+++ b/src/lib/signer-proxy.test.ts
@@ -1,0 +1,87 @@
+import test, { afterEach, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  getClientSignerApiUrl,
+  getLatestSignerApps,
+  getSignerVersionForApp,
+  isLatestSignerApp,
+} from "@/lib/signer-proxy";
+
+// Env vars that steer stable vs latest signer resolution. Snapshot + restore so
+// tests do not leak into each other or into DB-backed suites.
+const TOUCHED = [
+  "PYMTHOUSE_CLIENT_SIGNER_API_URL",
+  "PYMTHOUSE_SIGNER_URL",
+  "SIGNER_PUBLIC_URL",
+  "SIGNER_INTERNAL_URL",
+  "PYMTHOUSE_TEST_SIGNER_URL",
+  "PYMTHOUSE_SIGNER_LATEST_URL",
+  "LATEST_SIGNER_APPS",
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of TOUCHED) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  // Deterministic stable URL for every test in this file.
+  process.env.PYMTHOUSE_SIGNER_URL = "https://stable.example";
+});
+
+afterEach(() => {
+  for (const key of TOUCHED) {
+    if (saved[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved[key];
+    }
+  }
+});
+
+test("getLatestSignerApps parses comma/space separated ids and drops empties", () => {
+  process.env.LATEST_SIGNER_APPS = " app_123, app_234 ,, app_345 ";
+  assert.deepEqual(
+    [...getLatestSignerApps()].sort(),
+    ["app_123", "app_234", "app_345"],
+  );
+});
+
+test("getLatestSignerApps is empty when unset", () => {
+  assert.equal(getLatestSignerApps().size, 0);
+});
+
+test("isLatestSignerApp only matches listed ids", () => {
+  process.env.LATEST_SIGNER_APPS = "app_123,app_234";
+  assert.equal(isLatestSignerApp("app_123"), true);
+  assert.equal(isLatestSignerApp("app_999"), false);
+  assert.equal(isLatestSignerApp(""), false);
+  assert.equal(isLatestSignerApp(undefined), false);
+});
+
+test("getClientSignerApiUrl with no app id returns the stable signer", () => {
+  process.env.LATEST_SIGNER_APPS = "app_123";
+  process.env.PYMTHOUSE_SIGNER_LATEST_URL = "https://latest.example";
+  assert.match(getClientSignerApiUrl(), /stable\.example/);
+});
+
+test("listed app with a configured latest URL is routed to the latest signer", () => {
+  process.env.LATEST_SIGNER_APPS = "app_123,app_234";
+  process.env.PYMTHOUSE_SIGNER_LATEST_URL = "https://latest.example";
+  assert.match(getClientSignerApiUrl("app_123"), /latest\.example/);
+  assert.equal(getSignerVersionForApp("app_123"), "latest");
+});
+
+test("unlisted app stays on the stable signer even when latest URL is set", () => {
+  process.env.LATEST_SIGNER_APPS = "app_123";
+  process.env.PYMTHOUSE_SIGNER_LATEST_URL = "https://latest.example";
+  assert.match(getClientSignerApiUrl("app_999"), /stable\.example/);
+  assert.equal(getSignerVersionForApp("app_999"), "stable");
+});
+
+test("listed app falls back to stable when no latest URL is configured", () => {
+  process.env.LATEST_SIGNER_APPS = "app_123";
+  // PYMTHOUSE_SIGNER_LATEST_URL intentionally unset.
+  assert.match(getClientSignerApiUrl("app_123"), /stable\.example/);
+});

--- a/src/lib/signer-proxy.test.ts
+++ b/src/lib/signer-proxy.test.ts
@@ -15,7 +15,7 @@ const TOUCHED = [
   "SIGNER_PUBLIC_URL",
   "SIGNER_INTERNAL_URL",
   "PYMTHOUSE_TEST_SIGNER_URL",
-  "PYMTHOUSE_SIGNER_LATEST_URL",
+  "SIGNER_LATEST_URL",
   "LATEST_SIGNER_APPS",
 ] as const;
 
@@ -62,26 +62,26 @@ test("isLatestSignerApp only matches listed ids", () => {
 
 test("getClientSignerApiUrl with no app id returns the stable signer", () => {
   process.env.LATEST_SIGNER_APPS = "app_123";
-  process.env.PYMTHOUSE_SIGNER_LATEST_URL = "https://latest.example";
+  process.env.SIGNER_LATEST_URL = "https://latest.example";
   assert.match(getClientSignerApiUrl(), /stable\.example/);
 });
 
 test("listed app with a configured latest URL is routed to the latest signer", () => {
   process.env.LATEST_SIGNER_APPS = "app_123,app_234";
-  process.env.PYMTHOUSE_SIGNER_LATEST_URL = "https://latest.example";
+  process.env.SIGNER_LATEST_URL = "https://latest.example";
   assert.match(getClientSignerApiUrl("app_123"), /latest\.example/);
   assert.equal(getSignerVersionForApp("app_123"), "latest");
 });
 
 test("unlisted app stays on the stable signer even when latest URL is set", () => {
   process.env.LATEST_SIGNER_APPS = "app_123";
-  process.env.PYMTHOUSE_SIGNER_LATEST_URL = "https://latest.example";
+  process.env.SIGNER_LATEST_URL = "https://latest.example";
   assert.match(getClientSignerApiUrl("app_999"), /stable\.example/);
   assert.equal(getSignerVersionForApp("app_999"), "stable");
 });
 
 test("listed app falls back to stable when no latest URL is configured", () => {
   process.env.LATEST_SIGNER_APPS = "app_123";
-  // PYMTHOUSE_SIGNER_LATEST_URL intentionally unset.
+  // SIGNER_LATEST_URL intentionally unset.
   assert.match(getClientSignerApiUrl("app_123"), /stable\.example/);
 });

--- a/src/lib/signer-proxy.ts
+++ b/src/lib/signer-proxy.ts
@@ -59,11 +59,39 @@ export async function isSignerOperational(
   return senderInfo !== null;
 }
 
+/** Signer "version" a client is routed to: the newer A/B DMZ or the stable one. */
+export type SignerVersion = "latest" | "stable";
+
 /**
- * Public remote signer DMZ base URL for clients (gateway, builder-sdk).
- * Signing goes directly to the DMZ — not through PymtHouse /api/signer/*.
+ * Public client ids (`app_*`) that should be routed to the "latest" signer DMZ,
+ * parsed from LATEST_SIGNER_APPS (comma/space separated). Everyone else uses the
+ * stable production signer.
  */
-export function getClientSignerApiUrl(): string {
+export function getLatestSignerApps(): Set<string> {
+  return new Set(
+    (process.env.LATEST_SIGNER_APPS ?? "")
+      .split(/[\s,]+/)
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+}
+
+/** True when this app's public client id is opted in to the latest signer. */
+export function isLatestSignerApp(appClientId?: string | null): boolean {
+  const id = appClientId?.trim();
+  if (!id) {
+    return false;
+  }
+  return getLatestSignerApps().has(id);
+}
+
+/** Which signer version an app is routed to (defaults to stable). */
+export function getSignerVersionForApp(appClientId?: string | null): SignerVersion {
+  return isLatestSignerApp(appClientId) ? "latest" : "stable";
+}
+
+/** Stable production signer DMZ base URL (the default for all apps). */
+function getStableSignerApiUrl(): string {
   const explicit =
     process.env.PYMTHOUSE_CLIENT_SIGNER_API_URL?.trim() ||
     process.env.PYMTHOUSE_SIGNER_URL?.trim() ||
@@ -72,6 +100,33 @@ export function getClientSignerApiUrl(): string {
     return normalizeSignerBaseUrl(explicit);
   }
   return getSignerUrl();
+}
+
+/**
+ * "Latest" A/B signer DMZ base URL (the pymthouse-signer-test service), or empty
+ * when unconfigured — in which case opted-in apps safely fall back to stable.
+ */
+function getLatestSignerApiUrl(): string {
+  const explicit = process.env.PYMTHOUSE_SIGNER_LATEST_URL?.trim();
+  return explicit ? normalizeSignerBaseUrl(explicit) : "";
+}
+
+/**
+ * Public remote signer DMZ base URL for clients (gateway, builder-sdk).
+ * Signing goes directly to the DMZ — not through PymtHouse /api/signer/*.
+ *
+ * Apps in LATEST_SIGNER_APPS are routed to the "latest" signer DMZ
+ * (PYMTHOUSE_SIGNER_LATEST_URL) when it is configured; all other apps — and any
+ * call without an app client id — get the stable production signer.
+ */
+export function getClientSignerApiUrl(appClientId?: string | null): string {
+  if (isLatestSignerApp(appClientId)) {
+    const latest = getLatestSignerApiUrl();
+    if (latest) {
+      return latest;
+    }
+  }
+  return getStableSignerApiUrl();
 }
 
 export type SignerUrlSource = "env" | "saved" | "default";

--- a/src/lib/signer-proxy.ts
+++ b/src/lib/signer-proxy.ts
@@ -107,7 +107,7 @@ function getStableSignerApiUrl(): string {
  * when unconfigured — in which case opted-in apps safely fall back to stable.
  */
 function getLatestSignerApiUrl(): string {
-  const explicit = process.env.PYMTHOUSE_SIGNER_LATEST_URL?.trim();
+  const explicit = process.env.SIGNER_LATEST_URL?.trim();
   return explicit ? normalizeSignerBaseUrl(explicit) : "";
 }
 
@@ -116,7 +116,7 @@ function getLatestSignerApiUrl(): string {
  * Signing goes directly to the DMZ — not through PymtHouse /api/signer/*.
  *
  * Apps in LATEST_SIGNER_APPS are routed to the "latest" signer DMZ
- * (PYMTHOUSE_SIGNER_LATEST_URL) when it is configured; all other apps — and any
+ * (SIGNER_LATEST_URL) when it is configured; all other apps — and any
  * call without an app client id — get the stable production signer.
  */
 export function getClientSignerApiUrl(appClientId?: string | null): string {


### PR DESCRIPTION
Enhance the signing service by introducing a mechanism to route apps to either the stable or latest signer DMZ based on their public client IDs. The `LATEST_SIGNER_APPS` environment variable allows specific apps to opt into the latest signer, while others default to the stable version. Updates include modifications to the stack configuration, deployment scripts, and API handlers to support this feature. Additionally, tests have been added to ensure correct routing behavior.