### PR TITLE
fix(sonar): clear remaining smell findings

### DIFF
--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -17,20 +17,20 @@ ARG LIBJWT_COMMIT=1ea509e8eab34819a490ceac595df6ea365079a3
 ARG MOD_AUTHNZ_JWT_COMMIT=ba43b3f0c7a98603eb83ccbe83a37f0d33bc0700
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    make \
-    automake \
-    git \
-    g++ \
-    libtool \
-    pkg-config \
-    autoconf \
-    libssl-dev \
-    check \
-    libjansson-dev \
-    libz-dev \
     apache2 \
     apache2-dev \
+    autoconf \
+    automake \
+    ca-certificates \
+    check \
+    g++ \
+    git \
+    libjansson-dev \
+    libssl-dev \
+    libtool \
+    libz-dev \
+    make \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
@@ -107,7 +107,7 @@ RUN chmod +x /entrypoint.sh \
     mkdir -p /var/www/static && printf "OK\n" > /var/www/static/healthz && \
     groupadd --system --gid "${APP_GID}" "${APP_USER}" && \
     useradd --system --uid "${APP_UID}" --gid "${APP_GID}" \
-      --home-dir /home/${APP_USER} --create-home --shell /usr/sbin/nologin "${APP_USER}" && \
+      --home-dir "/home/${APP_USER}" --create-home --shell /usr/sbin/nologin "${APP_USER}" && \
     mkdir -p /run/jwt /run/signer-bootstrap /run/apache2 /var/lock/apache2 /var/log/apache2 /data && \
     sed -i \
       -e "s|^export APACHE_RUN_USER=.*|export APACHE_RUN_USER=${APP_USER}|" \

--- a/drizzle/0009_repair_developer_apps_m2m_billing.sql
+++ b/drizzle/0009_repair_developer_apps_m2m_billing.sql
@@ -7,12 +7,14 @@ BEGIN
   -- Clear dangling M2M FK targets so ADD CONSTRAINT cannot fail if oidc_clients rows were removed.
   UPDATE "developer_apps" d
   SET "m2m_oidc_client_id" = NULL
-  WHERE d."m2m_oidc_client_id" IS NOT NULL
-    AND NOT EXISTS (
-      SELECT 1
-      FROM "public"."oidc_clients" c
-      WHERE c."id" = d."m2m_oidc_client_id"
-    );
+  FROM (
+    SELECT d2."id"
+    FROM "developer_apps" d2
+    LEFT JOIN "public"."oidc_clients" c ON c."id" = d2."m2m_oidc_client_id"
+    WHERE d2."m2m_oidc_client_id" IS NOT NULL
+      AND c."id" IS NULL
+  ) dangling
+  WHERE d."id" = dangling."id";
 
   IF NOT EXISTS (
     SELECT 1

--- a/drizzle/0013_developer_apps_jwks_uri_platform_public.sql
+++ b/drizzle/0013_developer_apps_jwks_uri_platform_public.sql
@@ -2,5 +2,5 @@
 UPDATE "developer_apps"
 SET "jwks_uri" = 'https://pymthouse.com/api/v1/oidc/jwks'
 WHERE "jwks_uri" IS NULL
-   OR "jwks_uri" LIKE '%localhost%'
-   OR "jwks_uri" LIKE '%127.0.0.1%';
+   OR position('localhost' in "jwks_uri") > 0
+   OR position('127.0.0.1' in "jwks_uri") > 0;

--- a/drizzle/0017_discovery_allowed_capabilities.sql
+++ b/drizzle/0017_discovery_allowed_capabilities.sql
@@ -7,53 +7,57 @@ ALTER TABLE "plans" ADD COLUMN IF NOT EXISTS "discovery_excluded_capabilities" j
 --> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "idx_plans_network_default_per_client"
   ON "plans" ("client_id")
-  WHERE "is_network_default" = true;
+  WHERE "is_network_default";
 
 --> statement-breakpoint
 ALTER TABLE "plan_capability_bundles" DROP COLUMN IF EXISTS "sla_target_score";
 
 --> statement-breakpoint
-UPDATE "plans" p
-SET
-  "is_network_default" = true,
-  "updated_at" = to_char((now() AT TIME ZONE 'utc'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
-WHERE p."name" = '__pymthouse_network_default__'
-  AND p."is_network_default" = false
-  AND NOT EXISTS (
-    SELECT 1 FROM "plans" p2
-    WHERE p2."client_id" = p."client_id" AND p2."is_network_default" = true
-  );
+DO $migrate$
+DECLARE
+  ts_fmt constant text := 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"';
+  net_name constant text := '__pymthouse_network_default__';
+BEGIN
+  UPDATE "plans" p
+  SET
+    "is_network_default" = true,
+    "updated_at" = to_char((now() AT TIME ZONE 'utc'), ts_fmt)
+  WHERE p."name" = net_name
+    AND NOT p."is_network_default"
+    AND p."client_id" NOT IN (
+      SELECT p2."client_id" FROM "plans" p2 WHERE p2."is_network_default"
+    );
 
---> statement-breakpoint
-INSERT INTO "plans" (
-  "id",
-  "client_id",
-  "name",
-  "type",
-  "price_amount",
-  "price_currency",
-  "status",
-  "billing_cycle",
-  "is_network_default",
-  "discovery_excluded_capabilities",
-  "created_at",
-  "updated_at"
-)
-SELECT
-  gen_random_uuid()::text,
-  d."id",
-  '__pymthouse_network_default__',
-  'free',
-  '0',
-  'USD',
-  'active',
-  'monthly',
-  true,
-  NULL,
-  to_char((now() AT TIME ZONE 'utc'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
-  to_char((now() AT TIME ZONE 'utc'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
-FROM "developer_apps" d
-WHERE NOT EXISTS (
-  SELECT 1 FROM "plans" p
-  WHERE p."client_id" = d."id" AND p."is_network_default" = true
-);
+  INSERT INTO "plans" (
+    "id",
+    "client_id",
+    "name",
+    "type",
+    "price_amount",
+    "price_currency",
+    "status",
+    "billing_cycle",
+    "is_network_default",
+    "discovery_excluded_capabilities",
+    "created_at",
+    "updated_at"
+  )
+  SELECT
+    gen_random_uuid()::text,
+    d."id",
+    net_name,
+    'free',
+    '0',
+    'USD',
+    'active',
+    'monthly',
+    true,
+    NULL,
+    to_char((now() AT TIME ZONE 'utc'), ts_fmt),
+    to_char((now() AT TIME ZONE 'utc'), ts_fmt)
+  FROM "developer_apps" d
+  WHERE d."id" NOT IN (
+    SELECT p."client_id" FROM "plans" p WHERE p."is_network_default"
+  );
+END
+$migrate$;

--- a/scripts/lib/railway-auth.sh
+++ b/scripts/lib/railway-auth.sh
@@ -9,6 +9,7 @@
 
 railway_default_project_id() {
   echo "${RAILWAY_PROJECT_ID:-dab233aa-dd5f-429d-8cc4-9042e8735e2b}"
+  return 0
 }
 
 railway_export_auth() {
@@ -45,7 +46,9 @@ railway_export_auth() {
 
 # Args: environment name (e.g. production)
 railway_pe_flags() {
-  echo "-p $(railway_default_project_id) -e $1"
+  local env_name="$1"
+  echo "-p $(railway_default_project_id) -e ${env_name}"
+  return 0
 }
 
 railway_stack_json() {
@@ -117,9 +120,12 @@ railway_apply_livepeer_image() {
 # True when stderr looks like a transient network / API failure (retryable).
 railway_retryable_failure() {
   local err_file="$1"
-  grep -qiE \
+  if grep -qiE \
     'timed out|timeout|Failed to fetch|error sending request|connection reset|connection refused|temporarily unavailable|\b502\b|\b503\b|\b429\b' \
-    "$err_file"
+    "$err_file"; then
+    return 0
+  fi
+  return 1
 }
 
 # Run a Railway CLI command with exponential backoff on transient failures.

--- a/src/app/api/v1/apps/[id]/discovery-profiles/[profileId]/route.ts
+++ b/src/app/api/v1/apps/[id]/discovery-profiles/[profileId]/route.ts
@@ -152,7 +152,11 @@ export async function PUT(
   }
 
   const name =
-    record.name !== undefined ? String(record.name || "").trim() : existing.name;
+    record.name !== undefined
+      ? typeof record.name === "string"
+        ? record.name.trim()
+        : ""
+      : existing.name;
   if (!name) {
     return NextResponse.json({ error: "name is required" }, { status: 400 });
   }

--- a/src/app/api/v1/apps/[id]/discovery-profiles/route.ts
+++ b/src/app/api/v1/apps/[id]/discovery-profiles/route.ts
@@ -132,7 +132,7 @@ export async function POST(
   }
   const record = body as Record<string, unknown>;
 
-  const name = String(record.name || "").trim();
+  const name = typeof record.name === "string" ? record.name.trim() : "";
   if (!name) {
     return NextResponse.json({ error: "name is required" }, { status: 400 });
   }

--- a/src/app/api/v1/oidc/[...oidc]/route.ts
+++ b/src/app/api/v1/oidc/[...oidc]/route.ts
@@ -375,9 +375,15 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
         if (value !== undefined) {
           if (Array.isArray(value)) {
             for (const v of value) {
-              headers.append(key, String(v));
+              if (typeof v === "string") {
+                headers.append(key, v);
+              } else if (typeof v === "number") {
+                headers.append(key, String(v));
+              }
             }
-          } else {
+          } else if (typeof value === "string") {
+            headers.set(key, value);
+          } else if (typeof value === "number") {
             headers.set(key, String(value));
           }
         }

--- a/src/app/api/v1/oidc/device/verify/route.ts
+++ b/src/app/api/v1/oidc/device/verify/route.ts
@@ -9,7 +9,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/next-auth-options";
-import { SqliteAdapter } from "@/lib/oidc/adapter";
+import { PostgresOidcAdapter } from "@/lib/oidc/adapter";
 import { getClient } from "@/lib/oidc/clients";
 import { approveDeviceCodeForAccount } from "@/lib/oidc/device-approval";
 import { db } from "@/db/index";
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // Look up the device code through the adapter
-  const adapter = new SqliteAdapter("DeviceCode");
+  const adapter = new PostgresOidcAdapter("DeviceCode");
   const normalizedUserCode = normalizeUserCode(userCode);
   const deviceCode = await adapter.findByUserCode(normalizedUserCode);
 

--- a/src/app/oidc/device/page.tsx
+++ b/src/app/oidc/device/page.tsx
@@ -5,7 +5,7 @@ import { authOptions } from "@/lib/next-auth-options";
 import DeviceVerifyForm from "./device-verify-form";
 import { resolveHostContext } from "@/lib/oidc/host-resolution";
 import { getInitiateLoginUriForDeviceFlow } from "@/lib/oidc/clients";
-import { SqliteAdapter } from "@/lib/oidc/adapter";
+import { PostgresOidcAdapter } from "@/lib/oidc/adapter";
 import { normalizeUserCode } from "@/lib/oidc/device";
 import {
   buildDeviceFlowTargetLinkUri,
@@ -22,7 +22,7 @@ async function resolveAuthoritativeClientId(
 ): Promise<string | undefined> {
   if (userCode) {
     try {
-      const adapter = new SqliteAdapter("DeviceCode");
+      const adapter = new PostgresOidcAdapter("DeviceCode");
       const normalized = normalizeUserCode(userCode);
       const payload = await adapter.findByUserCode(normalized);
       if (payload) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -325,6 +325,7 @@ export default async function HomePage() {
         <div className="relative max-w-5xl mx-auto px-6 pt-20 pb-16 text-center">
           <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300 mb-6">
             <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+            {" "}
             Built for Livepeer builders
           </span>
           <h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-6 leading-tight">

--- a/src/components/SignerLogs.tsx
+++ b/src/components/SignerLogs.tsx
@@ -112,6 +112,7 @@ export default function SignerLogs({
               onChange={(e) => setAutoRefresh(e.target.checked)}
               className="rounded border-zinc-600"
             />
+            {" "}
             Auto-refresh
           </label>
 

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -843,8 +843,13 @@ function M2mTokenTestResult({
 
       {tokenKind === "api_key" ? (
         <p className="text-[11px] text-sky-300/70">
-          Use as <span className="font-mono text-sky-200/80">Authorization: Bearer</span> on the
-          remote signer, or as <span className="font-mono text-sky-200/80">subject_token</span> at <span className="font-mono text-sky-200/80">
+          Use as <span className="font-mono text-sky-200/80">Authorization: Bearer</span>
+          {" "}
+          on the remote signer, or as{" "}
+          <span className="font-mono text-sky-200/80">subject_token</span>
+          {" "}
+          at{" "}
+          <span className="font-mono text-sky-200/80">
             POST /api/v1/apps/{`{clientId}`}/oidc/token
           </span>
           .

--- a/src/lib/billing-runtime.ts
+++ b/src/lib/billing-runtime.ts
@@ -179,7 +179,12 @@ export function weiToEthString(weiAmt: bigint): string {
   const abs = negative ? -weiAmt : weiAmt;
   const whole = abs / 10n ** 18n;
   const frac = abs % 10n ** 18n;
-  const fracStr = frac.toString().padStart(18, "0").replace(/0+$/, "");
+  let fracStr = frac.toString().padStart(18, "0");
+  let end = fracStr.length;
+  while (end > 0 && fracStr.charCodeAt(end - 1) === 48 /* 0 */) {
+    end -= 1;
+  }
+  fracStr = end === fracStr.length ? fracStr : fracStr.slice(0, end);
   const result = fracStr ? `${whole}.${fracStr}` : whole.toString();
   return negative ? `-${result}` : result;
 }

--- a/src/lib/discovery-plans.ts
+++ b/src/lib/discovery-plans.ts
@@ -76,7 +76,13 @@ export function parseDiscoveryPolicyInput(
   }
 
   if (raw.sortBy !== undefined) {
-    const s = String(raw.sortBy).trim() as DiscoverySortBy;
+    if (typeof raw.sortBy !== "string") {
+      return {
+        ok: false,
+        error: `${pathPrefix}.sortBy must be one of: ${SORT_BY_VALUES.join(", ")}`,
+      };
+    }
+    const s = raw.sortBy.trim() as DiscoverySortBy;
     if (!SORT_BY_VALUES.includes(s)) {
       return {
         ok: false,

--- a/src/lib/docs-base-url.ts
+++ b/src/lib/docs-base-url.ts
@@ -5,9 +5,18 @@
  * Integration guides use paths like `/integration/device-flow` and
  * `/integration/interactive-login` (see https://docs.pymthouse.com/llms.txt).
  */
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* / */) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
 export function getDocsBaseUrl(): string {
   const defaultDocsUrl = "https://docs.pymthouse.com";
-  const fromEnv = process.env.NEXT_PUBLIC_DOCS_URL?.trim().replace(/\/+$/, "");
+  const rawEnv = process.env.NEXT_PUBLIC_DOCS_URL?.trim();
+  const fromEnv = rawEnv ? trimTrailingSlashes(rawEnv) : "";
   if (!fromEnv) return defaultDocsUrl;
 
   try {

--- a/src/lib/format-wei.ts
+++ b/src/lib/format-wei.ts
@@ -4,7 +4,14 @@ const WEI_PER_ETH = 10n ** 18n;
 const ETH_DISPLAY_THRESHOLD = WEI_PER_ETH / 1000n;
 
 function trimTrailingZeros(s: string): string {
-  return s.replace(/0+$/, "").replace(/\.$/, "");
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 48 /* 0 */) {
+    end -= 1;
+  }
+  if (end > 0 && s.charCodeAt(end - 1) === 46 /* . */) {
+    end -= 1;
+  }
+  return end === s.length ? s : s.slice(0, end);
 }
 
 function formatEthFraction(rem: bigint, maxDigits: number): string {

--- a/src/lib/naap-catalog.ts
+++ b/src/lib/naap-catalog.ts
@@ -9,12 +9,22 @@
  * the negotiated ticket facts from the request body (python-gateway + signer).
  */
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* / */) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
 function resolveNaapApiBaseUrl(): string {
-  const explicit = process.env.NAAP_API_BASE_URL?.trim().replace(/\/+$/, "");
+  const explicitRaw = process.env.NAAP_API_BASE_URL?.trim();
+  const explicit = explicitRaw ? trimTrailingSlashes(explicitRaw) : "";
   if (explicit) {
     return explicit;
   }
-  const nextAuth = process.env.NEXTAUTH_URL?.trim().replace(/\/+$/, "");
+  const nextAuthRaw = process.env.NEXTAUTH_URL?.trim();
+  const nextAuth = nextAuthRaw ? trimTrailingSlashes(nextAuthRaw) : "";
   if (
     process.env.NODE_ENV === "development" &&
     nextAuth &&

--- a/src/lib/oidc/device-approval.ts
+++ b/src/lib/oidc/device-approval.ts
@@ -2,7 +2,7 @@
  * Shared device-code approval logic for interactive UI and Builder API.
  */
 
-import { SqliteAdapter } from "@/lib/oidc/adapter";
+import { PostgresOidcAdapter } from "@/lib/oidc/adapter";
 import { getProvider } from "@/lib/oidc/provider";
 import { getIssuer } from "@/lib/oidc/issuer-urls";
 
@@ -36,7 +36,7 @@ export async function approveDeviceCodeForAccount(
   oidcClientId: string,
   accountId: string,
 ): Promise<DeviceApprovalSuccess | DeviceApprovalFailure> {
-  const adapter = new SqliteAdapter("DeviceCode");
+  const adapter = new PostgresOidcAdapter("DeviceCode");
   const deviceCode = await adapter.findByUserCode(normalizedUserCode);
 
   if (!deviceCode) {

--- a/src/lib/oidc/device-token-exchange.ts
+++ b/src/lib/oidc/device-token-exchange.ts
@@ -74,7 +74,11 @@ function parseDeviceCodeFromResource(resource: string): string | null {
 
 /** Normalize issuer / audience strings for comparison (trailing slashes). */
 function normalizeResourceOrAudienceUri(value: string): string {
-  return value.trim().replace(/\/+$/, "");
+  let out = value.trim();
+  while (out.endsWith("/")) {
+    out = out.slice(0, -1);
+  }
+  return out;
 }
 
 /**

--- a/src/lib/oidc/gateway-token-exchange.ts
+++ b/src/lib/oidc/gateway-token-exchange.ts
@@ -47,7 +47,11 @@ export const ISSUED_ACCESS_TOKEN_TYPE =
   "urn:ietf:params:oauth:token-type:access_token";
 
 function normalizeResourceOrAudienceUri(value: string): string {
-  return value.trim().replace(/\/+$/, "");
+  let out = value.trim();
+  while (out.endsWith("/")) {
+    out = out.slice(0, -1);
+  }
+  return out;
 }
 
 function assertRequestedTokenTypeForGateway(

--- a/src/lib/oidc/issuer-urls.ts
+++ b/src/lib/oidc/issuer-urls.ts
@@ -6,7 +6,11 @@
 export const OIDC_MOUNT_PATH = "/api/v1/oidc";
 
 function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, "");
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* / */) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
 }
 
 /** HTTP may stay http for loopback, RFC1918, IPv6 link-local, and *.local dev hosts. */

--- a/src/lib/oidc/third-party-initiate-login.ts
+++ b/src/lib/oidc/third-party-initiate-login.ts
@@ -16,7 +16,11 @@ function isLocalhostHostname(hostname: string): boolean {
 export function normalizeIssuerUrl(iss: string): string {
   try {
     const u = new URL(iss);
-    return u.href.replace(/\/+$/, "");
+    let out = u.href;
+    while (out.endsWith("/")) {
+      out = out.slice(0, -1);
+    }
+    return out;
   } catch {
     return iss.trim();
   }

--- a/src/lib/signer-cli.ts
+++ b/src/lib/signer-cli.ts
@@ -46,6 +46,15 @@ export interface SenderInfo {
   };
 }
 
+/** Coerce CLI JSON scalars to string; reject objects that would stringify as [object Object]. */
+function asCliString(value: unknown, fallback = "0"): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean") {
+    return String(value);
+  }
+  return fallback;
+}
+
 export interface SignerCliStatus {
   reachable: boolean;
   ethAddress: string | null;
@@ -108,8 +117,8 @@ export async function getSenderInfo(): Promise<SenderInfo | null> {
   try {
     const raw = await cliGet<Record<string, unknown>>("/senderInfo");
     // Normalize: go-livepeer may return PascalCase or camelCase field names
-    const deposit = String(raw.deposit ?? raw.Deposit ?? "0");
-    const withdrawRound = String(raw.withdrawRound ?? raw.WithdrawRound ?? "0");
+    const deposit = asCliString(raw.deposit ?? raw.Deposit);
+    const withdrawRound = asCliString(raw.withdrawRound ?? raw.WithdrawRound);
     const reserve = (raw.reserve ?? raw.Reserve) as
       | Record<string, unknown>
       | undefined;
@@ -117,11 +126,11 @@ export async function getSenderInfo(): Promise<SenderInfo | null> {
       deposit,
       withdrawRound,
       reserve: {
-        fundsRemaining: String(
-          reserve?.fundsRemaining ?? reserve?.FundsRemaining ?? "0"
+        fundsRemaining: asCliString(
+          reserve?.fundsRemaining ?? reserve?.FundsRemaining,
         ),
-        claimedInCurrentRound: String(
-          reserve?.claimedInCurrentRound ?? reserve?.ClaimedInCurrentRound ?? "0"
+        claimedInCurrentRound: asCliString(
+          reserve?.claimedInCurrentRound ?? reserve?.ClaimedInCurrentRound,
         ),
       },
     };


### PR DESCRIPTION
## Summary
- Clear leftover Sonar smells: deprecated SqliteAdapter (S1874), unsafe stringification (S6551), regex backtracking (S8786), JSX spacing (S6772), plus related SQL/shell/docker findings
- Rebased onto main after #277 (manual CodeRabbit)

Part of Phase 5 Sonar cleanup.

## Test plan
- [ ] CI tests pass
- [ ] Device OIDC flow still uses Postgres adapter
- [ ] Sonar smell counts drop on these files