### PR TITLE
fix(openmeter): skip publish when Owner Starter plan is already active

### DIFF
--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -40,6 +40,32 @@ function isSubjectKeyConflictError(err: unknown): boolean {
   );
 }
 
+/** Statuses that lock subject-key edits on Konnect (mirrors subscription-read). */
+function isSubjectKeyLockingSubscriptionStatus(status: string | undefined): boolean {
+  return status === "active" || status === "scheduled" || status === "pending";
+}
+
+/**
+ * True when the customer has a subscription that blocks subject-key changes.
+ * Local check (no subscription-read import) to avoid a customers↔subscription cycle.
+ */
+async function customerHasSubjectKeyLockingSubscription(
+  client: OpenMeter,
+  customerId: string,
+): Promise<boolean> {
+  try {
+    const listed = await client.customers.listSubscriptions(customerId, {
+      pageSize: 100,
+    });
+    return (listed?.items ?? []).some((item) =>
+      isSubjectKeyLockingSubscriptionStatus(item.status),
+    );
+  } catch {
+    // Fall through to the update attempt; catch still handles the 400.
+    return false;
+  }
+}
+
 async function ensureCustomerUsageAttribution(
   client: OpenMeter,
   customer: OpenMeterCustomerRecord,
@@ -63,6 +89,16 @@ async function ensureCustomerUsageAttribution(
     return;
   }
 
+  // Konnect rejects subject-key changes while a subscription is active.
+  // Skip the PUT (and the warn) when we already know it will fail; metadata-only
+  // updates (missing.length === 0) are still safe and proceed below.
+  if (
+    missing.length > 0 &&
+    (await customerHasSubjectKeyLockingSubscription(client, customer.id))
+  ) {
+    return;
+  }
+
   try {
     // Konnect customer update is a full replace (PUT) — always send the
     // current subjectKeys so a metadata-only update does not wipe them.
@@ -74,12 +110,12 @@ async function ensureCustomerUsageAttribution(
       ...(Object.keys(nextMetadata).length > 0 ? { metadata: nextMetadata } : {}),
     });
   } catch (err) {
-    // Konnect rejects subject-key changes while a subscription is active, or
-    // when keys are still owned by another customer (legacy owner: wallet).
-    if (
-      isActiveSubscriptionSubjectKeyError(err) ||
-      isSubjectKeyConflictError(err)
-    ) {
+    // Safety net for TOCTOU (sub activated between check and PUT) or when
+    // keys are still owned by another customer (legacy owner: wallet).
+    if (isActiveSubscriptionSubjectKeyError(err)) {
+      return;
+    }
+    if (isSubjectKeyConflictError(err)) {
       console.warn(
         "openmeter: skip subject key update",
         customer.key ?? customer.id,

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -543,6 +543,7 @@ test("ensureOpenMeterCustomer soft-fails subject update when subscription is act
         name: key,
         usageAttribution: { subjectKeys: [] },
       }),
+      listSubscriptions: async () => ({ items: [] }),
       update: async () => {
         throw new Error(
           "Request failed (https://us.api.konghq.com/v3/openmeter/customers/x) [400]: validation error: cannot change subject keys for customer with active subscriptions",
@@ -559,6 +560,37 @@ test("ensureOpenMeterCustomer soft-fails subject update when subscription is act
     "owner:uuid-1",
   );
   assert.deepEqual(identity, { id: "om-owner-1", key: "owner:uuid-1" });
+});
+
+test("ensureOpenMeterCustomer skips subject update when active sub is known", async () => {
+  let updateCalls = 0;
+  const client = {
+    customers: {
+      get: async (key: string) => ({
+        id: "om-owner-1",
+        key,
+        name: key,
+        usageAttribution: { subjectKeys: [] },
+      }),
+      listSubscriptions: async () => ({
+        items: [{ id: "sub-1", status: "active" }],
+      }),
+      update: async () => {
+        updateCalls += 1;
+        throw new Error("should not update");
+      },
+      create: async () => {
+        throw new Error("should not create");
+      },
+    },
+  };
+
+  const identity = await ensureOpenMeterCustomer(
+    openMeterTestClient(client),
+    "owner:uuid-1",
+  );
+  assert.deepEqual(identity, { id: "om-owner-1", key: "owner:uuid-1" });
+  assert.equal(updateCalls, 0);
 });
 
 test("buildUsageMeterSubjects dual-reads bare owner and compound forms", async () => {

--- a/src/lib/openmeter/owner-starter-plan.ts
+++ b/src/lib/openmeter/owner-starter-plan.ts
@@ -18,6 +18,7 @@ import {
 import { buildKonnectUsageRateCard } from "./konnect-plan-body";
 import {
   isOpenMeterConflictError,
+  isOpenMeterPlanAlreadyPublishedError,
   isOpenMeterPlanNotFoundError,
 } from "./plan-errors";
 import { shouldUseKonnectRoutes } from "./route-mode";
@@ -86,10 +87,17 @@ function buildOwnerStarterPlanBody(input: {
   };
 }
 
+type FoundPlan = {
+  id: string;
+  key?: string;
+  version?: number;
+  status?: string;
+};
+
 async function findPlanByKey(
   client: OpenMeter,
   planKey: string,
-): Promise<{ id: string; key?: string; version?: number } | null> {
+): Promise<FoundPlan | null> {
   try {
     const listed = await client.plans.list({
       // SDK typings vary; key filter is supported by Konnect.
@@ -97,8 +105,7 @@ async function findPlanByKey(
       page: 1,
       pageSize: 50,
     } as Parameters<OpenMeter["plans"]["list"]>[0]);
-    const items = (listed as { items?: Array<{ id: string; key?: string; version?: number }> })
-      ?.items ?? [];
+    const items = (listed as { items?: Array<FoundPlan> })?.items ?? [];
     const exact = items.find((item) => item.key === planKey);
     if (exact?.id) {
       return exact;
@@ -114,12 +121,18 @@ async function findPlanByKey(
         id: plan.id,
         key: plan.key,
         version: typeof plan.version === "number" ? plan.version : undefined,
+        status: plan.status,
       };
     }
   } catch {
     return null;
   }
   return null;
+}
+
+/** Publish is only legal for these plan states; any other state is already live. */
+function planNeedsPublish(status: string | undefined): boolean {
+  return status === "draft" || status === "scheduled";
 }
 
 async function publishOwnerStarterPlanBestEffort(
@@ -130,7 +143,10 @@ async function publishOwnerStarterPlanBestEffort(
     const published = await client.plans.publish(planId);
     return published?.id ?? planId;
   } catch (err) {
-    if (!isOpenMeterConflictError(err)) {
+    if (
+      !isOpenMeterConflictError(err) &&
+      !isOpenMeterPlanAlreadyPublishedError(err)
+    ) {
       console.warn(
         "openmeter: owner starter plan publish",
         err instanceof Error ? err.message : String(err),
@@ -166,7 +182,9 @@ export async function ensureOwnerStarterPlanSynced(): Promise<OwnerStarterPlanRe
 
   const existing = await findPlanByKey(client, OWNER_STARTER_PLAN_KEY);
   if (existing?.id) {
-    await publishOwnerStarterPlanBestEffort(client, existing.id);
+    if (planNeedsPublish(existing.status)) {
+      await publishOwnerStarterPlanBestEffort(client, existing.id);
+    }
     return {
       key: OWNER_STARTER_PLAN_KEY,
       openmeterPlanId: existing.id,

--- a/src/lib/openmeter/plan-errors.ts
+++ b/src/lib/openmeter/plan-errors.ts
@@ -19,6 +19,12 @@ export function isOpenMeterPlanImmutableError(err: unknown): boolean {
   return /only Plans in \[draft scheduled\] can be updated/i.test(message);
 }
 
+/** True when a publish is a no-op because the plan version is already active/published. */
+export function isOpenMeterPlanAlreadyPublishedError(err: unknown): boolean {
+  const message = errorMessage(err);
+  return /only Plans in \[draft scheduled\] can be published\/rescheduled/i.test(message);
+}
+
 /** True when OpenMeter rejects a duplicate subscription or entitlement for the same feature. */
 export function isOpenMeterConflictError(err: unknown): boolean {
   const message = errorMessage(err);


### PR DESCRIPTION
## Summary
- Skip re-publishing the shared Owner Starter plan when Konnect already reports `active`/`archived` status (only publish `draft`/`scheduled`).
- Treat the “only Plans in [draft scheduled] can be published/rescheduled” 400 as a benign no-op so remaining race/TOCTOU cases do not spam logs.

## Test plan
- [ ] Hit a path that calls `ensureOwnerStarterPlanSynced` (e.g. `/me/credits` or owner ensure) against an env where Owner Starter is already active — confirm no `owner starter plan publish` warn
- [ ] Confirm a freshly created draft plan still gets published (create path unchanged)
- [ ] Existing owner subscription ensure still returns an active sub without errors