### PR TITLE
fix(usage): restore admin signed-ticket history and clear Sonar findings

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -92,10 +92,10 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Vercel CLI
-        run: npm install -g vercel@latest
+        run: npm install -g vercel@56.4.0 --ignore-scripts
 
       - name: Pull Vercel project settings
         run: vercel pull --yes --environment=preview --git-branch="$DEPLOY_BRANCH" --token="$VERCEL_TOKEN"

--- a/scripts/openmeter-ensure-customer.ts
+++ b/scripts/openmeter-ensure-customer.ts
@@ -12,7 +12,7 @@
  */
 import "./load-env-first";
 import { eq } from "drizzle-orm";
-import { db, postgresClient } from "../src/db/index";
+import { closeDb, db } from "../src/db/index";
 import { appUsers } from "../src/db/schema";
 import {
   ensureAppUserKonnectCustomer,
@@ -202,7 +202,7 @@ async function main() {
       process.exit(1);
     }
   } finally {
-    await postgresClient.end({ timeout: 5 });
+    await closeDb({ timeout: 5 });
   }
 }
 

--- a/scripts/openmeter-fix-starter-allowance.ts
+++ b/scripts/openmeter-fix-starter-allowance.ts
@@ -80,6 +80,14 @@ function usage(): string {
   ].join("\n");
 }
 
+function statsKeyForChangeResult(
+  result: "changed" | "skipped" | "error",
+): "changed" | "skipped" | "errors" {
+  if (result === "changed") return "changed";
+  if (result === "error") return "errors";
+  return "skipped";
+}
+
 function parseArgs(argv: string[]): Args {
   const args: Args = { apply: false, timing: "immediate" };
   for (let i = 0; i < argv.length; i += 1) {
@@ -507,7 +515,7 @@ async function changeSubsOntoAllowancePlans(input: {
       plan,
       targetPlanId,
     });
-    stats[result === "changed" ? "changed" : result === "error" ? "errors" : "skipped"] += 1;
+    stats[statsKeyForChangeResult(result)] += 1;
   }
 
   return stats;

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -369,6 +369,7 @@ export default function DashboardLayout({
               </div>
             </div>
             <button
+              type="button"
               onClick={() => signOut({ callbackUrl: "/" })}
               className="w-full flex items-center justify-center gap-2 rounded-lg border border-zinc-700/60 bg-zinc-800/40 px-3 py-1.5 text-xs font-medium text-zinc-400 hover:border-zinc-600 hover:bg-zinc-800 hover:text-zinc-200 transition-colors"
             >

--- a/src/components/apps/FundAccountOnRampPanel.tsx
+++ b/src/components/apps/FundAccountOnRampPanel.tsx
@@ -305,11 +305,12 @@ export default function FundAccountOnRampPanel({
       clientState,
       httpClient,
     });
-    if (prereqError) {
-      setError(prereqError);
+    if (prereqError || !httpClient) {
+      setError(prereqError ?? "Turnkey client is not ready. Refresh and try again.");
       setPhase("error");
       return;
     }
+    const turnkeyClient = httpClient;
 
     pollAbortRef.current?.abort();
     const pollAbort = new AbortController();
@@ -328,7 +329,7 @@ export default function FundAccountOnRampPanel({
         throw new Error("Turnkey session is missing organization context.");
       }
 
-      const initResult = await httpClient.initFiatOnRamp({
+      const initResult = await turnkeyClient.initFiatOnRamp({
         organizationId,
         onrampProvider: FiatOnRampProvider.MOONPAY,
         walletAddress,
@@ -364,7 +365,7 @@ export default function FundAccountOnRampPanel({
       }
 
       const terminalStatus = await pollUntilTerminal(
-        httpClient,
+        turnkeyClient,
         initResult.onRampTransactionId,
         organizationId,
         pollAbort.signal,

--- a/src/components/apps/FundAccountOnRampPanel.tsx
+++ b/src/components/apps/FundAccountOnRampPanel.tsx
@@ -191,6 +191,27 @@ const POLL_INTERVAL_MS = 3000;
 /** Stop waiting for a stuck Turnkey status after this long. */
 const POLL_DEADLINE_MS = 15 * 60 * 1000;
 
+function fundingPrerequisiteError(input: {
+  turnkeyConfigured: boolean;
+  authState: AuthState;
+  clientState: ClientState;
+  httpClient: TurnkeyHttpClient | null | undefined;
+}): string | null {
+  if (!input.turnkeyConfigured) {
+    return "Turnkey Wallet Kit is not configured in this environment.";
+  }
+  if (
+    input.authState !== AuthState.Authenticated ||
+    input.clientState !== ClientState.Ready
+  ) {
+    return "Sign in with Turnkey Wallet Kit to fund your account.";
+  }
+  if (!input.httpClient) {
+    return "Turnkey client is not ready. Refresh and try again.";
+  }
+  return null;
+}
+
 function delay(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal.aborted) {
@@ -278,18 +299,14 @@ export default function FundAccountOnRampPanel({
     setLastGrantedUsdMicros(null);
     setCheckoutUrl(null);
 
-    if (!turnkeyConfigured) {
-      setError("Turnkey Wallet Kit is not configured in this environment.");
-      setPhase("error");
-      return;
-    }
-    if (authState !== AuthState.Authenticated || clientState !== ClientState.Ready) {
-      setError("Sign in with Turnkey Wallet Kit to fund your account.");
-      setPhase("error");
-      return;
-    }
-    if (!httpClient) {
-      setError("Turnkey client is not ready. Refresh and try again.");
+    const prereqError = fundingPrerequisiteError({
+      turnkeyConfigured,
+      authState,
+      clientState,
+      httpClient,
+    });
+    if (prereqError) {
+      setError(prereqError);
       setPhase("error");
       return;
     }

--- a/src/components/apps/FundAccountOnRampPanel.tsx
+++ b/src/components/apps/FundAccountOnRampPanel.tsx
@@ -193,8 +193,8 @@ const POLL_DEADLINE_MS = 15 * 60 * 1000;
 
 function fundingPrerequisiteError(input: {
   turnkeyConfigured: boolean;
-  authState: AuthState;
-  clientState: ClientState;
+  authState: AuthState | undefined;
+  clientState: ClientState | undefined;
   httpClient: TurnkeyHttpClient | null | undefined;
 }): string | null {
   if (!input.turnkeyConfigured) {

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -844,8 +844,7 @@ function M2mTokenTestResult({
       {tokenKind === "api_key" ? (
         <p className="text-[11px] text-sky-300/70">
           Use as <span className="font-mono text-sky-200/80">Authorization: Bearer</span> on the
-          remote signer, or as <span className="font-mono text-sky-200/80">subject_token</span> at{" "}
-          <span className="font-mono text-sky-200/80">
+          remote signer, or as <span className="font-mono text-sky-200/80">subject_token</span> at <span className="font-mono text-sky-200/80">
             POST /api/v1/apps/{`{clientId}`}/oidc/token
           </span>
           .

--- a/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
@@ -64,7 +64,7 @@ test("acceptedSignerAudiences includes issuer and legacy values", () => {
 });
 
 test("validateOptionalM2mClient allows empty credentials", async () => {
-  await validateOptionalM2mClient("", "");
+  await assert.doesNotReject(async () => validateOptionalM2mClient("", ""));
 });
 
 test("validateOptionalM2mClient rejects partial credentials", async () => {

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -129,25 +129,27 @@ export async function getTrialCreditBalance(input: {
 function entitlementAmountToMicros(value: unknown): bigint {
   if (value == null) return 0n;
   if (typeof value === "bigint") return value > 0n ? value : 0n;
-  if (typeof value === "number") {
-    if (!Number.isFinite(value) || value <= 0) return 0n;
-    return BigInt(Math.trunc(value));
-  }
-  if (typeof value === "string") {
-    const t = value.trim();
-    if (!t) return 0n;
-    if (/^\d+$/.test(t)) {
-      try {
-        return BigInt(t);
-      } catch {
-        return 0n;
-      }
-    }
-    const parsed = Number(t);
-    if (!Number.isFinite(parsed) || parsed <= 0) return 0n;
-    return BigInt(Math.trunc(parsed));
-  }
+  if (typeof value === "number") return numberToMicros(value);
+  if (typeof value === "string") return parseStringMicros(value);
   return 0n;
+}
+
+function numberToMicros(value: number): bigint {
+  if (!Number.isFinite(value) || value <= 0) return 0n;
+  return BigInt(Math.trunc(value));
+}
+
+function parseStringMicros(value: string): bigint {
+  const trimmed = value.trim();
+  if (!trimmed) return 0n;
+  if (/^\d+$/.test(trimmed)) {
+    try {
+      return BigInt(trimmed);
+    } catch {
+      return 0n;
+    }
+  }
+  return numberToMicros(Number(trimmed));
 }
 
 export type SignedTicketOpenMeterEvent = {

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -87,6 +87,8 @@ type IngestedEventLike = {
   ingestedAt?: Date | string;
 };
 
+type DateLikeValue = Date | string | undefined;
+
 type OffsetCursor = { offset: number };
 
 /** Normalize SDK / Konnect list payloads into IngestedEvent-shaped rows. */
@@ -100,8 +102,8 @@ export function coerceIngestedEvent(raw: unknown): IngestedEventLike | null {
   if (row.event && typeof row.event === "object") {
     const event = row.event as CloudEventLike;
     const ingestedAt =
-      (row.ingestedAt as Date | string | undefined) ??
-      (row.ingested_at as Date | string | undefined);
+      (row.ingestedAt as DateLikeValue) ??
+      (row.ingested_at as DateLikeValue);
     return { event, ingestedAt };
   }
 
@@ -123,8 +125,8 @@ export function coerceIngestedEvent(raw: unknown): IngestedEventLike | null {
             : null,
       },
       ingestedAt:
-        (row.ingestedAt as Date | string | undefined) ??
-        (row.ingested_at as Date | string | undefined),
+        (row.ingestedAt as DateLikeValue) ??
+        (row.ingested_at as DateLikeValue),
     };
   }
 
@@ -549,8 +551,11 @@ async function fetchSignedTicketEvents(input: {
 /**
  * Fetch recent create_signed_ticket events across the platform (admin path).
  * Prefer type-filtered listV2; fall back to unscoped list + client-side type filter.
- * When a small set of clientIds is selected, also query subject-contains per app
- * so quieter apps are not drowned out by busy platform traffic.
+ *
+ * Important: do not scope by `subject contains clientId` for subset app filters.
+ * Owner-wallet events often use owner-subject forms (`owner:{id}` / bare owner id)
+ * where client_id only exists in event data, so subject-scoped filtering can
+ * hide valid rows and make All Usage appear empty for a selected app.
  */
 async function fetchPlatformSignedTicketEvents(input: {
   client: OpenMeter;
@@ -558,19 +563,6 @@ async function fetchPlatformSignedTicketEvents(input: {
   from: string;
   to: string;
 }): Promise<IngestedEventLike[]> {
-  const clientIds = input.clientIds;
-  const preferPerClient =
-    clientIds != null && clientIds.size > 0 && clientIds.size <= 8;
-
-  if (preferPerClient) {
-    const batches = await Promise.all(
-      [...clientIds].map((clientId) =>
-        listSignedTicketEventsForSubjectContains(input.client, clientId, input.from, input.to),
-      ),
-    );
-    return batches.flat();
-  }
-
   try {
     const listedV2 = await input.client.events.listV2({
       limit: LIST_FETCH_LIMIT,
@@ -588,36 +580,6 @@ async function fetchPlatformSignedTicketEvents(input: {
         limit: LIST_FETCH_LIMIT,
         // subject omitted intentionally for platform-wide admin history
       } as { from: string; to: string; limit: number });
-      return coerceIngestedEvents(listed).filter(eventIsSignedTicket);
-    } catch {
-      return [];
-    }
-  }
-}
-
-async function listSignedTicketEventsForSubjectContains(
-  client: OpenMeter,
-  subjectFragment: string,
-  from: string,
-  to: string,
-): Promise<IngestedEventLike[]> {
-  try {
-    const listedV2 = await client.events.listV2({
-      limit: LIST_FETCH_LIMIT,
-      filter: JSON.stringify({
-        type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
-        subject: { contains: subjectFragment },
-      }),
-    });
-    return coerceIngestedEvents(listedV2?.items ?? listedV2);
-  } catch {
-    try {
-      const listed = await client.events.list({
-        subject: subjectFragment,
-        from,
-        to,
-        limit: LIST_FETCH_LIMIT,
-      });
       return coerceIngestedEvents(listed).filter(eventIsSignedTicket);
     } catch {
       return [];


### PR DESCRIPTION
## Summary
- restore admin `All Usage` signed-ticket history for app-filtered views by removing subject-based subset fetches that dropped owner-subject events
- include the Sonar-driven quality fixes already prepared in this branch (test assertion, button type, deprecated DB client usage, nested ternary cleanup, complexity reductions, and workflow hardening)
- keep existing `scope=all` admin behavior and `scope=own` viewer behavior unchanged outside the regression fix

## Test plan
- [x] `npm test -- src/lib/openmeter/signed-ticket-events.test.ts`
- [x] `npm test -- src/lib/oidc/app-scoped-signer-token-exchange.test.ts`
- [x] `ReadLints` on edited files
- [ ] verify `/usage` as admin in browser: select an app not owned by the admin and confirm signed-ticket history rows are shown