### PR TITLE
fix(openmeter): always send subjectKeys on customer update

### DIFF
--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -64,13 +64,13 @@ async function ensureCustomerUsageAttribution(
   }
 
   try {
+    // Konnect customer update is a full replace (PUT) — always send the
+    // current subjectKeys so a metadata-only update does not wipe them.
+    // nextKeys equals the existing set when nothing is missing (no real
+    // change), so this does not trip the active-subscription 400 guard.
     await client.customers.update(customer.id, {
       name: customer.name?.trim() || customer.key || requiredSubjectKeys[0],
-      // Only send subjectKeys when adding missing keys — Konnect 400s on
-      // "subject key change" for subscribed customers even when the set is identical.
-      ...(missing.length > 0
-        ? { usageAttribution: { subjectKeys: nextKeys } }
-        : {}),
+      usageAttribution: { subjectKeys: nextKeys },
       ...(Object.keys(nextMetadata).length > 0 ? { metadata: nextMetadata } : {}),
     });
   } catch (err) {

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -527,8 +527,9 @@ test("ensureOwnerCustomer keeps settlement subject only on existing customers", 
     ["app_aaa", "app_bbb"],
   );
   assert.deepEqual(identity, { id: "om-owner-1", key: ownerKey });
-  // Bare settlement key already present — subjectKeys must not be re-sent.
-  assert.equal(updatedSubjectKeys, undefined);
+  // Bare settlement key already present; update re-sends the same set (Konnect
+  // PUT is a full replace, so omitting it would wipe subject_keys).
+  assert.deepEqual(updatedSubjectKeys, [ownerKey]);
   assert.equal(customerRecord.metadata.pymthouse_owned_client_ids, "app_aaa,app_bbb");
   assert.ok(updateCalls >= 1);
 });


### PR DESCRIPTION
## Summary
- Konnect customer update is a full replace (PUT). #261 omitted `usageAttribution` on metadata-only updates, which **wiped `subject_keys`** and left settlement subjects null on customers with active subscriptions.
- Always re-send the current `subjectKeys` set. Identical keys are accepted by Konnect even with an active subscription (verified in staging), so this does not reintroduce the 400 noise that #261 silenced.
- Staging owner `8112311f-…` was already data-repaired; this prevents the wipe from recurring.

## Test plan
- [x] `npx tsx --test src/lib/openmeter/openmeter.test.ts` (35 pass)
- [ ] Hit `/api/v1/billing/dashboard` and `/api/v1/me/credits` for an owner with an active Owner Starter sub — no `skip subject key update` / 400 logs
- [ ] Confirm an owner customer's `subject_keys` still contain the bare settlement id after a metadata-only ensure (e.g. owned client-ids change)