### PR TITLE
fix(ci): handle vercel [SENSITIVE] placeholders in validate-env

### DIFF
--- a/scripts/validate-env.js
+++ b/scripts/validate-env.js
@@ -61,6 +61,16 @@ const optionalVars = {
 const isVercelBuild = process.env.VERCEL === "1";
 const buildOptionalOnVercel = new Set(["DATABASE_URL", "NEXTAUTH_URL"]);
 
+/**
+ * `vercel pull` redacts Sensitive env vars as the literal "[SENSITIVE]"
+ * (or empty string). Those are not real values and must not fail format checks.
+ */
+function isUnavailableEnvValue(value) {
+  if (value == null) return true;
+  const trimmed = String(value).trim();
+  return trimmed === "" || trimmed === "[SENSITIVE]";
+}
+
 function formatSet(value) {
   return `set (${value.length} chars)`;
 }
@@ -79,7 +89,7 @@ console.log("📋 Required Variables:");
 for (const [key, config] of Object.entries(requiredVars)) {
   const value = process.env[key];
 
-  if (!value) {
+  if (isUnavailableEnvValue(value)) {
     if (isVercelBuild && buildOptionalOnVercel.has(key)) {
       console.log(`  ⚠️  ${key}: not set for build (must be in Vercel Production env for runtime)`);
       console.log(`     → ${config.desc}`);
@@ -192,7 +202,7 @@ if (
 }
 
 const dbUrl = process.env.DATABASE_URL;
-if (dbUrl && !dbUrl.includes("sslmode")) {
+if (!isUnavailableEnvValue(dbUrl) && !dbUrl.includes("sslmode")) {
   console.log(
     "  ⚠️  DATABASE_URL missing SSL mode - add '?sslmode=require' for production",
   );


### PR DESCRIPTION
## Summary
- `vercel pull` redacts Sensitive env vars as the literal `[SENSITIVE]` during CI `vercel build`
- `validate-env` treated that placeholder as a real `DATABASE_URL`, failed format checks, and incorrectly warned about missing `sslmode`
- Treat `[SENSITIVE]` / empty values as unavailable at build time (same as missing for build-optional vars like `DATABASE_URL`)

## Test plan
- [ ] Confirm production deploy CI passes `npm run validate:env` with redacted `DATABASE_URL`
- [ ] Locally: `VERCEL=1 DATABASE_URL='[SENSITIVE]' … node scripts/validate-env.js` exits 0 with a build-time warning
- [ ] Real postgres URLs without `sslmode` still warn; URLs with `sslmode=require` do not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment validation by recognizing redacted or blank configuration values as unavailable.
  * Prevented misleading database connection warnings when deployment platforms provide placeholder values.
  * Preserved existing handling for skipped checks during supported deployment builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->