### PR TITLE
fix(openmeter): release incomplete legacy subjects and quiet owner ensure

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "openmeter:fix-starter-allowance": "npx tsx scripts/openmeter-fix-starter-allowance.ts",
     "openmeter:migrate-owner-customers": "npx tsx scripts/openmeter-migrate-owner-customers.ts",
     "openmeter:dedupe-owner-subscriptions": "npx tsx scripts/openmeter-dedupe-owner-subscriptions.ts",
+    "openmeter:release-legacy-subjects": "npx tsx scripts/openmeter-release-legacy-subjects.ts",
     "openmeter:audit-billing": "npx tsx scripts/openmeter-audit-billing-consistency.ts",
     "turnkey:create-webhook": "npx tsx scripts/turnkey-create-webhook.ts",
     "openmeter:railway:bootstrap": "bash scripts/openmeter-railway-bootstrap.sh",

--- a/scripts/lib/openmeter-konnect-migrate.ts
+++ b/scripts/lib/openmeter-konnect-migrate.ts
@@ -190,3 +190,50 @@ export async function changeKonnectSubscription(input: {
     },
   );
 }
+
+export type KonnectCustomer = {
+  id: string;
+  key: string;
+  name?: string;
+  usage_attribution?: { subject_keys?: string[] };
+};
+
+/** PUT replace subject_keys (SDK update can leave live keys alongside deprecated). */
+export async function replaceKonnectCustomerSubjectKeys(input: {
+  baseUrl: string;
+  apiKey: string;
+  customerId: string;
+  name: string;
+  subjectKeys: string[];
+}): Promise<KonnectCustomer> {
+  return konnectFetch<KonnectCustomer>(
+    input.baseUrl,
+    input.apiKey,
+    "PUT",
+    `/customers/${input.customerId}`,
+    {
+      name: input.name,
+      usage_attribution: { subject_keys: input.subjectKeys },
+    },
+  );
+}
+
+export async function getKonnectCustomer(
+  baseUrl: string,
+  apiKey: string,
+  customerId: string,
+): Promise<KonnectCustomer> {
+  return konnectFetch<KonnectCustomer>(
+    baseUrl,
+    apiKey,
+    "GET",
+    `/customers/${customerId}`,
+  );
+}
+
+export function readKonnectSubjectKeys(customer: KonnectCustomer): string[] {
+  const keys = customer.usage_attribution?.subject_keys;
+  return Array.isArray(keys)
+    ? keys.filter((key): key is string => typeof key === "string")
+    : [];
+}

--- a/scripts/openmeter-migrate-owner-customers.ts
+++ b/scripts/openmeter-migrate-owner-customers.ts
@@ -50,6 +50,11 @@ import {
   isOpenMeterSubscriptionActive,
   listOpenMeterSubscriptionsForCustomer,
 } from "../src/lib/openmeter/subscription-read";
+import {
+  readKonnectSubjectKeys,
+  replaceKonnectCustomerSubjectKeys,
+  requireKonnectConfig,
+} from "./lib/openmeter-konnect-migrate";
 
 type Args = {
   ownerId?: string;
@@ -213,10 +218,11 @@ function legacyCustomerKeys(ownerId: string, apps: OwnedApp[]): string[] {
 }
 
 async function releaseLegacySubjectKeys(input: {
-  client: ReturnType<typeof getHostedAdminClient>;
   customerId: string;
   customerKey: string;
   dryRun: boolean;
+  baseUrl: string;
+  apiKey: string;
 }): Promise<void> {
   if (input.dryRun) {
     console.log(
@@ -226,13 +232,24 @@ async function releaseLegacySubjectKeys(input: {
   }
   // Free wire subjects for the bare owner customer. Use a deprecated subject
   // so Konnect still has at least one key, including when the legacy customer
-  // key itself is owner:{id}.
+  // key itself is owner:{id}. PUT-replace via Konnect — SDK update has left
+  // live keys alongside deprecated: on incomplete releases.
   const retiredKey = `deprecated:${input.customerKey}`;
   try {
-    await input.client.customers.update(input.customerId, {
+    const updated = await replaceKonnectCustomerSubjectKeys({
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey,
+      customerId: input.customerId,
       name: `Legacy ${input.customerKey}`,
-      usageAttribution: { subjectKeys: [retiredKey] },
+      subjectKeys: [retiredKey],
     });
+    const after = readKonnectSubjectKeys(updated);
+    if (after.includes(input.customerKey)) {
+      console.warn(
+        `  [warn] release incomplete on ${input.customerKey}: still has live subject (${JSON.stringify(after)})`,
+      );
+      return;
+    }
     console.log(`  [ok] released subjectKeys on ${input.customerKey} → ${retiredKey}`);
   } catch (err) {
     console.warn(
@@ -278,6 +295,7 @@ async function processLegacyWallets(input: {
   cancelLegacy: boolean;
   dryRun: boolean;
   apiKey: string | undefined;
+  baseUrl: string;
 }): Promise<bigint> {
   let transferMicros = 0n;
   if (!input.transferBalances && !input.cancelLegacy) {
@@ -312,11 +330,15 @@ async function processLegacyWallets(input: {
         customerKey: legacyKey,
         dryRun: input.dryRun,
       });
+      if (!input.apiKey) {
+        throw new Error("OPENMETER_API_KEY is required to release legacy subjects");
+      }
       await releaseLegacySubjectKeys({
-        client: input.client,
         customerId: legacyId,
         customerKey: legacyKey,
         dryRun: input.dryRun,
+        baseUrl: input.baseUrl,
+        apiKey: input.apiKey,
       });
     }
   }
@@ -340,7 +362,7 @@ async function migrateOwner(input: {
   if (!isHostedAdminClientAvailable()) {
     throw new Error("OpenMeter is not configured");
   }
-  const apiKey = process.env.OPENMETER_API_KEY?.trim();
+  const { baseUrl, apiKey } = requireKonnectConfig();
   if (!shouldUseKonnectRoutes(getHostedOpenMeterUrl(), apiKey)) {
     throw new Error("Owner migration requires Konnect prepaid credit routes");
   }
@@ -378,6 +400,7 @@ async function migrateOwner(input: {
     cancelLegacy: input.cancelLegacy,
     dryRun: input.dryRun,
     apiKey,
+    baseUrl,
   });
 
   if (transferMicros > 0n) {

--- a/scripts/openmeter-migrate-owner-customers.ts
+++ b/scripts/openmeter-migrate-owner-customers.ts
@@ -244,9 +244,9 @@ async function releaseLegacySubjectKeys(input: {
       subjectKeys: [retiredKey],
     });
     const after = readKonnectSubjectKeys(updated);
-    if (after.includes(input.customerKey)) {
+    if (after.length !== 1 || after[0] !== retiredKey) {
       console.warn(
-        `  [warn] release incomplete on ${input.customerKey}: still has live subject (${JSON.stringify(after)})`,
+        `  [warn] release incomplete on ${input.customerKey}: got ${JSON.stringify(after)} (expected [${retiredKey}])`,
       );
       return;
     }

--- a/scripts/openmeter-release-legacy-subjects.ts
+++ b/scripts/openmeter-release-legacy-subjects.ts
@@ -1,0 +1,319 @@
+/**
+ * Finish incomplete legacy-owner subject-key releases.
+ *
+ * After migrate-owner-customers --cancel-legacy, some `owner:{users.id}` (and
+ * compound) wallets still keep the live subject alongside `deprecated:…`.
+ * That blocks transitional attribution on the bare owner customer (409) and
+ * floods logs when ensureOwnerCustomer retries.
+ *
+ * This script finds those customers and PUT-replaces subject_keys with only
+ * `deprecated:{customer.key}` (Konnect rejects empty subject_keys).
+ *
+ * Usage:
+ *   # Dry-run all app owners (default when unscoped)
+ *   npx tsx scripts/openmeter-release-legacy-subjects.ts --all
+ *
+ *   # One owner
+ *   npx tsx scripts/openmeter-release-legacy-subjects.ts --owner-id <users.id>
+ *
+ *   # Apply
+ *   npx tsx scripts/openmeter-release-legacy-subjects.ts --all --apply
+ *   npx tsx scripts/openmeter-release-legacy-subjects.ts --owner-id <id> --apply
+ */
+import "./load-env-first";
+
+import { closeDb, db } from "../src/db/index";
+import { developerApps } from "../src/db/schema";
+import {
+  getHostedAdminClient,
+  isHostedAdminClientAvailable,
+} from "../src/lib/openmeter/admin-client";
+import {
+  buildOpenMeterCustomerKey,
+  buildOwnerWireSubject,
+} from "../src/lib/openmeter/customer-key";
+import {
+  findOpenMeterCustomerByKey,
+  listOwnedPublicClientIds,
+} from "../src/lib/openmeter/customers";
+import {
+  getKonnectCustomer,
+  readKonnectSubjectKeys,
+  replaceKonnectCustomerSubjectKeys,
+  requireKonnectConfig,
+  takeArgValue,
+} from "./lib/openmeter-konnect-migrate";
+
+type Args = {
+  ownerId?: string;
+  all: boolean;
+  limit: number;
+  apply: boolean;
+  verbose: boolean;
+};
+
+function usage(): string {
+  return [
+    "openmeter-release-legacy-subjects",
+    "",
+    "Replace incomplete legacy subject_keys with deprecated-only.",
+    "Default is dry-run (no writes) unless --apply.",
+    "",
+    "Options:",
+    "  --all                   Scan every distinct app owner (recommended)",
+    "  --owner-id <users.id>   One owner",
+    "  --limit <n>             Cap owners when neither --all nor --owner-id (default 50)",
+    "  --apply                 Write changes",
+    "  --verbose               Log every skip (default: only actionable lines)",
+    "  --help",
+  ].join("\n");
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    all: false,
+    limit: 50,
+    apply: false,
+    verbose: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    switch (token) {
+      case "--owner-id":
+        args.ownerId = takeArgValue(argv, i, token);
+        i += 1;
+        break;
+      case "--all":
+        args.all = true;
+        break;
+      case "--limit": {
+        const raw = takeArgValue(argv, i, token);
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n < 1) {
+          throw new Error("--limit must be a positive integer");
+        }
+        args.limit = Math.floor(n);
+        i += 1;
+        break;
+      }
+      case "--apply":
+        args.apply = true;
+        break;
+      case "--verbose":
+        args.verbose = true;
+        break;
+      case "--help":
+      case "-h":
+        console.log(usage());
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+  return args;
+}
+
+function retiredSubjectKey(customerKey: string): string {
+  return `deprecated:${customerKey}`;
+}
+
+function needsRelease(customerKey: string, subjectKeys: string[]): boolean {
+  if (subjectKeys.includes(customerKey)) {
+    return true;
+  }
+  const retired = retiredSubjectKey(customerKey);
+  if (subjectKeys.includes(retired) && subjectKeys.length > 1) {
+    return true;
+  }
+  return false;
+}
+
+async function listOwnerIds(args: Args): Promise<string[]> {
+  if (args.ownerId?.trim()) {
+    return [args.ownerId.trim()];
+  }
+
+  const rows = await db
+    .selectDistinct({ ownerId: developerApps.ownerId })
+    .from(developerApps);
+  const ids = rows
+    .map((row) => row.ownerId?.trim())
+    .filter((id): id is string => Boolean(id));
+
+  if (args.all) {
+    return ids;
+  }
+  return ids.slice(0, args.limit);
+}
+
+function legacyKeysForOwner(ownerId: string, publicClientIds: string[]): string[] {
+  const wire = buildOwnerWireSubject(ownerId);
+  const keys = [wire];
+  for (const publicClientId of publicClientIds) {
+    keys.push(
+      buildOpenMeterCustomerKey(publicClientId, ownerId),
+      buildOpenMeterCustomerKey(publicClientId, wire),
+    );
+  }
+  return [...new Set(keys)];
+}
+
+async function releaseCustomer(input: {
+  baseUrl: string;
+  apiKey: string;
+  customerId: string;
+  customerKey: string;
+  apply: boolean;
+  verbose: boolean;
+}): Promise<"ok" | "dry-run" | "skip" | "fail"> {
+  const current = await getKonnectCustomer(
+    input.baseUrl,
+    input.apiKey,
+    input.customerId,
+  );
+  const subjectKeys = readKonnectSubjectKeys(current);
+  if (!needsRelease(input.customerKey, subjectKeys)) {
+    if (input.verbose) {
+      console.log(
+        `  [skip] ${input.customerKey} already released subjectKeys=${JSON.stringify(subjectKeys)}`,
+      );
+    }
+    return "skip";
+  }
+
+  const retired = retiredSubjectKey(input.customerKey);
+  const name =
+    current.name?.startsWith("Legacy ")
+      ? current.name
+      : `Legacy ${input.customerKey}`;
+
+  if (!input.apply) {
+    console.log(
+      `  [dry-run] would release ${input.customerKey} id=${input.customerId} ${JSON.stringify(subjectKeys)} → [${retired}]`,
+    );
+    return "dry-run";
+  }
+
+  try {
+    const updated = await replaceKonnectCustomerSubjectKeys({
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey,
+      customerId: input.customerId,
+      name,
+      subjectKeys: [retired],
+    });
+    const after = readKonnectSubjectKeys(updated);
+    if (
+      after.includes(input.customerKey) ||
+      after.length !== 1 ||
+      after[0] !== retired
+    ) {
+      console.warn(
+        `  [fail] release incomplete for ${input.customerKey}: got ${JSON.stringify(after)}`,
+      );
+      return "fail";
+    }
+    console.log(`  [ok] released ${input.customerKey} → ${retired}`);
+    return "ok";
+  } catch (err) {
+    console.warn(
+      `  [fail] ${input.customerKey}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return "fail";
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.ownerId && !args.all) {
+    console.log(
+      "Tip: pass --all to scan every app owner (dry-run by default). Continuing with --limit.\n",
+    );
+  }
+  if (!isHostedAdminClientAvailable()) {
+    throw new Error("OpenMeter is not configured");
+  }
+  const { baseUrl, apiKey } = requireKonnectConfig();
+  const client = getHostedAdminClient();
+  const ownerIds = await listOwnerIds(args);
+  console.log(
+    `Scanning owners=${ownerIds.length} apply=${args.apply} verbose=${args.verbose}`,
+  );
+
+  let ok = 0;
+  let dryRun = 0;
+  let skip = 0;
+  let missing = 0;
+  let fail = 0;
+  let ownersWithWork = 0;
+
+  for (const ownerId of ownerIds) {
+    const publicClientIds = await listOwnedPublicClientIds(ownerId);
+    const keys = legacyKeysForOwner(ownerId, publicClientIds);
+    let ownerLogged = false;
+    let ownerHadWork = false;
+
+    for (const customerKey of keys) {
+      const found = await findOpenMeterCustomerByKey(client, customerKey);
+      if (!found?.id) {
+        missing += 1;
+        if (args.verbose) {
+          if (!ownerLogged) {
+            console.log(`\n[owner] ${ownerId} apps=${publicClientIds.length}`);
+            ownerLogged = true;
+          }
+          console.log(`  [skip] no customer ${customerKey}`);
+        }
+        continue;
+      }
+
+      const result = await releaseCustomer({
+        baseUrl,
+        apiKey,
+        customerId: found.id,
+        customerKey,
+        apply: args.apply,
+        verbose: args.verbose,
+      });
+
+      if (result === "skip") {
+        skip += 1;
+        if (args.verbose && !ownerLogged) {
+          console.log(`\n[owner] ${ownerId} apps=${publicClientIds.length}`);
+          ownerLogged = true;
+        }
+        continue;
+      }
+
+      if (!ownerLogged) {
+        console.log(`\n[owner] ${ownerId} apps=${publicClientIds.length}`);
+        ownerLogged = true;
+      }
+      ownerHadWork = true;
+
+      if (result === "ok") ok += 1;
+      else if (result === "dry-run") dryRun += 1;
+      else fail += 1;
+    }
+
+    if (ownerHadWork) ownersWithWork += 1;
+  }
+
+  console.log(
+    `\nDone owners=${ownerIds.length} ownersWithWork=${ownersWithWork} apply=${args.apply} ok=${ok} dryRun=${dryRun} skip=${skip} missing=${missing} fail=${fail}`,
+  );
+  if (fail > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/scripts/openmeter-release-legacy-subjects.ts
+++ b/scripts/openmeter-release-legacy-subjects.ts
@@ -225,6 +225,107 @@ async function releaseCustomer(input: {
   }
 }
 
+type ReleaseResult = "ok" | "dry-run" | "skip" | "fail";
+
+type ScanTallies = {
+  ok: number;
+  dryRun: number;
+  skip: number;
+  missing: number;
+  fail: number;
+  ownersWithWork: number;
+};
+
+function emptyTallies(): ScanTallies {
+  return {
+    ok: 0,
+    dryRun: 0,
+    skip: 0,
+    missing: 0,
+    fail: 0,
+    ownersWithWork: 0,
+  };
+}
+
+function recordResult(tallies: ScanTallies, result: ReleaseResult): void {
+  if (result === "ok") tallies.ok += 1;
+  else if (result === "dry-run") tallies.dryRun += 1;
+  else if (result === "skip") tallies.skip += 1;
+  else tallies.fail += 1;
+}
+
+function ensureOwnerHeader(input: {
+  ownerLogged: boolean;
+  ownerId: string;
+  appCount: number;
+}): boolean {
+  if (input.ownerLogged) return true;
+  console.log(`\n[owner] ${input.ownerId} apps=${input.appCount}`);
+  return true;
+}
+
+async function processOwner(input: {
+  client: ReturnType<typeof getHostedAdminClient>;
+  baseUrl: string;
+  apiKey: string;
+  ownerId: string;
+  apply: boolean;
+  verbose: boolean;
+  tallies: ScanTallies;
+}): Promise<void> {
+  const publicClientIds = await listOwnedPublicClientIds(input.ownerId);
+  const keys = legacyKeysForOwner(input.ownerId, publicClientIds);
+  let ownerLogged = false;
+  let ownerHadWork = false;
+
+  for (const customerKey of keys) {
+    const found = await findOpenMeterCustomerByKey(input.client, customerKey);
+    if (!found?.id) {
+      input.tallies.missing += 1;
+      if (input.verbose) {
+        ownerLogged = ensureOwnerHeader({
+          ownerLogged,
+          ownerId: input.ownerId,
+          appCount: publicClientIds.length,
+        });
+        console.log(`  [skip] no customer ${customerKey}`);
+      }
+      continue;
+    }
+
+    const result = await releaseCustomer({
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey,
+      customerId: found.id,
+      customerKey,
+      apply: input.apply,
+      verbose: input.verbose,
+    });
+
+    if (result === "skip") {
+      input.tallies.skip += 1;
+      if (input.verbose) {
+        ownerLogged = ensureOwnerHeader({
+          ownerLogged,
+          ownerId: input.ownerId,
+          appCount: publicClientIds.length,
+        });
+      }
+      continue;
+    }
+
+    ownerLogged = ensureOwnerHeader({
+      ownerLogged,
+      ownerId: input.ownerId,
+      appCount: publicClientIds.length,
+    });
+    ownerHadWork = true;
+    recordResult(input.tallies, result);
+  }
+
+  if (ownerHadWork) input.tallies.ownersWithWork += 1;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (!args.ownerId && !args.all) {
@@ -242,69 +343,23 @@ async function main() {
     `Scanning owners=${ownerIds.length} apply=${args.apply} verbose=${args.verbose}`,
   );
 
-  let ok = 0;
-  let dryRun = 0;
-  let skip = 0;
-  let missing = 0;
-  let fail = 0;
-  let ownersWithWork = 0;
-
+  const tallies = emptyTallies();
   for (const ownerId of ownerIds) {
-    const publicClientIds = await listOwnedPublicClientIds(ownerId);
-    const keys = legacyKeysForOwner(ownerId, publicClientIds);
-    let ownerLogged = false;
-    let ownerHadWork = false;
-
-    for (const customerKey of keys) {
-      const found = await findOpenMeterCustomerByKey(client, customerKey);
-      if (!found?.id) {
-        missing += 1;
-        if (args.verbose) {
-          if (!ownerLogged) {
-            console.log(`\n[owner] ${ownerId} apps=${publicClientIds.length}`);
-            ownerLogged = true;
-          }
-          console.log(`  [skip] no customer ${customerKey}`);
-        }
-        continue;
-      }
-
-      const result = await releaseCustomer({
-        baseUrl,
-        apiKey,
-        customerId: found.id,
-        customerKey,
-        apply: args.apply,
-        verbose: args.verbose,
-      });
-
-      if (result === "skip") {
-        skip += 1;
-        if (args.verbose && !ownerLogged) {
-          console.log(`\n[owner] ${ownerId} apps=${publicClientIds.length}`);
-          ownerLogged = true;
-        }
-        continue;
-      }
-
-      if (!ownerLogged) {
-        console.log(`\n[owner] ${ownerId} apps=${publicClientIds.length}`);
-        ownerLogged = true;
-      }
-      ownerHadWork = true;
-
-      if (result === "ok") ok += 1;
-      else if (result === "dry-run") dryRun += 1;
-      else fail += 1;
-    }
-
-    if (ownerHadWork) ownersWithWork += 1;
+    await processOwner({
+      client,
+      baseUrl,
+      apiKey,
+      ownerId,
+      apply: args.apply,
+      verbose: args.verbose,
+      tallies,
+    });
   }
 
   console.log(
-    `\nDone owners=${ownerIds.length} ownersWithWork=${ownersWithWork} apply=${args.apply} ok=${ok} dryRun=${dryRun} skip=${skip} missing=${missing} fail=${fail}`,
+    `\nDone owners=${ownerIds.length} ownersWithWork=${tallies.ownersWithWork} apply=${args.apply} ok=${tallies.ok} dryRun=${tallies.dryRun} skip=${tallies.skip} missing=${tallies.missing} fail=${tallies.fail}`,
   );
-  if (fail > 0) {
+  if (tallies.fail > 0) {
     process.exitCode = 1;
   }
 }

--- a/scripts/openmeter-release-legacy-subjects.ts
+++ b/scripts/openmeter-release-legacy-subjects.ts
@@ -254,14 +254,8 @@ function recordResult(tallies: ScanTallies, result: ReleaseResult): void {
   else tallies.fail += 1;
 }
 
-function ensureOwnerHeader(input: {
-  ownerLogged: boolean;
-  ownerId: string;
-  appCount: number;
-}): boolean {
-  if (input.ownerLogged) return true;
-  console.log(`\n[owner] ${input.ownerId} apps=${input.appCount}`);
-  return true;
+function logOwnerHeader(ownerId: string, appCount: number): void {
+  console.log(`\n[owner] ${ownerId} apps=${appCount}`);
 }
 
 async function processOwner(input: {
@@ -278,16 +272,18 @@ async function processOwner(input: {
   let ownerLogged = false;
   let ownerHadWork = false;
 
+  const maybeLogOwner = () => {
+    if (ownerLogged) return;
+    logOwnerHeader(input.ownerId, publicClientIds.length);
+    ownerLogged = true;
+  };
+
   for (const customerKey of keys) {
     const found = await findOpenMeterCustomerByKey(input.client, customerKey);
     if (!found?.id) {
       input.tallies.missing += 1;
       if (input.verbose) {
-        ownerLogged = ensureOwnerHeader({
-          ownerLogged,
-          ownerId: input.ownerId,
-          appCount: publicClientIds.length,
-        });
+        maybeLogOwner();
         console.log(`  [skip] no customer ${customerKey}`);
       }
       continue;
@@ -304,21 +300,11 @@ async function processOwner(input: {
 
     if (result === "skip") {
       input.tallies.skip += 1;
-      if (input.verbose) {
-        ownerLogged = ensureOwnerHeader({
-          ownerLogged,
-          ownerId: input.ownerId,
-          appCount: publicClientIds.length,
-        });
-      }
+      if (input.verbose) maybeLogOwner();
       continue;
     }
 
-    ownerLogged = ensureOwnerHeader({
-      ownerLogged,
-      ownerId: input.ownerId,
-      appCount: publicClientIds.length,
-    });
+    maybeLogOwner();
     ownerHadWork = true;
     recordResult(input.tallies, result);
   }

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -66,7 +66,11 @@ async function ensureCustomerUsageAttribution(
   try {
     await client.customers.update(customer.id, {
       name: customer.name?.trim() || customer.key || requiredSubjectKeys[0],
-      usageAttribution: { subjectKeys: nextKeys },
+      // Only send subjectKeys when they actually change — Konnect 400s on
+      // "subject key change" for subscribed customers even when the set is identical.
+      ...(missing.length > 0
+        ? { usageAttribution: { subjectKeys: nextKeys } }
+        : {}),
       ...(Object.keys(nextMetadata).length > 0 ? { metadata: nextMetadata } : {}),
     });
   } catch (err) {
@@ -106,8 +110,13 @@ export async function ensureOwnerCustomerWireSubjects(
 /**
  * Ensure the shared owner Konnect customer (canonical key = bare users.id).
  * Created with subjectKeys = [bareId] so it does not conflict with a legacy
- * `owner:{id}` customer. Transitional wire/compound subjects are attached
- * best-effort afterward (skipped while another customer still owns them).
+ * `owner:{id}` customer.
+ *
+ * Existing customers only keep the bare settlement subject (+ metadata).
+ * Transitional wire/compound subjects (`owner:…`, `app_…:…`) are attached
+ * best-effort once at create time; Konnect rejects later changes while a
+ * subscription is active (400) or when a legacy wallet still claims them (409).
+ * Meter dual-read for usage does not require those keys on the customer record.
  */
 export async function ensureOwnerCustomer(
   client: OpenMeter,
@@ -121,8 +130,13 @@ export async function ensureOwnerCustomer(
       publicClientIds.map((id) => id.trim()).filter((id) => id.length > 0),
     ),
   ];
-  // Prefer full transitional attribution, but never block create on conflicts.
-  const preferredKeys = buildOwnerMeterSubjects(trimmedOwnerId, uniqueClientIds);
+  // Settlement subject only for existing customers. Transitional keys are
+  // create-time best-effort; see buildOwnerMeterSubjects for meter dual-read.
+  const settlementKeys = [ownerKey];
+  const transitionalKeys = buildOwnerMeterSubjects(
+    trimmedOwnerId,
+    uniqueClientIds,
+  );
   const metadata: Record<string, string> = {
     pymthouse_owner_user_id: trimmedOwnerId,
     pymthouse_owned_client_ids: uniqueClientIds.join(","),
@@ -130,7 +144,12 @@ export async function ensureOwnerCustomer(
 
   const existing = await findOpenMeterCustomerByKey(client, ownerKey);
   if (existing?.id) {
-    await ensureCustomerUsageAttribution(client, existing, preferredKeys, metadata);
+    await ensureCustomerUsageAttribution(
+      client,
+      existing,
+      settlementKeys,
+      metadata,
+    );
     return { id: existing.id, key: ownerKey };
   }
 
@@ -145,16 +164,26 @@ export async function ensureOwnerCustomer(
     if (!created?.id) {
       throw new Error(`OpenMeter customer create failed for key ${ownerKey}`);
     }
-    // Best-effort: attach transitional subjects if Konnect allows.
+    // Best-effort: attach transitional subjects before any subscription locks keys.
     const fresh = await findOpenMeterCustomerByKey(client, ownerKey);
     if (fresh?.id) {
-      await ensureCustomerUsageAttribution(client, fresh, preferredKeys, metadata);
+      await ensureCustomerUsageAttribution(
+        client,
+        fresh,
+        transitionalKeys,
+        metadata,
+      );
     }
     return { id: created.id, key: ownerKey };
   } catch (err) {
     const raced = await findOpenMeterCustomerByKey(client, ownerKey);
     if (raced?.id) {
-      await ensureCustomerUsageAttribution(client, raced, preferredKeys, metadata);
+      await ensureCustomerUsageAttribution(
+        client,
+        raced,
+        settlementKeys,
+        metadata,
+      );
       return { id: raced.id, key: ownerKey };
     }
     throw err;

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -66,7 +66,7 @@ async function ensureCustomerUsageAttribution(
   try {
     await client.customers.update(customer.id, {
       name: customer.name?.trim() || customer.key || requiredSubjectKeys[0],
-      // Only send subjectKeys when they actually change — Konnect 400s on
+      // Only send subjectKeys when adding missing keys — Konnect 400s on
       // "subject key change" for subscribed customers even when the set is identical.
       ...(missing.length > 0
         ? { usageAttribution: { subjectKeys: nextKeys } }
@@ -112,11 +112,13 @@ export async function ensureOwnerCustomerWireSubjects(
  * Created with subjectKeys = [bareId] so it does not conflict with a legacy
  * `owner:{id}` customer.
  *
- * Existing customers only keep the bare settlement subject (+ metadata).
- * Transitional wire/compound subjects (`owner:…`, `app_…:…`) are attached
- * best-effort once at create time; Konnect rejects later changes while a
- * subscription is active (400) or when a legacy wallet still claims them (409).
- * Meter dual-read for usage does not require those keys on the customer record.
+ * For existing customers, only ensure the bare settlement subject is present
+ * (+ metadata). Does not strip transitional keys already on the record; it
+ * simply avoids attaching more. Transitional wire/compound subjects
+ * (`owner:…`, `app_…:…`) are attached best-effort once at create time;
+ * Konnect rejects later changes while a subscription is active (400) or when
+ * a legacy wallet still claims them (409). Meter dual-read for usage does not
+ * require those keys on the customer record.
  */
 export async function ensureOwnerCustomer(
   client: OpenMeter,

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -422,7 +422,7 @@ test("ensureOpenMeterCustomer creates customer when missing", async () => {
   assert.deepEqual(identity, { id: "om-new", key: "app_1:user-2" });
 });
 
-test("ensureOwnerCustomerWireSubjects adds compound app keys to owner customer", async () => {
+test("ensureOwnerCustomer attaches transitional keys only on create", async () => {
   let updatedSubjectKeys: string[] | undefined;
   let createdBody: {
     key?: string;
@@ -481,6 +481,56 @@ test("ensureOwnerCustomerWireSubjects adds compound app keys to owner customer",
       "uuid-1",
     ].sort(),
   );
+});
+
+test("ensureOwnerCustomer keeps settlement subject only on existing customers", async () => {
+  let updateCalls = 0;
+  let updatedSubjectKeys: string[] | undefined;
+  const ownerKey = "uuid-1";
+  const customerRecord = {
+    id: "om-owner-1",
+    key: ownerKey,
+    name: ownerKey,
+    usageAttribution: { subjectKeys: [ownerKey] },
+    metadata: {} as Record<string, string>,
+  };
+  const client = {
+    customers: {
+      get: async () => customerRecord,
+      list: async () => ({ items: [customerRecord] }),
+      update: async (
+        _id: string,
+        input: {
+          usageAttribution?: { subjectKeys: string[] };
+          metadata?: Record<string, string>;
+        },
+      ) => {
+        updateCalls += 1;
+        if (input.usageAttribution) {
+          updatedSubjectKeys = input.usageAttribution.subjectKeys;
+          customerRecord.usageAttribution = { subjectKeys: updatedSubjectKeys };
+        }
+        if (input.metadata) {
+          customerRecord.metadata = input.metadata;
+        }
+        return customerRecord;
+      },
+      create: async () => {
+        throw new Error("should not create");
+      },
+    },
+  };
+
+  const identity = await ensureOwnerCustomerWireSubjects(
+    openMeterTestClient(client),
+    "uuid-1",
+    ["app_aaa", "app_bbb"],
+  );
+  assert.deepEqual(identity, { id: "om-owner-1", key: ownerKey });
+  // Bare settlement key already present — subjectKeys must not be re-sent.
+  assert.equal(updatedSubjectKeys, undefined);
+  assert.equal(customerRecord.metadata.pymthouse_owned_client_ids, "app_aaa,app_bbb");
+  assert.ok(updateCalls >= 1);
 });
 
 test("ensureOpenMeterCustomer soft-fails subject update when subscription is active", async () => {


### PR DESCRIPTION
## Summary
- Stop `ensureOwnerCustomer` from repeatedly attaching transitional subject keys (`owner:…`, `app_…:…`) on existing subscribed customers — settlement uses bare `{users.id}` only, and Konnect rejects those updates with 400/409 (noisy prod logs).
- Add `npm run openmeter:release-legacy-subjects` to dry-run/`--apply` incomplete legacy releases that still hold live subjects alongside `deprecated:…` (SDK update left both; PUT replace fixes it).
- Harden `migrate-owner-customers` release path to use the same Konnect PUT helper and verify the live subject is gone.

## Why a separate PR (not #260)
PR #260 is the usage-routes / external-user-id API refactor. This is ops + owner-customer attribution noise unrelated to that surface.

## Test plan
- [x] `npx tsx --test src/lib/openmeter/openmeter.test.ts`
- [ ] `npm run openmeter:release-legacy-subjects -- --all` (dry-run; expect `ownersWithWork=0` or only listed actionable owners)
- [ ] After deploy, confirm prod no longer logs `openmeter: skip subject key update … cannot change subject keys for customer with active subscriptions` on mint/usage for already-provisioned owners