### PR TITLE
chore: bump @pymthouse/builder-sdk to ^0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",
-        "@pymthouse/builder-sdk": "^0.5.0",
+        "@pymthouse/builder-sdk": "^0.6.1",
         "@pymthouse/clearinghouse-identity-webhook": "^0.4.2",
         "@tailwindcss/postcss": "^4.1.18",
         "@turnkey/crypto": "^2.10.0",
@@ -2248,9 +2248,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@pymthouse/builder-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.5.0.tgz",
-      "integrity": "sha512-Kn1bca6s5IybGlDhtQzz6kS+5tQUZhoLk8McAmK6YDItFCm2app1Yg6hMjEkb3lv+2f8bSpjkYb9p7qr7YASJw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.6.1.tgz",
+      "integrity": "sha512-ALGluRpNAdnoK0Qk1ugP7TVcTrEPtnkipeIsSx6UX6hD1MN8mtOrgZAi+dhB2VZGEM7OBdWz1YhK6V1yskialw==",
       "license": "MIT",
       "dependencies": {
         "oauth4webapi": "^3.8.5"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@braintree/sanitize-url": "^7.1.2",
     "@openmeter/sdk": "^1.0.0-beta.228",
-    "@pymthouse/builder-sdk": "^0.5.0",
+    "@pymthouse/builder-sdk": "^0.6.1",
     "@pymthouse/clearinghouse-identity-webhook": "^0.4.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@turnkey/crypto": "^2.10.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps `@pymthouse/builder-sdk` from `^0.5.0` to `^0.6.1` (resolved to 0.6.1).

No application code changes required — existing imports (`PmtHouseError`, `createDeviceExchangeHandler`, plan-pricing, billing types) remain compatible. Typecheck and billing/plan-pricing tests pass against 0.6.1.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2cb5e7a-e234-4921-965a-86e1dcb5a75c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cb5e7a-e234-4921-965a-86e1dcb5a75c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Builder SDK dependency to version 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->