### PR TITLE
perf: cut session and remote-signer latency; add end-user usage API

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -384,6 +384,19 @@ Session-authenticated (NextAuth). Lists OpenMeter `create_signed_ticket` CloudEv
 
 Do **not** pass `externalUserId` — the server derives subjects from the session (`users.id` plus `app_users.external_user_id` rows matching the session email). Responses include `items`, `nextCursor`, and `openMeterConfigured`.
 
+### End-user request history (Bearer subject)
+
+**Endpoint:** `GET /api/v1/user/usage/requests`
+
+End-user access token (`Authorization: Bearer` programmatic user JWT or signer JWT). Lists signed-ticket CloudEvents for the **token subject only** — newest first. Integrators (e.g. Livepeer Dashboard) mint a user JWT via Builder `POST .../users/{externalUserId}/token`, then call this route; the subject cannot be overridden by query params.
+
+| Query | Description |
+| --- | --- |
+| `cursor` | Opaque pagination cursor from a prior response |
+| `limit` | Page size (default 25, max 50) |
+
+Do **not** pass `externalUserId`. Responses include `items`, `nextCursor`, `openMeterConfigured`, plus `clientId` / `externalUserId` echoed from the credential.
+
 **Balance (subscription allowance):** `GET /api/v1/apps/{clientId}/usage/balance?externalUserId=...` returns prepaid credit balance (`balanceUsdMicros`, `hasAccess`, etc.). On Konnect this is `GET /credits/balance` (`live`); on self-hosted OpenMeter it is the entitlement grant balance.
 
 **Starter plan (per app):** Each app has a seeded **Starter** plan (`isStarterDefault`) for M2M end users, separate from **Network Price** (discovery-only, not synced to OpenMeter). End-user Starter syncs to OpenMeter/Konnect with a `network_spend` rate card for settlement (`credit_then_invoice`) and included usage via `discounts.usage` (amount from `OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS`, default `$5`). **App owners** instead share one platform **Owner Starter** plan (`pymthouse_owner_starter`) on their bare `{users.id}` Konnect customer — not a per-app Neon plan row. New end users are auto-subscribed to the app Starter when provisioned (`POST /users`, signer mint, Kafka collector ingest / `openmeter-ensure-customer`).

--- a/scripts/openmeter-ensure-customer.ts
+++ b/scripts/openmeter-ensure-customer.ts
@@ -133,7 +133,7 @@ async function ensureOne(input: {
       externalUserId: input.externalUserId,
     });
     console.log(
-      `[ok] ${label} provisioned appUser=${result.appUserId} starterReady=${result.starterSubscriptionReady} allowance=${result.allowance?.hasAccess ?? "n/a"}`,
+      `[ok] ${label} provisioned appUser=${result.appUserId} starterReady=${result.starterSubscriptionReady}`,
     );
     return;
   }

--- a/src/app/api/v1/apps/[id]/oidc/token/route.ts
+++ b/src/app/api/v1/apps/[id]/oidc/token/route.ts
@@ -106,11 +106,13 @@ export async function POST(
       correlationId,
     });
 
-    await writeAuditLog({
+    void writeAuditLog({
       clientId: app.id,
       action: "app_oidc_token_exchange",
       status: "success",
       correlationId,
+    }).catch((err) => {
+      console.error("[app-oidc-token] audit log failed:", err);
     });
 
     return NextResponse.json(session, {
@@ -118,11 +120,13 @@ export async function POST(
     });
   } catch (err) {
     if (err instanceof AppScopedSignerTokenExchangeError) {
-      await writeAuditLog({
+      void writeAuditLog({
         clientId: app.id,
         action: "app_oidc_token_exchange",
         status: err.code,
         correlationId,
+      }).catch((auditErr) => {
+        console.error("[app-oidc-token] audit log failed:", auditErr);
       });
       return tokenExchangeErrorResponse(err, correlationId);
     }

--- a/src/app/api/v1/user/usage/requests/route.ts
+++ b/src/app/api/v1/user/usage/requests/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { authenticateEndUser } from "@/lib/auth/end-user";
+import { listEndUserSignedTicketRequests } from "@/lib/openmeter/signed-ticket-events";
+
+/**
+ * End-user signed-ticket request history for the Bearer subject only.
+ * Auth: end-user / signer JWT (subject forced from the token — not queryable).
+ */
+export async function GET(request: NextRequest) {
+  const auth = await authenticateEndUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  if (params.has("externalUserId") || params.has("external_user_id")) {
+    return NextResponse.json(
+      {
+        error:
+          "externalUserId is not allowed; requests are scoped to the authenticated user",
+      },
+      { status: 400 },
+    );
+  }
+
+  const cursor = params.get("cursor")?.trim() || undefined;
+  const limitRaw = params.get("limit");
+  const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+
+  const result = await listEndUserSignedTicketRequests({
+    externalUserId: auth.externalUserId,
+    clientId: auth.publicClientId,
+    cursor,
+    limit: Number.isFinite(limit) ? limit : undefined,
+  });
+
+  return NextResponse.json({
+    items: result.items,
+    nextCursor: result.nextCursor,
+    openMeterConfigured: result.openMeterConfigured,
+    clientId: auth.publicClientId,
+    externalUserId: auth.externalUserId,
+  });
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -12,7 +12,7 @@ export default function Providers({
   session: Session | null;
 }) {
   return (
-    <SessionProvider session={session}>
+    <SessionProvider session={session} refetchOnWindowFocus={false}>
       <TurnkeyProviderWrapper>{children}</TurnkeyProviderWrapper>
     </SessionProvider>
   );

--- a/src/lib/auth/end-user.ts
+++ b/src/lib/auth/end-user.ts
@@ -1,0 +1,143 @@
+import { and, eq } from "drizzle-orm";
+
+import { splitCompositeApiKey } from "@/lib/app-api-keys";
+import { db } from "@/db/index";
+import { appUsers, developerApps, oidcClients } from "@/db/schema";
+import { verifyAccessToken } from "@/lib/oidc/access-token-verify";
+import {
+  resolveSubjectAccessToken,
+  SubjectAccessTokenResolveError,
+} from "@/lib/oidc/resolve-subject-access-token";
+
+export type EndUserAuth = {
+  publicClientId: string;
+  developerAppId: string;
+  externalUserId: string;
+};
+
+function readBearerToken(request: Request): string | null {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return null;
+  }
+  const token = authHeader.slice("Bearer ".length).trim();
+  return token || null;
+}
+
+function readTokenClientId(payload: Record<string, unknown>): string | null {
+  const clientId = payload.client_id;
+  if (typeof clientId === "string" && clientId.trim()) {
+    return clientId.trim();
+  }
+  const azp = payload.azp;
+  if (typeof azp === "string" && azp.trim()) {
+    return azp.trim();
+  }
+  return null;
+}
+
+function readExternalUserIdClaim(payload: Record<string, unknown>): string | null {
+  const fromClaim = payload.external_user_id;
+  if (typeof fromClaim === "string" && fromClaim.trim()) {
+    return fromClaim.trim();
+  }
+  return null;
+}
+
+async function resolveDeveloperAppFromPublicClient(
+  publicClientId: string,
+): Promise<{ appId: string } | null> {
+  const rows = await db
+    .select({ appId: developerApps.id })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, publicClientId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function resolveSignerJwtEndUser(
+  payload: Record<string, unknown>,
+): Promise<EndUserAuth | null> {
+  const publicClientId = readTokenClientId(payload);
+  const externalUserId =
+    readExternalUserIdClaim(payload) ||
+    (typeof payload.sub === "string" && payload.user_type === "external_user"
+      ? payload.sub.trim()
+      : null);
+  if (!publicClientId || !externalUserId) {
+    return null;
+  }
+
+  const developerApp = await resolveDeveloperAppFromPublicClient(publicClientId);
+  if (!developerApp) {
+    return null;
+  }
+
+  const appUserRows = await db
+    .select({ externalUserId: appUsers.externalUserId })
+    .from(appUsers)
+    .where(
+      and(
+        eq(appUsers.clientId, developerApp.appId),
+        eq(appUsers.externalUserId, externalUserId),
+        eq(appUsers.status, "active"),
+      ),
+    )
+    .limit(1);
+  if (!appUserRows[0]) {
+    return null;
+  }
+
+  return {
+    publicClientId,
+    developerAppId: developerApp.appId,
+    externalUserId,
+  };
+}
+
+/**
+ * Authenticate an end-user Bearer credential for `/api/v1/user/*`.
+ * Accepts programmatic user JWTs and signer JWTs (subject forced from the token).
+ */
+export async function authenticateEndUser(
+  request: Request,
+): Promise<EndUserAuth | null> {
+  const token = readBearerToken(request);
+  if (!token) {
+    return null;
+  }
+
+  // Reject obvious API-key shapes here — full key resolution lives on feat/api-refactor.
+  // Dashboard + Builder mint paths use JWTs.
+  const looksLikeJwt = token.split(".").length === 3;
+  const composite = splitCompositeApiKey(token);
+  if (composite || !looksLikeJwt) {
+    return null;
+  }
+
+  const payload = await verifyAccessToken(token);
+  if (!payload) {
+    return null;
+  }
+  const rec = payload as Record<string, unknown>;
+
+  const signerResolved = await resolveSignerJwtEndUser(rec);
+  if (signerResolved) {
+    return signerResolved;
+  }
+
+  try {
+    const resolved = await resolveSubjectAccessToken(token);
+    return {
+      publicClientId: resolved.publicClientId,
+      developerAppId: resolved.developerAppId,
+      externalUserId: resolved.externalUserId,
+    };
+  } catch (err) {
+    if (err instanceof SubjectAccessTokenResolveError) {
+      return null;
+    }
+    throw err;
+  }
+}

--- a/src/lib/billing/provision-app-user.ts
+++ b/src/lib/billing/provision-app-user.ts
@@ -4,7 +4,6 @@ import {
   ensureOpenMeterCustomerForAppUser,
   type OpenMeterCustomerIdentity,
 } from "@/lib/openmeter/customers";
-import { getTrialCreditBalance, type TrialCreditBalance } from "@/lib/openmeter/entitlements";
 import { ensureStarterSubscriptionForAppUser } from "@/lib/openmeter/starter-subscription";
 import { ensureTrialAllowanceForAppUser } from "@/lib/openmeter/trial-allowance";
 import { resolveOrCreateAppUser } from "@/lib/usage/record-signed-ticket";
@@ -13,7 +12,6 @@ export type ProvisionAppUserBillingResult = {
   appUserId: string;
   endUserId: string;
   externalUserId: string;
-  allowance: TrialCreditBalance | null;
   starterSubscriptionCreated: boolean;
   starterSubscriptionReady: boolean;
 };
@@ -38,8 +36,8 @@ export async function ensureAppUserKonnectCustomer(input: {
 }
 
 /**
- * Upsert app/end-user rows, ensure OpenMeter customer + Starter subscription,
- * and return subscription allowance balance (network_spend entitlement).
+ * Upsert app/end-user rows and ensure OpenMeter customer + Starter subscription.
+ * Callers that need a live balance should use {@link getSpendableUsdMicros}.
  */
 export async function provisionAppUserBilling(input: {
   clientId: string;
@@ -61,16 +59,10 @@ export async function provisionAppUserBilling(input: {
     externalUserId,
   });
 
-  const allowance = await getTrialCreditBalance({
-    clientId: input.clientId,
-    externalUserId,
-  });
-
   return {
     appUserId: appUser.id,
     endUserId,
     externalUserId,
-    allowance,
     starterSubscriptionCreated: sub.created,
     starterSubscriptionReady: isHostedAdminClientAvailable()
       ? Boolean(sub.openmeterSubscriptionId)

--- a/src/lib/next-auth-options.ts
+++ b/src/lib/next-auth-options.ts
@@ -115,6 +115,16 @@ export const authOptions: NextAuthOptions = {
       if (user?.id) {
         token.userId = user.id;
         token.role = (user as { role?: string }).role;
+      } else if (token.userId && token.role == null) {
+        // One-time backfill for JWTs minted before role was stashed on the token.
+        const rows = await db
+          .select({ role: users.role })
+          .from(users)
+          .where(eq(users.id, token.userId as string))
+          .limit(1);
+        if (rows[0]) {
+          token.role = rows[0].role;
+        }
       }
       return token;
     },

--- a/src/lib/next-auth-options.ts
+++ b/src/lib/next-auth-options.ts
@@ -115,16 +115,6 @@ export const authOptions: NextAuthOptions = {
       if (user?.id) {
         token.userId = user.id;
         token.role = (user as { role?: string }).role;
-      } else if (token.userId && token.role == null) {
-        // One-time backfill for JWTs minted before role was stashed on the token.
-        const rows = await db
-          .select({ role: users.role })
-          .from(users)
-          .where(eq(users.id, token.userId as string))
-          .limit(1);
-        if (rows[0]) {
-          token.role = rows[0].role;
-        }
       }
       return token;
     },

--- a/src/lib/next-auth-options.ts
+++ b/src/lib/next-auth-options.ts
@@ -2,7 +2,7 @@ import type { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { db } from "@/db/index";
 import { users } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { validateBearerToken, hasScope } from "@/lib/auth";
 import {
   findOrCreateDeveloperUser,
@@ -41,6 +41,7 @@ export const authOptions: NextAuthOptions = {
           id: user.id,
           email: user.email,
           name: user.name || user.email,
+          role: user.role,
         };
       },
     }),
@@ -86,6 +87,7 @@ export const authOptions: NextAuthOptions = {
           id: user.id,
           email: user.email || undefined,
           name: user.name || user.walletAddress || "Developer",
+          role: user.role,
         };
       },
     }),
@@ -100,40 +102,9 @@ export const authOptions: NextAuthOptions = {
       return false;
     },
     async session({ session, token }) {
-      if (session.user) {
-        if (token.userId) {
-          const pmthRows = await db
-            .select()
-            .from(users)
-            .where(eq(users.id, token.userId as string))
-            .limit(1);
-          const pmthUser = pmthRows[0];
-
-          if (pmthUser) {
-            (session.user as Record<string, unknown>).id = pmthUser.id;
-            (session.user as Record<string, unknown>).role = pmthUser.role;
-            return session;
-          }
-        }
-
-        if (token.provider && token.sub) {
-          const pmthRows = await db
-            .select()
-            .from(users)
-            .where(
-              and(
-                eq(users.oauthProvider, token.provider as string),
-                eq(users.oauthSubject, token.sub),
-              ),
-            )
-            .limit(1);
-          const pmthUser = pmthRows[0];
-
-          if (pmthUser) {
-            (session.user as Record<string, unknown>).id = pmthUser.id;
-            (session.user as Record<string, unknown>).role = pmthUser.role;
-          }
-        }
+      if (session.user && token.userId) {
+        (session.user as Record<string, unknown>).id = token.userId;
+        (session.user as Record<string, unknown>).role = token.role;
       }
       return session;
     },
@@ -143,6 +114,7 @@ export const authOptions: NextAuthOptions = {
       }
       if (user?.id) {
         token.userId = user.id;
+        token.role = (user as { role?: string }).role;
       }
       return token;
     },

--- a/src/lib/oidc/local-token-exchange-fetch.ts
+++ b/src/lib/oidc/local-token-exchange-fetch.ts
@@ -1,0 +1,111 @@
+import {
+  AppScopedSignerTokenExchangeError,
+  handleAppScopedSignerTokenExchange,
+} from "@/lib/oidc/app-scoped-signer-token-exchange";
+import { timeSignerWebhookPhase } from "@/lib/oidc/signer-webhook-metrics";
+
+const APP_TOKEN_PATH = /^\/api\/v1\/apps\/([^/]+)\/oidc\/token$/;
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function requestBody(init?: RequestInit): string {
+  if (typeof init?.body === "string") return init.body;
+  if (init?.body != null) return String(init.body);
+  return "";
+}
+
+function clientCredentialsFromExchangeInit(
+  form: URLSearchParams,
+  init?: RequestInit,
+): { clientId: string; clientSecret: string } {
+  let clientId = form.get("client_id") || "";
+  let clientSecret = form.get("client_secret") || "";
+  const auth = new Headers(init?.headers).get("authorization") || "";
+  if (!auth.startsWith("Basic ")) {
+    return { clientId, clientSecret };
+  }
+  try {
+    const decoded = Buffer.from(auth.slice(6), "base64").toString("utf-8");
+    const idx = decoded.indexOf(":");
+    if (idx > 0) {
+      return {
+        clientId: decoded.slice(0, idx),
+        clientSecret: decoded.slice(idx + 1),
+      };
+    }
+  } catch {
+    /* use form credentials */
+  }
+  return { clientId, clientSecret };
+}
+
+async function exchangeInProcess(
+  publicClientId: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const form = new URLSearchParams(requestBody(init));
+  const { clientId, clientSecret } = clientCredentialsFromExchangeInit(form, init);
+
+  try {
+    const session = await handleAppScopedSignerTokenExchange({
+      publicClientId,
+      clientId,
+      clientSecret,
+      grantType: form.get("grant_type") || "",
+      subjectToken: form.get("subject_token") || "",
+      subjectTokenType: form.get("subject_token_type") || "",
+      requestedTokenType: form.get("requested_token_type") || "",
+      resource: form.get("resource") || "",
+      audiences: form.getAll("audience"),
+      correlationId: "local-exchange",
+    });
+    return Response.json(session);
+  } catch (err) {
+    if (err instanceof AppScopedSignerTokenExchangeError) {
+      return Response.json(
+        { error: err.code, error_description: err.message },
+        { status: err.status },
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Prefer an in-process token exchange when the exchange origin is this app.
+ * Avoids a full public HTTPS round-trip (and a second lambda) back to self.
+ */
+export function createLocalTokenExchangeFetch(appOrigin: string): typeof fetch {
+  let origin: string;
+  try {
+    origin = new URL(appOrigin).origin;
+  } catch {
+    return (input, init) =>
+      timeSignerWebhookPhase("token_exchange", () => fetch(input, init));
+  }
+
+  return (input, init) =>
+    timeSignerWebhookPhase("token_exchange", async () => {
+      let parsed: URL;
+      try {
+        parsed = new URL(requestUrl(input));
+      } catch {
+        return fetch(input, init);
+      }
+
+      const match = APP_TOKEN_PATH.exec(parsed.pathname);
+      const isLocalPost =
+        parsed.origin === origin &&
+        match != null &&
+        (init?.method ?? "GET").toUpperCase() === "POST";
+      if (!isLocalPost) {
+        return fetch(input, init);
+      }
+
+      return exchangeInProcess(decodeURIComponent(match[1]!), init);
+    });
+}

--- a/src/lib/oidc/local-token-exchange-fetch.ts
+++ b/src/lib/oidc/local-token-exchange-fetch.ts
@@ -1,8 +1,10 @@
+import { createCorrelationId, writeAuditLog } from "@/lib/audit";
 import {
   AppScopedSignerTokenExchangeError,
   handleAppScopedSignerTokenExchange,
 } from "@/lib/oidc/app-scoped-signer-token-exchange";
 import { timeSignerWebhookPhase } from "@/lib/oidc/signer-webhook-metrics";
+import { getProviderApp } from "@/lib/provider-apps";
 
 const APP_TOKEN_PATH = /^\/api\/v1\/apps\/([^/]+)\/oidc\/token$/;
 
@@ -14,8 +16,11 @@ function requestUrl(input: RequestInfo | URL): string {
 
 function requestBody(init?: RequestInit): string {
   if (typeof init?.body === "string") return init.body;
-  if (init?.body != null) return String(init.body);
-  return "";
+  if (init?.body instanceof URLSearchParams) return init.body.toString();
+  if (init?.body == null) return "";
+  throw new TypeError(
+    "local token exchange expects a string or URLSearchParams body",
+  );
 }
 
 function clientCredentialsFromExchangeInit(
@@ -43,12 +48,33 @@ function clientCredentialsFromExchangeInit(
   return { clientId, clientSecret };
 }
 
+function writeExchangeAuditLog(
+  publicClientId: string,
+  status: string,
+  correlationId: string,
+): void {
+  void (async () => {
+    try {
+      const app = await getProviderApp(publicClientId);
+      await writeAuditLog({
+        clientId: app?.id ?? null,
+        action: "app_oidc_token_exchange",
+        status,
+        correlationId,
+      });
+    } catch (err) {
+      console.error("[local-token-exchange] audit log failed:", err);
+    }
+  })();
+}
+
 async function exchangeInProcess(
   publicClientId: string,
   init?: RequestInit,
 ): Promise<Response> {
   const form = new URLSearchParams(requestBody(init));
   const { clientId, clientSecret } = clientCredentialsFromExchangeInit(form, init);
+  const correlationId = createCorrelationId();
 
   try {
     const session = await handleAppScopedSignerTokenExchange({
@@ -61,13 +87,19 @@ async function exchangeInProcess(
       requestedTokenType: form.get("requested_token_type") || "",
       resource: form.get("resource") || "",
       audiences: form.getAll("audience"),
-      correlationId: "local-exchange",
+      correlationId,
     });
+    writeExchangeAuditLog(publicClientId, "success", correlationId);
     return Response.json(session);
   } catch (err) {
     if (err instanceof AppScopedSignerTokenExchangeError) {
+      writeExchangeAuditLog(publicClientId, err.code, correlationId);
       return Response.json(
-        { error: err.code, error_description: err.message },
+        {
+          error: err.code,
+          error_description: err.message,
+          correlation_id: correlationId,
+        },
         { status: err.status },
       );
     }

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -14,7 +14,7 @@ import { isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
 import { buildOwnerWireSubject } from "@/lib/openmeter/customer-key";
 import { hasPositiveUsdMicrosBalance } from "@/lib/format-usd-micros";
 import type { TrialCreditBalance } from "@/lib/openmeter/entitlements";
-import { getSpendableUsdMicros } from "@/lib/openmeter/spendable-allowance";
+import { getSpendableAllowanceDetails } from "@/lib/openmeter/spendable-allowance";
 import { SIGN_MINT_USER_TOKEN_SCOPE } from "@/lib/oidc/scopes";
 import { buildSignerSessionEnvelope } from "@/lib/openapi/signer-session";
 import { getClientSignerApiUrl } from "@/lib/signer-proxy";
@@ -231,23 +231,27 @@ export async function mintSignerJwtForExternalUser(input: {
 
   // Mint gate uses credits + remaining plan discount (discount covers included usage).
   if (isHostedAdminClientAvailable()) {
-    const spendable = await getSpendableUsdMicros({
+    const spendable = await getSpendableAllowanceDetails({
       clientId: identity.publicClientId,
       externalUserId: provisionExternalUserId,
       identity,
     });
     if (spendable != null) {
       allowance = {
-        hasAccess: BigInt(spendable) > 0n,
-        balanceUsdMicros: spendable,
-        consumedUsdMicros: "0",
-        lifetimeGrantedUsdMicros: "0",
+        hasAccess: BigInt(spendable.spendableUsdMicros) > 0n,
+        balanceUsdMicros: spendable.spendableUsdMicros,
+        consumedUsdMicros: spendable.consumedUsdMicros,
+        lifetimeGrantedUsdMicros: spendable.lifetimeGrantedUsdMicros,
       };
       // Same-request webhook balance_check uses owner: wire subject for owners.
       const gateSubject = identity.isOwner
         ? buildOwnerWireSubject(provisionExternalUserId)
         : provisionExternalUserId;
-      seedSignerSpendableBalance(input.publicClientId, gateSubject, spendable);
+      seedSignerSpendableBalance(
+        input.publicClientId,
+        gateSubject,
+        spendable.spendableUsdMicros,
+      );
     }
   }
 

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -7,12 +7,14 @@ import { validateClientSecret } from "@/lib/oidc/clients";
 import { ACCESS_TOKEN_JWT_TYP, ensureSigningKey } from "@/lib/oidc/jwks";
 import { getIssuer } from "@/lib/oidc/issuer-urls";
 import {
-  ensureAppUserKonnectCustomer,
   provisionAppUserBilling,
 } from "@/lib/billing/provision-app-user";
+import { seedSignerSpendableBalance } from "@/lib/oidc/signer-balance-gate";
 import { isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
+import { buildOwnerWireSubject } from "@/lib/openmeter/customer-key";
 import { hasPositiveUsdMicrosBalance } from "@/lib/format-usd-micros";
 import type { TrialCreditBalance } from "@/lib/openmeter/entitlements";
+import { getSpendableUsdMicros } from "@/lib/openmeter/spendable-allowance";
 import { SIGN_MINT_USER_TOKEN_SCOPE } from "@/lib/oidc/scopes";
 import { buildSignerSessionEnvelope } from "@/lib/openapi/signer-session";
 import { getClientSignerApiUrl } from "@/lib/signer-proxy";
@@ -210,18 +212,12 @@ export async function mintSignerJwtForExternalUser(input: {
     : externalUserId;
   const jwtExternalUserId = provisionExternalUserId;
 
-  let allowance: TrialCreditBalance | null;
+  let allowance: TrialCreditBalance | null = null;
   try {
-    if (isHostedAdminClientAvailable()) {
-      await ensureAppUserKonnectCustomer({
-        clientId: identity.developerAppId,
-        externalUserId: provisionExternalUserId,
-      });
-    }
-    ({ allowance } = await provisionAppUserBilling({
+    await provisionAppUserBilling({
       clientId: identity.developerAppId,
       externalUserId: provisionExternalUserId,
-    }));
+    });
   } catch (err) {
     if (isHostedAdminClientAvailable()) {
       throw new MintUserSignerTokenError(
@@ -235,18 +231,23 @@ export async function mintSignerJwtForExternalUser(input: {
 
   // Mint gate uses credits + remaining plan discount (discount covers included usage).
   if (isHostedAdminClientAvailable()) {
-    const { getSpendableUsdMicros } = await import("@/lib/openmeter/spendable-allowance");
     const spendable = await getSpendableUsdMicros({
       clientId: identity.publicClientId,
       externalUserId: provisionExternalUserId,
+      identity,
     });
     if (spendable != null) {
       allowance = {
         hasAccess: BigInt(spendable) > 0n,
         balanceUsdMicros: spendable,
-        consumedUsdMicros: allowance?.consumedUsdMicros ?? "0",
-        lifetimeGrantedUsdMicros: allowance?.lifetimeGrantedUsdMicros ?? "0",
+        consumedUsdMicros: "0",
+        lifetimeGrantedUsdMicros: "0",
       };
+      // Same-request webhook balance_check uses owner: wire subject for owners.
+      const gateSubject = identity.isOwner
+        ? buildOwnerWireSubject(provisionExternalUserId)
+        : provisionExternalUserId;
+      seedSignerSpendableBalance(input.publicClientId, gateSubject, spendable);
     }
   }
 

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -240,8 +240,9 @@ export async function mintSignerJwtForExternalUser(input: {
       allowance = {
         hasAccess: BigInt(spendable.spendableUsdMicros) > 0n,
         balanceUsdMicros: spendable.spendableUsdMicros,
-        consumedUsdMicros: spendable.consumedUsdMicros,
-        lifetimeGrantedUsdMicros: spendable.lifetimeGrantedUsdMicros,
+        // Not surfaced in the signer envelope; the mint gate reads balance only.
+        consumedUsdMicros: "0",
+        lifetimeGrantedUsdMicros: spendable.grantedUsdMicros,
       };
       // Same-request webhook balance_check uses owner: wire subject for owners.
       const gateSubject = identity.isOwner

--- a/src/lib/oidc/remote-signer-webhook-config.ts
+++ b/src/lib/oidc/remote-signer-webhook-config.ts
@@ -10,6 +10,7 @@ import {
   getPublicOrigin,
 } from "@/lib/oidc/issuer-urls";
 import { createLocalSignerJwksResolver } from "@/lib/oidc/local-signer-jwks";
+import { createLocalTokenExchangeFetch } from "@/lib/oidc/local-token-exchange-fetch";
 import { buildSignerBalanceCheck } from "@/lib/oidc/signer-balance-gate";
 import { timeSignerWebhookPhase } from "@/lib/oidc/signer-webhook-metrics";
 import { buildOwnerWireSubject } from "@/lib/openmeter/customer-key";
@@ -141,12 +142,6 @@ function isSelfIssuedJwtIssuer(jwtIssuer: string, appOrigin: string): boolean {
   }
 }
 
-/** fetch wrapper that logs composite token-exchange latency per request. */
-function createTimedExchangeFetch(): typeof fetch {
-  return (input, init) =>
-    timeSignerWebhookPhase("token_exchange", () => fetch(input, init));
-}
-
 function parseRequiredScopes(source: EnvSource): string[] {
   return trimEnv(source, "OIDC_REQUIRED_SCOPES").split(/[\s,]+/).filter(Boolean);
 }
@@ -179,6 +174,7 @@ function buildEndUserVerifier(
     return createEndUserVerifierFromEnv(source);
   }
 
+  const appOrigin = resolveAppOrigin(source, original);
   return createOidcVerifier({
     jwtIssuer,
     jwtAudience: trimEnv(source, "OIDC_AUDIENCE") || jwtIssuer,
@@ -192,7 +188,7 @@ function buildEndUserVerifier(
     exchangeM2mClientId: trimEnv(source, "OIDC_EXCHANGE_M2M_CLIENT_ID") || undefined,
     exchangeM2mClientSecret:
       trimEnv(source, "OIDC_EXCHANGE_M2M_CLIENT_SECRET") || undefined,
-    fetchImpl: createTimedExchangeFetch(),
+    fetchImpl: createLocalTokenExchangeFetch(appOrigin),
   });
 }
 

--- a/src/lib/oidc/signer-balance-gate-seed.test.ts
+++ b/src/lib/oidc/signer-balance-gate-seed.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { UsageIdentity } from "@pymthouse/clearinghouse-identity-webhook/protocol";
+import {
+  createSpendableBalanceCache,
+  seedSignerSpendableBalance,
+} from "@/lib/oidc/signer-balance-gate";
+
+function identity(subject: string): UsageIdentity {
+  return {
+    issuer: "https://pymthouse.com/api/v1/oidc",
+    client_id: "app_3b386c81a1db1169fd2c3986",
+    usage_subject: subject,
+    usage_subject_type: "external_user_id",
+  };
+}
+
+test("spendable balance cache seed serves without calling getBalance", async () => {
+  let calls = 0;
+  const cached = createSpendableBalanceCache({
+    ttlSeconds: 20,
+    getBalance: async () => {
+      calls += 1;
+      return "should-not-run";
+    },
+  });
+
+  cached.seed("app_3b386c81a1db1169fd2c3986", "user-1", "999");
+  assert.equal(await cached.get(identity("user-1")), "999");
+  assert.equal(calls, 0);
+});
+
+test("seedSignerSpendableBalance does not throw", () => {
+  assert.doesNotThrow(() =>
+    seedSignerSpendableBalance("app_x", "user-y", "1"),
+  );
+});

--- a/src/lib/oidc/signer-balance-gate.test.ts
+++ b/src/lib/oidc/signer-balance-gate.test.ts
@@ -24,13 +24,13 @@ test("spendable balance cache serves repeat lookups within the TTL", async () =>
     now: () => nowMs,
   });
 
-  assert.equal(await cached(identity("user-1")), "1000000");
+  assert.equal(await cached.get(identity("user-1")), "1000000");
   nowMs += 5_000;
-  assert.equal(await cached(identity("user-1")), "1000000");
+  assert.equal(await cached.get(identity("user-1")), "1000000");
   assert.equal(calls, 1);
 
   nowMs += 20_000;
-  assert.equal(await cached(identity("user-1")), "1000000");
+  assert.equal(await cached.get(identity("user-1")), "1000000");
   assert.equal(calls, 2);
 });
 
@@ -46,9 +46,9 @@ test("spendable balance cache coalesces concurrent lookups per identity", async 
   });
 
   const results = await Promise.all([
-    cached(identity("user-1")),
-    cached(identity("user-1")),
-    cached(identity("user-2")),
+    cached.get(identity("user-1")),
+    cached.get(identity("user-1")),
+    cached.get(identity("user-2")),
   ]);
 
   assert.deepEqual(results, ["111", "111", "222"]);
@@ -68,8 +68,8 @@ test("spendable balance cache does not cache failures", async () => {
     },
   });
 
-  await assert.rejects(cached(identity("user-1")), /openmeter unavailable/);
-  assert.equal(await cached(identity("user-1")), "42");
+  await assert.rejects(cached.get(identity("user-1")), /openmeter unavailable/);
+  assert.equal(await cached.get(identity("user-1")), "42");
   assert.equal(calls, 2);
 });
 
@@ -83,8 +83,8 @@ test("spendable balance cache is disabled when ttl is zero", async () => {
     },
   });
 
-  assert.equal(await cached(identity("user-1")), "7");
-  assert.equal(await cached(identity("user-1")), "7");
+  assert.equal(await cached.get(identity("user-1")), "7");
+  assert.equal(await cached.get(identity("user-1")), "7");
   assert.equal(calls, 2);
 });
 
@@ -108,10 +108,10 @@ test("spendable balance cache stays bounded when every entry is inflight", async
   });
 
   const pending = [
-    cached(identity("user-0")),
-    cached(identity("user-1")),
-    cached(identity("user-2")),
-    cached(identity("user-3")),
+    cached.get(identity("user-0")),
+    cached.get(identity("user-1")),
+    cached.get(identity("user-2")),
+    cached.get(identity("user-3")),
   ];
   assert.equal(calls, 4);
   assert.equal(waiters.length, 4);
@@ -125,11 +125,11 @@ test("spendable balance cache stays bounded when every entry is inflight", async
   // oldest identity from the burst is no longer cached.
   blockLookups = false;
   const callsAfterBurst = calls;
-  assert.equal(await cached(identity("user-1")), "user-1");
-  assert.equal(await cached(identity("user-2")), "user-2");
-  assert.equal(await cached(identity("user-3")), "user-3");
+  assert.equal(await cached.get(identity("user-1")), "user-1");
+  assert.equal(await cached.get(identity("user-2")), "user-2");
+  assert.equal(await cached.get(identity("user-3")), "user-3");
   assert.equal(calls, callsAfterBurst);
-  assert.equal(await cached(identity("user-0")), "user-0");
+  assert.equal(await cached.get(identity("user-0")), "user-0");
   assert.equal(calls, callsAfterBurst + 1);
 });
 
@@ -148,9 +148,9 @@ test("spendable balance cache repeats a lookup evicted while inflight", async ()
     },
   });
 
-  const first = cached(identity("user-1"));
-  const second = cached(identity("user-2"));
-  const repeatedFirst = cached(identity("user-1"));
+  const first = cached.get(identity("user-1"));
+  const second = cached.get(identity("user-2"));
+  const repeatedFirst = cached.get(identity("user-1"));
 
   assert.equal(calls, 3);
   assert.equal(waiters.length, 3);
@@ -176,13 +176,13 @@ test("spendable balance cache evicts oldest resolved entries at capacity", async
     },
   });
 
-  assert.equal(await cached(identity("x")), "x");
-  assert.equal(await cached(identity("y")), "y");
-  assert.equal(await cached(identity("z")), "z"); // evicts x
+  assert.equal(await cached.get(identity("x")), "x");
+  assert.equal(await cached.get(identity("y")), "y");
+  assert.equal(await cached.get(identity("z")), "z"); // evicts x
   assert.equal(calls, 3);
-  assert.equal(await cached(identity("y")), "y");
-  assert.equal(await cached(identity("z")), "z");
+  assert.equal(await cached.get(identity("y")), "y");
+  assert.equal(await cached.get(identity("z")), "z");
   assert.equal(calls, 3);
-  assert.equal(await cached(identity("x")), "x");
+  assert.equal(await cached.get(identity("x")), "x");
   assert.equal(calls, 4);
 });

--- a/src/lib/oidc/signer-balance-gate.ts
+++ b/src/lib/oidc/signer-balance-gate.ts
@@ -36,6 +36,15 @@ type BalanceCacheEntry = {
   inflight?: Promise<string | null>;
 };
 
+export type SpendableBalanceCache = {
+  get: (identity: UsageIdentity) => Promise<string | null>;
+  seed: (clientId: string, usageSubject: string, value: string) => void;
+};
+
+function cacheKey(clientId: string, usageSubject: string): string {
+  return `${clientId}\u0000${usageSubject}`;
+}
+
 /**
  * Short-lived keyed cache with singleflight for spendable-balance lookups
  * (issue #248). Concurrent webhook calls for the same identity share one
@@ -48,13 +57,13 @@ export function createSpendableBalanceCache(options: {
   now?: () => number;
   /** Override for tests; production uses {@link BALANCE_CACHE_MAX_ENTRIES}. */
   maxEntries?: number;
-}): (identity: UsageIdentity) => Promise<string | null> {
+}): SpendableBalanceCache {
   const { ttlSeconds, getBalance } = options;
   const now = options.now ?? Date.now;
   const maxEntries = options.maxEntries ?? BALANCE_CACHE_MAX_ENTRIES;
 
   if (ttlSeconds <= 0) {
-    return getBalance;
+    return { get: getBalance, seed: () => undefined };
   }
 
   const entries = new Map<string, BalanceCacheEntry>();
@@ -74,32 +83,40 @@ export function createSpendableBalanceCache(options: {
     entries.set(key, entry);
   }
 
-  return (identity) => {
-    const key = `${identity.client_id}\u0000${identity.usage_subject}`;
-    const existing = entries.get(key);
-    if (existing) {
-      if (existing.inflight) {
-        return existing.inflight;
-      }
-      if (existing.expiresAtMs > now()) {
-        return Promise.resolve(existing.value ?? null);
-      }
-      entries.delete(key);
-    }
-
-    const inflight = getBalance(identity).then(
-      (value) => {
-        setBounded(key, { expiresAtMs: now() + ttlSeconds * 1000, value });
-        return value;
-      },
-      (err) => {
+  return {
+    seed(clientId, usageSubject, value) {
+      setBounded(cacheKey(clientId, usageSubject), {
+        expiresAtMs: now() + ttlSeconds * 1000,
+        value,
+      });
+    },
+    get(identity) {
+      const key = cacheKey(identity.client_id, identity.usage_subject);
+      const existing = entries.get(key);
+      if (existing) {
+        if (existing.inflight) {
+          return existing.inflight;
+        }
+        if (existing.expiresAtMs > now()) {
+          return Promise.resolve(existing.value ?? null);
+        }
         entries.delete(key);
-        throw err;
-      },
-    );
+      }
 
-    setBounded(key, { expiresAtMs: now() + ttlSeconds * 1000, inflight });
-    return inflight;
+      const inflight = getBalance(identity).then(
+        (value) => {
+          setBounded(key, { expiresAtMs: now() + ttlSeconds * 1000, value });
+          return value;
+        },
+        (err) => {
+          entries.delete(key);
+          throw err;
+        },
+      );
+
+      setBounded(key, { expiresAtMs: now() + ttlSeconds * 1000, inflight });
+      return inflight;
+    },
   };
 }
 
@@ -116,6 +133,29 @@ async function readIdentityBalanceUsdMicros(
   });
 }
 
+/** Process-local cache shared by mint (seed) and the webhook balance gate. */
+let sharedSpendableCache: SpendableBalanceCache | null = null;
+
+function getSharedSpendableCache(): SpendableBalanceCache {
+  sharedSpendableCache ??= createSpendableBalanceCache({
+    ttlSeconds: resolvePositiveSecondsEnv(
+      "SIGNER_BALANCE_CACHE_TTL_SECONDS",
+      DEFAULT_BALANCE_CACHE_TTL_SECONDS,
+    ),
+    getBalance: readIdentityBalanceUsdMicros,
+  });
+  return sharedSpendableCache;
+}
+
+/** Seed the webhook balance cache after mint so the same request skips a re-fetch. */
+export function seedSignerSpendableBalance(
+  clientId: string,
+  usageSubject: string,
+  value: string,
+): void {
+  getSharedSpendableCache().seed(clientId, usageSubject, value);
+}
+
 /**
  * Build the live balance gate for the remote-signer webhook. Returns undefined
  * when hosted billing is not configured, so self-hosted / metering-off
@@ -125,15 +165,9 @@ export function buildSignerBalanceCheck(): BalanceCheck | undefined {
   if (!isHostedAdminClientAvailable()) {
     return undefined;
   }
-  const cachedBalance = createSpendableBalanceCache({
-    ttlSeconds: resolvePositiveSecondsEnv(
-      "SIGNER_BALANCE_CACHE_TTL_SECONDS",
-      DEFAULT_BALANCE_CACHE_TTL_SECONDS,
-    ),
-    getBalance: readIdentityBalanceUsdMicros,
-  });
+  const cache = getSharedSpendableCache();
   return createBalanceGate({
-    getBalanceUsdMicros: (identity) => cachedBalance(identity),
+    getBalanceUsdMicros: (identity) => cache.get(identity),
     reauthTtlSeconds: resolveReauthTtlSeconds(),
     failClosed: true,
     onError: (err) => {

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -300,9 +300,15 @@ export function normalizeSignedTicketEvent(
   };
 }
 
-export async function listViewerSignedTicketRequests(
-  input: ListViewerSignedTicketRequestsInput,
-): Promise<ListViewerSignedTicketRequestsResult> {
+async function listSignedTicketRequestsForSubjects(input: {
+  subjects: ReadonlySet<string>;
+  clientId?: string | null;
+  clientIds?: string[] | null;
+  cursor?: string | null;
+  limit?: number;
+  from?: string;
+  to?: string;
+}): Promise<ListViewerSignedTicketRequestsResult> {
   if (!requireOpenMeterForUsageReads() || !isOpenMeterEnabled()) {
     return { items: [], nextCursor: null, openMeterConfigured: false };
   }
@@ -312,8 +318,7 @@ export async function listViewerSignedTicketRequests(
     return { items: [], nextCursor: null, openMeterConfigured: false };
   }
 
-  const subjects = await resolveViewerUsageSubjects(input.userId);
-  if (subjects.size === 0) {
+  if (input.subjects.size === 0) {
     return { items: [], nextCursor: null, openMeterConfigured: true };
   }
 
@@ -326,14 +331,14 @@ export async function listViewerSignedTicketRequests(
 
   const rawEvents = await fetchSignedTicketEvents({
     client,
-    subjects,
+    subjects: input.subjects,
     clientIds: clientIdFilter,
     from,
     to,
   });
 
   const matching = rawEvents.filter((ev) =>
-    eventMatchesViewerSubjects(ev, subjects, clientIdFilter),
+    eventMatchesViewerSubjects(ev, input.subjects, clientIdFilter),
   );
 
   const appNames = await loadAppNames(
@@ -370,6 +375,54 @@ export async function listViewerSignedTicketRequests(
     nextCursor,
     openMeterConfigured: true,
   };
+}
+
+export async function listViewerSignedTicketRequests(
+  input: ListViewerSignedTicketRequestsInput,
+): Promise<ListViewerSignedTicketRequestsResult> {
+  const subjects = await resolveViewerUsageSubjects(input.userId);
+  return listSignedTicketRequestsForSubjects({
+    subjects,
+    clientId: input.clientId,
+    clientIds: input.clientIds,
+    cursor: input.cursor,
+    limit: input.limit,
+    from: input.from,
+    to: input.to,
+  });
+}
+
+export type ListEndUserSignedTicketRequestsInput = {
+  externalUserId: string;
+  /** Public OIDC client_id (app_…), not developer_apps.id. */
+  clientId: string;
+  cursor?: string | null;
+  limit?: number;
+  from?: string;
+  to?: string;
+};
+
+/** Signed-ticket history for one end-user subject (Bearer `/api/v1/user` API). */
+export async function listEndUserSignedTicketRequests(
+  input: ListEndUserSignedTicketRequestsInput,
+): Promise<ListViewerSignedTicketRequestsResult> {
+  const externalUserId = input.externalUserId.trim();
+  const clientId = input.clientId.trim();
+  if (!externalUserId || !clientId) {
+    return {
+      items: [],
+      nextCursor: null,
+      openMeterConfigured: isOpenMeterEnabled(),
+    };
+  }
+  return listSignedTicketRequestsForSubjects({
+    subjects: new Set([externalUserId]),
+    clientId,
+    cursor: input.cursor,
+    limit: input.limit,
+    from: input.from,
+    to: input.to,
+  });
 }
 
 async function fetchSignedTicketEvents(input: {

--- a/src/lib/openmeter/spendable-allowance.ts
+++ b/src/lib/openmeter/spendable-allowance.ts
@@ -275,6 +275,8 @@ async function remainingDiscountAfterUsage(input: {
 export async function getSpendableUsdMicros(input: {
   clientId: string;
   externalUserId: string;
+  /** Skip a Neon round-trip when the caller already resolved billing identity. */
+  identity?: ResolvedBillingIdentity;
 }): Promise<string | null> {
   if (!isHostedAdminClientAvailable()) {
     return null;
@@ -282,10 +284,12 @@ export async function getSpendableUsdMicros(input: {
 
   // Resolve the billing identity once and share it across both lookups so the
   // webhook balance gate performs a single Neon identity round-trip (#248).
-  const identity = await resolveOpenMeterBillingIdentity({
-    clientId: input.clientId,
-    externalUserId: input.externalUserId,
-  });
+  const identity =
+    input.identity ??
+    (await resolveOpenMeterBillingIdentity({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+    }));
 
   const [credits, discountRemaining] = await Promise.all([
     getTrialCreditBalance({

--- a/src/lib/openmeter/spendable-allowance.ts
+++ b/src/lib/openmeter/spendable-allowance.ts
@@ -268,16 +268,23 @@ async function remainingDiscountAfterUsage(input: {
   return used >= discount ? 0n : discount - used;
 }
 
+export type SpendableAllowanceDetails = {
+  spendableUsdMicros: string;
+  consumedUsdMicros: string;
+  lifetimeGrantedUsdMicros: string;
+};
+
 /**
  * Spendable allowance for mint/signer gates: prepaid credits + remaining
- * plan usage discount for the current cycle.
+ * plan usage discount for the current cycle. Also returns credit consumed /
+ * lifetime granted from the same trial-balance lookup (no extra OpenMeter call).
  */
-export async function getSpendableUsdMicros(input: {
+export async function getSpendableAllowanceDetails(input: {
   clientId: string;
   externalUserId: string;
   /** Skip a Neon round-trip when the caller already resolved billing identity. */
   identity?: ResolvedBillingIdentity;
-}): Promise<string | null> {
+}): Promise<SpendableAllowanceDetails | null> {
   if (!isHostedAdminClientAvailable()) {
     return null;
   }
@@ -301,5 +308,19 @@ export async function getSpendableUsdMicros(input: {
   ]);
 
   const creditMicros = BigInt(credits?.balanceUsdMicros ?? "0");
-  return (creditMicros + discountRemaining).toString();
+  return {
+    spendableUsdMicros: (creditMicros + discountRemaining).toString(),
+    consumedUsdMicros: credits?.consumedUsdMicros ?? "0",
+    lifetimeGrantedUsdMicros: credits?.lifetimeGrantedUsdMicros ?? "0",
+  };
+}
+
+export async function getSpendableUsdMicros(input: {
+  clientId: string;
+  externalUserId: string;
+  /** Skip a Neon round-trip when the caller already resolved billing identity. */
+  identity?: ResolvedBillingIdentity;
+}): Promise<string | null> {
+  const details = await getSpendableAllowanceDetails(input);
+  return details?.spendableUsdMicros ?? null;
 }

--- a/src/lib/openmeter/spendable-allowance.ts
+++ b/src/lib/openmeter/spendable-allowance.ts
@@ -158,18 +158,30 @@ async function discountForLocalPlanId(localPlanId: string): Promise<bigint | nul
   return rows[0] ? includedDiscountUsdMicrosForPlan(rows[0]) : null;
 }
 
+export type PlanDiscountUsdMicros = {
+  /** Plan's included usage discount for the current cycle (the granted total). */
+  totalUsdMicros: bigint;
+  /** Remaining discount after this cycle's usage. */
+  remainingUsdMicros: bigint;
+};
+
 /**
- * Remaining plan usage discount for the current calendar month, for the
- * customer's primary active subscription. Zero when no discount or exhausted.
+ * Plan usage discount for the current calendar month, for the customer's
+ * primary active subscription: both the included total (granted) and the
+ * remaining amount after usage. Zero when no discount applies.
  */
-export async function getRemainingPlanDiscountUsdMicros(input: {
+export async function getPlanDiscountUsdMicros(input: {
   clientId: string;
   externalUserId: string;
   /** Pre-resolved billing identity — avoids a duplicate DB lookup when the caller already has it. */
   identity?: ResolvedBillingIdentity;
-}): Promise<bigint> {
+}): Promise<PlanDiscountUsdMicros> {
+  const zero: PlanDiscountUsdMicros = {
+    totalUsdMicros: 0n,
+    remainingUsdMicros: 0n,
+  };
   if (!isHostedAdminClientAvailable()) {
-    return 0n;
+    return zero;
   }
 
   const identity =
@@ -184,7 +196,7 @@ export async function getRemainingPlanDiscountUsdMicros(input: {
     externalUserId: input.externalUserId,
   });
   if (!subscription) {
-    return 0n;
+    return zero;
   }
 
   const subscriptionForLookup = await resolveSubscriptionWithPlanKey(subscription);
@@ -196,9 +208,16 @@ export async function getRemainingPlanDiscountUsdMicros(input: {
   ) {
     const discount = parsePositiveMicros(ownerStarterIncludedUsdMicros());
     if (discount == null || discount <= 0n) {
-      return 0n;
+      return zero;
     }
-    return remainingDiscountAfterUsage({ identity, input, discount });
+    return {
+      totalUsdMicros: discount,
+      remainingUsdMicros: await remainingDiscountAfterUsage({
+        identity,
+        input,
+        discount,
+      }),
+    };
   }
 
   let localPlanId = await resolveLocalPlanIdFromOpenMeterSubscription(
@@ -224,10 +243,30 @@ export async function getRemainingPlanDiscountUsdMicros(input: {
   }
 
   if (discount == null || discount <= 0n) {
-    return 0n;
+    return zero;
   }
 
-  return remainingDiscountAfterUsage({ identity, input, discount });
+  return {
+    totalUsdMicros: discount,
+    remainingUsdMicros: await remainingDiscountAfterUsage({
+      identity,
+      input,
+      discount,
+    }),
+  };
+}
+
+/**
+ * Remaining plan usage discount for the current calendar month, for the
+ * customer's primary active subscription. Zero when no discount or exhausted.
+ */
+export async function getRemainingPlanDiscountUsdMicros(input: {
+  clientId: string;
+  externalUserId: string;
+  /** Pre-resolved billing identity — avoids a duplicate DB lookup when the caller already has it. */
+  identity?: ResolvedBillingIdentity;
+}): Promise<bigint> {
+  return (await getPlanDiscountUsdMicros(input)).remainingUsdMicros;
 }
 
 async function remainingDiscountAfterUsage(input: {
@@ -269,15 +308,16 @@ async function remainingDiscountAfterUsage(input: {
 }
 
 export type SpendableAllowanceDetails = {
+  /** Spendable now: prepaid credits + remaining plan usage discount. */
   spendableUsdMicros: string;
-  consumedUsdMicros: string;
-  lifetimeGrantedUsdMicros: string;
+  /** Granted total for the cycle: the plan's included usage discount. */
+  grantedUsdMicros: string;
 };
 
 /**
  * Spendable allowance for mint/signer gates: prepaid credits + remaining
- * plan usage discount for the current cycle. Also returns credit consumed /
- * lifetime granted from the same trial-balance lookup (no extra OpenMeter call).
+ * plan usage discount for the current cycle. Also returns the plan's included
+ * discount total (granted) for the cycle, computed in the same pass.
  */
 export async function getSpendableAllowanceDetails(input: {
   clientId: string;
@@ -298,20 +338,19 @@ export async function getSpendableAllowanceDetails(input: {
       externalUserId: input.externalUserId,
     }));
 
-  const [credits, discountRemaining] = await Promise.all([
+  const [credits, discount] = await Promise.all([
     getTrialCreditBalance({
       clientId: input.clientId,
       externalUserId: input.externalUserId,
       identity,
     }),
-    getRemainingPlanDiscountUsdMicros({ ...input, identity }),
+    getPlanDiscountUsdMicros({ ...input, identity }),
   ]);
 
   const creditMicros = BigInt(credits?.balanceUsdMicros ?? "0");
   return {
-    spendableUsdMicros: (creditMicros + discountRemaining).toString(),
-    consumedUsdMicros: credits?.consumedUsdMicros ?? "0",
-    lifetimeGrantedUsdMicros: credits?.lifetimeGrantedUsdMicros ?? "0",
+    spendableUsdMicros: (creditMicros + discount.remainingUsdMicros).toString(),
+    grantedUsdMicros: discount.totalUsdMicros.toString(),
   };
 }
 


### PR DESCRIPTION
## Summary

### Latency
- `/api/auth/session`: stash `id`/`role` on the JWT at sign-in; disable `refetchOnWindowFocus`
- `/webhooks/remote-signer`: in-process token exchange when the exchange origin is this app (avoids ~3s public self-HTTP + second lambda)
- Mint: drop redundant Konnect ensure + provision `getTrialCreditBalance`; reuse billing identity for spendable; seed the webhook balance cache for the same request
- Token exchange route: fire-and-forget audit log

### End-user usage API (new)
Bearer end-user surface (`authenticateEndUser` — programmatic user JWT or signer JWT; subject forced from the credential; `userId` / `externalUserId` query params rejected):
- `GET /api/v1/user/usage` — OpenMeter usage (same shape as apps/{id}/usage), always scoped to the Bearer subject
- `GET /api/v1/user/usage/balance` — prepaid credit balance for the Bearer subject
- `GET /api/v1/user/usage/requests` — signed-ticket CloudEvents for the Bearer subject
- Shared helpers: `authenticateEndUser`, `listEndUserSignedTicketRequests` (+ `listSignedTicketRequestsForSubjects` refactor)
- Docs: builder-api endpoint reference

These match what `@pymthouse/builder-sdk` already prefers after minting a user JWT (dashboard account-usage was 404ing before M2M fallback).

## Review feedback addressed
- Local in-process token exchange: per-request `correlationId` + fire-and-forget audit (success + error); error responses include `correlation_id`
- Dropped NextAuth JWT role backfill in favor of hard cutover (short-lived JWTs)
- Signer session envelope: `balanceUsdMicros` = spendable (remaining plan discount + credits); `lifetimeGrantedUsdMicros` = plan included-discount total for the cycle

## Test plan
- [x] `npm test` — 397 pass
- [ ] Sign in → `/api/auth/session` returns id/role with no Neon query on subsequent polls
- [ ] Composite API key webhook: `token_exchange` no longer ~3s public round-trip; `balance_check` near-zero after mint seed
- [ ] Dashboard account usage: `GET /api/v1/user/usage` + `/balance` + `/requests` succeed with end-user JWT (no 404 / M2M fallback)
- [ ] `userId` / `externalUserId` query params on `/api/v1/user/usage*` return 400; other subjects are not leaked
- [x] SonarCloud + Snyk + CodeQL green on the PR