### PR TITLE
fix(usage): discover admin ticket subjects via OpenMeter meters

### DIFF
--- a/src/lib/openmeter/signed-ticket-events.test.ts
+++ b/src/lib/openmeter/signed-ticket-events.test.ts
@@ -5,6 +5,7 @@ import { CREATE_SIGNED_TICKET_EVENT_TYPE } from "./constants";
 import {
   coerceIngestedEvent,
   coerceIngestedEvents,
+  collectAdminSubjectsFromMeterRows,
   eventClientId,
   eventMatchesAdminSignedTicket,
   eventMatchesClientIdFilter,
@@ -259,4 +260,53 @@ test("coerceIngestedEvents unwraps items/data envelopes and drops junk", () => {
   assert.equal(rows.length, 2);
   assert.equal(rows[0]?.event.id, "evt-1");
   assert.equal(rows[1]?.event.id, "flat-2");
+});
+
+test("collectAdminSubjectsFromMeterRows prefers CloudEvent subject", () => {
+  const subjects = collectAdminSubjectsFromMeterRows(
+    [
+      {
+        subject: "app_story:eu-1",
+        value: 10,
+        groupBy: { client_id: "app_story", external_user_id: "eu-1" },
+      },
+      {
+        subject: "owner-uuid-1",
+        value: 3,
+        groupBy: { client_id: "app_story", external_user_id: "owner-uuid-1" },
+      },
+      {
+        subject: "app_other:eu-2",
+        value: 99,
+        groupBy: { client_id: "app_other", external_user_id: "eu-2" },
+      },
+    ],
+    new Set(["app_story"]),
+  );
+  assert.ok(subjects.includes("app_story:eu-1"));
+  assert.ok(subjects.includes("owner-uuid-1"));
+  assert.ok(subjects.includes("eu-1"));
+  assert.ok(!subjects.includes("app_other:eu-2"));
+});
+
+test("collectAdminSubjectsFromMeterRows expands external_user_id without subject", () => {
+  const subjects = collectAdminSubjectsFromMeterRows(
+    [
+      {
+        subject: null,
+        value: "5",
+        groupBy: {
+          client_id: "app_98575870d7ae33589a3f0660",
+          external_user_id: "eu-story",
+        },
+      },
+    ],
+    new Set(["app_98575870d7ae33589a3f0660"]),
+  );
+  assert.ok(subjects.includes("app_98575870d7ae33589a3f0660:eu-story"));
+  assert.ok(subjects.includes("eu-story"));
+  assert.ok(subjects.includes("owner:eu-story"));
+  assert.ok(
+    subjects.includes("app_98575870d7ae33589a3f0660:owner:eu-story"),
+  );
 });

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -715,60 +715,70 @@ async function listSignedTicketEventsForSubjectContains(
  * expands external_user_id into compound + owner subject forms.
  */
 export function collectAdminSubjectsFromMeterRows(
-  rows: ReadonlyArray<{
-    subject?: string | null;
-    value?: unknown;
-    groupBy?: Record<string, string | null> | null;
-  }>,
+  rows: ReadonlyArray<AdminMeterRowLike>,
   clientIds: ReadonlySet<string>,
 ): string[] {
   const countBySubject = new Map<string, number>();
 
-  const addSubject = (raw: string, count: number) => {
-    const subject = raw.trim();
-    if (!subject) return;
-    countBySubject.set(subject, (countBySubject.get(subject) ?? 0) + count);
-  };
-
   for (const row of rows) {
-    const group = row.groupBy ?? {};
-    const rowClientId =
-      (typeof group.client_id === "string" && group.client_id.trim()) || "";
-    if (rowClientId && !clientIds.has(rowClientId)) {
-      continue;
-    }
     const count = meterValueToCount(row.value);
     if (count <= 0) continue;
-
-    const ceSubject = typeof row.subject === "string" ? row.subject.trim() : "";
-    if (ceSubject) {
-      addSubject(ceSubject, count);
+    for (const subject of subjectCandidatesForMeterRow(row, clientIds)) {
+      countBySubject.set(subject, (countBySubject.get(subject) ?? 0) + count);
     }
-
-    const externalUserId =
-      (typeof group.external_user_id === "string" &&
-        group.external_user_id.trim()) ||
-      "";
-    if (!externalUserId) continue;
-
-    const apps = rowClientId
-      ? [rowClientId]
-      : [...clientIds];
-    for (const clientId of apps) {
-      addSubject(buildOpenMeterCustomerKey(clientId, externalUserId), count);
-      addSubject(
-        buildOpenMeterCustomerKey(clientId, buildOwnerWireSubject(externalUserId)),
-        count,
-      );
-    }
-    addSubject(externalUserId, count);
-    addSubject(buildOwnerWireSubject(externalUserId), count);
   }
 
   return [...countBySubject.entries()]
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .slice(0, MAX_ADMIN_DISCOVERED_SUBJECTS)
     .map(([subject]) => subject);
+}
+
+type AdminMeterRowLike = {
+  subject?: string | null;
+  value?: unknown;
+  groupBy?: Record<string, string | null> | null;
+};
+
+function trimmedRecordField(
+  record: Record<string, string | null>,
+  key: string,
+): string {
+  const value = record[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/** Compound + bare + owner-wire subject forms for one meter row. */
+function subjectCandidatesForMeterRow(
+  row: AdminMeterRowLike,
+  clientIds: ReadonlySet<string>,
+): string[] {
+  const group = row.groupBy ?? {};
+  const rowClientId = trimmedRecordField(group, "client_id");
+  if (rowClientId && !clientIds.has(rowClientId)) {
+    return [];
+  }
+
+  const candidates: string[] = [];
+  const ceSubject = typeof row.subject === "string" ? row.subject.trim() : "";
+  if (ceSubject) {
+    candidates.push(ceSubject);
+  }
+
+  const externalUserId = trimmedRecordField(group, "external_user_id");
+  if (!externalUserId) {
+    return candidates;
+  }
+
+  const apps = rowClientId ? [rowClientId] : [...clientIds];
+  for (const clientId of apps) {
+    candidates.push(
+      buildOpenMeterCustomerKey(clientId, externalUserId),
+      buildOpenMeterCustomerKey(clientId, buildOwnerWireSubject(externalUserId)),
+    );
+  }
+  candidates.push(externalUserId, buildOwnerWireSubject(externalUserId));
+  return candidates.filter(Boolean);
 }
 
 function meterValueToCount(value: unknown): number {

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -8,12 +8,14 @@ import {
   CREATE_SIGNED_TICKET_EVENT_TYPE,
   isOpenMeterEnabled,
   requireOpenMeterForUsageReads,
+  SIGNED_TICKET_COUNT_METER,
 } from "@/lib/openmeter/constants";
 import { getHostedOpenMeterClient } from "@/lib/openmeter/client";
 import {
   buildOpenMeterCustomerKey,
   buildOwnerCustomerKey,
   buildOwnerMeterSubjects,
+  buildOwnerWireSubject,
   isOwnerCustomerKey,
   normalizePlatformUserId,
   parseOpenMeterCustomerKey,
@@ -23,6 +25,8 @@ import {
 const DEFAULT_PAGE_SIZE = 25;
 const MAX_PAGE_SIZE = 50;
 const LIST_FETCH_LIMIT = 100;
+/** Cap meter-discovered subjects so admin event fan-out stays bounded. */
+const MAX_ADMIN_DISCOVERED_SUBJECTS = 40;
 
 export type SignedTicketRequestRow = {
   time: string;
@@ -550,12 +554,17 @@ async function fetchSignedTicketEvents(input: {
 
 /**
  * Fetch recent create_signed_ticket events across the platform (admin path).
- * Prefer type-filtered listV2; fall back to unscoped list + client-side type filter.
  *
- * Important: do not scope by `subject contains clientId` for subset app filters.
- * Owner-wallet events often use owner-subject forms (`owner:{id}` / bare owner id)
- * where client_id only exists in event data, so subject-scoped filtering can
- * hide valid rows and make All Usage appear empty for a selected app.
+ * When clientIds are selected, discover usage subjects from the
+ * signed_ticket_count meter (scoped by client_id dimension — same source as the
+ * usage chart), then list events for those subjects. A global listV2(limit=100)
+ * drowns quieter apps out under busy platform traffic, which made storyboard
+ * (and similar) look empty despite non-zero meter usage.
+ *
+ * Do not use `subject contains clientId` alone: owner-wallet CloudEvents use
+ * bare / `owner:{id}` subjects with client_id only in event data.
+ *
+ * Unrestricted (all apps) still uses type-filtered listV2 / unscoped list.
  */
 async function fetchPlatformSignedTicketEvents(input: {
   client: OpenMeter;
@@ -563,8 +572,51 @@ async function fetchPlatformSignedTicketEvents(input: {
   from: string;
   to: string;
 }): Promise<IngestedEventLike[]> {
+  if (input.clientIds && input.clientIds.size > 0) {
+    const subjects = await discoverAdminUsageSubjects({
+      client: input.client,
+      clientIds: input.clientIds,
+      from: input.from,
+      to: input.to,
+    });
+    if (subjects.size > 0) {
+      // Exact subjects from meter discovery — do not re-expand via
+      // buildSubjectQueries (that would explode fan-out).
+      return fetchEventsForExactSubjects({
+        client: input.client,
+        subjects,
+        from: input.from,
+        to: input.to,
+      });
+    }
+    // Meter lag / empty discovery: still try compound end-user subjects via
+    // subject-contains, then merge with a short global window for owner events.
+    const [containsBatches, globalRecent] = await Promise.all([
+      Promise.all(
+        [...input.clientIds].map((clientId) =>
+          listSignedTicketEventsForSubjectContains(
+            input.client,
+            clientId,
+            input.from,
+            input.to,
+          ),
+        ),
+      ),
+      listRecentPlatformSignedTicketEvents(input.client, input.from, input.to),
+    ]);
+    return [...containsBatches.flat(), ...globalRecent];
+  }
+
+  return listRecentPlatformSignedTicketEvents(input.client, input.from, input.to);
+}
+
+async function listRecentPlatformSignedTicketEvents(
+  client: OpenMeter,
+  from: string,
+  to: string,
+): Promise<IngestedEventLike[]> {
   try {
-    const listedV2 = await input.client.events.listV2({
+    const listedV2 = await client.events.listV2({
       limit: LIST_FETCH_LIMIT,
       filter: JSON.stringify({
         type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
@@ -573,18 +625,193 @@ async function fetchPlatformSignedTicketEvents(input: {
     return coerceIngestedEvents(listedV2?.items ?? listedV2);
   } catch {
     try {
-      // Unscoped list (no subject) — Konnect returns latest global events.
-      const listed = await input.client.events.list({
-        from: input.from,
-        to: input.to,
+      const listed = await client.events.list({
+        from,
+        to,
         limit: LIST_FETCH_LIMIT,
-        // subject omitted intentionally for platform-wide admin history
       } as { from: string; to: string; limit: number });
       return coerceIngestedEvents(listed).filter(eventIsSignedTicket);
     } catch {
       return [];
     }
   }
+}
+
+/** List signed-ticket events for exact CloudEvent subjects (no key expansion). */
+async function fetchEventsForExactSubjects(input: {
+  client: OpenMeter;
+  subjects: ReadonlySet<string>;
+  from: string;
+  to: string;
+}): Promise<IngestedEventLike[]> {
+  const subjectList = [...input.subjects]
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, MAX_ADMIN_DISCOVERED_SUBJECTS);
+  const batches = await Promise.all(
+    subjectList.map(async (subject) => {
+      try {
+        const listed = await input.client.events.list({
+          subject,
+          from: input.from,
+          to: input.to,
+          limit: LIST_FETCH_LIMIT,
+        });
+        return coerceIngestedEvents(listed).filter(eventIsSignedTicket);
+      } catch {
+        try {
+          const listedV2 = await input.client.events.listV2({
+            limit: LIST_FETCH_LIMIT,
+            filter: JSON.stringify({
+              type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
+              subject: { eq: subject },
+            }),
+          });
+          return coerceIngestedEvents(listedV2?.items ?? listedV2);
+        } catch {
+          return [];
+        }
+      }
+    }),
+  );
+  return batches.flat();
+}
+
+async function listSignedTicketEventsForSubjectContains(
+  client: OpenMeter,
+  subjectFragment: string,
+  from: string,
+  to: string,
+): Promise<IngestedEventLike[]> {
+  try {
+    const listedV2 = await client.events.listV2({
+      limit: LIST_FETCH_LIMIT,
+      filter: JSON.stringify({
+        type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
+        subject: { contains: subjectFragment },
+      }),
+    });
+    return coerceIngestedEvents(listedV2?.items ?? listedV2);
+  } catch {
+    try {
+      const listed = await client.events.list({
+        subject: subjectFragment,
+        from,
+        to,
+        limit: LIST_FETCH_LIMIT,
+      });
+      return coerceIngestedEvents(listed).filter(eventIsSignedTicket);
+    } catch {
+      return [];
+    }
+  }
+}
+
+/**
+ * Resolve OpenMeter event subjects that have signed-ticket usage for the
+ * selected apps in [from, to], ranked by request count.
+ *
+ * Prefers the meter row `subject` (CloudEvent subject) when present; otherwise
+ * expands external_user_id into compound + owner subject forms.
+ */
+export function collectAdminSubjectsFromMeterRows(
+  rows: ReadonlyArray<{
+    subject?: string | null;
+    value?: unknown;
+    groupBy?: Record<string, string | null> | null;
+  }>,
+  clientIds: ReadonlySet<string>,
+): string[] {
+  const countBySubject = new Map<string, number>();
+
+  const addSubject = (raw: string, count: number) => {
+    const subject = raw.trim();
+    if (!subject) return;
+    countBySubject.set(subject, (countBySubject.get(subject) ?? 0) + count);
+  };
+
+  for (const row of rows) {
+    const group = row.groupBy ?? {};
+    const rowClientId =
+      (typeof group.client_id === "string" && group.client_id.trim()) || "";
+    if (rowClientId && !clientIds.has(rowClientId)) {
+      continue;
+    }
+    const count = meterValueToCount(row.value);
+    if (count <= 0) continue;
+
+    const ceSubject = typeof row.subject === "string" ? row.subject.trim() : "";
+    if (ceSubject) {
+      addSubject(ceSubject, count);
+    }
+
+    const externalUserId =
+      (typeof group.external_user_id === "string" &&
+        group.external_user_id.trim()) ||
+      "";
+    if (!externalUserId) continue;
+
+    const apps = rowClientId
+      ? [rowClientId]
+      : [...clientIds];
+    for (const clientId of apps) {
+      addSubject(buildOpenMeterCustomerKey(clientId, externalUserId), count);
+      addSubject(
+        buildOpenMeterCustomerKey(clientId, buildOwnerWireSubject(externalUserId)),
+        count,
+      );
+    }
+    addSubject(externalUserId, count);
+    addSubject(buildOwnerWireSubject(externalUserId), count);
+  }
+
+  return [...countBySubject.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, MAX_ADMIN_DISCOVERED_SUBJECTS)
+    .map(([subject]) => subject);
+}
+
+function meterValueToCount(value: unknown): number {
+  if (value == null) return 0;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : 0;
+  }
+  if (typeof value === "bigint") {
+    return value > 0n ? Number(value) : 0;
+  }
+  return 0;
+}
+
+async function discoverAdminUsageSubjects(input: {
+  client: OpenMeter;
+  clientIds: ReadonlySet<string>;
+  from: string;
+  to: string;
+}): Promise<Set<string>> {
+  const batches = await Promise.all(
+    [...input.clientIds].map(async (clientId) => {
+      try {
+        const result = await input.client.meters.query(SIGNED_TICKET_COUNT_METER, {
+          from: new Date(input.from),
+          to: new Date(input.to),
+          windowSize: "MONTH",
+          clientId,
+          groupBy: ["client_id", "external_user_id"],
+        });
+        return result?.data ?? [];
+      } catch {
+        return [];
+      }
+    }),
+  );
+
+  return new Set(
+    collectAdminSubjectsFromMeterRows(batches.flat(), input.clientIds),
+  );
 }
 
 function normalizeClientIdFilter(


### PR DESCRIPTION
## Summary
- Admin All Usage signed-ticket history for a selected app (e.g. storyboard `app_98575870d7ae33589a3f0660`) was empty despite non-zero chart usage.
- Root cause: after #273, filtered admin views only scanned the latest global `listV2(limit=100)` window, then client-filtered by `client_id`, so quieter apps were drowned out.
- Fix: discover subjects from the `signed_ticket_count` meter (same `client_id` dimension as the usage chart), fetch events for those subjects (compound + owner forms), and fall back to subject-contains + recent global window only if meter discovery is empty.

## Test plan
- [ ] Unit: `node --import tsx --test src/lib/openmeter/signed-ticket-events.test.ts`
- [ ] As admin on production `/usage` → All Usage → filter Apps to **storyboard**
- [ ] Confirm chart still shows requests for the billing period
- [ ] Confirm **Signed ticket requests** lists rows (not the empty state)
- [ ] Spot-check unfiltered All Usage still loads recent platform tickets
- [ ] Spot-check My Usage (non-admin / own scope) unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved admin signed-ticket history retrieval when filtering by one or more clients.
  * Added more accurate discovery of relevant ticket events using client and user information.
  * Added fallback retrieval to help surface recent events when discovery data is unavailable or delayed.
* **Bug Fixes**
  * Reduced unrelated events appearing in client-scoped history results.
  * Improved handling of events with missing subject information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->