### PR TITLE
Show Documentation and Usage tiles for all My Apps users

### DIFF
--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -3,13 +3,13 @@ export const dynamic = "force-dynamic";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/next-auth-options";
 import { redirect } from "next/navigation";
-import Link from "next/link";
 import { db } from "@/db/index";
 import { signerConfig } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import DashboardLayout from "@/components/DashboardLayout";
 import AppsListSection from "@/components/apps/AppsListSection";
 import AdminAppsHome from "@/components/apps/AdminAppsHome";
+import MyAppsShortcutTiles from "@/components/apps/MyAppsShortcutTiles";
 import { listUserAccessibleApps } from "@/lib/user-apps";
 import { syncSignerStatus } from "@/lib/signer-proxy";
 import NetworkLiveIndicator from "@/components/NetworkLiveIndicator";
@@ -47,20 +47,14 @@ async function DeveloperMyApps({ userId }: Readonly<{ userId: string }>) {
 
   return (
     <>
-      <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-zinc-100">My Apps</h1>
-          <p className="mt-1 text-sm text-zinc-500">
-            Manage your provider applications
-          </p>
-        </div>
-        <Link
-          href="/usage"
-          className="shrink-0 text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors"
-        >
-          Open Usage →
-        </Link>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-zinc-100">My Apps</h1>
+        <p className="mt-1 text-sm text-zinc-500">
+          Manage your provider applications
+        </p>
       </div>
+
+      <MyAppsShortcutTiles />
 
       <AppsListSection
         apps={apps}

--- a/src/components/apps/AdminAppsHome.tsx
+++ b/src/components/apps/AdminAppsHome.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import AdminAppsSection from "@/components/apps/AdminAppsSection";
+import MyAppsShortcutTiles from "@/components/apps/MyAppsShortcutTiles";
 import type { UserAppSummary } from "@/lib/user-apps";
-import { getDocsBaseUrl } from "@/lib/docs-base-url";
 
 /**
  * Admin My Apps body: docs + usage shortcuts and full apps list (own / all toggle).
- * Usage analytics live on /billing.
+ * Usage analytics live on /usage.
  */
 export default function AdminAppsHome({
   myApps,
@@ -19,38 +18,7 @@ export default function AdminAppsHome({
 
   return (
     <>
-      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 flex flex-col justify-between gap-3">
-          <div>
-            <h3 className="font-semibold text-zinc-100">Documentation</h3>
-            <p className="text-xs text-zinc-500 mt-1">
-              Builder API, OIDC, device flow, and integration guides.
-            </p>
-          </div>
-          <a
-            href={getDocsBaseUrl()}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors self-start"
-          >
-            Open Docs →
-          </a>
-        </div>
-        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 flex flex-col justify-between gap-3">
-          <div>
-            <h3 className="font-semibold text-zinc-100">Usage</h3>
-            <p className="text-xs text-zinc-500 mt-1">
-              Request charts and signed-ticket history are on the Usage page.
-            </p>
-          </div>
-          <Link
-            href="/usage"
-            className="text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors self-start"
-          >
-            Open Usage →
-          </Link>
-        </div>
-      </div>
+      <MyAppsShortcutTiles />
 
       <AdminAppsSection
         initialApps={myApps}

--- a/src/components/apps/MyAppsShortcutTiles.tsx
+++ b/src/components/apps/MyAppsShortcutTiles.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { getDocsBaseUrl } from "@/lib/docs-base-url";
+
+/**
+ * Documentation + Usage shortcuts shown above the apps list on My Apps.
+ */
+export default function MyAppsShortcutTiles() {
+  return (
+    <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 flex flex-col justify-between gap-3">
+        <div>
+          <h3 className="font-semibold text-zinc-100">Documentation</h3>
+          <p className="text-xs text-zinc-500 mt-1">
+            Builder API, OIDC, device flow, and integration guides.
+          </p>
+        </div>
+        <a
+          href={getDocsBaseUrl()}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors self-start"
+        >
+          Open Docs →
+        </a>
+      </div>
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 flex flex-col justify-between gap-3">
+        <div>
+          <h3 className="font-semibold text-zinc-100">Usage</h3>
+          <p className="text-xs text-zinc-500 mt-1">
+            Request charts and signed-ticket history are on the Usage page.
+          </p>
+        </div>
+        <Link
+          href="/usage"
+          className="text-sm font-medium text-emerald-400 hover:text-emerald-300 transition-colors self-start"
+        >
+          Open Usage →
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Documentation and Usage shortcut tiles were only shown to admin/operator users via `AdminAppsHome`. Developer users only got a small “Open Usage →” header link and no docs tile.

This change extracts those tiles into a shared `MyAppsShortcutTiles` component and renders them for every signed-in user on the My Apps page. The redundant header Usage link for developers is removed in favor of the Usage tile.

## Changes
- Add `src/components/apps/MyAppsShortcutTiles.tsx` with Documentation (docs site) and Usage (`/usage`) tiles
- Reuse the shared tiles from `AdminAppsHome`
- Render the same tiles in the developer My Apps view

## Test plan
- [ ] Sign in as a non-admin developer and open `/apps`
- [ ] Confirm Documentation and Usage tiles appear above the apps list
- [ ] Confirm “Open Docs →” opens the docs site and “Open Usage →” goes to `/usage`
- [ ] Sign in as admin/operator and confirm tiles still appear as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad1eed23-2806-492a-a3aa-f679e6f8348a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad1eed23-2806-492a-a3aa-f679e6f8348a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

