### PR TITLE
feat(apps): docs and usage panels on My Apps for all users

### DIFF
--- a/src/app/api/v1/apps/[id]/plans/route.test.ts
+++ b/src/app/api/v1/apps/[id]/plans/route.test.ts
@@ -248,6 +248,15 @@ run("plans API: network default plan rules", async (t) => {
 });
 
 run("plans POST accepts subscription with retail overageRateUsd", async (t) => {
+  installNaapCatalogMock({
+    catalog: [
+      { id: "text-to-image", name: "Text to Image", models: ["stabilityai/sdxl"] },
+    ],
+  });
+  t.after(() => {
+    uninstallNaapCatalogMock();
+  });
+
   const app = await seedDeveloperAppWithClient({ status: "approved" });
   authorizedApp = app;
   t.after(async () => {

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -3,13 +3,13 @@ export const dynamic = "force-dynamic";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/next-auth-options";
 import { redirect } from "next/navigation";
-import Link from "next/link";
 import { db } from "@/db/index";
 import { signerConfig } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import DashboardLayout from "@/components/DashboardLayout";
 import AppsListSection from "@/components/apps/AppsListSection";
 import AdminAppsHome from "@/components/apps/AdminAppsHome";
+import AppsHomeShortcutPanels from "@/components/apps/AppsHomeShortcutPanels";
 import { listUserAccessibleApps } from "@/lib/user-apps";
 import { syncSignerStatus } from "@/lib/signer-proxy";
 import NetworkLiveIndicator from "@/components/NetworkLiveIndicator";
@@ -51,16 +51,12 @@ async function DeveloperMyApps({ userId }: Readonly<{ userId: string }>) {
         <div>
           <h1 className="text-2xl font-bold text-zinc-100">My Apps</h1>
           <p className="mt-1 text-sm text-zinc-500">
-            Manage your provider applications
+            Manage provider applications
           </p>
         </div>
-        <Link
-          href="/usage"
-          className="shrink-0 text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors"
-        >
-          Open Usage →
-        </Link>
       </div>
+
+      <AppsHomeShortcutPanels />
 
       <AppsListSection
         apps={apps}

--- a/src/components/apps/AdminAppsHome.tsx
+++ b/src/components/apps/AdminAppsHome.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import AdminAppsSection from "@/components/apps/AdminAppsSection";
+import AppsHomeShortcutPanels from "@/components/apps/AppsHomeShortcutPanels";
 import type { UserAppSummary } from "@/lib/user-apps";
-import { getDocsBaseUrl } from "@/lib/docs-base-url";
 
 /**
  * Admin My Apps body: docs + usage shortcuts and full apps list (own / all toggle).
- * Usage analytics live on /billing.
+ * Usage analytics live on /usage.
  */
 export default function AdminAppsHome({
   myApps,
@@ -19,38 +18,7 @@ export default function AdminAppsHome({
 
   return (
     <>
-      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 flex flex-col justify-between gap-3">
-          <div>
-            <h3 className="font-semibold text-zinc-100">Documentation</h3>
-            <p className="text-xs text-zinc-500 mt-1">
-              Builder API, OIDC, device flow, and integration guides.
-            </p>
-          </div>
-          <a
-            href={getDocsBaseUrl()}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors self-start"
-          >
-            Open Docs →
-          </a>
-        </div>
-        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 flex flex-col justify-between gap-3">
-          <div>
-            <h3 className="font-semibold text-zinc-100">Usage</h3>
-            <p className="text-xs text-zinc-500 mt-1">
-              Request charts and signed-ticket history are on the Usage page.
-            </p>
-          </div>
-          <Link
-            href="/usage"
-            className="text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors self-start"
-          >
-            Open Usage →
-          </Link>
-        </div>
-      </div>
+      <AppsHomeShortcutPanels />
 
       <AdminAppsSection
         initialApps={myApps}

--- a/src/components/apps/AppsHomeShortcutPanels.tsx
+++ b/src/components/apps/AppsHomeShortcutPanels.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { getDocsBaseUrl } from "@/lib/docs-base-url";
+
+/**
+ * Docs + Usage shortcut panels shown above the apps list on My Apps.
+ */
+export default function AppsHomeShortcutPanels() {
+  return (
+    <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 flex flex-col justify-between gap-3">
+        <div>
+          <h3 className="font-semibold text-zinc-100">Documentation</h3>
+          <p className="text-xs text-zinc-500 mt-1">
+            Builder API, OIDC, device flow, and integration guides.
+          </p>
+        </div>
+        <a
+          href={getDocsBaseUrl()}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors self-start"
+        >
+          Open Docs →
+        </a>
+      </div>
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 flex flex-col justify-between gap-3">
+        <div>
+          <h3 className="font-semibold text-zinc-100">Usage</h3>
+          <p className="text-xs text-zinc-500 mt-1">
+            Request charts and signed-ticket history are on the Usage page.
+          </p>
+        </div>
+        <Link
+          href="/usage"
+          className="text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors self-start"
+        >
+          Open Usage →
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Shows the Documentation and Usage shortcut panels above the apps list on **My Apps for all users**, not only admins.

## Changes

- Extracted shared `AppsHomeShortcutPanels` (Docs → Mintlify, Usage → `/usage`).
- Rendered on the developer My Apps page as well as the admin home.
- Removed the redundant header “Open Usage →” link for non-admins (Usage panel covers it).
- Aligned developer subtitle copy to “Manage provider applications”.
- Stabilized the flaky retail `overageRateUsd` plans POST test with a NaaP catalog mock (CI was 503ing without it).

## How to verify

1. Sign in as a non-admin developer and open `/apps`.
2. Confirm Documentation and Usage panels appear above the apps list.
3. Confirm Docs and Usage links work.
4. Confirm admins still see the same panels (plus Network live / All apps toggle).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f7f176a-a81a-45c7-9720-2d47a8ec3a52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f7f176a-a81a-45c7-9720-2d47a8ec3a52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

