### PR TITLE
fix(sonar): mark React component props as Readonly (S6759)

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -8,9 +8,9 @@ import { authOptions } from "@/lib/next-auth-options";
  */
 export default async function AdminLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   const session = await getServerSession(authOptions);
   const role = (session?.user as Record<string, unknown> | undefined)?.role as
     | string

--- a/src/app/admin/oidc-clients/page.tsx
+++ b/src/app/admin/oidc-clients/page.tsx
@@ -295,10 +295,10 @@ export default function AdminOidcClientsPage() {
 function ClientCard({
   client,
   onEdit,
-}: {
+}: Readonly<{
   client: OidcClient;
   onEdit: (client: OidcClient) => void;
-}) {
+}>) {
   return (
     <div className="border border-zinc-800 rounded-xl p-5 bg-zinc-900/30">
       <div className="flex items-start justify-between mb-4">

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -4,8 +4,8 @@ import DashboardLayout from "@/components/DashboardLayout";
 
 export default function DashboardRouteLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   return <DashboardLayout>{children}</DashboardLayout>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,9 +36,9 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   const session = await getServerSession(authOptions);
 
   return (

--- a/src/app/marketplace/[id]/page.tsx
+++ b/src/app/marketplace/[id]/page.tsx
@@ -296,7 +296,7 @@ export default function MarketplaceAppDetailPage() {
   );
 }
 
-function PageShell({ children }: { children: React.ReactNode }) {
+function PageShell({ children }: Readonly<{ children: React.ReactNode }>) {
   const insideDashboard = useInsideDashboard();
 
   if (insideDashboard) {
@@ -326,7 +326,7 @@ function PageShell({ children }: { children: React.ReactNode }) {
   );
 }
 
-function ExternalLink({ href, label }: { href: string; label: string }) {
+function ExternalLink({ href, label }: Readonly<{ href: string; label: string }>) {
   return (
     <a
       href={href}

--- a/src/app/marketplace/layout.tsx
+++ b/src/app/marketplace/layout.tsx
@@ -6,9 +6,9 @@ import { MarketplaceLayoutProvider } from "@/context/MarketplaceLayoutContext";
 
 export default function MarketplaceLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   const { data: session, status } = useSession();
 
   if (status === "loading") {

--- a/src/app/oidc/consent/consent-form.tsx
+++ b/src/app/oidc/consent/consent-form.tsx
@@ -8,7 +8,7 @@ interface ConsentFormProps {
   branding?: AppBranding;
 }
 
-export default function ConsentForm({ uid, branding = getDefaultBranding() }: ConsentFormProps) {
+export default function ConsentForm({ uid, branding = getDefaultBranding() }: Readonly<ConsentFormProps>) {
   const [loading, setLoading] = useState(false);
 
   function submitConsent(action: "approve" | "deny") {

--- a/src/app/oidc/consent/page.tsx
+++ b/src/app/oidc/consent/page.tsx
@@ -44,9 +44,9 @@ function getExternalHref(value: string): string {
 
 export default async function ConsentPage({
   searchParams,
-}: {
+}: Readonly<{
   searchParams: Promise<SearchParams>;
-}) {
+}>) {
   const params = await searchParams;
   const uid = asSingleValue(params.uid);
 

--- a/src/app/oidc/device/page.tsx
+++ b/src/app/oidc/device/page.tsx
@@ -47,9 +47,9 @@ async function resolveAuthoritativeClientId(
 
 export default async function DeviceVerificationPage({
   searchParams,
-}: {
+}: Readonly<{
   searchParams: Promise<SearchParams>;
-}) {
+}>) {
   const params = await searchParams;
   const session = await getServerSession(authOptions);
   const hostContext = await resolveHostContext();

--- a/src/app/oidc/interaction/page.tsx
+++ b/src/app/oidc/interaction/page.tsx
@@ -43,9 +43,9 @@ function buildNodeRequest(
 
 export default async function OidcInteractionPage({
   searchParams,
-}: {
+}: Readonly<{
   searchParams: Promise<SearchParams>;
-}) {
+}>) {
   const params = await searchParams;
   const uid = asSingleValue(params.uid);
 

--- a/src/app/signer/page.tsx
+++ b/src/app/signer/page.tsx
@@ -246,11 +246,11 @@ function ConfigRow({
   label,
   value,
   mono = false,
-}: {
+}: Readonly<{
   label: string;
   value: string;
   mono?: boolean;
-}) {
+}>) {
   return (
     <div className="flex border-b border-zinc-800/50 last:border-b-0">
       <div className="w-40 shrink-0 px-5 py-2.5 text-zinc-500 bg-zinc-900/50">
@@ -271,11 +271,11 @@ function StatCard({
   label,
   value,
   color = "text-zinc-200",
-}: {
+}: Readonly<{
   label: string;
   value: string;
   color?: string;
-}) {
+}>) {
   return (
     <div className="border border-zinc-800 rounded-xl p-4 bg-zinc-900/30">
       <p className="text-xs text-zinc-500 uppercase tracking-wider mb-1">

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -13,9 +13,9 @@ import { confirmedUsageCountByStreamSessionId } from "@/lib/stream-session-stats
 
 export default async function UserDetailPage({
   params,
-}: {
+}: Readonly<{
   params: Promise<{ id: string }>;
-}) {
+}>) {
   const { id } = await params;
 
   const userRows = await db

--- a/src/components/AppCard.tsx
+++ b/src/components/AppCard.tsx
@@ -13,7 +13,7 @@ export type HomeApp = {
   developerName: string | null;
 };
 
-export function AppCard({ app }: { app: HomeApp }) {
+export function AppCard({ app }: Readonly<{ app: HomeApp }>) {
   return (
     <Link
       href={`/marketplace/${app.id}`}

--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -30,7 +30,7 @@ export default function ComboBox({
   placeholder = "Search…",
   disabled = false,
   emptyLabel = "— none —",
-}: ComboBoxProps) {
+}: Readonly<ComboBoxProps>) {
   const listId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -93,9 +93,9 @@ function roleBadgeClassName(role: string): string {
 
 export default function DashboardLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   const pathname = usePathname();
   const router = useRouter();
   const { data: session, status } = useSession();

--- a/src/components/MarketingFooter.tsx
+++ b/src/components/MarketingFooter.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export function MarketingFooter({ className = "" }: { className?: string }) {
+export function MarketingFooter({ className = "" }: Readonly<{ className?: string }>) {
   return (
     <footer
       className={`border-t border-zinc-800 pt-4 ${className}`.trim()}

--- a/src/components/MultiComboBox.tsx
+++ b/src/components/MultiComboBox.tsx
@@ -33,7 +33,7 @@ export default function MultiComboBox({
   placeholder = "Search…",
   disabled = false,
   chipLabel,
-}: MultiComboBoxProps) {
+}: Readonly<MultiComboBoxProps>) {
   const listId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/components/PipelineModelPicker.tsx
+++ b/src/components/PipelineModelPicker.tsx
@@ -32,7 +32,7 @@ export default function PipelineModelPicker({
   blockedConcreteKeys,
   blockedSelectionTitle = "Not available for custom plans under current Network Price exclusions.",
   showSelectedChips = true,
-}: PipelineModelPickerProps) {
+}: Readonly<PipelineModelPickerProps>) {
   const inputId = useId();
   const listboxId = `${inputId}-listbox`;
   const containerRef = useRef<HTMLDivElement>(null);
@@ -264,7 +264,7 @@ export default function PipelineModelPicker({
   );
 }
 
-function PipelineCheckMark({ state }: { state: PipelineCheckState }) {
+function PipelineCheckMark({ state }: Readonly<{ state: PipelineCheckState }>) {
   const base = "flex-shrink-0 w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] font-bold leading-none";
   if (state === "wildcard") {
     return <span className={`${base} border-emerald-600 bg-emerald-600 text-white`}>✓</span>;
@@ -278,7 +278,7 @@ function PipelineCheckMark({ state }: { state: PipelineCheckState }) {
   return <span className={`${base} border-zinc-600 bg-transparent`} />;
 }
 
-function ModelCheckMark({ checked, implicit }: { checked: boolean; implicit: boolean }) {
+function ModelCheckMark({ checked, implicit }: Readonly<{ checked: boolean; implicit: boolean }>) {
   const base = "flex-shrink-0 w-3 h-3 rounded border flex items-center justify-center text-[8px] font-bold leading-none";
   if (implicit) {
     return <span className={`${base} border-zinc-700 bg-zinc-800 text-zinc-600`}>✓</span>;

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -7,10 +7,10 @@ import TurnkeyProviderWrapper from "./TurnkeyProvider";
 export default function Providers({
   children,
   session,
-}: {
+}: Readonly<{
   children: React.ReactNode;
   session: Session | null;
-}) {
+}>) {
   return (
     <SessionProvider session={session} refetchOnWindowFocus={false}>
       <TurnkeyProviderWrapper>{children}</TurnkeyProviderWrapper>

--- a/src/components/SignerControlPanel.tsx
+++ b/src/components/SignerControlPanel.tsx
@@ -11,7 +11,7 @@ interface SignerControlPanelProps {
 export default function SignerControlPanel({
   currentStatus,
   managedRemote = false,
-}: SignerControlPanelProps) {
+}: Readonly<SignerControlPanelProps>) {
   const router = useRouter();
   const [loading, setLoading] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);

--- a/src/components/SignerLiveStats.tsx
+++ b/src/components/SignerLiveStats.tsx
@@ -54,12 +54,12 @@ function StatCard({
   value,
   color = "text-zinc-200",
   dim = false,
-}: {
+}: Readonly<{
   label: string;
   value: string;
   color?: string;
   dim?: boolean;
-}) {
+}>) {
   return (
     <div className={`border border-zinc-800 rounded-xl p-4 bg-zinc-900/30 ${dim ? "opacity-50" : ""}`}>
       <p className="text-xs text-zinc-500 uppercase tracking-wider mb-1">

--- a/src/components/StreamSessionTable.tsx
+++ b/src/components/StreamSessionTable.tsx
@@ -69,7 +69,7 @@ const statusBadge: Record<string, string> = {
 
 export default function StreamSessionTable({
   sessions,
-}: StreamSessionTableProps) {
+}: Readonly<StreamSessionTableProps>) {
   const orderedSessions = useMemo(
     () => sortSessionsByLastPaymentDesc(sessions),
     [sessions],

--- a/src/components/TransactionLog.tsx
+++ b/src/components/TransactionLog.tsx
@@ -49,7 +49,7 @@ const statusDot: Record<string, string> = {
 
 export default function TransactionLog({
   transactions,
-}: TransactionLogProps) {
+}: Readonly<TransactionLogProps>) {
   if (transactions.length === 0) {
     return (
       <div className="text-center py-12 text-zinc-500">

--- a/src/components/TurnkeyProvider.tsx
+++ b/src/components/TurnkeyProvider.tsx
@@ -137,9 +137,9 @@ function TurnkeyExpectedErrorGuard() {
 
 export default function TurnkeyProviderWrapper({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   const organizationId = process.env.NEXT_PUBLIC_ORGANIZATION_ID;
   const authProxyConfigId = process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID;
 

--- a/src/components/UsageLineChart.tsx
+++ b/src/components/UsageLineChart.tsx
@@ -74,7 +74,7 @@ export default function UsageLineChart({
   valueLabel = "Requests",
   className = "",
   height = 200,
-}: UsageLineChartProps) {
+}: Readonly<UsageLineChartProps>) {
   const width = 720;
   const padLeft = 44;
   const padRight = 12;

--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -35,7 +35,7 @@ const providerIcon: Record<string, string> = {
   github: "GH",
 };
 
-export default function UserTable({ users }: UserTableProps) {
+export default function UserTable({ users }: Readonly<UserTableProps>) {
   if (users.length === 0) {
     return (
       <div className="text-center py-12 text-zinc-500">

--- a/src/components/apps/AppSectionBreadcrumb.tsx
+++ b/src/components/apps/AppSectionBreadcrumb.tsx
@@ -8,7 +8,7 @@ interface Props {
 /**
  * In-app navigation: My Apps → app → Plans (current).
  */
-export default function AppSectionBreadcrumb({ appId, appName }: Props) {
+export default function AppSectionBreadcrumb({ appId, appName }: Readonly<Props>) {
   return (
     <nav className="text-sm text-zinc-500 mb-3" aria-label="Breadcrumb">
       <Link href="/apps" className="hover:text-zinc-300 transition-colors">

--- a/src/components/apps/AppSettingsPanel.tsx
+++ b/src/components/apps/AppSettingsPanel.tsx
@@ -18,7 +18,7 @@ interface Props {
   data: AppSettingsData;
 }
 
-export default function AppSettingsPanel({ data }: Props) {
+export default function AppSettingsPanel({ data }: Readonly<Props>) {
   const [redirectUris, setRedirectUris] = useState<string[]>(data.redirectUris);
   const [postLogoutRedirectUris, setPostLogoutRedirectUris] = useState<string[]>(
     data.postLogoutRedirectUris || [],
@@ -351,10 +351,10 @@ export default function AppSettingsPanel({ data }: Props) {
 function Field({
   label,
   value,
-}: {
+}: Readonly<{
   label: string;
   value: string;
-}) {
+}>) {
   return (
     <div>
       <label className="block text-xs font-medium text-zinc-500 mb-1.5">{label}</label>

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -96,7 +96,7 @@ export default function AppSettingsScreen({
   canManageBilling = false,
   ownerExternalUserId = null,
   initialTab,
-}: Props) {
+}: Readonly<Props>) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -700,13 +700,13 @@ function ReferenceEndpointsSection({
   authorizeUrl,
   tokenUrl,
   signerSessionUrl,
-}: {
+}: Readonly<{
   clientId: string;
   discoveryUrl: string;
   authorizeUrl: string;
   tokenUrl: string;
   signerSessionUrl: string;
-}) {
+}>) {
   const rows = useMemo(
     () =>
       [

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -76,7 +76,7 @@ function joinScopes(scopes: string[]): string {
   return scopes.join(" ");
 }
 
-export default function AppWizard({ initialData }: Props) {
+export default function AppWizard({ initialData }: Readonly<Props>) {
   const router = useRouter();
   const [formData, setFormData] = useState<AppFormData>({
     ...defaultAppFormData,

--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -336,11 +336,11 @@ function PlanTypePills({
   value,
   onChange,
   disabled,
-}: {
+}: Readonly<{
   value: string;
   onChange: (v: string) => void;
   disabled?: boolean;
-}) {
+}>) {
   return (
     <div
       className="flex w-full overflow-hidden rounded-lg border border-zinc-700"
@@ -369,10 +369,10 @@ function PlanTypePills({
 function CapabilityChips({
   capabilities,
   catalog,
-}: {
+}: Readonly<{
   capabilities: PlanRow["capabilities"];
   catalog: PipelineCatalogEntry[];
-}) {
+}>) {
   if (capabilities.length === 0) {
     return <span className="text-xs text-zinc-500">No pipeline overrides</span>;
   }
@@ -432,7 +432,7 @@ function CapabilityPricingRow({
   idPrefix,
   onMarkupChange,
   onRemove,
-}: {
+}: Readonly<{
   capKey: string;
   label: string;
   markupPct: string;
@@ -440,7 +440,7 @@ function CapabilityPricingRow({
   idPrefix: string;
   onMarkupChange: (pct: string) => void;
   onRemove: () => void;
-}) {
+}>) {
   const [markupFocused, setMarkupFocused] = useState(false);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -551,7 +551,7 @@ function CapabilityPricingRules({
   idPrefix,
   onMarkupChange,
   onRemove,
-}: {
+}: Readonly<{
   keys: string[];
   markupByKey: Record<string, string>;
   catalog: PipelineCatalogEntry[];
@@ -559,7 +559,7 @@ function CapabilityPricingRules({
   idPrefix: string;
   onMarkupChange: (key: string, pct: string) => void;
   onRemove: (key: string) => void;
-}) {
+}>) {
   const sorted = sortedCapabilityKeys(keys, catalog);
 
   return (
@@ -586,7 +586,7 @@ function CapabilityPricingRules({
   );
 }
 
-function TypeBadge({ type }: { type: string }) {
+function TypeBadge({ type }: Readonly<{ type: string }>) {
   const styles: Record<string, string> = {
     free: "text-emerald-400/90 border-emerald-500/30 bg-emerald-500/10",
     subscription: "text-sky-400/90 border-sky-500/30 bg-sky-500/10",
@@ -614,7 +614,7 @@ function PlanDraftForm({
   blockedConcreteKeys,
   canEdit,
   idPrefix,
-}: {
+}: Readonly<{
   draft: PlanDraft;
   onChange: (d: PlanDraft) => void;
   catalog: PipelineCatalogEntry[];
@@ -622,7 +622,7 @@ function PlanDraftForm({
   blockedConcreteKeys: Set<string>;
   canEdit: boolean;
   idPrefix: string;
-}) {
+}>) {
   return (
     <div className="space-y-4 pt-4 border-t border-zinc-800">
       <div>
@@ -880,11 +880,11 @@ function CollapsedPlanCardHitArea({
   enabled,
   ariaLabel,
   onActivate,
-}: {
+}: Readonly<{
   enabled: boolean;
   ariaLabel: string;
   onActivate: () => void;
-}) {
+}>) {
   if (!enabled) return null;
   return (
     <button
@@ -905,14 +905,14 @@ function NetworkPricePlanCard({
   catalogError,
   canEdit,
   onSaved,
-}: {
+}: Readonly<{
   appId: string;
   plan: PlanRow;
   catalog: PipelineCatalogEntry[];
   catalogError: string | null;
   canEdit: boolean;
   onSaved: () => void | Promise<void>;
-}) {
+}>) {
   const catalogLite = useMemo(() => catalogLiteFrom(catalog), [catalog]);
   const [expanded, setExpanded] = useState(false);
   const [pickerValues, setPickerValues] = useState<string[]>([]);
@@ -1353,7 +1353,7 @@ function CustomPlanCard({
   onCancelEdit,
   onSaved,
   onDelete,
-}: {
+}: Readonly<{
   appId: string;
   plan: PlanRow;
   catalog: PipelineCatalogEntry[];
@@ -1365,7 +1365,7 @@ function CustomPlanCard({
   onCancelEdit: () => void;
   onSaved: () => void | Promise<void>;
   onDelete: () => void;
-}) {
+}>) {
   const [draft, setDraft] = useState<PlanDraft>(() => planToDraft(plan));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -1534,14 +1534,14 @@ function AddPlanPanel({
   blockedConcreteKeys,
   canEdit,
   onCreated,
-}: {
+}: Readonly<{
   appId: string;
   catalog: PipelineCatalogEntry[];
   catalogError: string | null;
   blockedConcreteKeys: Set<string>;
   canEdit: boolean;
   onCreated: () => void | Promise<void>;
-}) {
+}>) {
   const [expanded, setExpanded] = useState(false);
   const [draft, setDraft] = useState<PlanDraft>(emptyDraft);
   const [saving, setSaving] = useState(false);
@@ -1664,7 +1664,7 @@ interface PlansTabProps {
   canEdit: boolean;
 }
 
-export default function PlansTab({ appId, canEdit }: PlansTabProps) {
+export default function PlansTab({ appId, canEdit }: Readonly<PlansTabProps>) {
   const [plans, setPlans] = useState<PlanRow[]>([]);
   const [catalog, setCatalog] = useState<PipelineCatalogEntry[]>([]);
   const [catalogError, setCatalogError] = useState<string | null>(null);

--- a/src/components/apps/steps/AppInfoStep.tsx
+++ b/src/components/apps/steps/AppInfoStep.tsx
@@ -8,7 +8,7 @@ interface Props {
   readOnly?: boolean;
 }
 
-export default function AppInfoStep({ data, onChange, readOnly = false }: Props) {
+export default function AppInfoStep({ data, onChange, readOnly = false }: Readonly<Props>) {
   return (
     <div className="space-y-6">
       <div>

--- a/src/components/apps/steps/AppModeStep.tsx
+++ b/src/components/apps/steps/AppModeStep.tsx
@@ -39,7 +39,7 @@ export default function AppModeStep({
   data,
   onChange,
   readOnly = false,
-}: Props) {
+}: Readonly<Props>) {
   const scopes = data.allowedScopes.split(/\s+/).filter(Boolean);
   const hasDeviceCode = data.grantTypes.includes(DEVICE_CODE_GRANT);
   const hasSignJob = scopes.includes("sign:job");

--- a/src/components/apps/steps/AuthorizationCodeRedirectBlock.tsx
+++ b/src/components/apps/steps/AuthorizationCodeRedirectBlock.tsx
@@ -31,7 +31,7 @@ export default function AuthorizationCodeRedirectBlock({
   domains,
   onDomainsChange,
   readOnly = false,
-}: Props) {
+}: Readonly<Props>) {
   const [newUri, setNewUri] = useState("");
   const [newDomain, setNewDomain] = useState("");
   const [adding, setAdding] = useState(false);

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -1560,7 +1560,7 @@ export default function TestingStep({
   readOnly = false,
   hideRedirectUriEditor = false,
   hideAuthCodeFlowSection = false,
-}: Props) {
+}: Readonly<Props>) {
   const [secret, setSecret] = useState<string | null>(null);
   const [backendSecret, setBackendSecret] = useState<string | null>(null);
   const [generating, setGenerating] = useState(false);

--- a/src/components/oidc/branded-layout.tsx
+++ b/src/components/oidc/branded-layout.tsx
@@ -11,7 +11,7 @@ interface BrandedLayoutProps {
   children: React.ReactNode;
 }
 
-export function BrandedLayout({ branding, children }: BrandedLayoutProps) {
+export function BrandedLayout({ branding, children }: Readonly<BrandedLayoutProps>) {
   const cssVars = getBrandingCssVars(branding);
   const isWhiteLabel = shouldUseWhiteLabelBranding(branding);
 
@@ -111,7 +111,7 @@ export function BrandedHeader({
   subtitle,
   badge,
   badgeColor = "emerald",
-}: BrandedHeaderProps) {
+}: Readonly<BrandedHeaderProps>) {
   const isWhiteLabel = shouldUseWhiteLabelBranding(branding);
   
   const badgeColors = {
@@ -177,7 +177,7 @@ export function BrandedButton({
   children,
   className = "",
   ...props
-}: BrandedButtonProps) {
+}: Readonly<BrandedButtonProps>) {
   const baseClasses = "px-6 py-3 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
   
   const variantClasses = {

--- a/src/context/MarketplaceLayoutContext.tsx
+++ b/src/context/MarketplaceLayoutContext.tsx
@@ -7,10 +7,10 @@ const MarketplaceLayoutContext = createContext<boolean>(false);
 export function MarketplaceLayoutProvider({
   insideDashboard,
   children,
-}: {
+}: Readonly<{
   insideDashboard: boolean;
   children: ReactNode;
-}) {
+}>) {
   return (
     <MarketplaceLayoutContext.Provider value={insideDashboard}>
       {children}


### PR DESCRIPTION
## Summary
- Wrap React component props in `Readonly<>` to clear all 55 typescript:S6759 findings across 37 files
- Type-only change; no runtime behavior impact

Part of the SonarCloud backlog cleanup (Phase 5).

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] CI test / lint pass
- [ ] Sonar S6759 issues clear on the PR