### PR TITLE
fix(a11y): associate form labels and set button types (S6853/S9011)

### DIFF
--- a/src/app/admin/oidc-clients/page.tsx
+++ b/src/app/admin/oidc-clients/page.tsx
@@ -140,6 +140,7 @@ export default function AdminOidcClientsPage() {
       <DashboardLayout>
         <div className="mb-8">
           <button
+            type="button"
             onClick={cancelEdit}
             className="text-sm text-zinc-400 hover:text-zinc-300 mb-4 flex items-center gap-2"
           >
@@ -157,10 +158,11 @@ export default function AdminOidcClientsPage() {
           <div className="space-y-6">
             {/* Display Name */}
             <div>
-              <label className="block text-sm font-medium text-zinc-300 mb-2">
+              <label htmlFor="oidc-edit-display-name" className="block text-sm font-medium text-zinc-300 mb-2">
                 Display Name
               </label>
               <input
+                id="oidc-edit-display-name"
                 type="text"
                 value={formData.displayName}
                 onChange={(e) =>
@@ -172,13 +174,14 @@ export default function AdminOidcClientsPage() {
 
             {/* Redirect URIs */}
             <div>
-              <label className="block text-sm font-medium text-zinc-300 mb-2">
+              <label htmlFor="oidc-edit-redirect-uris" className="block text-sm font-medium text-zinc-300 mb-2">
                 Redirect URIs
                 <span className="text-zinc-500 font-normal ml-2">
                   (one per line)
                 </span>
               </label>
               <textarea
+                id="oidc-edit-redirect-uris"
                 value={formData.redirectUris}
                 onChange={(e) =>
                   setFormData({ ...formData, redirectUris: e.target.value })
@@ -190,13 +193,14 @@ export default function AdminOidcClientsPage() {
 
             {/* Allowed Scopes */}
             <div>
-              <label className="block text-sm font-medium text-zinc-300 mb-2">
+              <label htmlFor="oidc-edit-allowed-scopes" className="block text-sm font-medium text-zinc-300 mb-2">
                 Allowed Scopes
                 <span className="text-zinc-500 font-normal ml-2">
                   (space-separated)
                 </span>
               </label>
               <input
+                id="oidc-edit-allowed-scopes"
                 type="text"
                 value={formData.allowedScopes}
                 onChange={(e) =>
@@ -250,6 +254,7 @@ export default function AdminOidcClientsPage() {
             {/* Actions */}
             <div className="flex gap-3 pt-4">
               <button
+                type="button"
                 onClick={saveEdit}
                 disabled={saving}
                 className="px-4 py-2 bg-emerald-600 text-white rounded-lg text-sm font-medium hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -257,6 +262,7 @@ export default function AdminOidcClientsPage() {
                 {saving ? "Saving..." : "Save Changes"}
               </button>
               <button
+                type="button"
                 onClick={cancelEdit}
                 disabled={saving}
                 className="px-4 py-2 bg-zinc-800 text-zinc-300 rounded-lg text-sm font-medium hover:bg-zinc-700 transition-colors disabled:opacity-50"
@@ -318,6 +324,7 @@ function ClientCard({
           </code>
         </div>
         <button
+          type="button"
           onClick={() => onEdit(client)}
           className="px-3 py-1.5 bg-zinc-800 text-zinc-300 rounded-lg text-sm hover:bg-zinc-700 transition-colors"
         >

--- a/src/app/marketplace/[id]/page.tsx
+++ b/src/app/marketplace/[id]/page.tsx
@@ -201,14 +201,15 @@ export default function MarketplaceAppDetailPage() {
             <div className="space-y-4">
               {app.clientId && (
                 <div>
-                  <label className="block text-xs text-zinc-500 mb-1.5">
+                  <div className="block text-xs text-zinc-500 mb-1.5">
                     OIDC Client ID
-                  </label>
+                  </div>
                   <div className="flex items-center gap-2">
                     <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-300 font-mono">
                       {app.clientId}
                     </code>
                     <button
+                      type="button"
                       onClick={() => copyToClipboard(app.clientId!, "clientId")}
                       className="px-3 py-2 text-xs text-zinc-400 hover:text-zinc-200 border border-zinc-700 rounded-lg hover:border-zinc-600 transition-colors shrink-0"
                     >
@@ -220,9 +221,9 @@ export default function MarketplaceAppDetailPage() {
 
               {grants.length > 0 && (
                 <div>
-                  <label className="block text-xs text-zinc-500 mb-1.5">
+                  <div className="block text-xs text-zinc-500 mb-1.5">
                     Supported Grant Types
-                  </label>
+                  </div>
                   <div className="flex flex-wrap gap-2">
                     {grants.map((g) => (
                       <span

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -126,6 +126,7 @@ export default function MarketplacePage() {
           {categories.length > 0 && (
             <div className="flex flex-wrap gap-2">
               <button
+                type="button"
                 onClick={() => setSelectedCategory(null)}
                 className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
                   selectedCategory === null
@@ -137,6 +138,7 @@ export default function MarketplacePage() {
               </button>
               {categories.map((cat) => (
                 <button
+                  type="button"
                   key={cat}
                   onClick={() =>
                     setSelectedCategory(selectedCategory === cat ? null : cat)

--- a/src/components/CreateEndUserForm.tsx
+++ b/src/components/CreateEndUserForm.tsx
@@ -43,6 +43,7 @@ export default function CreateEndUserForm() {
   return (
     <>
       <button
+        type="button"
         onClick={() => {
           setShowForm(!showForm);
           setError(null);
@@ -59,8 +60,11 @@ export default function CreateEndUserForm() {
           </h4>
           <form onSubmit={handleSubmit} className="space-y-3">
             <div>
-              <label className="block text-xs text-zinc-500 mb-1">Name</label>
+              <label htmlFor="end-user-name" className="block text-xs text-zinc-500 mb-1">
+                Name
+              </label>
               <input
+                id="end-user-name"
                 type="text"
                 value={formData.name}
                 onChange={(e) =>
@@ -71,8 +75,11 @@ export default function CreateEndUserForm() {
               />
             </div>
             <div>
-              <label className="block text-xs text-zinc-500 mb-1">Email</label>
+              <label htmlFor="end-user-email" className="block text-xs text-zinc-500 mb-1">
+                Email
+              </label>
               <input
+                id="end-user-email"
                 type="email"
                 value={formData.email}
                 onChange={(e) =>

--- a/src/components/SignerControlPanel.tsx
+++ b/src/components/SignerControlPanel.tsx
@@ -63,6 +63,7 @@ export default function SignerControlPanel({
       <div className="flex flex-wrap gap-3">
         {!managedRemote && !isRunning && (
           <button
+            type="button"
             onClick={() => doAction("start")}
             disabled={!!loading}
             className="px-4 py-2 bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 rounded-lg text-sm font-medium hover:bg-emerald-500/20 transition-colors disabled:opacity-50"
@@ -73,6 +74,7 @@ export default function SignerControlPanel({
 
         {!managedRemote && isRunning && (
           <button
+            type="button"
             onClick={() => doAction("stop")}
             disabled={!!loading}
             className="px-4 py-2 bg-red-500/10 text-red-400 border border-red-500/30 rounded-lg text-sm font-medium hover:bg-red-500/20 transition-colors disabled:opacity-50"
@@ -83,6 +85,7 @@ export default function SignerControlPanel({
 
         {!managedRemote && (
           <button
+            type="button"
             onClick={() => doAction("restart")}
             disabled={!!loading}
             className="px-4 py-2 bg-amber-500/10 text-amber-400 border border-amber-500/30 rounded-lg text-sm font-medium hover:bg-amber-500/20 transition-colors disabled:opacity-50"
@@ -92,6 +95,7 @@ export default function SignerControlPanel({
         )}
 
         <button
+          type="button"
           onClick={() => doAction("sync")}
           disabled={!!loading}
           className="px-4 py-2 bg-blue-500/10 text-blue-400 border border-blue-500/30 rounded-lg text-sm font-medium hover:bg-blue-500/20 transition-colors disabled:opacity-50"

--- a/src/components/SignerLiveStats.tsx
+++ b/src/components/SignerLiveStats.tsx
@@ -129,6 +129,7 @@ export default function SignerLiveStats() {
             </span>
           )}
           <button
+            type="button"
             onClick={fetchStats}
             className="px-2.5 py-1 bg-zinc-800 border border-zinc-700 rounded text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
           >

--- a/src/components/SignerLogs.tsx
+++ b/src/components/SignerLogs.tsx
@@ -116,6 +116,7 @@ export default function SignerLogs({
           </label>
 
           <button
+            type="button"
             onClick={fetchLogs}
             className="px-2.5 py-1 bg-zinc-800 border border-zinc-700 rounded text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
           >

--- a/src/components/apps/AppSettingsPanel.tsx
+++ b/src/components/apps/AppSettingsPanel.tsx
@@ -160,9 +160,12 @@ export default function AppSettingsPanel({ data }: Props) {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1.5">Redirect URIs</label>
+          <label htmlFor="settings-new-redirect-uri" className="block text-sm font-medium text-zinc-300 mb-1.5">
+            Redirect URIs
+          </label>
           <div className="flex gap-2 mb-2">
             <input
+              id="settings-new-redirect-uri"
               type="text"
               value={newRedirectUri}
               onChange={(event) => setNewRedirectUri(event.target.value)}
@@ -174,6 +177,7 @@ export default function AppSettingsPanel({ data }: Props) {
               className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-100"
             />
             <button
+              type="button"
               onClick={() => addValue(newRedirectUri, setNewRedirectUri, setRedirectUris)}
               className="px-4 py-2 rounded-lg bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors"
             >
@@ -185,6 +189,7 @@ export default function AppSettingsPanel({ data }: Props) {
               <div key={uri} className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-800/40 px-3 py-2">
                 <code className="text-xs text-zinc-300">{uri}</code>
                 <button
+                  type="button"
                   onClick={() => setRedirectUris((items) => items.filter((item) => item !== uri))}
                   className="text-xs text-zinc-500 hover:text-red-400"
                 >
@@ -196,9 +201,12 @@ export default function AppSettingsPanel({ data }: Props) {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1.5">Post-logout Redirect URIs</label>
+          <label htmlFor="settings-new-post-logout-uri" className="block text-sm font-medium text-zinc-300 mb-1.5">
+            Post-logout Redirect URIs
+          </label>
           <div className="flex gap-2 mb-2">
             <input
+              id="settings-new-post-logout-uri"
               type="text"
               value={newPostLogoutUri}
               onChange={(event) => setNewPostLogoutUri(event.target.value)}
@@ -210,6 +218,7 @@ export default function AppSettingsPanel({ data }: Props) {
               className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-100"
             />
             <button
+              type="button"
               onClick={() => addValue(newPostLogoutUri, setNewPostLogoutUri, setPostLogoutRedirectUris)}
               className="px-4 py-2 rounded-lg bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors"
             >
@@ -221,6 +230,7 @@ export default function AppSettingsPanel({ data }: Props) {
               <div key={uri} className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-800/40 px-3 py-2">
                 <code className="text-xs text-zinc-300">{uri}</code>
                 <button
+                  type="button"
                   onClick={() => setPostLogoutRedirectUris((items) => items.filter((item) => item !== uri))}
                   className="text-xs text-zinc-500 hover:text-red-400"
                 >
@@ -233,8 +243,11 @@ export default function AppSettingsPanel({ data }: Props) {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-zinc-300 mb-1.5">Initiate Login URI</label>
+            <label htmlFor="settings-initiate-login-uri" className="block text-sm font-medium text-zinc-300 mb-1.5">
+              Initiate Login URI
+            </label>
             <input
+              id="settings-initiate-login-uri"
               type="url"
               value={initiateLoginUri}
               onChange={(event) => setInitiateLoginUri(event.target.value)}
@@ -243,8 +256,11 @@ export default function AppSettingsPanel({ data }: Props) {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-zinc-300 mb-1.5">Token Auth Method</label>
+            <label htmlFor="settings-token-auth-method" className="block text-sm font-medium text-zinc-300 mb-1.5">
+              Token Auth Method
+            </label>
             <select
+              id="settings-token-auth-method"
               value={tokenEndpointAuthMethod}
               onChange={(event) => setTokenEndpointAuthMethod(event.target.value)}
               className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-100"
@@ -258,6 +274,7 @@ export default function AppSettingsPanel({ data }: Props) {
 
         <div className="flex items-center gap-3">
           <button
+            type="button"
             onClick={saveSettings}
             disabled={saving}
             className="px-4 py-2 rounded-lg bg-emerald-600 text-white text-sm hover:bg-emerald-500 disabled:opacity-50"
@@ -265,6 +282,7 @@ export default function AppSettingsPanel({ data }: Props) {
             Save Settings
           </button>
           <button
+            type="button"
             onClick={rotateSecret}
             disabled={saving}
             className="px-4 py-2 rounded-lg border border-zinc-700 text-zinc-200 text-sm hover:bg-zinc-800 disabled:opacity-50"
@@ -299,6 +317,7 @@ export default function AppSettingsPanel({ data }: Props) {
             className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-100"
           />
           <button
+            type="button"
             onClick={addDomain}
             disabled={saving}
             className="px-4 py-2 rounded-lg bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 disabled:opacity-50"
@@ -312,6 +331,7 @@ export default function AppSettingsPanel({ data }: Props) {
             <div key={domain.id} className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-800/40 px-3 py-2">
               <code className="text-xs text-zinc-300">{domain.domain}</code>
               <button
+                type="button"
                 onClick={() => removeDomain(domain.id)}
                 className="text-xs text-zinc-500 hover:text-red-400"
               >
@@ -357,7 +377,7 @@ function Field({
 }) {
   return (
     <div>
-      <label className="block text-xs font-medium text-zinc-500 mb-1.5">{label}</label>
+      <div className="block text-xs font-medium text-zinc-500 mb-1.5">{label}</div>
       <code className="block rounded-lg border border-zinc-800 bg-zinc-800/40 px-3 py-2 text-xs text-zinc-300 break-all">
         {value}
       </code>

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -210,10 +210,11 @@ export default function AppWizard({ initialData }: Props) {
 
         {/* Application name */}
         <div>
-          <label className="block text-sm font-medium text-zinc-200 mb-1.5">
+          <label htmlFor="wizard-app-name" className="block text-sm font-medium text-zinc-200 mb-1.5">
             Application name <span className="text-red-400">*</span>
           </label>
           <input
+            id="wizard-app-name"
             type="text"
             value={formData.name}
             onChange={(e) => set("name", e.target.value)}
@@ -226,10 +227,11 @@ export default function AppWizard({ initialData }: Props) {
 
         {/* Developer / organization name */}
         <div>
-          <label className="block text-sm font-medium text-zinc-200 mb-1.5">
+          <label htmlFor="wizard-developer-name" className="block text-sm font-medium text-zinc-200 mb-1.5">
             Developer / organization name
           </label>
           <input
+            id="wizard-developer-name"
             type="text"
             value={formData.developerName}
             onChange={(e) => set("developerName", e.target.value)}
@@ -240,10 +242,11 @@ export default function AppWizard({ initialData }: Props) {
 
         {/* Homepage URL (optional) */}
         <div>
-          <label className="block text-sm font-medium text-zinc-200 mb-1.5">
+          <label htmlFor="wizard-homepage-url" className="block text-sm font-medium text-zinc-200 mb-1.5">
             Homepage URL <span className="text-zinc-500 font-normal">(optional)</span>
           </label>
           <input
+            id="wizard-homepage-url"
             type="url"
             value={formData.websiteUrl}
             onChange={(e) => set("websiteUrl", e.target.value)}
@@ -257,10 +260,11 @@ export default function AppWizard({ initialData }: Props) {
 
         {/* Description */}
         <div>
-          <label className="block text-sm font-medium text-zinc-200 mb-1.5">
+          <label htmlFor="wizard-description" className="block text-sm font-medium text-zinc-200 mb-1.5">
             Application description
           </label>
           <textarea
+            id="wizard-description"
             value={formData.description}
             onChange={(e) => set("description", e.target.value)}
             rows={3}
@@ -281,31 +285,35 @@ export default function AppWizard({ initialData }: Props) {
             </p>
           </div>
 
-          <label className="flex items-start gap-3 cursor-pointer">
+          <label
+            aria-label="Confidential client"
+            className="flex items-start gap-3 cursor-pointer"
+          >
             <input
               type="checkbox"
               checked={Boolean(formData.backendDeviceHelper)}
               onChange={(e) => toggleConfidential(e.target.checked)}
               className="w-4 h-4 mt-0.5 rounded border-zinc-600 bg-zinc-800 text-emerald-500 focus:ring-emerald-500/40 shrink-0"
             />
-            <div>
-              <p className="text-sm font-medium text-zinc-200">
+            <span>
+              <span className="block text-sm font-medium text-zinc-200">
                 Confidential client{" "}
                 <span className="text-[10px] font-normal text-zinc-500 uppercase tracking-wide">
                   (client credentials)
                 </span>
-              </p>
-              <p className="text-xs text-zinc-500 mt-1">
+              </span>
+              <span className="block text-xs text-zinc-500 mt-1">
                 Provisions a confidential{" "}
                 <code className="font-mono text-zinc-400">m2m_</code> client for
                 server-to-server Builder APIs. Your public client stays unauthenticated for SDK
                 / CLI device login.
-              </p>
-            </div>
+              </span>
+            </span>
           </label>
 
           <div>
             <label
+              aria-label="Enable Device Flow"
               className={`flex items-start gap-3 ${
                 formData.backendDeviceHelper ? "cursor-pointer" : "cursor-not-allowed opacity-60"
               }`}
@@ -317,9 +325,9 @@ export default function AppWizard({ initialData }: Props) {
                 disabled={!formData.backendDeviceHelper}
                 className="w-4 h-4 mt-0.5 rounded border-zinc-600 bg-zinc-800 text-emerald-500 focus:ring-emerald-500/40 shrink-0 disabled:opacity-50"
               />
-              <div>
-                <p className="text-sm font-medium text-zinc-200">Enable Device Flow</p>
-                <p className="text-xs text-zinc-500 mt-0.5">
+              <span>
+                <span className="block text-sm font-medium text-zinc-200">Enable Device Flow</span>
+                <span className="block text-xs text-zinc-500 mt-0.5">
                   Allow CLI tools, SDKs, and headless clients to authorize via a user code.{" "}
                   <a
                     href={docsDeviceFlowUrl()}
@@ -329,8 +337,8 @@ export default function AppWizard({ initialData }: Props) {
                   >
                     Device Flow documentation
                   </a>
-                </p>
-              </div>
+                </span>
+              </span>
             </label>
             {!formData.backendDeviceHelper && (
               <p className="text-xs text-zinc-600 mt-1.5 ml-[26px]">
@@ -340,17 +348,20 @@ export default function AppWizard({ initialData }: Props) {
           </div>
 
           {formData.backendDeviceHelper && (
-            <label className="flex items-start gap-3 cursor-pointer rounded-lg border border-zinc-700/70 bg-zinc-800/30 p-3">
+            <label
+              aria-label={USERS_TOKEN_SCOPE.label}
+              className="flex items-start gap-3 cursor-pointer rounded-lg border border-zinc-700/70 bg-zinc-800/30 p-3"
+            >
               <input
                 type="checkbox"
                 checked={hasIssueUserTokens}
                 onChange={toggleIssueUserTokens}
                 className="w-4 h-4 mt-0.5 rounded border-zinc-600 bg-zinc-800 text-emerald-500 focus:ring-emerald-500/40 shrink-0"
               />
-              <div>
-                <p className="text-sm font-medium text-zinc-200">{USERS_TOKEN_SCOPE.label}</p>
-                <p className="text-xs text-zinc-500 mt-0.5">{USERS_TOKEN_SCOPE.description}</p>
-              </div>
+              <span>
+                <span className="block text-sm font-medium text-zinc-200">{USERS_TOKEN_SCOPE.label}</span>
+                <span className="block text-xs text-zinc-500 mt-0.5">{USERS_TOKEN_SCOPE.description}</span>
+              </span>
             </label>
           )}
 

--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -650,7 +650,7 @@ function PlanDraftForm({
       </div>
 
       <div>
-        <label className="block text-xs text-zinc-500 mb-1">Type</label>
+        <div className="block text-xs text-zinc-500 mb-1">Type</div>
         <PlanTypePills
           value={draft.type}
           onChange={(type) =>
@@ -1124,12 +1124,12 @@ function NetworkPricePlanCard({
                   Unselect all
                 </button>
               </div>
-              <label className="block text-xs text-zinc-500">
+              <div className="block text-xs text-zinc-500">
                 Pipelines &amp; models discoverable to integrators
                 <span className="block text-zinc-600 mt-0.5">
                   Per-capability price limits coming soon.
                 </span>
-              </label>
+              </div>
               <PipelineModelPicker
                 catalog={catalog}
                 values={pickerValues}

--- a/src/components/apps/steps/AppInfoStep.tsx
+++ b/src/components/apps/steps/AppInfoStep.tsx
@@ -15,10 +15,11 @@ export default function AppInfoStep({ data, onChange, readOnly = false }: Props)
         <h2 className="text-lg font-semibold text-zinc-100 mb-1">App Info</h2>
       </div>
       <div>
-        <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+        <label htmlFor="app-info-name" className="block text-sm font-medium text-zinc-300 mb-1.5">
           App Name <span className="text-red-400">*</span>
         </label>
         <input
+          id="app-info-name"
           type="text"
           value={data.name}
           onChange={(e) => onChange({ name: e.target.value })}
@@ -29,13 +30,14 @@ export default function AppInfoStep({ data, onChange, readOnly = false }: Props)
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+        <label htmlFor="app-info-description" className="block text-sm font-medium text-zinc-300 mb-1.5">
           Description
         </label>
         <p className="text-xs text-zinc-500 mb-1.5">
           Short internal description of the provider app and what it exposes.
         </p>
         <textarea
+          id="app-info-description"
           value={data.description}
           onChange={(e) => onChange({ description: e.target.value })}
           rows={4}
@@ -47,10 +49,11 @@ export default function AppInfoStep({ data, onChange, readOnly = false }: Props)
 
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+          <label htmlFor="app-info-developer" className="block text-sm font-medium text-zinc-300 mb-1.5">
             Developer Name
           </label>
           <input
+            id="app-info-developer"
             type="text"
             value={data.developerName}
             onChange={(e) => onChange({ developerName: e.target.value })}
@@ -60,10 +63,11 @@ export default function AppInfoStep({ data, onChange, readOnly = false }: Props)
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+          <label htmlFor="app-info-website" className="block text-sm font-medium text-zinc-300 mb-1.5">
             Website URL
           </label>
           <input
+            id="app-info-website"
             type="url"
             value={data.websiteUrl}
             onChange={(e) => onChange({ websiteUrl: e.target.value })}

--- a/src/components/apps/steps/AuthorizationCodeRedirectBlock.tsx
+++ b/src/components/apps/steps/AuthorizationCodeRedirectBlock.tsx
@@ -182,7 +182,9 @@ export default function AuthorizationCodeRedirectBlock({
   return (
     <div className="space-y-5">
       <div className="space-y-2">
-        <label className="block text-sm font-medium text-zinc-300">Redirect URIs</label>
+        <label htmlFor="auth-code-new-redirect-uri" className="block text-sm font-medium text-zinc-300">
+          Redirect URIs
+        </label>
         <p className="text-xs text-zinc-500">
           URIs where PymtHouse can redirect after authorization. Wildcards (*) are supported.
           {appId
@@ -194,6 +196,7 @@ export default function AuthorizationCodeRedirectBlock({
         )}
         <div className="flex gap-2 mb-2">
           <input
+            id="auth-code-new-redirect-uri"
             type="text"
             value={newUri}
             onChange={(e) => setNewUri(e.target.value)}

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -1335,10 +1335,11 @@ function DeviceInitiateLoginUriField({
   return (
     <div className="border-t border-zinc-800 pt-5">
       <div className="space-y-2">
-        <label className="block text-sm font-medium text-zinc-300">
+        <label htmlFor="device-initiate-login-uri" className="block text-sm font-medium text-zinc-300">
           Third-party initiate login URI
         </label>
         <input
+          id="device-initiate-login-uri"
           type="url"
           value={initiateLoginUri}
           onChange={(e) => {
@@ -1751,9 +1752,9 @@ export default function TestingStep({
       {primaryIsConfidential ? (
         <>
           <div>
-            <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+            <div className="block text-sm font-medium text-zinc-300 mb-1.5">
               Client ID
-            </label>
+            </div>
             <div className="flex items-center gap-2">
               <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-emerald-400 text-sm font-mono">
                 {clientId || "Create app first"}
@@ -1771,9 +1772,9 @@ export default function TestingStep({
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+            <div className="block text-sm font-medium text-zinc-300 mb-1.5">
               Client Secret
-            </label>
+            </div>
             {secret ? (
               <div>
                 <div className="flex items-center gap-2 mb-2">
@@ -1817,9 +1818,9 @@ export default function TestingStep({
       ) : (
         <>
           <div>
-            <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+            <div className="block text-sm font-medium text-zinc-300 mb-1.5">
               Public / SDK client ID
-            </label>
+            </div>
             <p className="text-xs text-zinc-500 mb-2">
               Use this in SDKs, CLIs, and the device authorization flow. It stays public (no secret).
             </p>
@@ -1854,7 +1855,7 @@ export default function TestingStep({
             Use Basic auth with this client for Builder APIs and server-side device approval. Never embed in public apps.
           </p>
           <div>
-            <label className="block text-xs font-medium text-zinc-400 mb-1">Client ID</label>
+            <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
             <div className="flex items-center gap-2">
               <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-cyan-300 text-sm font-mono">
                 {backendHelper.clientId}
@@ -1869,7 +1870,7 @@ export default function TestingStep({
             </div>
           </div>
           <div>
-            <label className="block text-xs font-medium text-zinc-400 mb-1">Client Secret</label>
+            <div className="block text-xs font-medium text-zinc-400 mb-1">Client Secret</div>
             {backendSecret ? (
               <div>
                 <div className="flex items-center gap-2 mb-2">

--- a/src/components/oidc/branded-layout.tsx
+++ b/src/components/oidc/branded-layout.tsx
@@ -176,6 +176,7 @@ export function BrandedButton({
   variant = "primary",
   children,
   className = "",
+  type = "button",
   ...props
 }: BrandedButtonProps) {
   const baseClasses = "px-6 py-3 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
@@ -192,6 +193,7 @@ export function BrandedButton({
 
   return (
     <button
+      type={type}
       className={`${baseClasses} ${variantClasses[variant]} ${className}`}
       style={style}
       {...props}


### PR DESCRIPTION
## Summary
- Add explicit `type` on buttons (S9011)
- Associate form labels via `htmlFor`/`id`, or convert decorative labels to `<div>` (S6853)
- Covers AppWizard, AppSettingsPanel, TestingStep, PlansTab, marketplace, signer panels, oidc-clients, CreateEndUserForm

Part of Phase 5 Sonar cleanup.

## Test plan
- [ ] App wizard / settings forms still submit correctly
- [ ] Buttons that should not submit forms do not submit
- [ ] Label clicks still focus associated inputs
- [ ] CI tests pass
- [ ] Sonar S6853 / S9011 clear on the PR