### PR TITLE
refactor(oidc): reduce Sonar S3776 cognitive complexity

### DIFF
--- a/src/app/oidc/device/page.tsx
+++ b/src/app/oidc/device/page.tsx
@@ -16,33 +16,102 @@ import { getIssuer } from "@/lib/oidc/issuer-urls";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
+function clientIdFromDevicePayload(
+  payload: Record<string, unknown>,
+): string | undefined {
+  if (typeof payload.clientId === "string") {
+    return payload.clientId;
+  }
+  if (
+    typeof payload.params === "object" &&
+    payload.params !== null &&
+    typeof (payload.params as Record<string, unknown>).client_id === "string"
+  ) {
+    return (payload.params as Record<string, unknown>).client_id as string;
+  }
+  return undefined;
+}
+
 async function resolveAuthoritativeClientId(
   userCode: string | undefined,
   clientIdParam: string | undefined,
 ): Promise<string | undefined> {
-  if (userCode) {
-    try {
-      const adapter = new SqliteAdapter("DeviceCode");
-      const normalized = normalizeUserCode(userCode);
-      const payload = await adapter.findByUserCode(normalized);
-      if (payload) {
-        const bound =
-          typeof payload.clientId === "string"
-            ? payload.clientId
-            : typeof payload.params === "object" &&
-                payload.params !== null &&
-                typeof (payload.params as Record<string, unknown>).client_id === "string"
-              ? ((payload.params as Record<string, unknown>).client_id as string)
-              : undefined;
-        if (bound) {
-          return bound;
-        }
-      }
-    } catch {
-      /* ignore */
+  if (!userCode) return clientIdParam;
+
+  try {
+    const adapter = new SqliteAdapter("DeviceCode");
+    const normalized = normalizeUserCode(userCode);
+    const payload = await adapter.findByUserCode(normalized);
+    if (payload) {
+      const bound = clientIdFromDevicePayload(payload as Record<string, unknown>);
+      if (bound) return bound;
     }
+  } catch {
+    /* ignore */
   }
   return clientIdParam;
+}
+
+async function maybeRedirectThirdPartyInitiate(input: {
+  authoritativeClientId: string;
+  userCode: string | undefined;
+  issParam: string;
+  loginHintParam: string | undefined;
+  expectedIssuer: string;
+}): Promise<void> {
+  const {
+    authoritativeClientId,
+    userCode,
+    issParam,
+    loginHintParam,
+    expectedIssuer,
+  } = input;
+
+  if (!issuerMatchesExpected(issParam, expectedIssuer)) return;
+
+  const skipCookieName = thirdPartyInitiateSkipCookieName(
+    authoritativeClientId,
+    userCode,
+  );
+  const skipThirdParty =
+    (await cookies()).get(skipCookieName)?.value === "1";
+  if (skipThirdParty) return;
+
+  const initiateLoginUri = await getInitiateLoginUriForDeviceFlow(
+    authoritativeClientId,
+  );
+  if (!initiateLoginUri) return;
+
+  const targetLinkUri = buildDeviceFlowTargetLinkUri({
+    user_code: userCode,
+    client_id: authoritativeClientId,
+    iss: issParam,
+    login_hint: loginHintParam,
+  });
+  redirect(
+    `/oidc/device/initiate-login?${new URLSearchParams({
+      client_id: authoritativeClientId,
+      target_link_uri: targetLinkUri,
+      ...(loginHintParam ? { login_hint: loginHintParam } : {}),
+    }).toString()}`,
+  );
+}
+
+function redirectToLoginForDevice(input: {
+  userCode: string | undefined;
+  authoritativeClientId: string | undefined;
+  issParam: string | undefined;
+  loginHintParam: string | undefined;
+}): never {
+  const qs = new URLSearchParams();
+  if (input.userCode) qs.set("user_code", input.userCode);
+  if (input.authoritativeClientId) {
+    qs.set("client_id", input.authoritativeClientId);
+  }
+  if (input.issParam) qs.set("iss", input.issParam);
+  if (input.loginHintParam) qs.set("login_hint", input.loginHintParam);
+  const devicePath = `/oidc/device${qs.toString() ? `?${qs.toString()}` : ""}`;
+  redirect(`/login?callbackUrl=${encodeURIComponent(devicePath)}`);
 }
 
 export default async function DeviceVerificationPage({
@@ -69,47 +138,22 @@ export default async function DeviceVerificationPage({
   );
 
   if (!session?.user) {
-    const skipCookieName = authoritativeClientId
-      ? thirdPartyInitiateSkipCookieName(authoritativeClientId, userCode)
-      : null;
-    const skipThirdParty =
-      skipCookieName !== null
-        ? (await cookies()).get(skipCookieName)?.value === "1"
-        : true;
-
-    if (
-      authoritativeClientId &&
-      issParam &&
-      issuerMatchesExpected(issParam, expectedIssuer) &&
-      !skipThirdParty
-    ) {
-      const initiateLoginUri = await getInitiateLoginUriForDeviceFlow(
+    if (authoritativeClientId && issParam) {
+      await maybeRedirectThirdPartyInitiate({
         authoritativeClientId,
-      );
-      if (initiateLoginUri) {
-        const targetLinkUri = buildDeviceFlowTargetLinkUri({
-          user_code: userCode,
-          client_id: authoritativeClientId,
-          iss: issParam,
-          login_hint: loginHintParam,
-        });
-        redirect(
-          `/oidc/device/initiate-login?${new URLSearchParams({
-            client_id: authoritativeClientId,
-            target_link_uri: targetLinkUri,
-            ...(loginHintParam ? { login_hint: loginHintParam } : {}),
-          }).toString()}`,
-        );
-      }
+        userCode,
+        issParam,
+        loginHintParam,
+        expectedIssuer,
+      });
     }
 
-    const qs = new URLSearchParams();
-    if (userCode) qs.set("user_code", userCode);
-    if (authoritativeClientId) qs.set("client_id", authoritativeClientId);
-    if (issParam) qs.set("iss", issParam);
-    if (loginHintParam) qs.set("login_hint", loginHintParam);
-    const devicePath = `/oidc/device${qs.toString() ? `?${qs.toString()}` : ""}`;
-    redirect(`/login?callbackUrl=${encodeURIComponent(devicePath)}`);
+    redirectToLoginForDevice({
+      userCode,
+      authoritativeClientId,
+      issParam,
+      loginHintParam,
+    });
   }
 
   return (

--- a/src/app/oidc/interaction/page.tsx
+++ b/src/app/oidc/interaction/page.tsx
@@ -3,11 +3,10 @@ import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { IncomingMessage, ServerResponse } from "http";
 import { Socket } from "net";
+import type { ReactNode } from "react";
 import { authOptions } from "@/lib/next-auth-options";
 import { getProvider } from "@/lib/oidc/provider";
 import { getPublicOrigin } from "@/lib/oidc/issuer-urls";
-import { resolveAppBrandingByClientId, shouldUseWhiteLabelBranding } from "@/lib/oidc/branding";
-import { resolveHostContext } from "@/lib/oidc/host-resolution";
 import { checkAppAccess } from "@/lib/oidc/app-access";
 
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -41,6 +40,112 @@ function buildNodeRequest(
   return { req, res };
 }
 
+function InteractionMessage({
+  title,
+  body,
+  borderClass,
+  titleClass,
+  children,
+}: {
+  title: string;
+  body: ReactNode;
+  borderClass: string;
+  titleClass: string;
+  children?: ReactNode;
+}) {
+  return (
+    <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-6">
+      <div className={`max-w-md w-full ${borderClass} bg-zinc-900/40 rounded-xl p-6`}>
+        <h1 className={`text-lg font-semibold ${titleClass} mb-2`}>{title}</h1>
+        <p className={`text-sm text-zinc-400${children ? " mb-4" : ""}`}>{body}</p>
+        {children}
+      </div>
+    </main>
+  );
+}
+
+function isNextRedirectError(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    "digest" in err &&
+    String((err as { digest?: string }).digest).startsWith("NEXT_REDIRECT")
+  );
+}
+
+async function peekClientIdFromInteraction(uid: string): Promise<string | null> {
+  try {
+    const requestHeaders = await headers();
+    const preflightReq = buildNodeRequest("GET", uid, requestHeaders);
+    const provider = await getProvider();
+    const preflightDetails = await provider.interactionDetails(
+      preflightReq.req,
+      preflightReq.res,
+    );
+    return (preflightDetails.params.client_id as string) || null;
+  } catch {
+    // Interaction may be invalid/expired; we'll handle this after session check
+    return null;
+  }
+}
+
+async function renderAccessDeniedIfNeeded(
+  requestedClientId: string | undefined,
+  userId: string | undefined,
+): Promise<ReactNode | null> {
+  if (!requestedClientId) return null;
+
+  const accessCheck = await checkAppAccess(requestedClientId, userId || null);
+  if (accessCheck.allowed) return null;
+
+  return (
+    <InteractionMessage
+      title={`${accessCheck.appName || "Application"} - Access Restricted`}
+      body={accessCheck.reason}
+      borderClass="border border-amber-500/20"
+      titleClass="text-amber-300"
+    >
+      {accessCheck.appStatus && (
+        <div className="px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-xs">
+          <span className="text-zinc-500">Status:</span>{" "}
+          <span className="text-zinc-300">{accessCheck.appStatus}</span>
+        </div>
+      )}
+    </InteractionMessage>
+  );
+}
+
+async function completeLoginInteraction(
+  provider: Awaited<ReturnType<typeof getProvider>>,
+  req: IncomingMessage,
+  res: ServerResponse,
+  userId: string | undefined,
+): Promise<ReactNode> {
+  if (!userId) {
+    return (
+      <InteractionMessage
+        title="Invalid Session"
+        body="Your session is invalid. Please sign in again."
+        borderClass="border border-red-500/20"
+        titleClass="text-red-300"
+      />
+    );
+  }
+
+  const result = {
+    login: {
+      accountId: userId,
+      remember: true,
+    },
+  };
+
+  const redirectTo = await provider.interactionResult(req, res, result, {
+    mergeWithLastSubmission: false,
+  });
+
+  redirect(redirectTo);
+}
+
 export default async function OidcInteractionPage({
   searchParams,
 }: {
@@ -51,30 +156,17 @@ export default async function OidcInteractionPage({
 
   if (!uid) {
     return (
-      <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-6">
-        <div className="max-w-md w-full border border-red-500/20 bg-zinc-900/40 rounded-xl p-6">
-          <h1 className="text-lg font-semibold text-red-300 mb-2">Invalid Authorization Request</h1>
-          <p className="text-sm text-zinc-400">
-            Missing interaction ID. Please restart authorization from the client application.
-          </p>
-        </div>
-      </main>
+      <InteractionMessage
+        title="Invalid Authorization Request"
+        body="Missing interaction ID. Please restart authorization from the client application."
+        borderClass="border border-red-500/20"
+        titleClass="text-red-300"
+      />
     );
   }
 
   const session = await getServerSession(authOptions);
-  
-  // Try to get interaction details early to extract client_id for branded login redirect
-  let clientId: string | null = null;
-  try {
-    const requestHeaders = await headers();
-    const preflightReq = buildNodeRequest("GET", uid, requestHeaders);
-    const provider = await getProvider();
-    const preflightDetails = await provider.interactionDetails(preflightReq.req, preflightReq.res);
-    clientId = preflightDetails.params.client_id as string || null;
-  } catch {
-    // Interaction may be invalid/expired; we'll handle this after session check
-  }
+  const clientId = await peekClientIdFromInteraction(uid);
 
   if (!session?.user) {
     const loginUrl = new URL("/login", getPublicOrigin());
@@ -92,63 +184,27 @@ export default async function OidcInteractionPage({
     const provider = await getProvider();
     const details = await provider.interactionDetails(req, res);
 
-    // Check app access before allowing authentication
-    const userId = (session?.user as Record<string, unknown> | undefined)?.id as string | undefined;
+    const userId = (session?.user as Record<string, unknown> | undefined)?.id as
+      | string
+      | undefined;
     const requestedClientId = details.params.client_id as string;
-    
-    if (requestedClientId) {
-      const accessCheck = await checkAppAccess(requestedClientId, userId || null);
-      
-      if (!accessCheck.allowed) {
-        return (
-          <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-6">
-            <div className="max-w-md w-full border border-amber-500/20 bg-zinc-900/40 rounded-xl p-6">
-              <h1 className="text-lg font-semibold text-amber-300 mb-2">
-                {accessCheck.appName || "Application"} - Access Restricted
-              </h1>
-              <p className="text-sm text-zinc-400 mb-4">
-                {accessCheck.reason}
-              </p>
-              {accessCheck.appStatus && (
-                <div className="px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-xs">
-                  <span className="text-zinc-500">Status:</span>{" "}
-                  <span className="text-zinc-300">{accessCheck.appStatus}</span>
-                </div>
-              )}
-            </div>
-          </main>
-        );
-      }
-    }
+
+    const accessDenied = await renderAccessDeniedIfNeeded(
+      requestedClientId,
+      userId,
+    );
+    if (accessDenied) return accessDenied;
 
     if (details.prompt.name === "login") {
       // Complete login server-side in the same request that has the cookie.
       // A client-side POST to /api/v1/oidc/interaction/:uid would not receive the
       // _interaction cookie (path=/oidc/interaction) so we must do it here.
-      const userId = (session.user as Record<string, unknown>).id as string;
-      if (!userId) {
-        return (
-          <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-6">
-            <div className="max-w-md w-full border border-red-500/20 bg-zinc-900/40 rounded-xl p-6">
-              <h1 className="text-lg font-semibold text-red-300 mb-2">Invalid Session</h1>
-              <p className="text-sm text-zinc-400">Your session is invalid. Please sign in again.</p>
-            </div>
-          </main>
-        );
-      }
-
-      const result = {
-        login: {
-          accountId: userId,
-          remember: true,
-        },
-      };
-
-      const redirectTo = await provider.interactionResult(req, res, result, {
-        mergeWithLastSubmission: false,
-      });
-
-      redirect(redirectTo);
+      return completeLoginInteraction(
+        provider,
+        req,
+        res,
+        (session.user as Record<string, unknown>).id as string,
+      );
     }
 
     if (details.prompt.name === "consent") {
@@ -156,30 +212,30 @@ export default async function OidcInteractionPage({
     }
 
     return (
-      <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-6">
-        <div className="max-w-md w-full border border-zinc-800 bg-zinc-900/40 rounded-xl p-6">
-          <h1 className="text-lg font-semibold text-zinc-100 mb-2">Unsupported Interaction</h1>
-          <p className="text-sm text-zinc-400">
-            Prompt <span className="text-zinc-200">{details.prompt.name}</span> is not handled by this
-            page.
-          </p>
-        </div>
-      </main>
+      <InteractionMessage
+        title="Unsupported Interaction"
+        body={
+          <>
+            Prompt <span className="text-zinc-200">{details.prompt.name}</span> is
+            not handled by this page.
+          </>
+        }
+        borderClass="border border-zinc-800"
+        titleClass="text-zinc-100"
+      />
     );
   } catch (err) {
     // interactionResult can throw if something fails; redirect() also throws
-    if (err && typeof err === "object" && "digest" in err && String((err as { digest?: string }).digest).startsWith("NEXT_REDIRECT")) {
+    if (isNextRedirectError(err)) {
       throw err;
     }
     return (
-      <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-6">
-        <div className="max-w-md w-full border border-red-500/20 bg-zinc-900/40 rounded-xl p-6">
-          <h1 className="text-lg font-semibold text-red-300 mb-2">Expired or Invalid Request</h1>
-          <p className="text-sm text-zinc-400">
-            This authorization request has expired. Please return to the application and try again.
-          </p>
-        </div>
-      </main>
+      <InteractionMessage
+        title="Expired or Invalid Request"
+        body="This authorization request has expired. Please return to the application and try again."
+        borderClass="border border-red-500/20"
+        titleClass="text-red-300"
+      />
     );
   }
 }

--- a/src/lib/discovery-allowlist.ts
+++ b/src/lib/discovery-allowlist.ts
@@ -181,11 +181,10 @@ export function pickerValuesFromExcludedDocument(
   return out;
 }
 
-/** Convert picker selection into minimal exclusion rows for persistence. */
-export function excludedDocumentFromPickerValues(
+function includedConcreteFromPickerValues(
   catalog: PipelineCatalogEntryLite[],
   values: string[],
-): DiscoveryAllowlistCapability[] {
+): Set<string> {
   const wild = new Set(values.filter((v) => !v.includes("|")));
   const indiv = new Set(values.filter((v) => v.includes("|")));
   const includedConcrete = new Set<string>();
@@ -194,16 +193,21 @@ export function excludedDocumentFromPickerValues(
       for (const m of e.models) {
         includedConcrete.add(`${e.id}|${m}`);
       }
-    } else {
-      for (const m of e.models) {
-        if (indiv.has(`${e.id}|${m}`)) {
-          includedConcrete.add(`${e.id}|${m}`);
-        }
+      continue;
+    }
+    for (const m of e.models) {
+      if (indiv.has(`${e.id}|${m}`)) {
+        includedConcrete.add(`${e.id}|${m}`);
       }
     }
   }
-  const all = fullCatalogConcreteKeys(catalog);
-  const excludedKeys = [...all].filter((k) => !includedConcrete.has(k));
+  return includedConcrete;
+}
+
+function exclusionRowsFromExcludedKeys(
+  catalog: PipelineCatalogEntryLite[],
+  excludedKeys: string[],
+): DiscoveryAllowlistCapability[] {
   const out: DiscoveryAllowlistCapability[] = [];
   for (const e of catalog) {
     const exModels = excludedKeys
@@ -212,11 +216,22 @@ export function excludedDocumentFromPickerValues(
     if (exModels.length === 0) continue;
     if (exModels.length === e.models.length) {
       out.push({ pipeline: e.id, modelId: "*" });
-    } else {
-      for (const m of exModels) {
-        out.push({ pipeline: e.id, modelId: m });
-      }
+      continue;
+    }
+    for (const m of exModels) {
+      out.push({ pipeline: e.id, modelId: m });
     }
   }
   return out.sort(sortCap);
+}
+
+/** Convert picker selection into minimal exclusion rows for persistence. */
+export function excludedDocumentFromPickerValues(
+  catalog: PipelineCatalogEntryLite[],
+  values: string[],
+): DiscoveryAllowlistCapability[] {
+  const includedConcrete = includedConcreteFromPickerValues(catalog, values);
+  const all = fullCatalogConcreteKeys(catalog);
+  const excludedKeys = [...all].filter((k) => !includedConcrete.has(k));
+  return exclusionRowsFromExcludedKeys(catalog, excludedKeys);
 }

--- a/src/lib/discovery-plans.ts
+++ b/src/lib/discovery-plans.ts
@@ -52,6 +52,62 @@ function parseTopN(raw: unknown): { ok: true; value: number } | { ok: false; err
   return { ok: true, value: n };
 }
 
+function assignOptionalNonNegative(
+  target: DiscoveryPolicyFilters,
+  key: keyof DiscoveryPolicyFilters,
+  raw: unknown,
+  path: string,
+): { ok: true } | { ok: false; error: string } {
+  if (raw === undefined) return { ok: true };
+  const v = parseNonNegativeNumber(raw, path);
+  if (!v.ok) return v;
+  target[key] = v.value;
+  return { ok: true };
+}
+
+function parseDiscoveryFilters(
+  rawFilters: unknown,
+  pathPrefix: string,
+): { ok: true; filters: DiscoveryPolicyFilters | undefined } | { ok: false; error: string } {
+  if (!isPlainObject(rawFilters)) {
+    return { ok: false, error: `${pathPrefix}.filters must be an object` };
+  }
+  const f: DiscoveryPolicyFilters = {};
+  const fl = rawFilters;
+
+  for (const [key, path] of [
+    ["gpuRamGbMin", `${pathPrefix}.filters.gpuRamGbMin`],
+    ["gpuRamGbMax", `${pathPrefix}.filters.gpuRamGbMax`],
+    ["priceMax", `${pathPrefix}.filters.priceMax`],
+    ["maxAvgLatencyMs", `${pathPrefix}.filters.maxAvgLatencyMs`],
+  ] as const) {
+    const assigned = assignOptionalNonNegative(f, key, fl[key], path);
+    if (!assigned.ok) return assigned;
+  }
+
+  if (fl.maxSwapRatio !== undefined) {
+    const v = parseRatio(fl.maxSwapRatio, `${pathPrefix}.filters.maxSwapRatio`);
+    if (!v.ok) return { ok: false, error: v.error };
+    f.maxSwapRatio = v.value;
+  }
+
+  if (
+    f.gpuRamGbMin !== undefined &&
+    f.gpuRamGbMax !== undefined &&
+    f.gpuRamGbMin > f.gpuRamGbMax
+  ) {
+    return {
+      ok: false,
+      error: `${pathPrefix}.filters: gpuRamGbMin must be <= gpuRamGbMax`,
+    };
+  }
+
+  return {
+    ok: true,
+    filters: Object.keys(f).length > 0 ? f : undefined,
+  };
+}
+
 /**
  * Parse and validate a discovery policy object.
  * `null` / `undefined` input → success with `policy: null` (clear / omit).
@@ -87,47 +143,9 @@ export function parseDiscoveryPolicyInput(
   }
 
   if (raw.filters !== undefined) {
-    if (!isPlainObject(raw.filters)) {
-      return { ok: false, error: `${pathPrefix}.filters must be an object` };
-    }
-    const f: DiscoveryPolicyFilters = {};
-    const fl = raw.filters;
-    if (fl.gpuRamGbMin !== undefined) {
-      const v = parseNonNegativeNumber(fl.gpuRamGbMin, `${pathPrefix}.filters.gpuRamGbMin`);
-      if (!v.ok) return { ok: false, error: v.error };
-      f.gpuRamGbMin = v.value;
-    }
-    if (fl.gpuRamGbMax !== undefined) {
-      const v = parseNonNegativeNumber(fl.gpuRamGbMax, `${pathPrefix}.filters.gpuRamGbMax`);
-      if (!v.ok) return { ok: false, error: v.error };
-      f.gpuRamGbMax = v.value;
-    }
-    if (fl.priceMax !== undefined) {
-      const v = parseNonNegativeNumber(fl.priceMax, `${pathPrefix}.filters.priceMax`);
-      if (!v.ok) return { ok: false, error: v.error };
-      f.priceMax = v.value;
-    }
-    if (fl.maxAvgLatencyMs !== undefined) {
-      const v = parseNonNegativeNumber(fl.maxAvgLatencyMs, `${pathPrefix}.filters.maxAvgLatencyMs`);
-      if (!v.ok) return { ok: false, error: v.error };
-      f.maxAvgLatencyMs = v.value;
-    }
-    if (fl.maxSwapRatio !== undefined) {
-      const v = parseRatio(fl.maxSwapRatio, `${pathPrefix}.filters.maxSwapRatio`);
-      if (!v.ok) return { ok: false, error: v.error };
-      f.maxSwapRatio = v.value;
-    }
-    if (
-      f.gpuRamGbMin !== undefined &&
-      f.gpuRamGbMax !== undefined &&
-      f.gpuRamGbMin > f.gpuRamGbMax
-    ) {
-      return {
-        ok: false,
-        error: `${pathPrefix}.filters: gpuRamGbMin must be <= gpuRamGbMax`,
-      };
-    }
-    if (Object.keys(f).length > 0) out.filters = f;
+    const parsed = parseDiscoveryFilters(raw.filters, pathPrefix);
+    if (!parsed.ok) return parsed;
+    if (parsed.filters) out.filters = parsed.filters;
   }
 
   if (Object.keys(out).length === 0) {
@@ -142,6 +160,44 @@ export function discoveryPolicyFromDb(raw: unknown): DiscoveryPolicy | null {
   if (!isPlainObject(raw)) return null;
   const parsed = parseDiscoveryPolicyInput(raw, "discoveryPolicy");
   return parsed.ok ? parsed.policy : null;
+}
+
+function mergeOptionalMax(
+  appVal: number | undefined,
+  userVal: number | undefined,
+): number | undefined {
+  if (appVal !== undefined && userVal !== undefined) return Math.min(appVal, userVal);
+  if (userVal !== undefined) return userVal;
+  if (appVal !== undefined) return appVal;
+  return undefined;
+}
+
+function mergeDiscoveryFilters(
+  af: DiscoveryPolicyFilters | undefined,
+  uf: DiscoveryPolicyFilters | undefined,
+): DiscoveryPolicyFilters | undefined {
+  if (!af && !uf) return undefined;
+
+  const f: DiscoveryPolicyFilters = {};
+  const gminA = af?.gpuRamGbMin;
+  const gminU = uf?.gpuRamGbMin;
+  if (gminA !== undefined || gminU !== undefined) {
+    f.gpuRamGbMin = Math.max(gminA ?? 0, gminU ?? 0);
+  }
+
+  const gmax = mergeOptionalMax(af?.gpuRamGbMax, uf?.gpuRamGbMax);
+  if (gmax !== undefined) f.gpuRamGbMax = gmax;
+
+  const priceMax = mergeOptionalMax(af?.priceMax, uf?.priceMax);
+  if (priceMax !== undefined) f.priceMax = priceMax;
+
+  const latency = mergeOptionalMax(af?.maxAvgLatencyMs, uf?.maxAvgLatencyMs);
+  if (latency !== undefined) f.maxAvgLatencyMs = latency;
+
+  const swap = mergeOptionalMax(af?.maxSwapRatio, uf?.maxSwapRatio);
+  if (swap !== undefined) f.maxSwapRatio = swap;
+
+  return Object.keys(f).length > 0 ? f : undefined;
 }
 
 /**
@@ -167,40 +223,9 @@ export function mergeDiscoveryPolicies(
     out.sortBy = user.sortBy;
   }
 
-  const af = app.filters;
-  const uf = user.filters;
-  if (af || uf) {
-    const f: DiscoveryPolicyFilters = {};
-    const gminA = af?.gpuRamGbMin;
-    const gminU = uf?.gpuRamGbMin;
-    if (gminA !== undefined || gminU !== undefined) {
-      f.gpuRamGbMin = Math.max(gminA ?? 0, gminU ?? 0);
-    }
-    const gmaxA = af?.gpuRamGbMax;
-    const gmaxU = uf?.gpuRamGbMax;
-    if (gmaxA !== undefined && gmaxU !== undefined) f.gpuRamGbMax = Math.min(gmaxA, gmaxU);
-    else if (gmaxU !== undefined) f.gpuRamGbMax = gmaxU;
-    else if (gmaxA !== undefined) f.gpuRamGbMax = gmaxA;
-
-    const pA = af?.priceMax;
-    const pU = uf?.priceMax;
-    if (pA !== undefined && pU !== undefined) f.priceMax = Math.min(pA, pU);
-    else if (pU !== undefined) f.priceMax = pU;
-    else if (pA !== undefined) f.priceMax = pA;
-
-    const lA = af?.maxAvgLatencyMs;
-    const lU = uf?.maxAvgLatencyMs;
-    if (lA !== undefined && lU !== undefined) f.maxAvgLatencyMs = Math.min(lA, lU);
-    else if (lU !== undefined) f.maxAvgLatencyMs = lU;
-    else if (lA !== undefined) f.maxAvgLatencyMs = lA;
-
-    const sA = af?.maxSwapRatio;
-    const sU = uf?.maxSwapRatio;
-    if (sA !== undefined && sU !== undefined) f.maxSwapRatio = Math.min(sA, sU);
-    else if (sU !== undefined) f.maxSwapRatio = sU;
-    else if (sA !== undefined) f.maxSwapRatio = sA;
-
-    if (Object.keys(f).length > 0) out.filters = f;
+  if (app.filters || user.filters) {
+    const merged = mergeDiscoveryFilters(app.filters, user.filters);
+    if (merged) out.filters = merged;
     else delete out.filters;
   }
 

--- a/src/lib/domain-whitelist.ts
+++ b/src/lib/domain-whitelist.ts
@@ -41,6 +41,93 @@ function getDefaultPort(scheme: string): number {
   return scheme === "http" ? DEFAULT_HTTP_PORT : DEFAULT_HTTPS_PORT;
 }
 
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === SLASH_CHAR_CODE) {
+    end--;
+  }
+  return end !== value.length ? value.slice(0, end) : value;
+}
+
+function stripAuthoritySuffix(value: string): string {
+  const end = value.search(/[/?#]/);
+  return end !== -1 ? value.slice(0, end) : value;
+}
+
+function parseSchemeAndHostPort(trimmed: string): {
+  scheme: string | null;
+  hostPort: string;
+} {
+  const schemeMatch = trimmed.match(/^([a-z][a-z0-9+.-]*):\/\//i);
+  if (schemeMatch) {
+    return {
+      scheme: schemeMatch[1].toLowerCase(),
+      hostPort: stripAuthoritySuffix(trimmed.slice(schemeMatch[0].length)),
+    };
+  }
+  return {
+    scheme: null,
+    hostPort: stripAuthoritySuffix(trimmed),
+  };
+}
+
+function parseHostAndPort(hostPort: string): {
+  host: string;
+  port: number | null;
+} {
+  const ipv6Match = hostPort.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (ipv6Match) {
+    return {
+      host: `[${ipv6Match[1]}]`,
+      port: ipv6Match[2] ? parseInt(ipv6Match[2], 10) : null,
+    };
+  }
+
+  const lastColon = hostPort.lastIndexOf(":");
+  if (lastColon !== -1 && hostPort.indexOf(":") === lastColon) {
+    const possiblePort = hostPort.slice(lastColon + 1);
+    if (/^\d+$/.test(possiblePort)) {
+      return {
+        host: hostPort.slice(0, lastColon),
+        port: parseInt(possiblePort, 10),
+      };
+    }
+  }
+
+  return { host: hostPort, port: null };
+}
+
+function validateSchemeForHost(
+  scheme: string,
+  host: string,
+): NormalizationError | null {
+  if (scheme !== "http" && scheme !== "https") {
+    return {
+      success: false,
+      error: `Unsupported scheme: ${scheme} (only http and https are allowed)`,
+    };
+  }
+  if (scheme === "http" && !isLocalhost(host.replace(/[\[\]]/g, ""))) {
+    return {
+      success: false,
+      error: "http scheme is only allowed for localhost, 127.0.0.1, and [::1]",
+    };
+  }
+  return null;
+}
+
+function buildCanonicalOrigin(
+  scheme: string,
+  host: string,
+  port: number | null,
+): string {
+  const defaultPort = getDefaultPort(scheme);
+  const effectivePort = port === defaultPort ? null : port;
+  return effectivePort !== null
+    ? `${scheme}://${host}:${effectivePort}`
+    : `${scheme}://${host}`;
+}
+
 export function normalizeDomainWhitelist(input: string): NormalizeResult {
   if (typeof input !== "string") {
     return { success: false, error: "Domain must be a string" };
@@ -61,63 +148,10 @@ export function normalizeDomainWhitelist(input: string): NormalizeResult {
   // Strip trailing slashes without a regex (e.g. "example.com///").
   // Using a bounded index scan guarantees O(n) worst case and avoids the
   // polynomial-regex ReDoS surface flagged by CodeQL (js/polynomial-redos).
-  let end = trimmed.length;
-  while (end > 0 && trimmed.charCodeAt(end - 1) === SLASH_CHAR_CODE) {
-    end--;
-  }
-  if (end !== trimmed.length) {
-    trimmed = trimmed.slice(0, end);
-  }
+  trimmed = stripTrailingSlashes(trimmed);
 
-  // Parse scheme and host:port
-  let scheme: string | null = null;
-  let hostPort: string;
-
-  const schemeMatch = trimmed.match(/^([a-z][a-z0-9+.-]*):\/\//i);
-  if (schemeMatch) {
-    scheme = schemeMatch[1].toLowerCase();
-    hostPort = trimmed.slice(schemeMatch[0].length);
-    // For full URLs, ignore path/query/fragment and keep only authority.
-    const authorityEnd = hostPort.search(/[/?#]/);
-    if (authorityEnd !== -1) {
-      hostPort = hostPort.slice(0, authorityEnd);
-    }
-  } else {
-    // No scheme provided - determine based on host
-    hostPort = trimmed;
-    // For host input without scheme, allow accidental path/query suffixes.
-    const hostEnd = hostPort.search(/[/?#]/);
-    if (hostEnd !== -1) {
-      hostPort = hostPort.slice(0, hostEnd);
-    }
-  }
-
-  // Parse host and port
-  let host: string;
-  let port: number | null = null;
-
-  // IPv6 addresses in URLs are wrapped in brackets like [::1]
-  const ipv6Match = hostPort.match(/^\[([^\]]+)\](?::(\d+))?$/);
-  if (ipv6Match) {
-    host = `[${ipv6Match[1]}]`;
-    if (ipv6Match[2]) {
-      port = parseInt(ipv6Match[2], 10);
-    }
-  } else {
-    const lastColon = hostPort.lastIndexOf(":");
-    if (lastColon !== -1 && hostPort.indexOf(":") === lastColon) {
-      // Only one colon, likely host:port
-      const possiblePort = hostPort.slice(lastColon + 1);
-      if (/^\d+$/.test(possiblePort)) {
-        host = hostPort.slice(0, lastColon);
-        port = parseInt(possiblePort, 10);
-      } else {
-        host = hostPort;
-      }
-    } else {
-      host = hostPort;
-    }
-  }
+  const { scheme: parsedScheme, hostPort } = parseSchemeAndHostPort(trimmed);
+  let { host, port } = parseHostAndPort(hostPort);
 
   if (!host) {
     return { success: false, error: "Invalid domain: no host found" };
@@ -125,36 +159,19 @@ export function normalizeDomainWhitelist(input: string): NormalizeResult {
 
   host = host.toLowerCase();
 
-  // Validate port
-  if (port !== null) {
-    if (port < 1 || port > 65535) {
-      return { success: false, error: `Invalid port: ${port} (must be 1-65535)` };
-    }
+  if (port !== null && (port < 1 || port > 65535)) {
+    return { success: false, error: `Invalid port: ${port} (must be 1-65535)` };
   }
 
-  // Determine scheme if not provided
-  if (!scheme) {
-    scheme = isLocalhost(host.replace(/[\[\]]/g, "")) ? "http" : "https";
-  }
+  const scheme =
+    parsedScheme ??
+    (isLocalhost(host.replace(/[\[\]]/g, "")) ? "http" : "https");
 
-  // Validate scheme
-  if (scheme !== "http" && scheme !== "https") {
-    return { success: false, error: `Unsupported scheme: ${scheme} (only http and https are allowed)` };
-  }
+  const schemeError = validateSchemeForHost(scheme, host);
+  if (schemeError) return schemeError;
 
-  // http is only allowed for localhost
-  if (scheme === "http" && !isLocalhost(host.replace(/[\[\]]/g, ""))) {
-    return { success: false, error: "http scheme is only allowed for localhost, 127.0.0.1, and [::1]" };
-  }
-
-  // Normalize port: omit if it's the default for the scheme
-  const defaultPort = getDefaultPort(scheme);
-  if (port === defaultPort) {
-    port = null;
-  }
-
-  // Build canonical origin
-  const normalized = port !== null ? `${scheme}://${host}:${port}` : `${scheme}://${host}`;
-
-  return { success: true, normalized };
+  return {
+    success: true,
+    normalized: buildCanonicalOrigin(scheme, host, port),
+  };
 }

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -90,36 +90,41 @@ export async function registerClient(config: OidcClientConfig): Promise<void> {
   });
 }
 
+const COMMON_REDIRECT_PORTS = [
+  "3000", "3001", "3002", "3003", "3004", "3005",
+  "4000", "4001", "4200", "5000", "5173", "5174",
+  "8000", "8080", "8081", "8888", "9000",
+];
+
+function tryAddOrigin(origins: Set<string>, uri: string): void {
+  try {
+    origins.add(new URL(uri).origin);
+  } catch {
+    /* malformed URI, skip */
+  }
+}
+
+function addRedirectUriOrigins(origins: Set<string>, uri: string): void {
+  if (!uri.includes("*")) {
+    tryAddOrigin(origins, uri);
+    return;
+  }
+  for (const port of COMMON_REDIRECT_PORTS) {
+    tryAddOrigin(origins, uri.replace(/:\*/, `:${port}`).replace(/\*/g, ""));
+  }
+}
+
 /**
  * Return the set of allowed redirect URI origins for all registered clients.
  */
 export async function getRegisteredRedirectOrigins(): Promise<Set<string>> {
   const rows = await db.select().from(oidcClients);
   const origins = new Set<string>();
-  const commonPorts = [
-    "3000", "3001", "3002", "3003", "3004", "3005",
-    "4000", "4001", "4200", "5000", "5173", "5174",
-    "8000", "8080", "8081", "8888", "9000",
-  ];
 
   for (const row of rows) {
     const uris = JSON.parse(row.redirectUris) as string[];
     for (const uri of uris) {
-      if (uri.includes("*")) {
-        for (const port of commonPorts) {
-          try {
-            origins.add(new URL(uri.replace(/:\*/, `:${port}`).replace(/\*/g, "")).origin);
-          } catch {
-            /* malformed URI, skip */
-          }
-        }
-      } else {
-        try {
-          origins.add(new URL(uri).origin);
-        } catch {
-          /* malformed URI, skip */
-        }
-      }
+      addRedirectUriOrigins(origins, uri);
     }
   }
 
@@ -563,35 +568,30 @@ export async function loadM2mOidcClientSummary(
   };
 }
 
-export async function updateClientConfig(
+type ClientConfigPatch = {
+  displayName?: string;
+  redirectUris?: string[];
+  allowedScopes?: string;
+  grantTypes?: string[];
+  tokenEndpointAuthMethod?: "none" | "client_secret_post" | "client_secret_basic";
+  postLogoutRedirectUris?: string[];
+  deviceThirdPartyInitiateLogin?: boolean;
+  initiateLoginUri?: string | null;
+  logoUri?: string | null;
+  policyUri?: string | null;
+  tosUri?: string | null;
+  clientUri?: string | null;
+};
+
+function buildClientConfigUpdates(
   clientId: string,
-  config: {
-    displayName?: string;
-    redirectUris?: string[];
-    allowedScopes?: string;
-    grantTypes?: string[];
-    tokenEndpointAuthMethod?: "none" | "client_secret_post" | "client_secret_basic";
-    postLogoutRedirectUris?: string[];
-    deviceThirdPartyInitiateLogin?: boolean;
-    initiateLoginUri?: string | null;
-    logoUri?: string | null;
-    policyUri?: string | null;
-    tosUri?: string | null;
-    clientUri?: string | null;
-  },
-): Promise<boolean> {
-  const rows = await db
-    .select()
-    .from(oidcClients)
-    .where(eq(oidcClients.clientId, clientId))
-    .limit(1);
-  const existing = rows[0];
-
-  if (!existing) return false;
-
+  config: ClientConfigPatch,
+): Record<string, unknown> {
   const updates: Record<string, unknown> = {};
   if (config.displayName !== undefined) updates.displayName = config.displayName;
-  if (config.redirectUris !== undefined) updates.redirectUris = JSON.stringify(config.redirectUris);
+  if (config.redirectUris !== undefined) {
+    updates.redirectUris = JSON.stringify(config.redirectUris);
+  }
   if (config.allowedScopes !== undefined) {
     updates.allowedScopes = normalizePublicAllowedScopes(
       config.allowedScopes,
@@ -610,12 +610,30 @@ export async function updateClientConfig(
   if (config.deviceThirdPartyInitiateLogin !== undefined) {
     updates.deviceThirdPartyInitiateLogin = config.deviceThirdPartyInitiateLogin ? 1 : 0;
   }
-  if (config.initiateLoginUri !== undefined) updates.initiateLoginUri = config.initiateLoginUri;
+  if (config.initiateLoginUri !== undefined) {
+    updates.initiateLoginUri = config.initiateLoginUri;
+  }
   if (config.logoUri !== undefined) updates.logoUri = config.logoUri;
   if (config.policyUri !== undefined) updates.policyUri = config.policyUri;
   if (config.tosUri !== undefined) updates.tosUri = config.tosUri;
   if (config.clientUri !== undefined) updates.clientUri = config.clientUri;
+  return updates;
+}
 
+export async function updateClientConfig(
+  clientId: string,
+  config: ClientConfigPatch,
+): Promise<boolean> {
+  const rows = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  const existing = rows[0];
+
+  if (!existing) return false;
+
+  const updates = buildClientConfigUpdates(clientId, config);
   if (Object.keys(updates).length === 0) return true;
 
   await db.update(oidcClients).set(updates).where(eq(oidcClients.clientId, clientId));

--- a/src/lib/oidc/device-approval.ts
+++ b/src/lib/oidc/device-approval.ts
@@ -27,63 +27,32 @@ function isDeviceCodeBound(payload: Record<string, unknown>): boolean {
   return false;
 }
 
-/**
- * Bind a pending device code to an OIDC account and grant scopes.
- * `oidcClientId` must match the client that requested the device code.
- */
-export async function approveDeviceCodeForAccount(
-  normalizedUserCode: string,
-  oidcClientId: string,
-  accountId: string,
-): Promise<DeviceApprovalSuccess | DeviceApprovalFailure> {
-  const adapter = new SqliteAdapter("DeviceCode");
-  const deviceCode = await adapter.findByUserCode(normalizedUserCode);
+function approvalFailure(
+  error: string,
+  description: string,
+  status = 400,
+): DeviceApprovalFailure {
+  return { ok: false, error, description, status };
+}
 
-  if (!deviceCode) {
-    return {
-      ok: false,
-      error: "invalid_grant",
-      description: "Invalid, expired, or already used device code",
-      status: 400,
-    };
+function extractBoundClientId(deviceCode: Record<string, unknown>): string | null {
+  if (typeof deviceCode.clientId === "string") {
+    return deviceCode.clientId;
   }
-
-  if (deviceCode.consumed) {
-    return {
-      ok: false,
-      error: "invalid_grant",
-      description: "Device code already used",
-      status: 400,
-    };
+  if (
+    typeof deviceCode.params === "object" &&
+    deviceCode.params !== null &&
+    typeof (deviceCode.params as Record<string, unknown>).client_id === "string"
+  ) {
+    return (deviceCode.params as Record<string, unknown>).client_id as string;
   }
+  return null;
+}
 
-  if (deviceCode.exp && deviceCode.exp < Math.floor(Date.now() / 1000)) {
-    return {
-      ok: false,
-      error: "expired_token",
-      description: "The device code has expired",
-      status: 400,
-    };
-  }
-
-  const boundClient =
-    typeof deviceCode.clientId === "string"
-      ? deviceCode.clientId
-      : typeof deviceCode.params === "object" &&
-          deviceCode.params !== null &&
-          typeof (deviceCode.params as Record<string, unknown>).client_id === "string"
-        ? ((deviceCode.params as Record<string, unknown>).client_id as string)
-        : null;
-
-  if (!boundClient || boundClient !== oidcClientId) {
-    return {
-      ok: false,
-      error: "invalid_grant",
-      description: "Device code does not match this client",
-      status: 400,
-    };
-  }
-
+function resolveDeviceResourceAndScope(deviceCode: Record<string, unknown>): {
+  resource: string;
+  scope: string;
+} {
   const params =
     typeof deviceCode.params === "object" && deviceCode.params !== null
       ? (deviceCode.params as Record<string, unknown>)
@@ -103,29 +72,59 @@ export async function approveDeviceCodeForAccount(
         ? params.scope
         : "";
 
+  return { resource, scope };
+}
+
+function validatePendingDeviceCode(
+  deviceCode: Record<string, unknown> | null | undefined,
+  oidcClientId: string,
+): DeviceApprovalFailure | null {
+  if (!deviceCode) {
+    return approvalFailure(
+      "invalid_grant",
+      "Invalid, expired, or already used device code",
+    );
+  }
+
+  if (deviceCode.consumed) {
+    return approvalFailure("invalid_grant", "Device code already used");
+  }
+
+  if (
+    deviceCode.exp &&
+    typeof deviceCode.exp === "number" &&
+    deviceCode.exp < Math.floor(Date.now() / 1000)
+  ) {
+    return approvalFailure("expired_token", "The device code has expired");
+  }
+
+  const boundClient = extractBoundClientId(deviceCode);
+  if (!boundClient || boundClient !== oidcClientId) {
+    return approvalFailure(
+      "invalid_grant",
+      "Device code does not match this client",
+    );
+  }
+
   if (typeof deviceCode.jti !== "string" || deviceCode.jti.length === 0) {
-    return {
-      ok: false,
-      error: "invalid_grant",
-      description: "Invalid, expired, or already used device code",
-      status: 400,
-    };
+    return approvalFailure(
+      "invalid_grant",
+      "Invalid, expired, or already used device code",
+    );
   }
 
-  const latest = await adapter.find(deviceCode.jti);
-  if (!latest) {
-    return {
-      ok: false,
-      error: "invalid_grant",
-      description: "Invalid, expired, or already used device code",
-      status: 400,
-    };
-  }
+  return null;
+}
 
-  if (isDeviceCodeBound(latest as Record<string, unknown>)) {
-    return { ok: true };
-  }
-
+async function bindDeviceApproval(
+  adapter: InstanceType<typeof SqliteAdapter>,
+  deviceCode: Record<string, unknown>,
+  latest: Record<string, unknown>,
+  oidcClientId: string,
+  accountId: string,
+  resource: string,
+  scope: string,
+): Promise<DeviceApprovalSuccess> {
   const provider = await getProvider();
   const grant = new provider.Grant();
   grant.clientId = oidcClientId;
@@ -137,12 +136,14 @@ export async function approveDeviceCodeForAccount(
   const newGrantId = await grant.save();
 
   const now = Math.floor(Date.now() / 1000);
-  const expiresIn = deviceCode.exp ? Math.max(deviceCode.exp - now, 1) : 600;
+  const expiresIn = deviceCode.exp
+    ? Math.max((deviceCode.exp as number) - now, 1)
+    : 600;
 
   let bound: boolean;
   try {
     bound = await adapter.bindDeviceApprovalIfUnbound(
-      deviceCode.jti,
+      deviceCode.jti as string,
       {
         ...latest,
         accountId,
@@ -158,7 +159,7 @@ export async function approveDeviceCodeForAccount(
       expiresIn,
     );
   } catch (err) {
-    const after = await adapter.find(deviceCode.jti);
+    const after = await adapter.find(deviceCode.jti as string);
     const payloadGrantId =
       after && typeof (after as Record<string, unknown>).grantId === "string"
         ? ((after as Record<string, unknown>).grantId as string)
@@ -171,8 +172,51 @@ export async function approveDeviceCodeForAccount(
 
   if (!bound) {
     await grant.destroy();
-    return { ok: true };
   }
 
   return { ok: true };
+}
+
+/**
+ * Bind a pending device code to an OIDC account and grant scopes.
+ * `oidcClientId` must match the client that requested the device code.
+ */
+export async function approveDeviceCodeForAccount(
+  normalizedUserCode: string,
+  oidcClientId: string,
+  accountId: string,
+): Promise<DeviceApprovalSuccess | DeviceApprovalFailure> {
+  const adapter = new SqliteAdapter("DeviceCode");
+  const deviceCode = await adapter.findByUserCode(normalizedUserCode);
+
+  const earlyFailure = validatePendingDeviceCode(
+    deviceCode as Record<string, unknown> | null | undefined,
+    oidcClientId,
+  );
+  if (earlyFailure) return earlyFailure;
+
+  const code = deviceCode as Record<string, unknown>;
+  const { resource, scope } = resolveDeviceResourceAndScope(code);
+
+  const latest = await adapter.find(code.jti as string);
+  if (!latest) {
+    return approvalFailure(
+      "invalid_grant",
+      "Invalid, expired, or already used device code",
+    );
+  }
+
+  if (isDeviceCodeBound(latest as Record<string, unknown>)) {
+    return { ok: true };
+  }
+
+  return bindDeviceApproval(
+    adapter,
+    code,
+    latest as Record<string, unknown>,
+    oidcClientId,
+    accountId,
+    resource,
+    scope,
+  );
 }

--- a/src/lib/oidc/device-token-exchange.ts
+++ b/src/lib/oidc/device-token-exchange.ts
@@ -132,6 +132,199 @@ function expiresInFromPayload(payload: Record<string, unknown>): number {
   return Math.max(1, exp - now);
 }
 
+function tokenClientIdFromPayload(rec: Record<string, unknown>): string | null {
+  if (typeof rec.client_id === "string") return rec.client_id;
+  if (typeof rec.azp === "string") return rec.azp;
+  return null;
+}
+
+async function loadConfidentialDeviceApprovalClient(
+  dbConn: DrizzleDb,
+  clientId: string,
+  clientSecret: string,
+  validateSecret: typeof validateClientSecret,
+) {
+  if (!(await validateSecret(clientId, clientSecret))) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "Invalid client credentials",
+      "Invalid client credentials",
+    );
+  }
+
+  const clientRows = await dbConn
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  const m2mRow = clientRows[0];
+  if (!m2mRow?.clientSecretHash) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "Client not found or not confidential",
+      "Invalid client credentials",
+    );
+  }
+
+  if (
+    !hasScope(m2mRow.allowedScopes, "device:approve") &&
+    !hasScope(m2mRow.allowedScopes, "users:token")
+  ) {
+    throw new TokenExchangeError(
+      "invalid_scope",
+      "Requires device:approve or users:token on the confidential client",
+      "Missing required scope for device approval token exchange",
+    );
+  }
+
+  return m2mRow;
+}
+
+function normalizeDeviceUserCodeFromResource(
+  resource: string | null | undefined,
+): string {
+  const resourceStr = resource?.trim() ?? "";
+  if (!resourceStr.startsWith(DEVICE_CODE_RESOURCE_PREFIX)) {
+    throw new TokenExchangeError(
+      "invalid_target",
+      `resource must start with ${DEVICE_CODE_RESOURCE_PREFIX}`,
+      "Invalid resource for device approval",
+    );
+  }
+
+  const userCodeRaw = parseDeviceCodeFromResource(resourceStr);
+  if (!userCodeRaw) {
+    throw new TokenExchangeError(
+      "invalid_target",
+      "device user_code missing from resource",
+      "Invalid resource for device approval",
+    );
+  }
+  return normalizeUserCode(userCodeRaw);
+}
+
+async function resolvePublicClientIdForDeviceExchange(
+  dbConn: DrizzleDb,
+  m2mInternalId: string,
+): Promise<string> {
+  let publicClientId: string | null;
+  try {
+    publicClientId = await resolvePublicClientIdForOidcRow(dbConn, m2mInternalId);
+  } catch (err) {
+    if (err instanceof DeveloperAppSiblingAmbiguousError) {
+      console.error("[device-token-exchange] ambiguous developer app mapping", {
+        message: err.message,
+        conflictingDeveloperAppIds: err.conflictingDeveloperAppIds,
+      });
+      throw new TokenExchangeError(
+        "invalid_request",
+        "Ambiguous developer app mapping for this client",
+        "Multiple developer apps found for this client",
+      );
+    }
+    throw err;
+  }
+  if (!publicClientId) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "No developer app linked to this client",
+      "Invalid client credentials",
+    );
+  }
+  return publicClientId;
+}
+
+async function resolveDeveloperAppForPublicClient(
+  dbConn: DrizzleDb,
+  publicClientId: string,
+): Promise<string> {
+  const publicOidcRows = await dbConn
+    .select({
+      id: oidcClients.id,
+      deviceThirdPartyInitiateLogin: oidcClients.deviceThirdPartyInitiateLogin,
+    })
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, publicClientId))
+    .limit(1);
+  const publicOidc = publicOidcRows[0];
+  if (!publicOidc) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "Public client not found",
+      "Public client not found",
+    );
+  }
+  if (publicOidc.deviceThirdPartyInitiateLogin !== 1) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "Device third-party login is not enabled for this client",
+      "Device third-party login is not enabled for this client",
+    );
+  }
+
+  const devAppRows = await dbConn
+    .select({ id: developerApps.id })
+    .from(developerApps)
+    .where(eq(developerApps.oidcClientId, publicOidc.id))
+    .limit(1);
+  const developerAppId = devAppRows[0]?.id;
+  if (!developerAppId) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "Developer app not found",
+      "Developer app not found",
+    );
+  }
+  return developerAppId;
+}
+
+async function resolveAccountIdFromSubjectToken(
+  dbConn: DrizzleDb,
+  subjectToken: string,
+  publicClientId: string,
+  developerAppId: string,
+  verifySubject: typeof verifyAccessToken,
+  resolveEndUser: typeof findOrCreateAppEndUser,
+): Promise<{ accountId: string; payload: Record<string, unknown> }> {
+  const payload = await verifySubject(subjectToken);
+  if (!payload || typeof payload.sub !== "string" || !payload.sub) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token is not a valid access token for this issuer",
+      "Invalid subject token",
+    );
+  }
+
+  const rec = payload as Record<string, unknown>;
+  const tokenClientId = tokenClientIdFromPayload(rec);
+  if (!tokenClientId || tokenClientId !== publicClientId) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token must have been issued to this app's public client_id",
+      "Invalid subject token",
+    );
+  }
+
+  // subject_token `sub` is an app_users.id (see programmatic-tokens.ts), but
+  // node-oidc-provider `findAccount` resolves `users`/`end_users`. Translate to
+  // the end_users.id so the bound grant is servable when the CLI polls /token.
+  const appUserRows = await dbConn
+    .select({ externalUserId: appUsers.externalUserId })
+    .from(appUsers)
+    .where(eq(appUsers.id, payload.sub))
+    .limit(1);
+  const externalUserId = appUserRows[0]?.externalUserId;
+  if (!externalUserId) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token sub does not map to an app user",
+      "Invalid subject token",
+    );
+  }
+  const { id: accountId } = await resolveEndUser(developerAppId, externalUserId);
+  return { accountId, payload: rec };
+}
+
 export async function handleDeviceApprovalTokenExchange(
   params: {
     clientId: string;
@@ -172,16 +365,7 @@ export async function handleDeviceApprovalTokenExchange(
     audience: audienceParams,
   } = params;
 
-  if (!(await validateSecret(clientId, clientSecret))) {
-    throw new TokenExchangeError(
-      "invalid_client",
-      "Invalid client credentials",
-      "Invalid client credentials",
-    );
-  }
-
-  const normalizedSubjectTokenType = subjectTokenType.trim();
-  if (normalizedSubjectTokenType !== SUBJECT_ACCESS_TOKEN_TYPE) {
+  if (subjectTokenType.trim() !== SUBJECT_ACCESS_TOKEN_TYPE) {
     throw new TokenExchangeError(
       "invalid_request",
       `subject_token_type must be ${SUBJECT_ACCESS_TOKEN_TYPE}`,
@@ -189,159 +373,32 @@ export async function handleDeviceApprovalTokenExchange(
     );
   }
 
-  const clientRows = await dbConn
-    .select()
-    .from(oidcClients)
-    .where(eq(oidcClients.clientId, clientId))
-    .limit(1);
-  const m2mRow = clientRows[0];
-  if (!m2mRow?.clientSecretHash) {
-    throw new TokenExchangeError(
-      "invalid_client",
-      "Client not found or not confidential",
-      "Invalid client credentials",
-    );
-  }
-
-  if (
-    !hasScope(m2mRow.allowedScopes, "device:approve") &&
-    !hasScope(m2mRow.allowedScopes, "users:token")
-  ) {
-    throw new TokenExchangeError(
-      "invalid_scope",
-      "Requires device:approve or users:token on the confidential client",
-      "Missing required scope for device approval token exchange",
-    );
-  }
-
+  const m2mRow = await loadConfidentialDeviceApprovalClient(
+    dbConn,
+    clientId,
+    clientSecret,
+    validateSecret,
+  );
   assertRequestedTokenTypeForDeviceApproval(requestedTokenType);
-
-  const resourceStr = resource?.trim() ?? "";
-  if (!resourceStr.startsWith(DEVICE_CODE_RESOURCE_PREFIX)) {
-    throw new TokenExchangeError(
-      "invalid_target",
-      `resource must start with ${DEVICE_CODE_RESOURCE_PREFIX}`,
-      "Invalid resource for device approval",
-    );
-  }
-
-  const userCodeRaw = parseDeviceCodeFromResource(resourceStr);
-  if (!userCodeRaw) {
-    throw new TokenExchangeError(
-      "invalid_target",
-      "device user_code missing from resource",
-      "Invalid resource for device approval",
-    );
-  }
-  const normalizedUserCode = normalizeUserCode(userCodeRaw);
-
+  const normalizedUserCode = normalizeDeviceUserCodeFromResource(resource);
   assertDeviceApprovalAudiences(audienceParams ?? []);
 
-  let publicClientId: string | null;
-  try {
-    publicClientId = await resolvePublicClientIdForOidcRow(dbConn, m2mRow.id);
-  } catch (err) {
-    if (err instanceof DeveloperAppSiblingAmbiguousError) {
-      console.error("[device-token-exchange] ambiguous developer app mapping", {
-        message: err.message,
-        conflictingDeveloperAppIds: err.conflictingDeveloperAppIds,
-      });
-      throw new TokenExchangeError(
-        "invalid_request",
-        "Ambiguous developer app mapping for this client",
-        "Multiple developer apps found for this client",
-      );
-    }
-    throw err;
-  }
-  if (!publicClientId) {
-    throw new TokenExchangeError(
-      "invalid_client",
-      "No developer app linked to this client",
-      "Invalid client credentials",
-    );
-  }
-
-  const payload = await verifySubject(subjectToken);
-  if (!payload || typeof payload.sub !== "string" || !payload.sub) {
-    throw new TokenExchangeError(
-      "invalid_grant",
-      "subject_token is not a valid access token for this issuer",
-      "Invalid subject token",
-    );
-  }
-
-  const rec = payload as Record<string, unknown>;
-  const tokenClientId =
-    typeof rec.client_id === "string"
-      ? rec.client_id
-      : typeof rec.azp === "string"
-        ? rec.azp
-        : null;
-  if (!tokenClientId || tokenClientId !== publicClientId) {
-    throw new TokenExchangeError(
-      "invalid_grant",
-      "subject_token must have been issued to this app's public client_id",
-      "Invalid subject token",
-    );
-  }
-
-  const publicOidcRows = await dbConn
-    .select({
-      id: oidcClients.id,
-      deviceThirdPartyInitiateLogin: oidcClients.deviceThirdPartyInitiateLogin,
-    })
-    .from(oidcClients)
-    .where(eq(oidcClients.clientId, publicClientId))
-    .limit(1);
-  const publicOidc = publicOidcRows[0];
-  if (!publicOidc) {
-    throw new TokenExchangeError(
-      "invalid_client",
-      "Public client not found",
-      "Public client not found",
-    );
-  }
-  if (publicOidc.deviceThirdPartyInitiateLogin !== 1) {
-    throw new TokenExchangeError(
-      "invalid_client",
-      "Device third-party login is not enabled for this client",
-      "Device third-party login is not enabled for this client",
-    );
-  }
-  const publicInternalId = publicOidc.id;
-
-  const devAppRows = await dbConn
-    .select({ id: developerApps.id })
-    .from(developerApps)
-    .where(eq(developerApps.oidcClientId, publicInternalId))
-    .limit(1);
-  const developerAppId = devAppRows[0]?.id;
-  if (!developerAppId) {
-    throw new TokenExchangeError(
-      "invalid_client",
-      "Developer app not found",
-      "Developer app not found",
-    );
-  }
-
-  // subject_token `sub` is an app_users.id (see programmatic-tokens.ts), but
-  // node-oidc-provider `findAccount` resolves `users`/`end_users`. Translate to
-  // the end_users.id so the bound grant is servable when the CLI polls /token.
-  const appUserRows = await dbConn
-    .select({ externalUserId: appUsers.externalUserId })
-    .from(appUsers)
-    .where(eq(appUsers.id, payload.sub))
-    .limit(1);
-  const externalUserId = appUserRows[0]?.externalUserId;
-  if (!externalUserId) {
-    throw new TokenExchangeError(
-      "invalid_grant",
-      "subject_token sub does not map to an app user",
-      "Invalid subject token",
-    );
-  }
-  const { id: accountId } = await resolveEndUser(developerAppId, externalUserId);
+  const publicClientId = await resolvePublicClientIdForDeviceExchange(
+    dbConn,
+    m2mRow.id,
+  );
+  const developerAppId = await resolveDeveloperAppForPublicClient(
+    dbConn,
+    publicClientId,
+  );
+  const { accountId, payload: rec } = await resolveAccountIdFromSubjectToken(
+    dbConn,
+    subjectToken,
+    publicClientId,
+    developerAppId,
+    verifySubject,
+    resolveEndUser,
+  );
 
   const approve = await approveDevice(
     normalizedUserCode,
@@ -355,9 +412,6 @@ export async function handleDeviceApprovalTokenExchange(
       approve.description,
     );
   }
-
-  const scopeStr = scopeStringFromAccessPayload(rec);
-  const expiresIn = expiresInFromPayload(rec);
 
   const correlationId = newCorrelationId();
   await auditLog({
@@ -382,8 +436,8 @@ export async function handleDeviceApprovalTokenExchange(
   return {
     access_token: subjectToken,
     token_type: "Bearer",
-    expires_in: expiresIn,
-    scope: scopeStr,
+    expires_in: expiresInFromPayload(rec),
+    scope: scopeStringFromAccessPayload(rec),
     issued_token_type: ISSUED_ACCESS_TOKEN_TYPE,
   };
 }

--- a/src/lib/oidc/gateway-token-exchange.ts
+++ b/src/lib/oidc/gateway-token-exchange.ts
@@ -89,6 +89,138 @@ function assertGatewayResource(resource: string | null | undefined): void {
   );
 }
 
+async function loadGatewayCallerRow(
+  dbConn: DrizzleDb,
+  clientId: string,
+  clientSecret: string,
+  validateSecret: typeof validateClientSecret,
+) {
+  if (!(await validateSecret(clientId, clientSecret))) {
+    throw new TokenExchangeError("invalid_client", "Invalid client credentials");
+  }
+
+  const clientRows = await dbConn
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  const callerRow = clientRows[0];
+  if (!callerRow?.clientSecretHash) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "Client not found or not confidential",
+    );
+  }
+
+  if (!hasScope(callerRow.allowedScopes, "users:token")) {
+    throw new TokenExchangeError(
+      "invalid_scope",
+      "Requires users:token on the confidential client",
+    );
+  }
+
+  if (
+    billingPatternFromAllowedScopesString(callerRow.allowedScopes) !== "per_user"
+  ) {
+    throw new TokenExchangeError(
+      "invalid_request",
+      "Remote signer session exchange requires per-user billing (users:token scope on the OAuth client)",
+    );
+  }
+
+  return callerRow;
+}
+
+async function resolveGatewaySibling(
+  dbConn: DrizzleDb,
+  callerInternalId: string,
+  resolveSibling: typeof resolveDeveloperAppAndPublicClientForOidcRow,
+): Promise<{ developerAppId: string; publicClientId: string }> {
+  let sibling: { developerAppId: string; publicClientId: string } | null;
+  try {
+    sibling = await resolveSibling(dbConn, callerInternalId);
+  } catch (err) {
+    if (err instanceof DeveloperAppSiblingAmbiguousError) {
+      console.error("[gateway-token-exchange] ambiguous developer app mapping", {
+        message: err.message,
+        conflictingDeveloperAppIds: err.conflictingDeveloperAppIds,
+      });
+      throw new TokenExchangeError(
+        "invalid_request",
+        err.message,
+        "Ambiguous developer app mapping for this client",
+      );
+    }
+    throw err;
+  }
+  if (!sibling) {
+    throw new TokenExchangeError(
+      "invalid_client",
+      "No developer app linked to this client",
+    );
+  }
+  return sibling;
+}
+
+function tokenClientIdFromPayload(rec: Record<string, unknown>): string | null {
+  if (typeof rec.client_id === "string") return rec.client_id;
+  if (typeof rec.azp === "string") return rec.azp;
+  return null;
+}
+
+function effectiveScopesFromPayload(payload: Record<string, unknown>): string {
+  const scopeFromScope =
+    typeof payload.scope === "string" ? payload.scope : "";
+  const scpRaw = payload.scp;
+  const scopeFromScp = Array.isArray(scpRaw)
+    ? scpRaw.filter((v): v is string => typeof v === "string").join(" ")
+    : typeof scpRaw === "string"
+      ? scpRaw
+      : "";
+  return (scopeFromScope || scopeFromScp).trim().replace(/\s+/g, ",");
+}
+
+function assertGatewaySubjectToken(
+  payload: Awaited<ReturnType<typeof verifyAccessToken>>,
+  clientId: string,
+  publicClientId: string,
+): Record<string, unknown> {
+  if (!payload || typeof payload.sub !== "string" || !payload.sub) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token is not a valid OIDC access token for this issuer",
+    );
+  }
+
+  const rec = payload as Record<string, unknown>;
+  const tokenClientId = tokenClientIdFromPayload(rec);
+  if (!tokenClientId) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token must include client_id or azp",
+    );
+  }
+
+  const callerIsM2M = clientId !== publicClientId;
+  const subjectMatchesCaller = tokenClientId === clientId;
+  const subjectMatchesPublicSibling = tokenClientId === publicClientId;
+  if (!subjectMatchesCaller && !(callerIsM2M && subjectMatchesPublicSibling)) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token must have been issued to this app's public client or to the same confidential client as this request",
+    );
+  }
+
+  if (!hasScope(effectiveScopesFromPayload(rec), "sign:job")) {
+    throw new TokenExchangeError(
+      "invalid_grant",
+      "subject_token must include sign:job scope for remote signer session exchange",
+    );
+  }
+
+  return rec;
+}
+
 /**
  * Remote signer session exchange: OIDC access token (JWT from this issuer) -> long-lived `pmth_*`
  * session, via RFC 8693 at POST /api/v1/oidc/token.
@@ -135,129 +267,32 @@ export async function handleGatewayTokenExchange(
     );
   }
 
-  if (!(await deps.validateClientSecret(clientId, clientSecret))) {
-    throw new TokenExchangeError("invalid_client", "Invalid client credentials");
-  }
-
-  const clientRows = await dbConn
-    .select()
-    .from(oidcClients)
-    .where(eq(oidcClients.clientId, clientId))
-    .limit(1);
-  const callerRow = clientRows[0];
-  if (!callerRow?.clientSecretHash) {
-    throw new TokenExchangeError(
-      "invalid_client",
-      "Client not found or not confidential",
-    );
-  }
-
-  if (!hasScope(callerRow.allowedScopes, "users:token")) {
-    throw new TokenExchangeError(
-      "invalid_scope",
-      "Requires users:token on the confidential client",
-    );
-  }
-
-  if (
-    billingPatternFromAllowedScopesString(callerRow.allowedScopes) !== "per_user"
-  ) {
-    throw new TokenExchangeError(
-      "invalid_request",
-      "Remote signer session exchange requires per-user billing (users:token scope on the OAuth client)",
-    );
-  }
+  const callerRow = await loadGatewayCallerRow(
+    dbConn,
+    clientId,
+    clientSecret,
+    deps.validateClientSecret,
+  );
 
   assertRequestedTokenTypeForGateway(requestedTokenType);
   assertGatewayAudiences(audienceParams);
   assertGatewayResource(resource);
 
-  let sibling: { developerAppId: string; publicClientId: string } | null;
-  try {
-    sibling = await deps.resolveDeveloperAppAndPublicClientForOidcRow(
-      dbConn,
-      callerRow.id,
-    );
-  } catch (err) {
-    if (err instanceof DeveloperAppSiblingAmbiguousError) {
-      console.error("[gateway-token-exchange] ambiguous developer app mapping", {
-        message: err.message,
-        conflictingDeveloperAppIds: err.conflictingDeveloperAppIds,
-      });
-      throw new TokenExchangeError(
-        "invalid_request",
-        err.message,
-        "Ambiguous developer app mapping for this client",
-      );
-    }
-    throw err;
-  }
-  if (!sibling) {
-    throw new TokenExchangeError(
-      "invalid_client",
-      "No developer app linked to this client",
-    );
-  }
-
-  const { publicClientId, developerAppId } = sibling;
+  const { publicClientId, developerAppId } = await resolveGatewaySibling(
+    dbConn,
+    callerRow.id,
+    deps.resolveDeveloperAppAndPublicClientForOidcRow,
+  );
 
   const payload = await deps.verifyAccessToken(subjectToken);
-  if (!payload || typeof payload.sub !== "string" || !payload.sub) {
-    throw new TokenExchangeError(
-      "invalid_grant",
-      "subject_token is not a valid OIDC access token for this issuer",
-    );
-  }
-
-  const rec = payload as Record<string, unknown>;
-  const tokenClientId =
-    typeof rec.client_id === "string"
-      ? rec.client_id
-      : typeof rec.azp === "string"
-        ? rec.azp
-        : null;
-  if (!tokenClientId) {
-    throw new TokenExchangeError(
-      "invalid_grant",
-      "subject_token must include client_id or azp",
-    );
-  }
-
-  const callerIsM2M = clientId !== publicClientId;
-  const subjectMatchesCaller = tokenClientId === clientId;
-  const subjectMatchesPublicSibling = tokenClientId === publicClientId;
-  if (!subjectMatchesCaller && !(callerIsM2M && subjectMatchesPublicSibling)) {
-    throw new TokenExchangeError(
-      "invalid_grant",
-      "subject_token must have been issued to this app's public client or to the same confidential client as this request",
-    );
-  }
-
-  const scopeFromScope =
-    typeof payload.scope === "string" ? payload.scope : "";
-  const scpRaw = (payload as Record<string, unknown>).scp;
-  const scopeFromScp = Array.isArray(scpRaw)
-    ? scpRaw.filter((v): v is string => typeof v === "string").join(" ")
-    : typeof scpRaw === "string"
-      ? scpRaw
-      : "";
-  const normalizedScopes = (scopeFromScope || scopeFromScp)
-    .trim()
-    .replace(/\s+/g, ",");
-  const effectiveScopes = normalizedScopes;
-
-  if (!hasScope(effectiveScopes, "sign:job")) {
-    throw new TokenExchangeError(
-      "invalid_grant",
-      "subject_token must include sign:job scope for remote signer session exchange",
-    );
-  }
+  const rec = assertGatewaySubjectToken(payload, clientId, publicClientId);
+  const tokenClientId = tokenClientIdFromPayload(rec)!;
 
   const sessionBinding = await resolveGatewaySessionPrincipal(
     {
       dbConn,
       developerAppId,
-      sub: payload.sub,
+      sub: payload!.sub as string,
       tokenClientId,
       clientId,
     },
@@ -286,12 +321,10 @@ export async function handleGatewayTokenExchange(
     },
   });
 
-  const expiresIn = 90 * 24 * 60 * 60;
-
   return {
     access_token: token,
     token_type: "Bearer",
-    expires_in: expiresIn,
+    expires_in: 90 * 24 * 60 * 60,
     issued_token_type: ISSUED_ACCESS_TOKEN_TYPE,
     scope: "sign:job",
   };

--- a/src/lib/oidc/issuer-urls.ts
+++ b/src/lib/oidc/issuer-urls.ts
@@ -9,6 +9,36 @@ function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
 }
 
+function isPrivateOrLoopbackIpv4(
+  a: number,
+  b: number,
+  c: number,
+  d: number,
+): boolean {
+  if (![a, b, c, d].every((x) => x >= 0 && x <= 255)) return false;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  return false;
+}
+
+function isPrivateIpv4Match(match: RegExpMatchArray): boolean {
+  return isPrivateOrLoopbackIpv4(
+    Number(match[1]),
+    Number(match[2]),
+    Number(match[3]),
+    Number(match[4]),
+  );
+}
+
+function isLinkLocalIpv6(hostname: string): boolean {
+  const firstHextet = hostname.split(":")[0];
+  if (!firstHextet) return false;
+  const n = parseInt(firstHextet, 16);
+  return !Number.isNaN(n) && n >= 0xfe80 && n <= 0xfebf;
+}
+
 /** HTTP may stay http for loopback, RFC1918, IPv6 link-local, and *.local dev hosts. */
 function isLocalOrPrivateHost(hostname: string): boolean {
   let h = hostname.trim().toLowerCase();
@@ -23,39 +53,15 @@ function isLocalOrPrivateHost(hostname: string): boolean {
   const dottedQuad = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
   const plain4 = h.match(dottedQuad);
   if (plain4) {
-    const a = Number(plain4[1]);
-    const b = Number(plain4[2]);
-    const c = Number(plain4[3]);
-    const d = Number(plain4[4]);
-    if (![a, b, c, d].every((x) => x >= 0 && x <= 255)) return false;
-    if (a === 10) return true;
-    if (a === 127) return true;
-    if (a === 192 && b === 168) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    return false;
+    return isPrivateIpv4Match(plain4);
   }
 
   const embedded4 = h.match(/(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (embedded4) {
-    const a = Number(embedded4[1]);
-    const b = Number(embedded4[2]);
-    const c = Number(embedded4[3]);
-    const d = Number(embedded4[4]);
-    if ([a, b, c, d].every((x) => x >= 0 && x <= 255)) {
-      if (a === 10) return true;
-      if (a === 127) return true;
-      if (a === 192 && b === 168) return true;
-      if (a === 172 && b >= 16 && b <= 31) return true;
-    }
+  if (embedded4 && isPrivateIpv4Match(embedded4)) {
+    return true;
   }
 
-  const firstHextet = h.split(":")[0];
-  if (firstHextet) {
-    const n = parseInt(firstHextet, 16);
-    if (!Number.isNaN(n) && n >= 0xfe80 && n <= 0xfebf) return true;
-  }
-
-  return false;
+  return isLinkLocalIpv6(h);
 }
 
 /** Upgrade http→https for public hosts; leave http for local/private hosts. */

--- a/src/lib/oidc/security.ts
+++ b/src/lib/oidc/security.ts
@@ -33,6 +33,113 @@ export async function buildSecurityContext(requestHost: string): Promise<Securit
   };
 }
 
+function matchesHostWildcard(
+  redirectUrl: URL,
+  templateUrl: URL,
+): boolean {
+  const hostSuffix = templateUrl.host.replace("WILDCARD", "");
+  return (
+    redirectUrl.protocol === templateUrl.protocol &&
+    (redirectUrl.host === hostSuffix.replace(/^\./, "") ||
+      redirectUrl.host.endsWith(hostSuffix)) &&
+    redirectUrl.pathname === templateUrl.pathname &&
+    redirectUrl.search === templateUrl.search
+  );
+}
+
+function matchesPathWildcard(
+  redirectUrl: URL,
+  templateUrl: URL,
+): boolean {
+  const pathPrefix = templateUrl.pathname.split("WILDCARD")[0];
+  return (
+    redirectUrl.protocol === templateUrl.protocol &&
+    redirectUrl.host === templateUrl.host &&
+    redirectUrl.pathname.startsWith(pathPrefix)
+  );
+}
+
+function matchesMiddleWildcard(
+  redirectUrl: URL,
+  allowedUri: string,
+): boolean {
+  try {
+    const templateUrl = new URL(allowedUri.replace(/\*/g, "WILDCARD"));
+    if (templateUrl.host.includes("WILDCARD")) {
+      return matchesHostWildcard(redirectUrl, templateUrl);
+    }
+    if (templateUrl.pathname.includes("WILDCARD")) {
+      return matchesPathWildcard(redirectUrl, templateUrl);
+    }
+    // Wildcard in query/fragment — too permissive, skip
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function matchesWildcardAllowedUri(
+  redirectUrl: URL,
+  allowedUri: string,
+): boolean {
+  // Only allow a single wildcard; reject entries with multiple wildcards
+  const wildcardCount = (allowedUri.match(/\*/g) || []).length;
+  if (wildcardCount !== 1) return false;
+
+  const starIdx = allowedUri.indexOf("*");
+  const prefix = allowedUri.slice(0, starIdx);
+  const suffix = allowedUri.slice(starIdx + 1);
+
+  if (prefix && suffix) {
+    return matchesMiddleWildcard(redirectUrl, allowedUri);
+  }
+  if (prefix) {
+    // Prefix-only wildcard (e.g. "https://*"): compare via URL href
+    return redirectUrl.href.startsWith(prefix);
+  }
+  if (suffix) {
+    // Suffix-only wildcard (e.g. "*.example.com"): compare host component only
+    return (
+      redirectUrl.host === suffix.replace(/^\./, "") ||
+      redirectUrl.host.endsWith(suffix)
+    );
+  }
+  return false;
+}
+
+function matchesLooseOriginPath(
+  redirectUrl: URL,
+  allowedUri: string,
+): boolean {
+  try {
+    const allowedUrl = new URL(allowedUri);
+    return (
+      redirectUrl.origin === allowedUrl.origin &&
+      redirectUrl.pathname === allowedUrl.pathname
+    );
+  } catch {
+    return false;
+  }
+}
+
+function matchesAllowedUri(
+  redirectUri: string,
+  redirectUrl: URL,
+  allowedUri: string,
+  strictMode: boolean,
+): boolean {
+  if (allowedUri.includes("*")) {
+    return matchesWildcardAllowedUri(redirectUrl, allowedUri);
+  }
+  if (redirectUri === allowedUri) {
+    return true;
+  }
+  if (!strictMode) {
+    return matchesLooseOriginPath(redirectUrl, allowedUri);
+  }
+  return false;
+}
+
 export function validateRedirectUri(
   redirectUri: string,
   allowedUris: string[],
@@ -40,76 +147,13 @@ export function validateRedirectUri(
 ): boolean {
   try {
     const redirectUrl = new URL(redirectUri);
-    
+
     for (const allowedUri of allowedUris) {
-      if (allowedUri.includes("*")) {
-        // Only allow a single wildcard; reject entries with multiple wildcards
-        const wildcardCount = (allowedUri.match(/\*/g) || []).length;
-        if (wildcardCount !== 1) continue;
-
-        const starIdx = allowedUri.indexOf("*");
-        const prefix = allowedUri.slice(0, starIdx);
-        const suffix = allowedUri.slice(starIdx + 1);
-
-        if (prefix && suffix) {
-          // Wildcard in the middle (e.g. https://*.example.com/callback):
-          // parse URL components to avoid matching across URL boundaries
-          try {
-            const templateUrl = new URL(allowedUri.replace(/\*/g, "WILDCARD"));
-            if (templateUrl.host.includes("WILDCARD")) {
-              // Wildcard is in the host component
-              const hostSuffix = templateUrl.host.replace("WILDCARD", "");
-              if (
-                redirectUrl.protocol === templateUrl.protocol &&
-                (redirectUrl.host === hostSuffix.replace(/^\./, "") ||
-                  redirectUrl.host.endsWith(hostSuffix)) &&
-                redirectUrl.pathname === templateUrl.pathname &&
-                redirectUrl.search === templateUrl.search
-              ) {
-                return true;
-              }
-            } else if (templateUrl.pathname.includes("WILDCARD")) {
-              // Wildcard is in the path component
-              const pathPrefix = templateUrl.pathname.split("WILDCARD")[0];
-              if (
-                redirectUrl.protocol === templateUrl.protocol &&
-                redirectUrl.host === templateUrl.host &&
-                redirectUrl.pathname.startsWith(pathPrefix)
-              ) {
-                return true;
-              }
-            }
-            // Wildcard in query/fragment — too permissive, skip
-          } catch {
-            continue;
-          }
-        } else if (prefix) {
-          // Prefix-only wildcard (e.g. "https://*"): compare via URL href
-          if (redirectUrl.href.startsWith(prefix)) return true;
-        } else if (suffix) {
-          // Suffix-only wildcard (e.g. "*.example.com"): compare host component only
-          if (
-            redirectUrl.host === suffix.replace(/^\./, "") ||
-            redirectUrl.host.endsWith(suffix)
-          ) {
-            return true;
-          }
-        }
-      } else if (redirectUri === allowedUri) {
+      if (matchesAllowedUri(redirectUri, redirectUrl, allowedUri, strictMode)) {
         return true;
-      } else if (!strictMode) {
-        try {
-          const allowedUrl = new URL(allowedUri);
-          if (redirectUrl.origin === allowedUrl.origin && 
-              redirectUrl.pathname === allowedUrl.pathname) {
-            return true;
-          }
-        } catch {
-          continue;
-        }
       }
     }
-    
+
     return false;
   } catch {
     return false;

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -112,18 +112,109 @@ function subscriptionViewFromCreateResult(
   };
 }
 
-async function createStarterSubscriptionWithRecovery(input: {
+type StarterRecoveryInput = {
   client: OpenMeter;
   customerId: string;
   clientId: string;
   starter: typeof plans.$inferSelect;
   planKey: string;
-}): Promise<{
+};
+
+type StarterRecoveryResult = {
   subscription: OpenMeterSubscriptionView | null;
   starter: typeof plans.$inferSelect;
   created: boolean;
-}> {
-  let activeStarter = input.starter;
+};
+
+function createdStarterResult(
+  createdSub: NonNullable<Awaited<ReturnType<OpenMeter["subscriptions"]["create"]>>>,
+  planKey: string,
+  starter: typeof plans.$inferSelect,
+): StarterRecoveryResult {
+  return {
+    subscription: subscriptionViewFromCreateResult(
+      createdSub,
+      planKey,
+      starter.openmeterPlanId,
+    ),
+    starter,
+    created: true,
+  };
+}
+
+async function recreateAfterPlanNotFound(
+  input: StarterRecoveryInput,
+  starter: typeof plans.$inferSelect,
+): Promise<StarterRecoveryResult> {
+  const sync = await syncPlanToOpenMeter(starter.id);
+  if (!sync.ok) {
+    throw new Error(sync.error ?? "Failed to sync Starter plan to OpenMeter");
+  }
+  const activeStarter = await refreshStarterPlan(starter.id);
+  const createdSub = await createStarterOpenMeterSubscription({
+    client: input.client,
+    customerId: input.customerId,
+    starter: activeStarter,
+    planKey: input.planKey,
+  });
+  if (!createdSub?.id) {
+    throw new Error("Failed to create OpenMeter Starter subscription after plan sync");
+  }
+  return createdStarterResult(createdSub, input.planKey, activeStarter);
+}
+
+async function recoverFromConflict(
+  input: StarterRecoveryInput,
+  starter: typeof plans.$inferSelect,
+  originalErr: unknown,
+): Promise<StarterRecoveryResult> {
+  const existing = await findOpenMeterSubscriptionByPlanKey(
+    input.client,
+    input.customerId,
+    input.planKey,
+    { openmeterPlanId: starter.openmeterPlanId },
+  );
+  if (existing) {
+    return { subscription: existing, starter, created: false };
+  }
+
+  await applyFreeBillingProfileToCustomer({
+    client: input.client,
+    customerId: input.customerId,
+  });
+  try {
+    const createdSub = await createStarterOpenMeterSubscription({
+      client: input.client,
+      customerId: input.customerId,
+      starter,
+      planKey: input.planKey,
+    });
+    if (createdSub?.id) {
+      return createdStarterResult(createdSub, input.planKey, starter);
+    }
+  } catch (retryErr) {
+    const existingAfterRetry = await findOpenMeterSubscriptionByPlanKey(
+      input.client,
+      input.customerId,
+      input.planKey,
+      { openmeterPlanId: starter.openmeterPlanId },
+    );
+    if (existingAfterRetry) {
+      return {
+        subscription: existingAfterRetry,
+        starter,
+        created: false,
+      };
+    }
+    throw retryErr;
+  }
+  throw originalErr;
+}
+
+async function createStarterSubscriptionWithRecovery(
+  input: StarterRecoveryInput,
+): Promise<StarterRecoveryResult> {
+  const activeStarter = input.starter;
   try {
     const createdSub = await createStarterOpenMeterSubscription({
       client: input.client,
@@ -134,91 +225,13 @@ async function createStarterSubscriptionWithRecovery(input: {
     if (!createdSub?.id) {
       throw new Error("Failed to create OpenMeter Starter subscription");
     }
-    return {
-      subscription: subscriptionViewFromCreateResult(
-        createdSub,
-        input.planKey,
-        activeStarter.openmeterPlanId,
-      ),
-      starter: activeStarter,
-      created: true,
-    };
+    return createdStarterResult(createdSub, input.planKey, activeStarter);
   } catch (err) {
     if (isOpenMeterPlanNotFoundError(err)) {
-      const sync = await syncPlanToOpenMeter(activeStarter.id);
-      if (!sync.ok) {
-        throw new Error(sync.error ?? "Failed to sync Starter plan to OpenMeter");
-      }
-      activeStarter = await refreshStarterPlan(activeStarter.id);
-      const createdSub = await createStarterOpenMeterSubscription({
-        client: input.client,
-        customerId: input.customerId,
-        starter: activeStarter,
-        planKey: input.planKey,
-      });
-      if (!createdSub?.id) {
-        throw new Error("Failed to create OpenMeter Starter subscription after plan sync");
-      }
-      return {
-        subscription: subscriptionViewFromCreateResult(
-          createdSub,
-          input.planKey,
-          activeStarter.openmeterPlanId,
-        ),
-        starter: activeStarter,
-        created: true,
-      };
+      return recreateAfterPlanNotFound(input, activeStarter);
     }
     if (isOpenMeterConflictError(err)) {
-      const existing = await findOpenMeterSubscriptionByPlanKey(
-        input.client,
-        input.customerId,
-        input.planKey,
-        { openmeterPlanId: activeStarter.openmeterPlanId },
-      );
-      if (existing) {
-        return { subscription: existing, starter: activeStarter, created: false };
-      }
-
-      await applyFreeBillingProfileToCustomer({
-        client: input.client,
-        customerId: input.customerId,
-      });
-      try {
-        const createdSub = await createStarterOpenMeterSubscription({
-          client: input.client,
-          customerId: input.customerId,
-          starter: activeStarter,
-          planKey: input.planKey,
-        });
-        if (createdSub?.id) {
-          return {
-            subscription: subscriptionViewFromCreateResult(
-              createdSub,
-              input.planKey,
-              activeStarter.openmeterPlanId,
-            ),
-            starter: activeStarter,
-            created: true,
-          };
-        }
-      } catch (retryErr) {
-        const existingAfterRetry = await findOpenMeterSubscriptionByPlanKey(
-          input.client,
-          input.customerId,
-          input.planKey,
-          { openmeterPlanId: activeStarter.openmeterPlanId },
-        );
-        if (existingAfterRetry) {
-          return {
-            subscription: existingAfterRetry,
-            starter: activeStarter,
-            created: false,
-          };
-        }
-        throw retryErr;
-      }
-      throw err;
+      return recoverFromConflict(input, activeStarter, err);
     }
     throw err;
   }


### PR DESCRIPTION
## Summary
- Extract helpers to bring OIDC/discovery/domain functions under Sonar cognitive-complexity limit (S3776)
- Covers clients, device/gateway token exchange, issuer URLs, security, domain whitelist, discovery allowlist/plans, starter subscription, device + interaction pages
- Behavior preserved; targeted unit tests passed in the agent run

Part of Phase 4 Sonar cleanup (OIDC batch).

## Test plan
- [ ] Device authorization + interaction pages still load
- [ ] Redirect URI / domain whitelist validation unchanged
- [ ] Discovery plan parse/merge still works
- [ ] CI tests pass
- [ ] Sonar S3776 clears on these files