### PR TITLE
feat(api): add end-user usage and balance routes

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -384,20 +384,30 @@ Session-authenticated (NextAuth). Lists OpenMeter `create_signed_ticket` CloudEv
 
 Do **not** pass `externalUserId` — the server derives subjects from the session (`users.id` plus `app_users.external_user_id` rows matching the session email). Responses include `items`, `nextCursor`, and `openMeterConfigured`.
 
-### End-user request history (Bearer subject)
+### End-user usage (Bearer subject)
+
+Integrators (e.g. Livepeer Dashboard / `@pymthouse/builder-sdk`) mint a user JWT via Builder `POST .../users/{externalUserId}/token`, then call these routes. Subject is forced from the credential — do **not** pass `userId` / `externalUserId` query params (rejected with 400).
+
+**Endpoint:** `GET /api/v1/user/usage`
+
+Same OpenMeter usage shape as `GET /api/v1/apps/{clientId}/usage`, always scoped to the Bearer subject. Supports `startDate`, `endDate`, `groupBy` (`none` / `user` / `pipeline_model` / `daily_pipeline`), and `include=retail`.
+
+**Endpoint:** `GET /api/v1/user/usage/balance`
+
+Same prepaid credit balance shape as `GET /api/v1/apps/{clientId}/usage/balance?externalUserId=...` (`balanceUsdMicros`, `consumedUsdMicros`, `lifetimeGrantedUsdMicros`, `hasAccess`, `remainingUsdMicros`), for the Bearer subject only. On Konnect this is `GET /credits/balance` (`live`); on self-hosted OpenMeter it is the entitlement grant balance.
 
 **Endpoint:** `GET /api/v1/user/usage/requests`
 
-End-user access token (`Authorization: Bearer` programmatic user JWT or signer JWT). Lists signed-ticket CloudEvents for the **token subject only** — newest first. Integrators (e.g. Livepeer Dashboard) mint a user JWT via Builder `POST .../users/{externalUserId}/token`, then call this route; the subject cannot be overridden by query params.
+Lists signed-ticket CloudEvents for the **token subject only** — newest first.
 
 | Query | Description |
 | --- | --- |
 | `cursor` | Opaque pagination cursor from a prior response |
 | `limit` | Page size (default 25, max 50) |
 
-Do **not** pass `externalUserId`. Responses include `items`, `nextCursor`, `openMeterConfigured`, plus `clientId` / `externalUserId` echoed from the credential.
+Responses include `items`, `nextCursor`, `openMeterConfigured`, plus `clientId` / `externalUserId` echoed from the credential.
 
-**Balance (subscription allowance):** `GET /api/v1/apps/{clientId}/usage/balance?externalUserId=...` returns prepaid credit balance (`balanceUsdMicros`, `hasAccess`, etc.). On Konnect this is `GET /credits/balance` (`live`); on self-hosted OpenMeter it is the entitlement grant balance.
+**Balance (Builder M2M):** `GET /api/v1/apps/{clientId}/usage/balance?externalUserId=...` is the confidential-client equivalent when an end-user JWT is not available.
 
 **Starter plan (per app):** Each app has a seeded **Starter** plan (`isStarterDefault`) for M2M end users, separate from **Network Price** (discovery-only, not synced to OpenMeter). End-user Starter syncs to OpenMeter/Konnect with a `network_spend` rate card for settlement (`credit_then_invoice`) and included usage via `discounts.usage` (amount from `OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS`, default `$5`). **App owners** instead share one platform **Owner Starter** plan (`pymthouse_owner_starter`) on their bare `{users.id}` Konnect customer — not a per-app Neon plan row. New end users are auto-subscribed to the app Starter when provisioned (`POST /users`, signer mint, Kafka collector ingest / `openmeter-ensure-customer`).
 

--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -394,7 +394,7 @@ Same OpenMeter usage shape as `GET /api/v1/apps/{clientId}/usage`, always scoped
 
 **Endpoint:** `GET /api/v1/user/usage/balance`
 
-Same prepaid credit balance shape as `GET /api/v1/apps/{clientId}/usage/balance?externalUserId=...` (`balanceUsdMicros`, `consumedUsdMicros`, `lifetimeGrantedUsdMicros`, `hasAccess`, `remainingUsdMicros`), for the Bearer subject only. On Konnect this is `GET /credits/balance` (`live`); on self-hosted OpenMeter it is the entitlement grant balance.
+Plan included-usage allowance for the Bearer subject (`balanceUsdMicros` / `remainingUsdMicros` = remaining plan discount, `lifetimeGrantedUsdMicros` = included total for the cycle, `consumedUsdMicros` = granted − remaining, `hasAccess` from spendable). Prepaid credits settle invoices/charges and are not the meter source. Builder M2M equivalent: `GET /api/v1/apps/{clientId}/usage/balance?externalUserId=...`.
 
 **Endpoint:** `GET /api/v1/user/usage/requests`
 

--- a/src/app/api/v1/apps/[id]/usage/balance/route.ts
+++ b/src/app/api/v1/apps/[id]/usage/balance/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateAppClient } from "@/lib/auth";
 import { getAuthorizedProviderApp, getProviderApp } from "@/lib/provider-apps";
-import { getTrialCreditBalance } from "@/lib/openmeter/entitlements";
+import { getUsageBalanceAllowance } from "@/lib/openmeter/spendable-allowance";
 
 export async function GET(
   request: NextRequest,
@@ -27,7 +27,7 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  const balance = await getTrialCreditBalance({
+  const balance = await getUsageBalanceAllowance({
     clientId: app.id,
     externalUserId,
   });
@@ -38,6 +38,5 @@ export async function GET(
   return NextResponse.json({
     externalUserId,
     ...balance,
-    remainingUsdMicros: balance.balanceUsdMicros,
   });
 }

--- a/src/app/api/v1/apps/[id]/usage/route.ts
+++ b/src/app/api/v1/apps/[id]/usage/route.ts
@@ -1,19 +1,12 @@
 import { NextResponse } from "next/server";
 import { authenticateAppClient } from "@/lib/auth";
-import {
-  estimateEndUserBillableMicros,
-  loadActiveRetailRatesForApp,
-  resolveRetailRateForUsage,
-} from "@/lib/billing/retail-usage";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
 import { getAuthorizedProviderApp, getProviderApp } from "@/lib/provider-apps";
 import {
-  buildOpenMeterUsageResponse,
-  queryOpenMeterAppDashboardUsage,
-  queryOpenMeterUsage,
-  queryOpenMeterUserDailyByPipeline,
-  queryOpenMeterUserPipelineByModel,
-} from "@/lib/usage/query-openmeter";
+  buildAppUsageResponse,
+  parseUsageQueryParams,
+  validateUsageDateParams,
+} from "@/lib/usage/build-app-usage-response";
 
 export async function GET(
   request: Request,
@@ -50,9 +43,9 @@ export async function GET(
   }
 
   const url = new URL(request.url);
-  const startDate = url.searchParams.get("startDate");
-  const endDate = url.searchParams.get("endDate");
-  const groupBy = url.searchParams.get("groupBy") || "none";
+  const { startDate, endDate, groupBy, includeRetail } = parseUsageQueryParams(
+    url.searchParams,
+  );
   const filterUserId = url.searchParams.get("userId");
 
   if (groupBy === "daily_pipeline" && !filterUserId?.trim()) {
@@ -62,106 +55,18 @@ export async function GET(
     );
   }
 
-  if (startDate && Number.isNaN(Date.parse(startDate))) {
-    return NextResponse.json({ error: "Invalid startDate format" }, { status: 400 });
-  }
-  if (endDate && Number.isNaN(Date.parse(endDate))) {
-    return NextResponse.json({ error: "Invalid endDate format" }, { status: 400 });
+  const dateError = validateUsageDateParams(startDate, endDate);
+  if (dateError) {
+    return NextResponse.json({ error: dateError }, { status: 400 });
   }
 
-  const includeRetail =
-    url.searchParams.get("include") === "retail" ||
-    url.searchParams.get("includeRetail") === "1" ||
-    url.searchParams.get("includeRetail") === "true";
-
-  const omRows = await queryOpenMeterUsage({
-    clientId: app.id,
-    startDate,
-    endDate,
-    externalUserId: filterUserId,
-  });
-
-  let pipelineRows;
-  let dailyPipelineRows;
-  if (groupBy === "pipeline_model") {
-    if (filterUserId?.trim()) {
-      pipelineRows = await queryOpenMeterUserPipelineByModel({
-        clientId: app.id,
-        startDate,
-        endDate,
-        externalUserId: filterUserId.trim(),
-      });
-    } else {
-      const dashboard = await queryOpenMeterAppDashboardUsage({
-        clientId: app.id,
-        startDate,
-        endDate,
-      });
-      pipelineRows = dashboard?.byPipelineModel ?? [];
-    }
-  }
-  if (groupBy === "daily_pipeline" && filterUserId) {
-    dailyPipelineRows = await queryOpenMeterUserDailyByPipeline({
-      clientId: app.id,
-      startDate,
-      endDate,
-      externalUserId: filterUserId,
-    });
-  }
-
-  let retailByPipelineModel: Map<
-    string,
-    { endUserBillableUsdMicros: string; retailRateUsd: string }
-  > | undefined;
-  if (includeRetail) {
-    const lookup = await loadActiveRetailRatesForApp(app.id);
-    retailByPipelineModel = new Map();
-    const rowsForRetail = pipelineRows ?? [];
-    if (rowsForRetail.length === 0 && omRows.length > 0) {
-      const rate = resolveRetailRateForUsage({ lookup });
-      const network = omRows.reduce(
-        (sum, row) => sum + BigInt(row.networkFeeUsdMicros),
-        0n,
-      );
-      retailByPipelineModel.set("*|*", {
-        retailRateUsd: rate,
-        endUserBillableUsdMicros: estimateEndUserBillableMicros({
-          networkFeeUsdMicros: network,
-          lookup,
-        }),
-      });
-    } else {
-      for (const row of rowsForRetail) {
-        const key = `${row.pipeline}|${row.modelId}`;
-        const rate = resolveRetailRateForUsage({
-          lookup,
-          pipeline: row.pipeline,
-          modelId: row.modelId,
-        });
-        retailByPipelineModel.set(key, {
-          retailRateUsd: rate,
-          endUserBillableUsdMicros: estimateEndUserBillableMicros({
-            networkFeeUsdMicros: BigInt(row.networkFeeUsdMicros),
-            lookup,
-            pipeline: row.pipeline,
-            modelId: row.modelId,
-          }),
-        });
-      }
-    }
-  }
-
-  const response = buildOpenMeterUsageResponse({
-    clientId: app.id,
+  const response = await buildAppUsageResponse({
+    appId: app.id,
     startDate,
     endDate,
     groupBy,
     filterUserId,
-    rows: omRows,
-    pipelineRows,
-    dailyPipelineRows,
     includeRetail,
-    retailByPipelineModel,
   });
   return NextResponse.json(response);
 }

--- a/src/app/api/v1/user/usage/balance/route.ts
+++ b/src/app/api/v1/user/usage/balance/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { authenticateEndUser } from "@/lib/auth/end-user";
+import {
+  authenticateEndUser,
+  endUserSubjectOverrideError,
+} from "@/lib/auth/end-user";
 import { getUsageBalanceAllowance } from "@/lib/openmeter/spendable-allowance";
 
 /**
@@ -11,20 +14,15 @@ import { getUsageBalanceAllowance } from "@/lib/openmeter/spendable-allowance";
  * consumed), not prepaid trial-credit ledger fields.
  */
 export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const override = endUserSubjectOverrideError(params, "balance");
+  if (override) {
+    return override;
+  }
+
   const auth = await authenticateEndUser(request);
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const params = request.nextUrl.searchParams;
-  if (params.has("externalUserId") || params.has("external_user_id")) {
-    return NextResponse.json(
-      {
-        error:
-          "externalUserId is not allowed; balance is scoped to the authenticated user",
-      },
-      { status: 400 },
-    );
   }
 
   const balance = await getUsageBalanceAllowance({

--- a/src/app/api/v1/user/usage/balance/route.ts
+++ b/src/app/api/v1/user/usage/balance/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authenticateEndUser } from "@/lib/auth/end-user";
-import { getTrialCreditBalance } from "@/lib/openmeter/entitlements";
+import { getUsageBalanceAllowance } from "@/lib/openmeter/spendable-allowance";
 
 /**
  * End-user allowance balance for the Bearer subject only.
  * Auth: programmatic user JWT or signer JWT (subject forced — not queryable).
+ *
+ * Returns the plan's included usage discount for the cycle (granted / remaining /
+ * consumed), not prepaid trial-credit ledger fields.
  */
 export async function GET(request: NextRequest) {
   const auth = await authenticateEndUser(request);
@@ -24,7 +27,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const balance = await getTrialCreditBalance({
+  const balance = await getUsageBalanceAllowance({
     clientId: auth.developerAppId,
     externalUserId: auth.externalUserId,
   });
@@ -35,6 +38,5 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({
     externalUserId: auth.externalUserId,
     ...balance,
-    remainingUsdMicros: balance.balanceUsdMicros,
   });
 }

--- a/src/app/api/v1/user/usage/balance/route.ts
+++ b/src/app/api/v1/user/usage/balance/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { authenticateEndUser } from "@/lib/auth/end-user";
+import { getTrialCreditBalance } from "@/lib/openmeter/entitlements";
+
+/**
+ * End-user allowance balance for the Bearer subject only.
+ * Auth: programmatic user JWT or signer JWT (subject forced — not queryable).
+ */
+export async function GET(request: NextRequest) {
+  const auth = await authenticateEndUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  if (params.has("externalUserId") || params.has("external_user_id")) {
+    return NextResponse.json(
+      {
+        error:
+          "externalUserId is not allowed; balance is scoped to the authenticated user",
+      },
+      { status: 400 },
+    );
+  }
+
+  const balance = await getTrialCreditBalance({
+    clientId: auth.developerAppId,
+    externalUserId: auth.externalUserId,
+  });
+  if (!balance) {
+    return NextResponse.json({ error: "OpenMeter not configured" }, { status: 503 });
+  }
+
+  return NextResponse.json({
+    externalUserId: auth.externalUserId,
+    ...balance,
+    remainingUsdMicros: balance.balanceUsdMicros,
+  });
+}

--- a/src/app/api/v1/user/usage/requests/route.ts
+++ b/src/app/api/v1/user/usage/requests/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { authenticateEndUser } from "@/lib/auth/end-user";
+import {
+  authenticateEndUser,
+  endUserSubjectOverrideError,
+} from "@/lib/auth/end-user";
 import { listEndUserSignedTicketRequests } from "@/lib/openmeter/signed-ticket-events";
 
 /**
@@ -8,20 +11,15 @@ import { listEndUserSignedTicketRequests } from "@/lib/openmeter/signed-ticket-e
  * Auth: end-user / signer JWT (subject forced from the token — not queryable).
  */
 export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const override = endUserSubjectOverrideError(params, "requests");
+  if (override) {
+    return override;
+  }
+
   const auth = await authenticateEndUser(request);
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const params = request.nextUrl.searchParams;
-  if (params.has("externalUserId") || params.has("external_user_id")) {
-    return NextResponse.json(
-      {
-        error:
-          "externalUserId is not allowed; requests are scoped to the authenticated user",
-      },
-      { status: 400 },
-    );
   }
 
   const cursor = params.get("cursor")?.trim() || undefined;

--- a/src/app/api/v1/user/usage/route.test.ts
+++ b/src/app/api/v1/user/usage/route.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { NextRequest } from "next/server";
+
+test("end-user usage routes reject subject overrides and require auth", async () => {
+  const usage = await import("./route");
+  const balance = await import("./balance/route");
+
+  for (const [label, GET] of [
+    ["usage", usage.GET],
+    ["balance", balance.GET],
+  ] as const) {
+    const noAuth = await GET(
+      new NextRequest(`http://localhost/api/v1/user/${label}`),
+    );
+    assert.equal(noAuth.status, 401, `${label} requires auth`);
+
+    for (const key of ["userId", "externalUserId", "external_user_id"]) {
+      const overridden = await GET(
+        new NextRequest(
+          `http://localhost/api/v1/user/${label}?${key}=other-user`,
+        ),
+      );
+      assert.equal(overridden.status, 400, `${label} rejects ${key}`);
+      const body = (await overridden.json()) as { error?: string };
+      assert.match(body.error ?? "", /userId\/externalUserId/);
+    }
+  }
+});

--- a/src/app/api/v1/user/usage/route.ts
+++ b/src/app/api/v1/user/usage/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { authenticateEndUser } from "@/lib/auth/end-user";
+import {
+  authenticateEndUser,
+  endUserSubjectOverrideError,
+} from "@/lib/auth/end-user";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
 import {
   buildAppUsageResponse,
@@ -13,24 +16,15 @@ import {
  * Auth: programmatic user JWT or signer JWT (subject forced — not queryable).
  */
 export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const override = endUserSubjectOverrideError(params, "usage");
+  if (override) {
+    return override;
+  }
+
   const auth = await authenticateEndUser(request);
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const params = request.nextUrl.searchParams;
-  if (
-    params.has("externalUserId") ||
-    params.has("external_user_id") ||
-    params.has("userId")
-  ) {
-    return NextResponse.json(
-      {
-        error:
-          "userId/externalUserId are not allowed; usage is scoped to the authenticated user",
-      },
-      { status: 400 },
-    );
   }
 
   if (!requireOpenMeterForUsageReads()) {

--- a/src/app/api/v1/user/usage/route.ts
+++ b/src/app/api/v1/user/usage/route.ts
@@ -1,18 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authenticateEndUser } from "@/lib/auth/end-user";
-import {
-  estimateEndUserBillableMicros,
-  loadActiveRetailRatesForApp,
-  resolveRetailRateForUsage,
-} from "@/lib/billing/retail-usage";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
 import {
-  buildOpenMeterUsageResponse,
-  queryOpenMeterUsage,
-  queryOpenMeterUserDailyByPipeline,
-  queryOpenMeterUserPipelineByModel,
-} from "@/lib/usage/query-openmeter";
+  buildAppUsageResponse,
+  parseUsageQueryParams,
+  validateUsageDateParams,
+} from "@/lib/usage/build-app-usage-response";
 
 /**
  * End-user usage for the Bearer subject only.
@@ -46,103 +40,19 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const startDate = params.get("startDate");
-  const endDate = params.get("endDate");
-  const groupBy = params.get("groupBy") || "none";
-
-  if (startDate && Number.isNaN(Date.parse(startDate))) {
-    return NextResponse.json({ error: "Invalid startDate format" }, { status: 400 });
-  }
-  if (endDate && Number.isNaN(Date.parse(endDate))) {
-    return NextResponse.json({ error: "Invalid endDate format" }, { status: 400 });
+  const { startDate, endDate, groupBy, includeRetail } = parseUsageQueryParams(params);
+  const dateError = validateUsageDateParams(startDate, endDate);
+  if (dateError) {
+    return NextResponse.json({ error: dateError }, { status: 400 });
   }
 
-  const includeRetail =
-    params.get("include") === "retail" ||
-    params.get("includeRetail") === "1" ||
-    params.get("includeRetail") === "true";
-
-  const filterUserId = auth.externalUserId;
-  const appId = auth.developerAppId;
-
-  const omRows = await queryOpenMeterUsage({
-    clientId: appId,
-    startDate,
-    endDate,
-    externalUserId: filterUserId,
-  });
-
-  let pipelineRows;
-  let dailyPipelineRows;
-  if (groupBy === "pipeline_model") {
-    pipelineRows = await queryOpenMeterUserPipelineByModel({
-      clientId: appId,
-      startDate,
-      endDate,
-      externalUserId: filterUserId,
-    });
-  }
-  if (groupBy === "daily_pipeline") {
-    dailyPipelineRows = await queryOpenMeterUserDailyByPipeline({
-      clientId: appId,
-      startDate,
-      endDate,
-      externalUserId: filterUserId,
-    });
-  }
-
-  let retailByPipelineModel:
-    | Map<string, { endUserBillableUsdMicros: string; retailRateUsd: string }>
-    | undefined;
-  if (includeRetail) {
-    const lookup = await loadActiveRetailRatesForApp(appId);
-    retailByPipelineModel = new Map();
-    const rowsForRetail = pipelineRows ?? [];
-    if (rowsForRetail.length === 0 && omRows.length > 0) {
-      const rate = resolveRetailRateForUsage({ lookup });
-      const network = omRows.reduce(
-        (sum, row) => sum + BigInt(row.networkFeeUsdMicros),
-        0n,
-      );
-      retailByPipelineModel.set("*|*", {
-        retailRateUsd: rate,
-        endUserBillableUsdMicros: estimateEndUserBillableMicros({
-          networkFeeUsdMicros: network,
-          lookup,
-        }),
-      });
-    } else {
-      for (const row of rowsForRetail) {
-        const key = `${row.pipeline}|${row.modelId}`;
-        const rate = resolveRetailRateForUsage({
-          lookup,
-          pipeline: row.pipeline,
-          modelId: row.modelId,
-        });
-        retailByPipelineModel.set(key, {
-          retailRateUsd: rate,
-          endUserBillableUsdMicros: estimateEndUserBillableMicros({
-            networkFeeUsdMicros: BigInt(row.networkFeeUsdMicros),
-            lookup,
-            pipeline: row.pipeline,
-            modelId: row.modelId,
-          }),
-        });
-      }
-    }
-  }
-
-  const response = buildOpenMeterUsageResponse({
-    clientId: appId,
+  const response = await buildAppUsageResponse({
+    appId: auth.developerAppId,
     startDate,
     endDate,
     groupBy,
-    filterUserId,
-    rows: omRows,
-    pipelineRows,
-    dailyPipelineRows,
+    filterUserId: auth.externalUserId,
     includeRetail,
-    retailByPipelineModel,
   });
   return NextResponse.json(response);
 }

--- a/src/app/api/v1/user/usage/route.ts
+++ b/src/app/api/v1/user/usage/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { authenticateEndUser } from "@/lib/auth/end-user";
+import {
+  estimateEndUserBillableMicros,
+  loadActiveRetailRatesForApp,
+  resolveRetailRateForUsage,
+} from "@/lib/billing/retail-usage";
+import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
+import {
+  buildOpenMeterUsageResponse,
+  queryOpenMeterUsage,
+  queryOpenMeterUserDailyByPipeline,
+  queryOpenMeterUserPipelineByModel,
+} from "@/lib/usage/query-openmeter";
+
+/**
+ * End-user usage for the Bearer subject only.
+ * Auth: programmatic user JWT or signer JWT (subject forced — not queryable).
+ */
+export async function GET(request: NextRequest) {
+  const auth = await authenticateEndUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  if (
+    params.has("externalUserId") ||
+    params.has("external_user_id") ||
+    params.has("userId")
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "userId/externalUserId are not allowed; usage is scoped to the authenticated user",
+      },
+      { status: 400 },
+    );
+  }
+
+  if (!requireOpenMeterForUsageReads()) {
+    return NextResponse.json(
+      { error: "OpenMeter not configured (OPENMETER_URL required)" },
+      { status: 503 },
+    );
+  }
+
+  const startDate = params.get("startDate");
+  const endDate = params.get("endDate");
+  const groupBy = params.get("groupBy") || "none";
+
+  if (startDate && Number.isNaN(Date.parse(startDate))) {
+    return NextResponse.json({ error: "Invalid startDate format" }, { status: 400 });
+  }
+  if (endDate && Number.isNaN(Date.parse(endDate))) {
+    return NextResponse.json({ error: "Invalid endDate format" }, { status: 400 });
+  }
+
+  const includeRetail =
+    params.get("include") === "retail" ||
+    params.get("includeRetail") === "1" ||
+    params.get("includeRetail") === "true";
+
+  const filterUserId = auth.externalUserId;
+  const appId = auth.developerAppId;
+
+  const omRows = await queryOpenMeterUsage({
+    clientId: appId,
+    startDate,
+    endDate,
+    externalUserId: filterUserId,
+  });
+
+  let pipelineRows;
+  let dailyPipelineRows;
+  if (groupBy === "pipeline_model") {
+    pipelineRows = await queryOpenMeterUserPipelineByModel({
+      clientId: appId,
+      startDate,
+      endDate,
+      externalUserId: filterUserId,
+    });
+  }
+  if (groupBy === "daily_pipeline") {
+    dailyPipelineRows = await queryOpenMeterUserDailyByPipeline({
+      clientId: appId,
+      startDate,
+      endDate,
+      externalUserId: filterUserId,
+    });
+  }
+
+  let retailByPipelineModel:
+    | Map<string, { endUserBillableUsdMicros: string; retailRateUsd: string }>
+    | undefined;
+  if (includeRetail) {
+    const lookup = await loadActiveRetailRatesForApp(appId);
+    retailByPipelineModel = new Map();
+    const rowsForRetail = pipelineRows ?? [];
+    if (rowsForRetail.length === 0 && omRows.length > 0) {
+      const rate = resolveRetailRateForUsage({ lookup });
+      const network = omRows.reduce(
+        (sum, row) => sum + BigInt(row.networkFeeUsdMicros),
+        0n,
+      );
+      retailByPipelineModel.set("*|*", {
+        retailRateUsd: rate,
+        endUserBillableUsdMicros: estimateEndUserBillableMicros({
+          networkFeeUsdMicros: network,
+          lookup,
+        }),
+      });
+    } else {
+      for (const row of rowsForRetail) {
+        const key = `${row.pipeline}|${row.modelId}`;
+        const rate = resolveRetailRateForUsage({
+          lookup,
+          pipeline: row.pipeline,
+          modelId: row.modelId,
+        });
+        retailByPipelineModel.set(key, {
+          retailRateUsd: rate,
+          endUserBillableUsdMicros: estimateEndUserBillableMicros({
+            networkFeeUsdMicros: BigInt(row.networkFeeUsdMicros),
+            lookup,
+            pipeline: row.pipeline,
+            modelId: row.modelId,
+          }),
+        });
+      }
+    }
+  }
+
+  const response = buildOpenMeterUsageResponse({
+    clientId: appId,
+    startDate,
+    endDate,
+    groupBy,
+    filterUserId,
+    rows: omRows,
+    pipelineRows,
+    dailyPipelineRows,
+    includeRetail,
+    retailByPipelineModel,
+  });
+  return NextResponse.json(response);
+}

--- a/src/lib/auth/end-user.test.ts
+++ b/src/lib/auth/end-user.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { endUserSubjectOverrideError } from "@/lib/auth/end-user";
+
+test("endUserSubjectOverrideError rejects userId and externalUserId", () => {
+  for (const key of ["userId", "externalUserId", "external_user_id"]) {
+    const params = new URLSearchParams({ [key]: "someone-else" });
+    const res = endUserSubjectOverrideError(params, "usage");
+    assert.ok(res);
+    assert.equal(res.status, 400);
+  }
+  assert.equal(endUserSubjectOverrideError(new URLSearchParams(), "usage"), null);
+});

--- a/src/lib/auth/end-user.ts
+++ b/src/lib/auth/end-user.ts
@@ -15,6 +15,29 @@ export type EndUserAuth = {
   externalUserId: string;
 };
 
+/**
+ * Reject client-supplied subject overrides on `/api/v1/user/*` routes.
+ * Subject is always taken from the Bearer credential.
+ */
+export function endUserSubjectOverrideError(
+  searchParams: URLSearchParams,
+  resourceLabel: string,
+): Response | null {
+  if (
+    searchParams.has("externalUserId") ||
+    searchParams.has("external_user_id") ||
+    searchParams.has("userId")
+  ) {
+    return Response.json(
+      {
+        error: `userId/externalUserId are not allowed; ${resourceLabel} is scoped to the authenticated user`,
+      },
+      { status: 400 },
+    );
+  }
+  return null;
+}
+
 function readBearerToken(request: Request): string | null {
   const authHeader = request.headers.get("authorization");
   if (!authHeader?.startsWith("Bearer ")) {

--- a/src/lib/openmeter/spendable-allowance.ts
+++ b/src/lib/openmeter/spendable-allowance.ts
@@ -312,12 +312,14 @@ export type SpendableAllowanceDetails = {
   spendableUsdMicros: string;
   /** Granted total for the cycle: the plan's included usage discount. */
   grantedUsdMicros: string;
+  /** Remaining plan usage discount only (excludes prepaid credits). */
+  remainingPlanDiscountUsdMicros: string;
 };
 
 /**
  * Spendable allowance for mint/signer gates: prepaid credits + remaining
  * plan usage discount for the current cycle. Also returns the plan's included
- * discount total (granted) for the cycle, computed in the same pass.
+ * discount total (granted) and remaining plan discount for the cycle.
  */
 export async function getSpendableAllowanceDetails(input: {
   clientId: string;
@@ -351,6 +353,39 @@ export async function getSpendableAllowanceDetails(input: {
   return {
     spendableUsdMicros: (creditMicros + discount.remainingUsdMicros).toString(),
     grantedUsdMicros: discount.totalUsdMicros.toString(),
+    remainingPlanDiscountUsdMicros: discount.remainingUsdMicros.toString(),
+  };
+}
+
+/** Allowance shape for `GET .../usage/balance` (plan discount, not trial credit). */
+export async function getUsageBalanceAllowance(input: {
+  clientId: string;
+  externalUserId: string;
+  identity?: ResolvedBillingIdentity;
+}): Promise<{
+  balanceUsdMicros: string;
+  consumedUsdMicros: string;
+  lifetimeGrantedUsdMicros: string;
+  hasAccess: boolean;
+  remainingUsdMicros: string;
+} | null> {
+  const details = await getSpendableAllowanceDetails(input);
+  if (!details) {
+    return null;
+  }
+
+  const granted = BigInt(details.grantedUsdMicros);
+  const remaining = BigInt(details.remainingPlanDiscountUsdMicros);
+  const consumed = granted > remaining ? granted - remaining : 0n;
+  const spendable = BigInt(details.spendableUsdMicros);
+
+  return {
+    // Meter remaining / granted is the plan included-discount cycle.
+    balanceUsdMicros: remaining.toString(),
+    remainingUsdMicros: remaining.toString(),
+    lifetimeGrantedUsdMicros: granted.toString(),
+    consumedUsdMicros: consumed.toString(),
+    hasAccess: spendable > 0n,
   };
 }
 

--- a/src/lib/usage/build-app-usage-response.ts
+++ b/src/lib/usage/build-app-usage-response.ts
@@ -105,7 +105,8 @@ export async function buildAppUsageResponse(input: {
   filterUserId: string | null;
   includeRetail: boolean;
 }): Promise<ReturnType<typeof buildOpenMeterUsageResponse>> {
-  const { appId, startDate, endDate, groupBy, filterUserId, includeRetail } = input;
+  const { appId, startDate, endDate, groupBy, includeRetail } = input;
+  const filterUserId = input.filterUserId?.trim() || null;
 
   const omRows = await queryOpenMeterUsage({
     clientId: appId,
@@ -117,12 +118,12 @@ export async function buildAppUsageResponse(input: {
   let pipelineRows: OpenMeterPipelineModelRow[] | undefined;
   let dailyPipelineRows;
   if (groupBy === "pipeline_model") {
-    if (filterUserId?.trim()) {
+    if (filterUserId) {
       pipelineRows = await queryOpenMeterUserPipelineByModel({
         clientId: appId,
         startDate,
         endDate,
-        externalUserId: filterUserId.trim(),
+        externalUserId: filterUserId,
       });
     } else {
       const dashboard = await queryOpenMeterAppDashboardUsage({

--- a/src/lib/usage/build-app-usage-response.ts
+++ b/src/lib/usage/build-app-usage-response.ts
@@ -10,6 +10,7 @@ import {
   queryOpenMeterUserDailyByPipeline,
   queryOpenMeterUserPipelineByModel,
   type OpenMeterPipelineModelRow,
+  type OpenMeterDailyPipelineRow,
   type OpenMeterUsageRow,
 } from "@/lib/usage/query-openmeter";
 
@@ -116,7 +117,7 @@ export async function buildAppUsageResponse(input: {
   });
 
   let pipelineRows: OpenMeterPipelineModelRow[] | undefined;
-  let dailyPipelineRows;
+  let dailyPipelineRows: OpenMeterDailyPipelineRow[] | undefined;
   if (groupBy === "pipeline_model") {
     if (filterUserId) {
       pipelineRows = await queryOpenMeterUserPipelineByModel({

--- a/src/lib/usage/build-app-usage-response.ts
+++ b/src/lib/usage/build-app-usage-response.ts
@@ -1,0 +1,161 @@
+import {
+  estimateEndUserBillableMicros,
+  loadActiveRetailRatesForApp,
+  resolveRetailRateForUsage,
+} from "@/lib/billing/retail-usage";
+import {
+  buildOpenMeterUsageResponse,
+  queryOpenMeterAppDashboardUsage,
+  queryOpenMeterUsage,
+  queryOpenMeterUserDailyByPipeline,
+  queryOpenMeterUserPipelineByModel,
+  type OpenMeterPipelineModelRow,
+  type OpenMeterUsageRow,
+} from "@/lib/usage/query-openmeter";
+
+export type UsageQueryParams = {
+  startDate: string | null;
+  endDate: string | null;
+  groupBy: string;
+  includeRetail: boolean;
+};
+
+export function parseUsageQueryParams(searchParams: URLSearchParams): UsageQueryParams {
+  return {
+    startDate: searchParams.get("startDate"),
+    endDate: searchParams.get("endDate"),
+    groupBy: searchParams.get("groupBy") || "none",
+    includeRetail:
+      searchParams.get("include") === "retail" ||
+      searchParams.get("includeRetail") === "1" ||
+      searchParams.get("includeRetail") === "true",
+  };
+}
+
+export function validateUsageDateParams(
+  startDate: string | null,
+  endDate: string | null,
+): string | null {
+  if (startDate && Number.isNaN(Date.parse(startDate))) {
+    return "Invalid startDate format";
+  }
+  if (endDate && Number.isNaN(Date.parse(endDate))) {
+    return "Invalid endDate format";
+  }
+  return null;
+}
+
+async function buildRetailByPipelineModel(input: {
+  appId: string;
+  pipelineRows: OpenMeterPipelineModelRow[] | undefined;
+  omRows: OpenMeterUsageRow[];
+}): Promise<
+  Map<string, { endUserBillableUsdMicros: string; retailRateUsd: string }>
+> {
+  const lookup = await loadActiveRetailRatesForApp(input.appId);
+  const retailByPipelineModel = new Map<
+    string,
+    { endUserBillableUsdMicros: string; retailRateUsd: string }
+  >();
+  const rowsForRetail = input.pipelineRows ?? [];
+  if (rowsForRetail.length === 0 && input.omRows.length > 0) {
+    const rate = resolveRetailRateForUsage({ lookup });
+    const network = input.omRows.reduce(
+      (sum, row) => sum + BigInt(row.networkFeeUsdMicros),
+      0n,
+    );
+    retailByPipelineModel.set("*|*", {
+      retailRateUsd: rate,
+      endUserBillableUsdMicros: estimateEndUserBillableMicros({
+        networkFeeUsdMicros: network,
+        lookup,
+      }),
+    });
+    return retailByPipelineModel;
+  }
+
+  for (const row of rowsForRetail) {
+    const key = `${row.pipeline}|${row.modelId}`;
+    const rate = resolveRetailRateForUsage({
+      lookup,
+      pipeline: row.pipeline,
+      modelId: row.modelId,
+    });
+    retailByPipelineModel.set(key, {
+      retailRateUsd: rate,
+      endUserBillableUsdMicros: estimateEndUserBillableMicros({
+        networkFeeUsdMicros: BigInt(row.networkFeeUsdMicros),
+        lookup,
+        pipeline: row.pipeline,
+        modelId: row.modelId,
+      }),
+    });
+  }
+  return retailByPipelineModel;
+}
+
+/**
+ * Shared OpenMeter usage payload for apps/{id}/usage and /api/v1/user/usage.
+ */
+export async function buildAppUsageResponse(input: {
+  appId: string;
+  startDate: string | null;
+  endDate: string | null;
+  groupBy: string;
+  filterUserId: string | null;
+  includeRetail: boolean;
+}): Promise<ReturnType<typeof buildOpenMeterUsageResponse>> {
+  const { appId, startDate, endDate, groupBy, filterUserId, includeRetail } = input;
+
+  const omRows = await queryOpenMeterUsage({
+    clientId: appId,
+    startDate,
+    endDate,
+    externalUserId: filterUserId,
+  });
+
+  let pipelineRows: OpenMeterPipelineModelRow[] | undefined;
+  let dailyPipelineRows;
+  if (groupBy === "pipeline_model") {
+    if (filterUserId?.trim()) {
+      pipelineRows = await queryOpenMeterUserPipelineByModel({
+        clientId: appId,
+        startDate,
+        endDate,
+        externalUserId: filterUserId.trim(),
+      });
+    } else {
+      const dashboard = await queryOpenMeterAppDashboardUsage({
+        clientId: appId,
+        startDate,
+        endDate,
+      });
+      pipelineRows = dashboard?.byPipelineModel ?? [];
+    }
+  }
+  if (groupBy === "daily_pipeline" && filterUserId) {
+    dailyPipelineRows = await queryOpenMeterUserDailyByPipeline({
+      clientId: appId,
+      startDate,
+      endDate,
+      externalUserId: filterUserId,
+    });
+  }
+
+  const retailByPipelineModel = includeRetail
+    ? await buildRetailByPipelineModel({ appId, pipelineRows, omRows })
+    : undefined;
+
+  return buildOpenMeterUsageResponse({
+    clientId: appId,
+    startDate,
+    endDate,
+    groupBy,
+    filterUserId,
+    rows: omRows,
+    pipelineRows,
+    dailyPipelineRows,
+    includeRetail,
+    retailByPipelineModel,
+  });
+}


### PR DESCRIPTION
## Summary

Builder SDK already prefers `GET /api/v1/user/usage*` after minting a user JWT; only `/requests` shipped in #269, so dashboard account-usage 404'd before falling back to M2M.

This PR adds the missing end-user usage + balance routes (Bearer subject forced), shares the OpenMeter usage response builder with `apps/{id}/usage`, and switches **balance** responses to **plan included-discount** allowance (not trial-credit ledger fields).

## Auth

All `/api/v1/user/usage*` routes use `authenticateEndUser`:
- `Authorization: Bearer` programmatic user JWT or signer JWT
- Subject is forced from the credential — `userId` / `externalUserId` query params are rejected with **400**
- Composite API-key shapes are rejected (401)

## Routes added

### `GET /api/v1/user/usage`

OpenMeter usage for the Bearer subject only. Same response shape as `GET /api/v1/apps/{clientId}/usage` (via shared `buildAppUsageResponse`).

| Query | Description |
| --- | --- |
| `startDate` | ISO start (optional) |
| `endDate` | ISO end (optional) |
| `groupBy` | `none` (default) / `user` / `pipeline_model` / `daily_pipeline` |
| `include=retail` | Include retail billable micros when set |

**200 response:**

```json
{
  "clientId": "<developer_apps.id>",
  "source": "openmeter",
  "period": { "start": "2026-07-01T00:00:00.000Z", "end": "2026-07-18T23:59:59.999Z" },
  "totals": {
    "requestCount": 28,
    "currency": "USD",
    "networkFeeUsdMicros": "160000",
    "ownerChargeUsdMicros": "160000",
    "platformFeeUsdMicros": "0",
    "endUserBillableUsdMicros": "160000"
  },
  "byUser": [],
  "byPipelineModel": [
    {
      "pipeline": "streamdiffusion",
      "modelId": "sdxl-v2v",
      "requestCount": 28,
      "currency": "USD",
      "networkFeeUsdMicros": "160000",
      "endUserBillableUsdMicros": "160000",
      "retailRateUsd": "..."
    }
  ],
  "byDailyPipeline": []
}
```

`byUser` / `byPipelineModel` / `byDailyPipeline` are only present for the matching `groupBy`. `endUserBillableUsdMicros` on totals is present when `include=retail`.

**Errors:** `401` unauthorized · `400` subject override / bad dates · `503` OpenMeter not configured

---

### `GET /api/v1/user/usage/balance`

Plan included-usage allowance for the Bearer subject (Starter discount cycle). Prepaid credits settle invoices/charges and are **not** the meter source.

**200 response:**

```json
{
  "externalUserId": "<subject>",
  "balanceUsdMicros": "4810000",
  "remainingUsdMicros": "4810000",
  "lifetimeGrantedUsdMicros": "5000000",
  "consumedUsdMicros": "190000",
  "hasAccess": true
}
```

| Field | Meaning |
| --- | --- |
| `lifetimeGrantedUsdMicros` | Plan included discount total for the cycle (e.g. `$5.00`) |
| `balanceUsdMicros` / `remainingUsdMicros` | Remaining plan discount |
| `consumedUsdMicros` | `granted − remaining` (e.g. `$0.19`) |
| `hasAccess` | `true` when spendable (credits + remaining discount) > 0 |

Dashboard sidebar meter displays this as **`$0.19 / $5.00` used**.

**Errors:** `401` · `400` subject override · `503` OpenMeter not configured

---

### Already on main (from #269) — documented for context

`GET /api/v1/user/usage/requests` — signed-ticket CloudEvents for the Bearer subject (`cursor`, `limit`). Not changed in this PR beyond docs cross-links.

## Routes updated

### `GET /api/v1/apps/{clientId}/usage`

Behavior unchanged. Internals now call shared `buildAppUsageResponse` (same payload builder as the end-user route) to remove duplication / Sonar quality-gate failure.

### `GET /api/v1/apps/{clientId}/usage/balance?externalUserId=...`

**Response semantics changed** to match the end-user balance route: plan included-discount allowance instead of `getTrialCreditBalance` trial-credit fields. Same JSON shape as `/api/v1/user/usage/balance` (M2M still requires `externalUserId` query).

Auth unchanged: app M2M / provider session.

## Docs

`docs/builder-api.md` — end-user usage / balance / requests section updated for Bearer-subject auth, query rules, and plan-discount balance fields.

## Test plan

- [x] `npm test` (shared usage builder; existing apps usage tests)
- [ ] Mint end-user JWT → `GET /api/v1/user/usage?groupBy=pipeline_model&include=retail` returns subject-scoped rows
- [ ] `GET /api/v1/user/usage/balance` returns `lifetimeGrantedUsdMicros` ≈ Starter included (`5000000`) and `consumedUsdMicros` matching MTD usage
- [ ] `?userId=` / `?externalUserId=` on `/api/v1/user/usage*` → 400
- [ ] Dashboard account-usage: no 404 on usage/balance; sidebar shows `$X.XX / $5.00` used
- [x] SonarCloud + CodeQL green