### PR TITLE
fix(sonar): optional chaining and unnest ternaries (S6582/S3358)

### DIFF
--- a/src/app/api/v1/apps/[id]/route.ts
+++ b/src/app/api/v1/apps/[id]/route.ts
@@ -234,13 +234,18 @@ export async function PUT(
         ? String(body.billingOracleProviderKey)
         : (existingPricing?.billingOracleProviderKey ?? "global_eth_usd"),
     ).key;
-    const nextConfig =
-      body.billingOracleProviderConfig !== undefined
-        ? (body.billingOracleProviderConfig &&
-          typeof body.billingOracleProviderConfig === "object"
-            ? body.billingOracleProviderConfig
-            : null)
-        : (existingPricing?.billingOracleProviderConfig ?? null);
+    let nextConfig: Record<string, unknown> | null =
+      existingPricing?.billingOracleProviderConfig ?? null;
+    if (body.billingOracleProviderConfig !== undefined) {
+      if (
+        body.billingOracleProviderConfig &&
+        typeof body.billingOracleProviderConfig === "object"
+      ) {
+        nextConfig = body.billingOracleProviderConfig as Record<string, unknown>;
+      } else {
+        nextConfig = null;
+      }
+    }
     if (existingPricing) {
       await db
         .update(appBillingOracleConfig)

--- a/src/app/api/v1/apps/[id]/users/[externalUserId]/token/route.ts
+++ b/src/app/api/v1/apps/[id]/users/[externalUserId]/token/route.ts
@@ -124,7 +124,7 @@ export async function POST(
     .limit(1);
   const appUser = appUserRows[0];
 
-  if (!appUser || appUser.status !== "active") {
+  if (appUser?.status !== "active") {
     await writeAuditLog({
       clientId: app.id,
       action: "programmatic_token_issued",

--- a/src/app/api/v1/auth/validate/route.ts
+++ b/src/app/api/v1/auth/validate/route.ts
@@ -59,7 +59,7 @@ async function resolveKeyValidation(keyHash: string): Promise<ResolvedKey> {
     .where(eq(apiKeys.keyHash, keyHash))
     .limit(1);
   const apiKey = apiKeyRows[0];
-  if (!apiKey || apiKey.status !== "active") {
+  if (apiKey?.status !== "active") {
     return { kind: "invalid" };
   }
 

--- a/src/app/api/v1/oidc/device/verify/route.ts
+++ b/src/app/api/v1/oidc/device/verify/route.ts
@@ -78,12 +78,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       typeof clientId === "string"
         ? await resolveAppBrandingByClientId(clientId)
         : null;
-    const scope =
-      typeof deviceCode.scope === "string"
-        ? deviceCode.scope
-        : typeof deviceCode.params?.scope === "string"
-          ? deviceCode.params.scope
-          : "";
+    let scope = "";
+    if (typeof deviceCode.scope === "string") {
+      scope = deviceCode.scope;
+    } else if (typeof deviceCode.params?.scope === "string") {
+      scope = deviceCode.params.scope;
+    }
     let impliedDeviceConsent = false;
     if (typeof clientId === "string") {
       const policyRows = await db

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -32,11 +32,13 @@ export function LoginForm() {
   const accessDenied =
     authError === "AccessDenied" ||
     (typeof authError === "string" && authError.includes("AccessDenied"));
-  const oauthCallbackMessage = accessDenied
-    ? "Sign-in was denied. You can try again or use a different sign-in method."
-    : authError
-      ? "Sign-in failed. Please try again."
-      : null;
+  let oauthCallbackMessage: string | null = null;
+  if (accessDenied) {
+    oauthCallbackMessage =
+      "Sign-in was denied. You can try again or use a different sign-in method.";
+  } else if (authError) {
+    oauthCallbackMessage = "Sign-in failed. Please try again.";
+  }
 
   // Preserve legacy ?admin=1 links by sending them to the dedicated admin login.
   useEffect(() => {

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -157,11 +157,12 @@ export default function MarketplacePage() {
         </div>
 
         {/* App grid */}
-        {loading ? (
+        {loading && (
           <div className="text-zinc-500 text-center py-16 animate-pulse">
             Loading apps...
           </div>
-        ) : filtered.length === 0 ? (
+        )}
+        {!loading && filtered.length === 0 && (
           <div className="text-center py-16 border border-zinc-800 rounded-xl bg-zinc-900/20">
             <div className="w-16 h-16 bg-zinc-800 rounded-xl flex items-center justify-center mx-auto mb-4">
               <svg
@@ -189,7 +190,8 @@ export default function MarketplacePage() {
                 : "Try adjusting your search or filter criteria."}
             </p>
           </div>
-        ) : (
+        )}
+        {!loading && filtered.length > 0 && (
           <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
             {filtered.map((app) => (
               <AppCard key={app.id} app={app} />

--- a/src/app/oidc/device/page.tsx
+++ b/src/app/oidc/device/page.tsx
@@ -26,14 +26,16 @@ async function resolveAuthoritativeClientId(
       const normalized = normalizeUserCode(userCode);
       const payload = await adapter.findByUserCode(normalized);
       if (payload) {
-        const bound =
-          typeof payload.clientId === "string"
-            ? payload.clientId
-            : typeof payload.params === "object" &&
-                payload.params !== null &&
-                typeof (payload.params as Record<string, unknown>).client_id === "string"
-              ? ((payload.params as Record<string, unknown>).client_id as string)
-              : undefined;
+        let bound: string | undefined;
+        if (typeof payload.clientId === "string") {
+          bound = payload.clientId;
+        } else if (
+          typeof payload.params === "object" &&
+          payload.params !== null &&
+          typeof (payload.params as Record<string, unknown>).client_id === "string"
+        ) {
+          bound = (payload.params as Record<string, unknown>).client_id as string;
+        }
         if (bound) {
           return bound;
         }

--- a/src/components/SignerControlPanel.tsx
+++ b/src/components/SignerControlPanel.tsx
@@ -32,11 +32,14 @@ export default function SignerControlPanel({
       const data = await res.json();
 
       if (res.ok && data.success) {
-        setMessage(
-          action === "sync"
-            ? `Synced. Reachable: ${data.reachable}${data.ethAddress ? `, address: ${data.ethAddress}` : ""}`
-            : `${action} completed successfully`
-        );
+        let successMessage = `${action} completed successfully`;
+        if (action === "sync") {
+          const addressSuffix = data.ethAddress
+            ? `, address: ${data.ethAddress}`
+            : "";
+          successMessage = `Synced. Reachable: ${data.reachable}${addressSuffix}`;
+        }
+        setMessage(successMessage);
         router.refresh();
       } else {
         setError(data.error || `${action} failed`);

--- a/src/components/SignerLogs.tsx
+++ b/src/components/SignerLogs.tsx
@@ -129,17 +129,19 @@ export default function SignerLogs({
         ref={scrollRef}
         className="bg-zinc-950 border border-zinc-800 rounded-lg p-4 font-mono text-xs leading-relaxed max-h-96 overflow-auto"
       >
-        {loading ? (
+        {loading && (
           <p className="text-zinc-500 animate-pulse">Loading logs...</p>
-        ) : lines.length === 0 ? (
+        )}
+        {!loading && lines.length === 0 && (
           <p className="text-zinc-500">No logs available</p>
-        ) : (
+        )}
+        {!loading &&
+          lines.length > 0 &&
           lines.map((line, i) => (
             <div key={i} className={`${classifyLine(line)} whitespace-pre-wrap`}>
               {line}
             </div>
-          ))
-        )}
+          ))}
       </div>
     </div>
   );

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -445,6 +445,12 @@ function getCredentialsIntroText(isM2MOnly: boolean, hideAuthCodeFlowSection: bo
   return "Configure redirect URLs, generate and rotate credentials, try a live authorization request, and copy reference endpoints.";
 }
 
+function getSecretButtonLabel(generating: boolean, hasSecret: boolean): string {
+  if (generating) return "Generating...";
+  if (hasSecret) return "Rotate Secret";
+  return "Generate Secret";
+}
+
 function scopesForInitiateLoginUri(allowedScopes: string, isValid: boolean): string {
   const scopes = allowedScopes.split(/[,\s]+/).filter(Boolean);
   if (!isValid) return scopes.filter((scope) => scope !== "users:token").join(" ");
@@ -1806,7 +1812,7 @@ export default function TestingStep({
                   disabled={readOnly || generating || !appId}
                   className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
                 >
-                  {generating ? "Generating..." : hasSecret ? "Rotate Secret" : "Generate Secret"}
+                  {getSecretButtonLabel(generating, hasSecret)}
                 </button>
               </div>
             )}
@@ -1848,7 +1854,7 @@ export default function TestingStep({
         (`backendHelper` / `backendDeviceHelper`), refreshed when the
         Credentials tab loads and after save.
       */}
-      {backendHelper ? (
+      {backendHelper && (
         <div className="p-4 rounded-xl border border-cyan-500/20 bg-cyan-500/5 space-y-3">
           <h3 className="text-sm font-semibold text-cyan-200/90">Backend helper (confidential)</h3>
           <p className="text-xs text-zinc-500">
@@ -1902,11 +1908,7 @@ export default function TestingStep({
                   disabled={readOnly || generatingBackend || !appId}
                   className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
                 >
-                  {generatingBackend
-                    ? "Generating..."
-                    : backendHelper.hasSecret
-                      ? "Rotate Secret"
-                      : "Generate Secret"}
+                  {getSecretButtonLabel(generatingBackend, backendHelper.hasSecret)}
                 </button>
               </div>
             )}
@@ -1915,21 +1917,23 @@ export default function TestingStep({
             )}
           </div>
         </div>
-      ) : !isM2MOnly && backendDeviceHelper ? (
+      )}
+      {!backendHelper && !isM2MOnly && backendDeviceHelper && (
         <p className="text-sm text-zinc-500 mt-4">
           <strong className="text-zinc-400">Backend device helper</strong> is enabled but not yet provisioned.
           Save the app to provision the Backend device helper and create a confidential{" "}
           <code className="font-mono text-zinc-400">m2m_</code> client for Builder APIs and NaaP-side device
           approval, then return here.
         </p>
-      ) : !isM2MOnly ? (
+      )}
+      {!backendHelper && !isM2MOnly && !backendDeviceHelper && (
         <p className="text-sm text-zinc-500 mt-4">
           Confidential M2M backend is off on{" "}
           <strong className="text-zinc-400">App profile</strong>. Turn on{" "}
           <strong className="text-zinc-400">Confidential M2M backend</strong>{" "}
           there to manage M2M credentials on this tab.
         </p>
-      ) : null}
+      )}
 
       {showAuthTestSection ? (
         <div className="p-4 rounded-xl border border-zinc-800 bg-zinc-900/30 space-y-4">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -245,12 +245,12 @@ export async function authenticateRequestAsync(request: NextRequest): Promise<Au
   const scopeFromScope =
     typeof jwtPayload.scope === "string" ? jwtPayload.scope : "";
   const scpRaw = (jwtPayload as Record<string, unknown>).scp;
-  const scopeFromScp =
-    Array.isArray(scpRaw)
-      ? scpRaw.filter((v): v is string => typeof v === "string").join(" ")
-      : typeof scpRaw === "string"
-        ? scpRaw
-        : "";
+  let scopeFromScp = "";
+  if (Array.isArray(scpRaw)) {
+    scopeFromScp = scpRaw.filter((v): v is string => typeof v === "string").join(" ");
+  } else if (typeof scpRaw === "string") {
+    scopeFromScp = scpRaw;
+  }
   const normalizedScopes = (scopeFromScope || scopeFromScp)
     .trim()
     .replace(/\s+/g, ",");

--- a/src/lib/oidc/branding.ts
+++ b/src/lib/oidc/branding.ts
@@ -66,7 +66,7 @@ export async function resolveAppBrandingByCustomDomain(
     .limit(1);
   const app = appRows[0];
 
-  if (!app || !app.customLoginEnabled || app.brandingMode !== "whiteLabel") {
+  if (!app?.customLoginEnabled || app?.brandingMode !== "whiteLabel") {
     return null;
   }
 

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -141,7 +141,7 @@ export async function getInitiateLoginUriForDeviceFlow(
     .where(eq(oidcClients.clientId, clientId))
     .limit(1);
   const row = rows[0];
-  if (!row || row.deviceThirdPartyInitiateLogin !== 1) return null;
+  if (row?.deviceThirdPartyInitiateLogin !== 1) return null;
   const uri = row.initiateLoginUri;
   return typeof uri === "string" && uri.trim() ? uri.trim() : null;
 }
@@ -232,7 +232,7 @@ export async function validateClientSecret(
   clientSecret: string,
 ): Promise<boolean> {
   const client = await getClient(clientId);
-  if (!client || !client.clientSecretHash) return false;
+  if (!client?.clientSecretHash) return false;
 
   const providedHash = hashClientSecret(clientSecret);
   return providedHash === client.clientSecretHash;

--- a/src/lib/oidc/custom-domains.ts
+++ b/src/lib/oidc/custom-domains.ts
@@ -40,7 +40,7 @@ export async function getAppByCustomDomain(
     .limit(1);
   const app = rows[0];
 
-  if (!app || !app.customDomainVerifiedAt) {
+  if (!app?.customDomainVerifiedAt) {
     return null;
   }
 
@@ -173,7 +173,7 @@ export async function enableCustomLoginDomain(appId: string): Promise<boolean> {
     .limit(1);
   const app = appRows[0];
 
-  if (!app || !app.customDomainVerifiedAt) {
+  if (!app?.customDomainVerifiedAt) {
     return false;
   }
 
@@ -222,7 +222,7 @@ export async function getCustomDomainStatus(
     .limit(1);
   const app = appRows[0];
 
-  if (!app || !app.customLoginDomain) {
+  if (!app?.customLoginDomain) {
     return null;
   }
 

--- a/src/lib/oidc/device-approval.ts
+++ b/src/lib/oidc/device-approval.ts
@@ -66,14 +66,16 @@ export async function approveDeviceCodeForAccount(
     };
   }
 
-  const boundClient =
-    typeof deviceCode.clientId === "string"
-      ? deviceCode.clientId
-      : typeof deviceCode.params === "object" &&
-          deviceCode.params !== null &&
-          typeof (deviceCode.params as Record<string, unknown>).client_id === "string"
-        ? ((deviceCode.params as Record<string, unknown>).client_id as string)
-        : null;
+  let boundClient: string | null = null;
+  if (typeof deviceCode.clientId === "string") {
+    boundClient = deviceCode.clientId;
+  } else if (
+    typeof deviceCode.params === "object" &&
+    deviceCode.params !== null &&
+    typeof (deviceCode.params as Record<string, unknown>).client_id === "string"
+  ) {
+    boundClient = (deviceCode.params as Record<string, unknown>).client_id as string;
+  }
 
   if (!boundClient || boundClient !== oidcClientId) {
     return {
@@ -89,19 +91,19 @@ export async function approveDeviceCodeForAccount(
       ? (deviceCode.params as Record<string, unknown>)
       : null;
   const resourceFromParams = params?.resource;
-  const resource =
-    typeof resourceFromParams === "string" && resourceFromParams.length > 0
-      ? resourceFromParams
-      : typeof deviceCode.resource === "string" && deviceCode.resource.length > 0
-        ? deviceCode.resource
-        : getIssuer();
+  let resource = getIssuer();
+  if (typeof resourceFromParams === "string" && resourceFromParams.length > 0) {
+    resource = resourceFromParams;
+  } else if (typeof deviceCode.resource === "string" && deviceCode.resource.length > 0) {
+    resource = deviceCode.resource;
+  }
 
-  const scope =
-    typeof deviceCode.scope === "string"
-      ? deviceCode.scope
-      : params && typeof params.scope === "string"
-        ? params.scope
-        : "";
+  let scope = "";
+  if (typeof deviceCode.scope === "string") {
+    scope = deviceCode.scope;
+  } else if (params && typeof params.scope === "string") {
+    scope = params.scope;
+  }
 
   if (typeof deviceCode.jti !== "string" || deviceCode.jti.length === 0) {
     return {

--- a/src/lib/oidc/device-token-exchange.ts
+++ b/src/lib/oidc/device-token-exchange.ts
@@ -272,12 +272,12 @@ export async function handleDeviceApprovalTokenExchange(
   }
 
   const rec = payload as Record<string, unknown>;
-  const tokenClientId =
-    typeof rec.client_id === "string"
-      ? rec.client_id
-      : typeof rec.azp === "string"
-        ? rec.azp
-        : null;
+  let tokenClientId: string | null = null;
+  if (typeof rec.client_id === "string") {
+    tokenClientId = rec.client_id;
+  } else if (typeof rec.azp === "string") {
+    tokenClientId = rec.azp;
+  }
   if (!tokenClientId || tokenClientId !== publicClientId) {
     throw new TokenExchangeError(
       "invalid_grant",

--- a/src/lib/oidc/gateway-token-exchange.ts
+++ b/src/lib/oidc/gateway-token-exchange.ts
@@ -210,12 +210,12 @@ export async function handleGatewayTokenExchange(
   }
 
   const rec = payload as Record<string, unknown>;
-  const tokenClientId =
-    typeof rec.client_id === "string"
-      ? rec.client_id
-      : typeof rec.azp === "string"
-        ? rec.azp
-        : null;
+  let tokenClientId: string | null = null;
+  if (typeof rec.client_id === "string") {
+    tokenClientId = rec.client_id;
+  } else if (typeof rec.azp === "string") {
+    tokenClientId = rec.azp;
+  }
   if (!tokenClientId) {
     throw new TokenExchangeError(
       "invalid_grant",
@@ -236,11 +236,12 @@ export async function handleGatewayTokenExchange(
   const scopeFromScope =
     typeof payload.scope === "string" ? payload.scope : "";
   const scpRaw = (payload as Record<string, unknown>).scp;
-  const scopeFromScp = Array.isArray(scpRaw)
-    ? scpRaw.filter((v): v is string => typeof v === "string").join(" ")
-    : typeof scpRaw === "string"
-      ? scpRaw
-      : "";
+  let scopeFromScp = "";
+  if (Array.isArray(scpRaw)) {
+    scopeFromScp = scpRaw.filter((v): v is string => typeof v === "string").join(" ");
+  } else if (typeof scpRaw === "string") {
+    scopeFromScp = scpRaw;
+  }
   const normalizedScopes = (scopeFromScope || scopeFromScp)
     .trim()
     .replace(/\s+/g, ",");

--- a/src/lib/oidc/programmatic-tokens.ts
+++ b/src/lib/oidc/programmatic-tokens.ts
@@ -192,7 +192,7 @@ export async function rotateProgrammaticRefreshToken(input: {
     .limit(1);
   const appUser = appUserRows[0];
 
-  if (!appUser || appUser.status !== "active") {
+  if (appUser?.status !== "active") {
     return null;
   }
 

--- a/src/lib/oidc/third-party-initiate-login.ts
+++ b/src/lib/oidc/third-party-initiate-login.ts
@@ -23,7 +23,7 @@ export function normalizeIssuerUrl(iss: string): string {
 }
 
 export function issuerMatchesExpected(iss: string | null, expectedIssuer: string): boolean {
-  if (!iss || !iss.trim()) return false;
+  if (!iss?.trim()) return false;
   try {
     return normalizeIssuerUrl(iss) === normalizeIssuerUrl(expectedIssuer);
   } catch {
@@ -119,7 +119,7 @@ export function buildInitiateLoginRedirectUrl(
   const dest = new URL(initiateLoginUri);
   dest.searchParams.set("iss", args.iss);
   dest.searchParams.set("target_link_uri", args.target_link_uri);
-  if (args.login_hint && args.login_hint.trim()) {
+  if (args.login_hint?.trim()) {
     dest.searchParams.set("login_hint", args.login_hint.trim());
   }
   return dest.toString();

--- a/src/lib/prices/fiat-oracle-registry.ts
+++ b/src/lib/prices/fiat-oracle-registry.ts
@@ -43,7 +43,7 @@ export function resolveBillingOracleProviderKey(
 ): FiatOracleProviderDefinition {
   const normalized = key?.trim() ?? "";
   const provider = providerByKey.get(normalized);
-  if (!provider || !provider.enabled) {
+  if (!provider?.enabled) {
     return providerByKey.get("global_eth_usd")!;
   }
   return provider;

--- a/src/lib/prices/public-exchange-spot.ts
+++ b/src/lib/prices/public-exchange-spot.ts
@@ -26,7 +26,12 @@ async function fetchWithTimeout(url: string): Promise<Response> {
 
 /** Parse and validate a price number: must be finite and positive. */
 function parsePositiveNumber(v: unknown): number | null {
-  const n = typeof v === "string" ? Number.parseFloat(v) : typeof v === "number" ? v : Number.NaN;
+  let n = Number.NaN;
+  if (typeof v === "string") {
+    n = Number.parseFloat(v);
+  } else if (typeof v === "number") {
+    n = v;
+  }
   return Number.isFinite(n) && n > 0 ? n : null;
 }
 


### PR DESCRIPTION
## Summary
- Prefer optional chaining (`?.`) for 12 S6582 findings
- Extract nested ternaries into helpers / if-else for 19 S3358 findings
- Behavior preserved

Part of the SonarCloud backlog cleanup (Phase 5).

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] CI tests pass
- [ ] Sonar S6582 / S3358 clear on the PR