### PR TITLE
refactor(api): reduce Sonar S3776 cognitive complexity

### DIFF
--- a/src/app/api/v1/apps/[id]/billing/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/route.ts
@@ -39,33 +39,102 @@ function buildBillingSubscriptionPayload(input: {
   return null;
 }
 
+async function resolveAppForBilling(
+  clientId: string,
+  request: NextRequest,
+): Promise<{ app: NonNullable<Awaited<ReturnType<typeof getProviderApp>>> } | { error: NextResponse }> {
+  const clientAuth = await authenticateAppClient(request);
+  if (clientAuth?.appId === clientId) {
+    const app = await getProviderApp(clientId);
+    if (!app) {
+      return { error: NextResponse.json({ error: "Not found" }, { status: 404 }) };
+    }
+    return { app };
+  }
+
+  let providerAuth: Awaited<ReturnType<typeof getAuthorizedProviderApp>> | null = null;
+  try {
+    providerAuth = await getAuthorizedProviderApp(clientId);
+  } catch (err) {
+    console.error("getAuthorizedProviderApp failed", err);
+    providerAuth = null;
+  }
+  if (!providerAuth?.app) {
+    return { error: NextResponse.json({ error: "Not found" }, { status: 404 }) };
+  }
+  return { app: providerAuth.app };
+}
+
+async function loadBillingPlanRow(
+  appId: string,
+  ownerSubscription: (typeof subscriptions.$inferSelect) | null,
+) {
+  if (ownerSubscription) {
+    const pr = await db
+      .select()
+      .from(plans)
+      .where(eq(plans.id, ownerSubscription.planId))
+      .limit(1);
+    if (pr[0]) {
+      return pr[0];
+    }
+  }
+  const fallbackPlans = await db
+    .select()
+    .from(plans)
+    .where(and(eq(plans.clientId, appId), eq(plans.status, "active")))
+    .orderBy(desc(plans.updatedAt))
+    .limit(1);
+  return fallbackPlans[0] ?? null;
+}
+
+function resolveBillingPeriod(
+  openMeterOwnerSubscription: Awaited<ReturnType<typeof verifyOpenMeterSubscriptionId>>,
+  ownerSubscription: (typeof subscriptions.$inferSelect) | null,
+): { periodStart: string; periodEnd: string } {
+  if (openMeterOwnerSubscription?.activeFrom && openMeterOwnerSubscription?.activeTo) {
+    return {
+      periodStart: openMeterOwnerSubscription.activeFrom,
+      periodEnd: openMeterOwnerSubscription.activeTo,
+    };
+  }
+  if (ownerSubscription?.currentPeriodStart && ownerSubscription?.currentPeriodEnd) {
+    return {
+      periodStart: ownerSubscription.currentPeriodStart,
+      periodEnd: ownerSubscription.currentPeriodEnd,
+    };
+  }
+  const cal = calendarMonthBoundsUtc(new Date());
+  return { periodStart: cal.start, periodEnd: cal.end };
+}
+
+function computeOverageUnits(
+  planType: string,
+  includedUnits: bigint | null | undefined,
+  totalUnits: bigint,
+): string {
+  if (
+    (planType === "subscription" || planType === "usage") &&
+    includedUnits != null
+  ) {
+    const included = BigInt(includedUnits);
+    if (totalUnits > included) {
+      return (totalUnits - included).toString();
+    }
+  }
+  return "0";
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id: clientId } = await params;
-  const clientAuth = await authenticateAppClient(request);
-
-  let app: Awaited<ReturnType<typeof getProviderApp>> | null = null;
-  if (clientAuth?.appId === clientId) {
-    app = await getProviderApp(clientId);
-  } else {
-    let providerAuth: Awaited<ReturnType<typeof getAuthorizedProviderApp>> | null = null;
-    try {
-      providerAuth = await getAuthorizedProviderApp(clientId);
-    } catch (err) {
-      console.error("getAuthorizedProviderApp failed", err);
-      providerAuth = null;
-    }
-    if (!providerAuth) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    }
-    app = providerAuth.app;
+  const resolved = await resolveAppForBilling(clientId, request);
+  if ("error" in resolved) {
+    return resolved.error;
   }
-
-  if (!app) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+  const { app } = resolved;
 
   if (!requireOpenMeterForUsageReads()) {
     return NextResponse.json(
@@ -95,25 +164,7 @@ export async function GET(
     .limit(1);
   const ownerSubscription = ownerSubRows[0] ?? null;
 
-  let planRow: typeof plans.$inferSelect | null = null;
-  if (ownerSubscription) {
-    const pr = await db
-      .select()
-      .from(plans)
-      .where(eq(plans.id, ownerSubscription.planId))
-      .limit(1);
-    planRow = pr[0] ?? null;
-  }
-
-  if (!planRow) {
-    const fallbackPlans = await db
-      .select()
-      .from(plans)
-      .where(and(eq(plans.clientId, app.id), eq(plans.status, "active")))
-      .orderBy(desc(plans.updatedAt))
-      .limit(1);
-    planRow = fallbackPlans[0] ?? null;
-  }
+  const planRow = await loadBillingPlanRow(app.id, ownerSubscription);
 
   let openMeterOwnerSubscription: Awaited<
     ReturnType<typeof verifyOpenMeterSubscriptionId>
@@ -128,22 +179,10 @@ export async function GET(
     );
   }
 
-  let periodStart: string;
-  let periodEnd: string;
-  if (openMeterOwnerSubscription?.activeFrom && openMeterOwnerSubscription?.activeTo) {
-    periodStart = openMeterOwnerSubscription.activeFrom;
-    periodEnd = openMeterOwnerSubscription.activeTo;
-  } else if (
-    ownerSubscription?.currentPeriodStart &&
-    ownerSubscription?.currentPeriodEnd
-  ) {
-    periodStart = ownerSubscription.currentPeriodStart;
-    periodEnd = ownerSubscription.currentPeriodEnd;
-  } else {
-    const cal = calendarMonthBoundsUtc(new Date());
-    periodStart = cal.start;
-    periodEnd = cal.end;
-  }
+  const { periodStart, periodEnd } = resolveBillingPeriod(
+    openMeterOwnerSubscription,
+    ownerSubscription,
+  );
 
   const [omRows, omDashboard] = await Promise.all([
     queryOpenMeterUsage({
@@ -185,17 +224,8 @@ export async function GET(
 
   const planType = planRow?.type ?? "free";
   const totalUnits = 0n;
-  let overageUnits = "0";
-  let overageWei = "0";
-  if (
-    (planType === "subscription" || planType === "usage") &&
-    planRow?.includedUnits != null
-  ) {
-    const included = BigInt(planRow.includedUnits);
-    if (totalUnits > included) {
-      overageUnits = (totalUnits - included).toString();
-    }
-  }
+  const overageUnits = computeOverageUnits(planType, planRow?.includedUnits, totalUnits);
+  const overageWei = "0";
 
   const includedUsdMicros = planRow?.includedUsdMicros
     ? BigInt(planRow.includedUsdMicros)

--- a/src/app/api/v1/apps/[id]/discovery-profiles/[profileId]/route.ts
+++ b/src/app/api/v1/apps/[id]/discovery-profiles/[profileId]/route.ts
@@ -69,6 +69,74 @@ async function resolveAppForDiscoveryProfilesRead(clientId: string, request: Nex
   return auth?.app ?? null;
 }
 
+function parsePutDiscoveryProfileBody(body: unknown): {
+  ok: true;
+  record: Record<string, unknown>;
+} | { ok: false; response: NextResponse } {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "invalid JSON" }, { status: 400 }),
+    };
+  }
+  return { ok: true, record: body as Record<string, unknown> };
+}
+
+async function applyDiscoveryProfileUpdates(input: {
+  appId: string;
+  profileId: string;
+  setFields: {
+    name: string;
+    updatedAt: string;
+    policy?: DiscoveryPolicy | null;
+  };
+  parsedCaps: ReturnType<typeof parseDiscoveryProfileCapabilities> | null;
+  now: string;
+}): Promise<NextResponse | null> {
+  const { appId, profileId, setFields, parsedCaps, now } = input;
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .update(discoveryProfiles)
+        .set(setFields)
+        .where(and(eq(discoveryProfiles.id, profileId), eq(discoveryProfiles.clientId, appId)));
+
+      if (!parsedCaps) {
+        return;
+      }
+      await tx
+        .delete(discoveryProfileBundles)
+        .where(
+          and(
+            eq(discoveryProfileBundles.profileId, profileId),
+            eq(discoveryProfileBundles.clientId, appId),
+          ),
+        );
+      for (const cap of parsedCaps.capabilities) {
+        await tx.insert(discoveryProfileBundles).values({
+          id: uuidv4(),
+          profileId,
+          clientId: appId,
+          pipeline: cap.pipeline,
+          modelId: cap.modelId,
+          discoveryPolicy: cap.discoveryPolicy,
+          createdAt: now,
+        });
+      }
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("idx_discovery_profiles_client_name") || msg.includes("unique")) {
+      return NextResponse.json(
+        { error: "A discovery profile with this name already exists" },
+        { status: 400 },
+      );
+    }
+    throw e;
+  }
+  return null;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; profileId: string }> },
@@ -135,10 +203,11 @@ export async function PUT(
   } catch {
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
-  if (body === null || typeof body !== "object" || Array.isArray(body)) {
-    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  const parsedBody = parsePutDiscoveryProfileBody(body);
+  if (!parsedBody.ok) {
+    return parsedBody.response;
   }
-  const record = body as Record<string, unknown>;
+  const { record } = parsedBody;
 
   const appId = auth.app.id;
   const existingRows = await db
@@ -181,41 +250,15 @@ export async function PUT(
     }
   }
 
-  try {
-    await db.transaction(async (tx) => {
-      await tx
-        .update(discoveryProfiles)
-        .set(setFields)
-        .where(and(eq(discoveryProfiles.id, profileId), eq(discoveryProfiles.clientId, appId)));
-
-      if (parsedCaps) {
-        await tx
-          .delete(discoveryProfileBundles)
-          .where(
-            and(
-              eq(discoveryProfileBundles.profileId, profileId),
-              eq(discoveryProfileBundles.clientId, appId),
-            ),
-          );
-        for (const cap of parsedCaps.capabilities) {
-          await tx.insert(discoveryProfileBundles).values({
-            id: uuidv4(),
-            profileId,
-            clientId: appId,
-            pipeline: cap.pipeline,
-            modelId: cap.modelId,
-            discoveryPolicy: cap.discoveryPolicy,
-            createdAt: now,
-          });
-        }
-      }
-    });
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (msg.includes("idx_discovery_profiles_client_name") || msg.includes("unique")) {
-      return NextResponse.json({ error: "A discovery profile with this name already exists" }, { status: 400 });
-    }
-    throw e;
+  const updateErr = await applyDiscoveryProfileUpdates({
+    appId,
+    profileId,
+    setFields,
+    parsedCaps,
+    now,
+  });
+  if (updateErr) {
+    return updateErr;
   }
 
   return NextResponse.json({ success: true });

--- a/src/app/api/v1/apps/[id]/plans/route.ts
+++ b/src/app/api/v1/apps/[id]/plans/route.ts
@@ -210,6 +210,400 @@ async function resolveAppForPlansRead(clientId: string, request: Request) {
   return auth?.app ?? null;
 }
 
+function reservedPlanNameError(name: string): string | null {
+  if (name === NETWORK_DEFAULT_PLAN_INTERNAL_NAME || name === NETWORK_DEFAULT_PLAN_DISPLAY_NAME) {
+    return "This plan name is reserved for the Network Price default plan";
+  }
+  if (name === STARTER_DEFAULT_PLAN_INTERNAL_NAME || name === STARTER_DEFAULT_PLAN_DISPLAY_NAME) {
+    return "This plan name is reserved for the Starter default plan";
+  }
+  return null;
+}
+
+function parseDiscoveryProfileIdField(
+  raw: unknown,
+): { ok: true; value: string | null } | { ok: false; error: string } {
+  if (raw === null || raw === "") {
+    return { ok: true, value: null };
+  }
+  if (typeof raw === "string" && raw.trim()) {
+    return { ok: true, value: raw.trim() };
+  }
+  return { ok: false, error: "discoveryProfileId must be a non-empty string or null" };
+}
+
+function parseIncludedUsdMicrosField(
+  raw: unknown,
+): { ok: true; value: string | null } | { ok: false; error: string } {
+  if (raw === undefined || raw === null) {
+    return { ok: true, value: null };
+  }
+  const s = coerceJsonScalarString(raw).trim();
+  if (s !== "" && !isNonNegativeIntegerString(s)) {
+    return { ok: false, error: "includedUsdMicros must be a non-negative integer string" };
+  }
+  return { ok: true, value: s || null };
+}
+
+function parseIncludedUsdMicrosPutField(
+  raw: unknown,
+): { ok: true; value: string | null | undefined } | { ok: false; error: string } {
+  if (raw === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (raw === null) {
+    return { ok: true, value: null };
+  }
+  const s = coerceJsonScalarString(raw).trim();
+  if (s !== "" && !isNonNegativeIntegerString(s)) {
+    return { ok: false, error: "includedUsdMicros must be a non-negative integer string" };
+  }
+  return { ok: true, value: s || null };
+}
+
+type ParsedCapability = ReturnType<typeof parseCapabilities>;
+
+async function validateCapabilitiesDiscoverable(
+  appId: string,
+  capabilities: ParsedCapability["capabilities"],
+): Promise<NextResponse | null> {
+  if (capabilities.length === 0) {
+    return null;
+  }
+  let catalogLite;
+  try {
+    const cat = await fetchPipelineCatalog();
+    catalogLite = cat.map((e) => ({ id: e.id, models: e.models }));
+  } catch {
+    return NextResponse.json(
+      { error: "Pipeline catalog unavailable; cannot validate capabilities" },
+      { status: 503 },
+    );
+  }
+  const discoverable = await loadDiscoverableSetForApp(appId, catalogLite, db);
+  const discCheck = assertCapabilityRowsDiscoverable(
+    catalogLite,
+    discoverable,
+    capabilities,
+  );
+  if (!discCheck.ok) {
+    return NextResponse.json(
+      {
+        error:
+          "One or more capabilities are not discoverable under Network Price exclusions. Un-exclude them there first.",
+        conflicts: discCheck.conflicts,
+      },
+      { status: 400 },
+    );
+  }
+  return null;
+}
+
+function tryParseCapabilities(
+  input: unknown,
+): { ok: true; parsed: ParsedCapability } | { ok: false; response: NextResponse } {
+  try {
+    const parsed = parseCapabilities(input);
+    if (parsed.error) {
+      return { ok: false, response: NextResponse.json({ error: parsed.error }, { status: 400 }) };
+    }
+    return { ok: true, parsed };
+  } catch (err) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: err instanceof Error ? err.message : "Invalid capabilities" },
+        { status: 400 },
+      ),
+    };
+  }
+}
+
+function isDiscoveryProfileError(e: unknown): e is Error {
+  return (
+    !!e &&
+    typeof e === "object" &&
+    "code" in e &&
+    (e as { code?: string }).code === "DISCOVERY_PROFILE" &&
+    e instanceof Error
+  );
+}
+
+async function insertPlanCapabilities(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  appId: string,
+  planId: string,
+  capabilities: ParsedCapability["capabilities"],
+  now: string,
+) {
+  for (const capability of capabilities) {
+    await tx.insert(planCapabilityBundles).values({
+      id: uuidv4(),
+      planId,
+      clientId: appId,
+      pipeline: capability.pipeline,
+      modelId: capability.modelId,
+      slaTargetP95Ms: null,
+      maxPricePerUnit: capability.maxPricePerUnit,
+      retailRateUsd: capability.retailRateUsd,
+      openmeterFeatureKey: resolveCapabilityFeatureKey({
+        clientId: appId,
+        planId,
+        pipeline: capability.pipeline,
+        modelId: capability.modelId,
+      }),
+      createdAt: now,
+    });
+  }
+}
+
+type PutTxnResult =
+  | { tag: "notfound" }
+  | { tag: "network_default" }
+  | { tag: "starter_default" }
+  | { tag: "validation"; error: string }
+  | { tag: "ok" };
+
+function buildPlanUpdateSet(input: {
+  existing: typeof plans.$inferSelect;
+  body: Record<string, unknown>;
+  putPlanName: string | undefined;
+  nextType: string;
+  overageRateUsd: string | null;
+  includedUsdMicrosPut: string | null | undefined;
+  discoveryProfileIdPut: string | null | undefined;
+  now: string;
+}) {
+  const {
+    existing,
+    body,
+    putPlanName,
+    nextType,
+    overageRateUsd,
+    includedUsdMicrosPut,
+    discoveryProfileIdPut,
+    now,
+  } = input;
+  return {
+    name: putPlanName ?? existing.name,
+    type: nextType,
+    priceAmount:
+      body.priceAmount === undefined
+        ? existing.priceAmount
+        : coerceJsonScalarString(body.priceAmount),
+    priceCurrency:
+      body.priceCurrency === undefined
+        ? existing.priceCurrency
+        : coerceJsonScalarString(body.priceCurrency),
+    status:
+      body.status === undefined ? existing.status : coerceJsonScalarString(body.status),
+    overageRateUsd,
+    ...(includedUsdMicrosPut !== undefined ? { includedUsdMicros: includedUsdMicrosPut } : {}),
+    ...(body.billingCycle === undefined
+      ? {}
+      : { billingCycle: coerceJsonScalarString(body.billingCycle) }),
+    ...(discoveryProfileIdPut !== undefined
+      ? { discoveryProfileId: discoveryProfileIdPut }
+      : {}),
+    updatedAt: now,
+  };
+}
+
+async function loadOwnedPlanForUpdate(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  appId: string,
+  planId: string,
+): Promise<PutTxnResult | { tag: "existing"; existing: typeof plans.$inferSelect }> {
+  const existingRows = await tx
+    .select()
+    .from(plans)
+    .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
+    .limit(1);
+  const existing = existingRows[0];
+  if (!existing) {
+    return { tag: "notfound" };
+  }
+  if (existing.isNetworkDefault) {
+    return { tag: "network_default" };
+  }
+  if (existing.isStarterDefault) {
+    return { tag: "starter_default" };
+  }
+  return { tag: "existing", existing };
+}
+
+async function runPutPlanTransaction(input: {
+  appId: string;
+  planId: string;
+  body: Record<string, unknown>;
+  putPlanName: string | undefined;
+  discoveryProfileIdPut: string | null | undefined;
+  parsedCapabilities: ParsedCapability | null;
+  now: string;
+}): Promise<PutTxnResult> {
+  const {
+    appId,
+    planId,
+    body,
+    putPlanName,
+    discoveryProfileIdPut,
+    parsedCapabilities,
+    now,
+  } = input;
+
+  return db.transaction(async (tx) => {
+    const loaded = await loadOwnedPlanForUpdate(tx, appId, planId);
+    if (loaded.tag !== "existing") {
+      return loaded;
+    }
+    const { existing } = loaded;
+
+    if (discoveryProfileIdPut !== undefined && discoveryProfileIdPut !== null) {
+      const profCheck = await requireOwnedDiscoveryProfile(appId, discoveryProfileIdPut, tx);
+      if (!profCheck.ok) {
+        return { tag: "validation" as const, error: profCheck.error };
+      }
+    }
+
+    const nextType =
+      body.type === undefined ? existing.type : coerceJsonScalarString(body.type);
+    const overageRate = resolveOverageRateUsdForPut(nextType, body, existing.overageRateUsd);
+    if (!overageRate.ok) {
+      return { tag: "validation" as const, error: overageRate.error };
+    }
+
+    const includedParsed = parseIncludedUsdMicrosPutField(body.includedUsdMicros);
+    if (!includedParsed.ok) {
+      return { tag: "validation" as const, error: includedParsed.error };
+    }
+
+    const updated = await tx
+      .update(plans)
+      .set(
+        buildPlanUpdateSet({
+          existing,
+          body,
+          putPlanName,
+          nextType,
+          overageRateUsd: overageRate.value,
+          includedUsdMicrosPut: includedParsed.value,
+          discoveryProfileIdPut,
+          now,
+        }),
+      )
+      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
+      .returning({ id: plans.id });
+
+    if (updated.length === 0) {
+      return { tag: "notfound" as const };
+    }
+
+    if (parsedCapabilities) {
+      await tx
+        .delete(planCapabilityBundles)
+        .where(
+          and(
+            eq(planCapabilityBundles.planId, planId),
+            eq(planCapabilityBundles.clientId, appId),
+          ),
+        );
+      await insertPlanCapabilities(tx, appId, planId, parsedCapabilities.capabilities, now);
+    }
+
+    return { tag: "ok" as const };
+  });
+}
+
+function putTxnErrorResponse(txnResult: PutTxnResult): NextResponse | null {
+  if (txnResult.tag === "notfound") {
+    return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+  }
+  if (txnResult.tag === "validation") {
+    return NextResponse.json({ error: txnResult.error }, { status: 400 });
+  }
+  if (txnResult.tag === "network_default") {
+    return NextResponse.json(
+      {
+        error:
+          "The Network Price default plan cannot be edited via this endpoint; update exclusions via PUT /manifest",
+      },
+      { status: 400 },
+    );
+  }
+  if (txnResult.tag === "starter_default") {
+    return NextResponse.json(
+      {
+        error:
+          "The Starter default plan cannot be edited via this endpoint; use PUT /starter-plan",
+      },
+      { status: 400 },
+    );
+  }
+  return null;
+}
+
+type DeleteTxnResult = false | true | "network_default" | "starter_default";
+
+async function runDeletePlanTransaction(
+  appId: string,
+  planId: string,
+): Promise<DeleteTxnResult> {
+  return db.transaction(async (tx) => {
+    const planRows = await tx
+      .select({
+        id: plans.id,
+        isNetworkDefault: plans.isNetworkDefault,
+        isStarterDefault: plans.isStarterDefault,
+      })
+      .from(plans)
+      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
+      .limit(1);
+
+    if (!planRows[0]) {
+      return false;
+    }
+    if (planRows[0].isNetworkDefault) {
+      return "network_default" as const;
+    }
+    if (planRows[0].isStarterDefault) {
+      return "starter_default" as const;
+    }
+
+    await tx
+      .delete(planCapabilityBundles)
+      .where(
+        and(
+          eq(planCapabilityBundles.planId, planId),
+          eq(planCapabilityBundles.clientId, appId),
+        ),
+      );
+    const removed = await tx
+      .delete(plans)
+      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
+      .returning({ id: plans.id });
+    return removed.length > 0;
+  });
+}
+
+function deleteTxnErrorResponse(deleted: DeleteTxnResult): NextResponse | null {
+  if (!deleted) {
+    return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+  }
+  if (deleted === "network_default") {
+    return NextResponse.json(
+      { error: "The Network Price default plan cannot be deleted" },
+      { status: 409 },
+    );
+  }
+  if (deleted === "starter_default") {
+    return NextResponse.json(
+      { error: "The Starter default plan cannot be deleted" },
+      { status: 409 },
+    );
+  }
+  return null;
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -280,17 +674,9 @@ export async function POST(
     return NextResponse.json({ error: nameCheck.error }, { status: 400 });
   }
   const name = nameCheck.value;
-  if (name === NETWORK_DEFAULT_PLAN_INTERNAL_NAME || name === NETWORK_DEFAULT_PLAN_DISPLAY_NAME) {
-    return NextResponse.json(
-      { error: "This plan name is reserved for the Network Price default plan" },
-      { status: 400 },
-    );
-  }
-  if (name === STARTER_DEFAULT_PLAN_INTERNAL_NAME || name === STARTER_DEFAULT_PLAN_DISPLAY_NAME) {
-    return NextResponse.json(
-      { error: "This plan name is reserved for the Starter default plan" },
-      { status: 400 },
-    );
+  const reservedErr = reservedPlanNameError(name);
+  if (reservedErr) {
+    return NextResponse.json({ error: reservedErr }, { status: 400 });
   }
   if ("is_network_default" in body || "is_starter_default" in body) {
     return NextResponse.json(
@@ -299,61 +685,27 @@ export async function POST(
     );
   }
 
-  let parsedCapabilities: ReturnType<typeof parseCapabilities>;
-  try {
-    parsedCapabilities = parseCapabilities(body.capabilities);
-  } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Invalid capabilities" },
-      { status: 400 },
-    );
+  const capsResult = tryParseCapabilities(body.capabilities);
+  if (!capsResult.ok) {
+    return capsResult.response;
   }
+  const parsedCapabilities = capsResult.parsed;
 
-  if (parsedCapabilities.error) {
-    return NextResponse.json({ error: parsedCapabilities.error }, { status: 400 });
-  }
-
-  if (parsedCapabilities.capabilities.length > 0) {
-    let catalogLite;
-    try {
-      const cat = await fetchPipelineCatalog();
-      catalogLite = cat.map((e) => ({ id: e.id, models: e.models }));
-    } catch {
-      return NextResponse.json(
-        { error: "Pipeline catalog unavailable; cannot validate capabilities" },
-        { status: 503 },
-      );
-    }
-    const discoverable = await loadDiscoverableSetForApp(appId, catalogLite, db);
-    const discCheck = assertCapabilityRowsDiscoverable(
-      catalogLite,
-      discoverable,
-      parsedCapabilities.capabilities,
-    );
-    if (!discCheck.ok) {
-      return NextResponse.json(
-        {
-          error:
-            "One or more capabilities are not discoverable under Network Price exclusions. Un-exclude them there first.",
-          conflicts: discCheck.conflicts,
-        },
-        { status: 400 },
-      );
-    }
+  const discErr = await validateCapabilitiesDiscoverable(
+    appId,
+    parsedCapabilities.capabilities,
+  );
+  if (discErr) {
+    return discErr;
   }
 
   let discoveryProfileId: string | null = null;
   if (body.discoveryProfileId !== undefined) {
-    if (body.discoveryProfileId === null || body.discoveryProfileId === "") {
-      discoveryProfileId = null;
-    } else if (typeof body.discoveryProfileId === "string" && body.discoveryProfileId.trim()) {
-      discoveryProfileId = body.discoveryProfileId.trim();
-    } else {
-      return NextResponse.json(
-        { error: "discoveryProfileId must be a non-empty string or null" },
-        { status: 400 },
-      );
+    const parsed = parseDiscoveryProfileIdField(body.discoveryProfileId);
+    if (!parsed.ok) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
+    discoveryProfileId = parsed.value;
   }
 
   const planType = coerceJsonScalarString(body.type, "free");
@@ -362,15 +714,11 @@ export async function POST(
     return NextResponse.json({ error: overageRate.error }, { status: 400 });
   }
 
-  const rawIncludedUsd = body.includedUsdMicros;
-  let includedUsdMicros: string | null = null;
-  if (rawIncludedUsd !== undefined && rawIncludedUsd !== null) {
-    const s = coerceJsonScalarString(rawIncludedUsd).trim();
-    if (s !== "" && !isNonNegativeIntegerString(s)) {
-      return NextResponse.json({ error: "includedUsdMicros must be a non-negative integer string" }, { status: 400 });
-    }
-    includedUsdMicros = s || null;
+  const includedParsed = parseIncludedUsdMicrosField(body.includedUsdMicros);
+  if (!includedParsed.ok) {
+    return NextResponse.json({ error: includedParsed.error }, { status: 400 });
   }
+  const includedUsdMicros = includedParsed.value;
 
   const planId = uuidv4();
   if (planType !== "free" && parsedCapabilities.capabilities.length > 0) {
@@ -408,35 +756,10 @@ export async function POST(
         createdAt: now,
         updatedAt: now,
       });
-
-      for (const capability of parsedCapabilities.capabilities) {
-        await tx.insert(planCapabilityBundles).values({
-          id: uuidv4(),
-          planId,
-          clientId: appId,
-          pipeline: capability.pipeline,
-          modelId: capability.modelId,
-          slaTargetP95Ms: null,
-          maxPricePerUnit: capability.maxPricePerUnit,
-          retailRateUsd: capability.retailRateUsd,
-          openmeterFeatureKey: resolveCapabilityFeatureKey({
-            clientId: appId,
-            planId,
-            pipeline: capability.pipeline,
-            modelId: capability.modelId,
-          }),
-          createdAt: now,
-        });
-      }
+      await insertPlanCapabilities(tx, appId, planId, parsedCapabilities.capabilities, now);
     });
   } catch (e: unknown) {
-    if (
-      e &&
-      typeof e === "object" &&
-      "code" in e &&
-      (e as { code?: string }).code === "DISCOVERY_PROFILE" &&
-      e instanceof Error
-    ) {
+    if (isDiscoveryProfileError(e)) {
       return NextResponse.json({ error: e.message }, { status: 400 });
     }
     throw e;
@@ -509,59 +832,29 @@ export async function PUT(
 
   let discoveryProfileIdPut: string | null | undefined = undefined;
   if (body.discoveryProfileId !== undefined) {
-    if (body.discoveryProfileId === null || body.discoveryProfileId === "") {
-      discoveryProfileIdPut = null;
-    } else if (typeof body.discoveryProfileId === "string" && body.discoveryProfileId.trim()) {
-      discoveryProfileIdPut = body.discoveryProfileId.trim();
-    } else {
-      return NextResponse.json(
-        { error: "discoveryProfileId must be a non-empty string or null" },
-        { status: 400 },
-      );
+    const parsed = parseDiscoveryProfileIdField(body.discoveryProfileId);
+    if (!parsed.ok) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
+    discoveryProfileIdPut = parsed.value;
   }
-  let parsedCapabilities: ReturnType<typeof parseCapabilities> | null = null;
-  if (body.capabilities !== undefined) {
-    try {
-      parsedCapabilities = parseCapabilities(body.capabilities);
-    } catch (err) {
-      return NextResponse.json(
-        { error: err instanceof Error ? err.message : "Invalid capabilities" },
-        { status: 400 },
-      );
-    }
 
-    if (parsedCapabilities.error) {
-      return NextResponse.json({ error: parsedCapabilities.error }, { status: 400 });
+  let parsedCapabilities: ParsedCapability | null = null;
+  if (body.capabilities !== undefined) {
+    const capsResult = tryParseCapabilities(body.capabilities);
+    if (!capsResult.ok) {
+      return capsResult.response;
     }
+    parsedCapabilities = capsResult.parsed;
   }
 
   if (parsedCapabilities && parsedCapabilities.capabilities.length > 0) {
-    let catalogLite;
-    try {
-      const cat = await fetchPipelineCatalog();
-      catalogLite = cat.map((e) => ({ id: e.id, models: e.models }));
-    } catch {
-      return NextResponse.json(
-        { error: "Pipeline catalog unavailable; cannot validate capabilities" },
-        { status: 503 },
-      );
-    }
-    const discoverable = await loadDiscoverableSetForApp(appId, catalogLite, db);
-    const discCheck = assertCapabilityRowsDiscoverable(
-      catalogLite,
-      discoverable,
+    const discErr = await validateCapabilitiesDiscoverable(
+      appId,
       parsedCapabilities.capabilities,
     );
-    if (!discCheck.ok) {
-      return NextResponse.json(
-        {
-          error:
-            "One or more capabilities are not discoverable under Network Price exclusions. Un-exclude them there first.",
-          conflicts: discCheck.conflicts,
-        },
-        { status: 400 },
-      );
+    if (discErr) {
+      return discErr;
     }
 
     const featureKeys = validateCapabilityFeatureKeys({
@@ -575,140 +868,19 @@ export async function PUT(
   }
 
   const now = new Date().toISOString();
-  const txnResult = await db.transaction(async (tx) => {
-    const existingRows = await tx
-      .select()
-      .from(plans)
-      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
-      .limit(1);
-    const existing = existingRows[0];
-    if (!existing) {
-      return { tag: "notfound" as const };
-    }
-
-    if (existing.isNetworkDefault) {
-      return { tag: "network_default" as const };
-    }
-    if (existing.isStarterDefault) {
-      return { tag: "starter_default" as const };
-    }
-
-    if (discoveryProfileIdPut !== undefined && discoveryProfileIdPut !== null) {
-      const profCheck = await requireOwnedDiscoveryProfile(appId, discoveryProfileIdPut, tx);
-      if (!profCheck.ok) {
-        return { tag: "validation" as const, error: profCheck.error };
-      }
-    }
-
-    const nextType =
-      body.type === undefined ? existing.type : coerceJsonScalarString(body.type);
-    const overageRate = resolveOverageRateUsdForPut(nextType, body, existing.overageRateUsd);
-    if (!overageRate.ok) {
-      return { tag: "validation" as const, error: overageRate.error };
-    }
-
-    const rawIncludedUsdPut = body.includedUsdMicros;
-    let includedUsdMicrosPut: string | null | undefined = undefined; // undefined = don't change
-    if (rawIncludedUsdPut !== undefined) {
-      if (rawIncludedUsdPut === null) {
-        includedUsdMicrosPut = null;
-      } else {
-        const s = coerceJsonScalarString(rawIncludedUsdPut).trim();
-        if (s !== "" && !isNonNegativeIntegerString(s)) {
-          return { tag: "validation" as const, error: "includedUsdMicros must be a non-negative integer string" };
-        }
-        includedUsdMicrosPut = s || null;
-      }
-    }
-
-    const updated = await tx
-      .update(plans)
-      .set({
-        name: putPlanName ?? existing.name,
-        type: nextType,
-        priceAmount:
-          body.priceAmount === undefined
-            ? existing.priceAmount
-            : coerceJsonScalarString(body.priceAmount),
-        priceCurrency:
-          body.priceCurrency === undefined
-            ? existing.priceCurrency
-            : coerceJsonScalarString(body.priceCurrency),
-        status:
-          body.status === undefined ? existing.status : coerceJsonScalarString(body.status),
-        overageRateUsd: overageRate.value,
-        ...(includedUsdMicrosPut !== undefined ? { includedUsdMicros: includedUsdMicrosPut } : {}),
-        ...(body.billingCycle === undefined
-          ? {}
-          : { billingCycle: coerceJsonScalarString(body.billingCycle) }),
-        ...(discoveryProfileIdPut !== undefined
-          ? { discoveryProfileId: discoveryProfileIdPut }
-          : {}),
-        updatedAt: now,
-      })
-      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
-      .returning({ id: plans.id });
-
-    if (updated.length === 0) {
-      return { tag: "notfound" as const };
-    }
-
-    if (parsedCapabilities) {
-      await tx
-        .delete(planCapabilityBundles)
-        .where(
-          and(
-            eq(planCapabilityBundles.planId, planId),
-            eq(planCapabilityBundles.clientId, appId),
-          ),
-        );
-      for (const capability of parsedCapabilities.capabilities) {
-        await tx.insert(planCapabilityBundles).values({
-          id: uuidv4(),
-          planId,
-          clientId: appId,
-          pipeline: capability.pipeline,
-          modelId: capability.modelId,
-          slaTargetP95Ms: null,
-          maxPricePerUnit: capability.maxPricePerUnit,
-          retailRateUsd: capability.retailRateUsd,
-          openmeterFeatureKey: resolveCapabilityFeatureKey({
-            clientId: appId,
-            planId,
-            pipeline: capability.pipeline,
-            modelId: capability.modelId,
-          }),
-          createdAt: now,
-        });
-      }
-    }
-
-    return { tag: "ok" as const };
+  const txnResult = await runPutPlanTransaction({
+    appId,
+    planId,
+    body,
+    putPlanName,
+    discoveryProfileIdPut,
+    parsedCapabilities,
+    now,
   });
 
-  if (txnResult.tag === "notfound") {
-    return NextResponse.json({ error: "Plan not found" }, { status: 404 });
-  }
-  if (txnResult.tag === "validation") {
-    return NextResponse.json({ error: txnResult.error }, { status: 400 });
-  }
-  if (txnResult.tag === "network_default") {
-    return NextResponse.json(
-      {
-        error:
-          "The Network Price default plan cannot be edited via this endpoint; update exclusions via PUT /manifest",
-      },
-      { status: 400 },
-    );
-  }
-  if (txnResult.tag === "starter_default") {
-    return NextResponse.json(
-      {
-        error:
-          "The Starter default plan cannot be edited via this endpoint; use PUT /starter-plan",
-      },
-      { status: 400 },
-    );
+  const txnErr = putTxnErrorResponse(txnResult);
+  if (txnErr) {
+    return txnErr;
   }
 
   const updatedStatus =
@@ -747,56 +919,10 @@ export async function DELETE(
     return NextResponse.json({ error: "planId is required" }, { status: 400 });
   }
 
-  const deleted = await db.transaction(async (tx) => {
-    const planRows = await tx
-      .select({
-        id: plans.id,
-        isNetworkDefault: plans.isNetworkDefault,
-        isStarterDefault: plans.isStarterDefault,
-      })
-      .from(plans)
-      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
-      .limit(1);
-
-    if (!planRows[0]) {
-      return false;
-    }
-    if (planRows[0].isNetworkDefault) {
-      return "network_default" as const;
-    }
-    if (planRows[0].isStarterDefault) {
-      return "starter_default" as const;
-    }
-
-    await tx
-      .delete(planCapabilityBundles)
-      .where(
-        and(
-          eq(planCapabilityBundles.planId, planId),
-          eq(planCapabilityBundles.clientId, appId),
-        ),
-      );
-    const removed = await tx
-      .delete(plans)
-      .where(and(eq(plans.id, planId), eq(plans.clientId, appId)))
-      .returning({ id: plans.id });
-    return removed.length > 0;
-  });
-
-  if (!deleted) {
-    return NextResponse.json({ error: "Plan not found" }, { status: 404 });
-  }
-  if (deleted === "network_default") {
-    return NextResponse.json(
-      { error: "The Network Price default plan cannot be deleted" },
-      { status: 409 },
-    );
-  }
-  if (deleted === "starter_default") {
-    return NextResponse.json(
-      { error: "The Starter default plan cannot be deleted" },
-      { status: 409 },
-    );
+  const deleted = await runDeletePlanTransaction(appId, planId);
+  const deleteErr = deleteTxnErrorResponse(deleted);
+  if (deleteErr) {
+    return deleteErr;
   }
 
   try {

--- a/src/app/api/v1/apps/[id]/route.ts
+++ b/src/app/api/v1/apps/[id]/route.ts
@@ -37,27 +37,273 @@ import {
 
 const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
+async function loadPublicOidcClientInfo(app: {
+  oidcClientId: string | null;
+  m2mOidcClientId: string | null;
+}) {
+  if (!app.oidcClientId) {
+    return null;
+  }
+  const clientRowsGet = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.id, app.oidcClientId))
+    .limit(1);
+  const client = clientRowsGet[0];
+  if (!client) {
+    return null;
+  }
+  return {
+    clientId: client.clientId,
+    redirectUris: JSON.parse(client.redirectUris) as string[],
+    allowedScopes: client.allowedScopes,
+    grantTypes: client.grantTypes,
+    tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
+    // Public app_ row must never report a secret when a confidential m2m_ sibling exists.
+    hasSecret: app.m2mOidcClientId
+      ? false
+      : client.tokenEndpointAuthMethod !== "none" &&
+        !!client.clientSecretHash,
+    postLogoutRedirectUris: client.postLogoutRedirectUris
+      ? (JSON.parse(client.postLogoutRedirectUris) as string[])
+      : [],
+    initiateLoginUri: client.initiateLoginUri,
+    deviceThirdPartyInitiateLogin: client.deviceThirdPartyInitiateLogin === 1,
+    logoUri: client.logoUri,
+    policyUri: client.policyUri,
+    tosUri: client.tosUri,
+    clientUri: client.clientUri,
+  };
+}
+
+async function loadM2mOidcClientSummaryForApp(m2mOidcClientId: string | null) {
+  if (!m2mOidcClientId) {
+    return null;
+  }
+  const m2mRows = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.id, m2mOidcClientId))
+    .limit(1);
+  const m2m = m2mRows[0];
+  if (!m2m) {
+    return null;
+  }
+  return {
+    clientId: m2m.clientId,
+    hasSecret: !!m2m.clientSecretHash,
+  };
+}
+
+async function getAppForClientAuth(clientId: string, request: NextRequest): Promise<
+  | { kind: "ok"; publicClientId: string; app: NonNullable<Awaited<ReturnType<typeof getProviderApp>>>; allowedScopes: string }
+  | { kind: "notfound" }
+  | null
+> {
+  const clientAuth = await authenticateAppClient(request);
+  if (clientAuth?.appId !== clientId) {
+    return null;
+  }
+  const app = await getProviderApp(clientId);
+  if (!app) {
+    return { kind: "notfound" };
+  }
+  let allowedScopes = DEFAULT_OIDC_SCOPES;
+  if (app.oidcClientId) {
+    const clientRows = await db
+      .select({ allowedScopes: oidcClients.allowedScopes })
+      .from(oidcClients)
+      .where(eq(oidcClients.id, app.oidcClientId))
+      .limit(1);
+    allowedScopes = clientRows[0]?.allowedScopes ?? DEFAULT_OIDC_SCOPES;
+  }
+  return { kind: "ok", publicClientId: clientAuth.appId, app, allowedScopes };
+}
+
+async function upsertBillingOracleConfig(
+  appId: string,
+  body: Record<string, unknown>,
+  now: string,
+): Promise<NextResponse | null> {
+  const hasBillingUpdate =
+    body.billingDisplayCurrency !== undefined ||
+    body.billingOracleProviderKey !== undefined ||
+    body.billingOracleProviderConfig !== undefined;
+  if (!hasBillingUpdate) {
+    return null;
+  }
+
+  const existingPricingRows = await db
+    .select()
+    .from(appBillingOracleConfig)
+    .where(eq(appBillingOracleConfig.clientId, appId))
+    .limit(1)
+    .catch(() => []);
+  const existingPricing = existingPricingRows[0] ?? null;
+  const nextCurrency =
+    body.billingDisplayCurrency !== undefined
+      ? String(body.billingDisplayCurrency || "USD").toUpperCase()
+      : (existingPricing?.billingDisplayCurrency ?? "USD");
+  if (nextCurrency !== "USD") {
+    return NextResponse.json(
+      { error: "billingDisplayCurrency must be USD" },
+      { status: 400 },
+    );
+  }
+  const nextProvider = resolveBillingOracleProviderKey(
+    body.billingOracleProviderKey !== undefined
+      ? String(body.billingOracleProviderKey)
+      : (existingPricing?.billingOracleProviderKey ?? "global_eth_usd"),
+  ).key;
+  const nextConfig =
+    body.billingOracleProviderConfig !== undefined
+      ? (body.billingOracleProviderConfig &&
+        typeof body.billingOracleProviderConfig === "object"
+          ? (body.billingOracleProviderConfig as Record<string, unknown>)
+          : null)
+      : (existingPricing?.billingOracleProviderConfig ?? null);
+  if (existingPricing) {
+    await db
+      .update(appBillingOracleConfig)
+      .set({
+        billingDisplayCurrency: nextCurrency,
+        billingOracleProviderKey: nextProvider,
+        billingOracleProviderConfig: nextConfig,
+        updatedAt: now,
+      })
+      .where(eq(appBillingOracleConfig.id, existingPricing.id));
+  } else {
+    await db.insert(appBillingOracleConfig).values({
+      id: uuidv4(),
+      clientId: appId,
+      billingDisplayCurrency: nextCurrency,
+      billingOracleProviderKey: nextProvider,
+      billingOracleProviderConfig: nextConfig,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+  return null;
+}
+
+function buildOidcClientUpdates(
+  body: Record<string, unknown>,
+  client: typeof oidcClients.$inferSelect,
+): Parameters<typeof updateClientConfig>[1] {
+  const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
+  if (body.name) clientUpdates.displayName = body.name as string;
+  if (body.redirectUris) clientUpdates.redirectUris = body.redirectUris as string[];
+  if (body.tokenEndpointAuthMethod) {
+    clientUpdates.tokenEndpointAuthMethod =
+      body.tokenEndpointAuthMethod as "none" | "client_secret_post" | "client_secret_basic";
+  }
+  if (body.allowedScopes) {
+    const validScopeValues = new Set(OIDC_SCOPES.map((s) => s.value));
+    const filtered = String(body.allowedScopes)
+      .split(/[,\s]+/)
+      .filter((s) => s && validScopeValues.has(s))
+      .join(" ");
+    clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
+  }
+  if (body.grantTypes) clientUpdates.grantTypes = body.grantTypes as string[];
+
+  // Resolve the final redirect URIs (updated or unchanged) and enforce the
+  // authorization_code ↔ redirect_uris invariant on every write.
+  const finalRedirectUris =
+    clientUpdates.redirectUris ??
+    (JSON.parse(client.redirectUris) as string[]);
+  const baseGrants =
+    clientUpdates.grantTypes ?? client.grantTypes.split(",").filter(Boolean);
+  clientUpdates.grantTypes = syncPublicClientGrantTypes(
+    baseGrants,
+    finalRedirectUris,
+    client.clientId,
+  );
+
+  const nextGrantTypes = clientUpdates.grantTypes;
+  const nextInitiateLoginUri = client.initiateLoginUri?.trim();
+  const nextDeviceThirdPartyInitiateLogin = client.deviceThirdPartyInitiateLogin === 1;
+  if (
+    nextDeviceThirdPartyInitiateLogin &&
+    nextInitiateLoginUri &&
+    nextGrantTypes.includes(DEVICE_CODE_GRANT)
+  ) {
+    const allowedScopes = (
+      clientUpdates.allowedScopes ?? client.allowedScopes
+    )
+      .split(/[,\s]+/)
+      .filter(Boolean);
+    if (!allowedScopes.includes("users:token")) {
+      clientUpdates.allowedScopes = [...allowedScopes, "users:token"].join(" ");
+    }
+  }
+  return clientUpdates;
+}
+
+async function applyPublicOidcClientUpdates(
+  app: { id: string; oidcClientId: string | null; m2mOidcClientId: string | null },
+  body: Record<string, unknown>,
+) {
+  if (!app.oidcClientId) {
+    return;
+  }
+  const clientRowsPut = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.id, app.oidcClientId))
+    .limit(1);
+  const client = clientRowsPut[0];
+  if (!client) {
+    return;
+  }
+
+  const clientUpdates = buildOidcClientUpdates(body, client);
+  if (Object.keys(clientUpdates).length > 0) {
+    await updateClientConfig(client.clientId, clientUpdates);
+    resetProvider();
+  }
+
+  if (app.m2mOidcClientId && (await demotePublicClientWhenM2mSiblingExists(app.id))) {
+    resetProvider();
+  }
+}
+
+async function applyBackendDeviceHelper(
+  app: { id: string; name: string },
+  body: Record<string, unknown>,
+) {
+  if (body.backendDeviceHelper === false) {
+    if (await removeM2mBackendClient(app.id)) {
+      resetProvider();
+    }
+    return;
+  }
+  if (body.backendDeviceHelper !== true) {
+    return;
+  }
+  await ensureM2mBackendClient({
+    appInternalId: app.id,
+    appDisplayName:
+      typeof body.name === "string" && body.name.trim()
+        ? body.name.trim()
+        : app.name,
+  });
+  if (await demotePublicClientWhenM2mSiblingExists(app.id)) {
+    resetProvider();
+  }
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: clientId } = await params;
-  const clientAuth = await authenticateAppClient(request);
-  if (clientAuth?.appId === clientId) {
-    const app = await getProviderApp(clientId);
-    if (!app) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    }
-    let allowedScopes = DEFAULT_OIDC_SCOPES;
-    if (app.oidcClientId) {
-      const clientRows = await db
-        .select({ allowedScopes: oidcClients.allowedScopes })
-        .from(oidcClients)
-        .where(eq(oidcClients.id, app.oidcClientId))
-        .limit(1);
-      allowedScopes = clientRows[0]?.allowedScopes ?? DEFAULT_OIDC_SCOPES;
-    }
-    const publicClientId = clientAuth.appId;
+  const clientAuthPayload = await getAppForClientAuth(clientId, request);
+  if (clientAuthPayload?.kind === "notfound") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (clientAuthPayload?.kind === "ok") {
+    const { publicClientId, app, allowedScopes } = clientAuthPayload;
     return NextResponse.json({
       clientId: publicClientId,
       name: app.name,
@@ -76,59 +322,8 @@ export async function GET(
   }
 
   const { app } = auth;
-
-  let clientInfo = null;
-  let m2mOidcClient: {
-    clientId: string;
-    hasSecret: boolean;
-  } | null = null;
-  if (app.oidcClientId) {
-    const clientRowsGet = await db
-      .select()
-      .from(oidcClients)
-      .where(eq(oidcClients.id, app.oidcClientId))
-      .limit(1);
-    const client = clientRowsGet[0];
-
-    if (client) {
-      clientInfo = {
-        clientId: client.clientId,
-        redirectUris: JSON.parse(client.redirectUris) as string[],
-        allowedScopes: client.allowedScopes,
-        grantTypes: client.grantTypes,
-        tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
-        // Public app_ row must never report a secret when a confidential m2m_ sibling exists.
-        hasSecret: app.m2mOidcClientId
-          ? false
-          : client.tokenEndpointAuthMethod !== "none" &&
-            !!client.clientSecretHash,
-        postLogoutRedirectUris: client.postLogoutRedirectUris
-          ? (JSON.parse(client.postLogoutRedirectUris) as string[])
-          : [],
-        initiateLoginUri: client.initiateLoginUri,
-        deviceThirdPartyInitiateLogin: client.deviceThirdPartyInitiateLogin === 1,
-        logoUri: client.logoUri,
-        policyUri: client.policyUri,
-        tosUri: client.tosUri,
-        clientUri: client.clientUri,
-      };
-    }
-  }
-
-  if (app.m2mOidcClientId) {
-    const m2mRows = await db
-      .select()
-      .from(oidcClients)
-      .where(eq(oidcClients.id, app.m2mOidcClientId))
-      .limit(1);
-    const m2m = m2mRows[0];
-    if (m2m) {
-      m2mOidcClient = {
-        clientId: m2m.clientId,
-        hasSecret: !!m2m.clientSecretHash,
-      };
-    }
-  }
+  const clientInfo = await loadPublicOidcClientInfo(app);
+  const m2mOidcClient = await loadM2mOidcClientSummaryForApp(app.m2mOidcClientId);
 
   const domains = await db
     .select()
@@ -209,146 +404,14 @@ export async function PUT(
 
   await db.update(developerApps).set(appUpdates).where(eq(developerApps.id, app.id));
 
-  if (
-    body.billingDisplayCurrency !== undefined ||
-    body.billingOracleProviderKey !== undefined ||
-    body.billingOracleProviderConfig !== undefined
-  ) {
-    const existingPricingRows = await db
-      .select()
-      .from(appBillingOracleConfig)
-      .where(eq(appBillingOracleConfig.clientId, app.id))
-      .limit(1)
-      .catch(() => []);
-    const existingPricing = existingPricingRows[0] ?? null;
-    const nextCurrency =
-      body.billingDisplayCurrency !== undefined
-        ? String(body.billingDisplayCurrency || "USD").toUpperCase()
-        : (existingPricing?.billingDisplayCurrency ?? "USD");
-    if (nextCurrency !== "USD") {
-      return NextResponse.json(
-        { error: "billingDisplayCurrency must be USD" },
-        { status: 400 },
-      );
-    }
-    const nextProvider = resolveBillingOracleProviderKey(
-      body.billingOracleProviderKey !== undefined
-        ? String(body.billingOracleProviderKey)
-        : (existingPricing?.billingOracleProviderKey ?? "global_eth_usd"),
-    ).key;
-    const nextConfig =
-      body.billingOracleProviderConfig !== undefined
-        ? (body.billingOracleProviderConfig &&
-          typeof body.billingOracleProviderConfig === "object"
-            ? body.billingOracleProviderConfig
-            : null)
-        : (existingPricing?.billingOracleProviderConfig ?? null);
-    if (existingPricing) {
-      await db
-        .update(appBillingOracleConfig)
-        .set({
-          billingDisplayCurrency: nextCurrency,
-          billingOracleProviderKey: nextProvider,
-          billingOracleProviderConfig: nextConfig,
-          updatedAt: now,
-        })
-        .where(eq(appBillingOracleConfig.id, existingPricing.id));
-    } else {
-      await db.insert(appBillingOracleConfig).values({
-        id: uuidv4(),
-        clientId: app.id,
-        billingDisplayCurrency: nextCurrency,
-        billingOracleProviderKey: nextProvider,
-        billingOracleProviderConfig: nextConfig,
-        createdAt: now,
-        updatedAt: now,
-      });
-    }
+  const billingErr = await upsertBillingOracleConfig(app.id, body, now);
+  if (billingErr) {
+    return billingErr;
   }
 
   // Provider apps are self-service in the MVP, so OIDC config updates apply immediately.
-  if (app.oidcClientId) {
-    const clientRowsPut = await db
-      .select()
-      .from(oidcClients)
-      .where(eq(oidcClients.id, app.oidcClientId))
-      .limit(1);
-    const client = clientRowsPut[0];
-
-    if (client) {
-      const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
-      if (body.name) clientUpdates.displayName = body.name;
-      if (body.redirectUris) clientUpdates.redirectUris = body.redirectUris;
-      if (body.tokenEndpointAuthMethod)
-        clientUpdates.tokenEndpointAuthMethod = body.tokenEndpointAuthMethod;
-      if (body.allowedScopes) {
-        const validScopeValues = new Set(OIDC_SCOPES.map((s) => s.value));
-        const filtered = String(body.allowedScopes)
-          .split(/[,\s]+/)
-          .filter((s) => s && validScopeValues.has(s))
-          .join(" ");
-        clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
-      }
-      if (body.grantTypes) clientUpdates.grantTypes = body.grantTypes;
-
-      // Resolve the final redirect URIs (updated or unchanged) and enforce the
-      // authorization_code ↔ redirect_uris invariant on every write.
-      const finalRedirectUris =
-        clientUpdates.redirectUris ??
-        (JSON.parse(client.redirectUris) as string[]);
-      const baseGrants =
-        clientUpdates.grantTypes ?? client.grantTypes.split(",").filter(Boolean);
-      clientUpdates.grantTypes = syncPublicClientGrantTypes(
-        baseGrants,
-        finalRedirectUris,
-        client.clientId,
-      );
-
-      const nextGrantTypes = clientUpdates.grantTypes;
-      const nextInitiateLoginUri = client.initiateLoginUri?.trim();
-      const nextDeviceThirdPartyInitiateLogin = client.deviceThirdPartyInitiateLogin === 1;
-      if (
-        nextDeviceThirdPartyInitiateLogin &&
-        nextInitiateLoginUri &&
-        nextGrantTypes.includes(DEVICE_CODE_GRANT)
-      ) {
-        const allowedScopes = (
-          clientUpdates.allowedScopes ?? client.allowedScopes
-        )
-          .split(/[,\s]+/)
-          .filter(Boolean);
-        if (!allowedScopes.includes("users:token")) {
-          clientUpdates.allowedScopes = [...allowedScopes, "users:token"].join(" ");
-        }
-      }
-
-      if (Object.keys(clientUpdates).length > 0) {
-        await updateClientConfig(client.clientId, clientUpdates);
-        resetProvider();
-      }
-
-      if (app.m2mOidcClientId && (await demotePublicClientWhenM2mSiblingExists(app.id))) {
-        resetProvider();
-      }
-    }
-  }
-
-  if (body.backendDeviceHelper === false) {
-    if (await removeM2mBackendClient(app.id)) {
-      resetProvider();
-    }
-  } else if (body.backendDeviceHelper === true) {
-    await ensureM2mBackendClient({
-      appInternalId: app.id,
-      appDisplayName:
-        typeof body.name === "string" && body.name.trim()
-          ? body.name.trim()
-          : app.name,
-    });
-    if (await demotePublicClientWhenM2mSiblingExists(app.id)) {
-      resetProvider();
-    }
-  }
+  await applyPublicOidcClientUpdates(app, body);
+  await applyBackendDeviceHelper(app, body);
 
   if (await syncBackendM2mAllowedScopesFromPublicApp(app.id)) {
     resetProvider();

--- a/src/app/api/v1/apps/[id]/settings/route.ts
+++ b/src/app/api/v1/apps/[id]/settings/route.ts
@@ -28,6 +28,131 @@ function extractOrigins(uris: string[]): string[] {
   return Array.from(origins);
 }
 
+function buildSettingsClientUpdates(
+  body: Record<string, unknown>,
+  client: typeof oidcClients.$inferSelect,
+  app: {
+    logoLightUrl: string | null;
+    websiteUrl: string | null;
+    privacyPolicyUrl: string | null;
+    tosUrl: string | null;
+  },
+): Parameters<typeof updateClientConfig>[1] {
+  const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
+
+  if (Array.isArray(body.redirectUris)) {
+    clientUpdates.redirectUris = body.redirectUris as string[];
+  }
+  if (Array.isArray(body.postLogoutRedirectUris)) {
+    clientUpdates.postLogoutRedirectUris = body.postLogoutRedirectUris as string[];
+  }
+  if (body.initiateLoginUri !== undefined) {
+    clientUpdates.initiateLoginUri = (body.initiateLoginUri as string) || null;
+  }
+  if (body.deviceThirdPartyInitiateLogin !== undefined) {
+    clientUpdates.deviceThirdPartyInitiateLogin = Boolean(
+      body.deviceThirdPartyInitiateLogin,
+    );
+  }
+  if (body.tokenEndpointAuthMethod !== undefined) {
+    clientUpdates.tokenEndpointAuthMethod =
+      body.tokenEndpointAuthMethod as "none" | "client_secret_post" | "client_secret_basic";
+  }
+
+  // Auto-sync branding from developerApps
+  clientUpdates.logoUri = app.logoLightUrl || null;
+  clientUpdates.clientUri = app.websiteUrl || null;
+  clientUpdates.policyUri = app.privacyPolicyUrl || null;
+  clientUpdates.tosUri = app.tosUrl || null;
+
+  const nextInitiateLoginUri =
+    body.initiateLoginUri !== undefined
+      ? ((body.initiateLoginUri as string) || null)
+      : client.initiateLoginUri;
+  const nextDeviceThirdParty =
+    body.deviceThirdPartyInitiateLogin !== undefined
+      ? Boolean(body.deviceThirdPartyInitiateLogin)
+      : client.deviceThirdPartyInitiateLogin === 1;
+
+  if (nextDeviceThirdParty && nextInitiateLoginUri?.trim()) {
+    const grantTypes = client.grantTypes.split(",").filter(Boolean);
+    if (grantTypes.includes(DEVICE_CODE_GRANT)) {
+      const allowedScopes = client.allowedScopes.split(/[,\s]+/).filter(Boolean);
+      if (!allowedScopes.includes("users:token")) {
+        clientUpdates.allowedScopes = [...allowedScopes, "users:token"].join(" ");
+      }
+    }
+  }
+
+  return clientUpdates;
+}
+
+function validateDeviceThirdPartySettings(
+  body: Record<string, unknown>,
+  client: typeof oidcClients.$inferSelect,
+): NextResponse | null {
+  let nextInitiateLoginUri = client.initiateLoginUri;
+  if (body.initiateLoginUri !== undefined) {
+    nextInitiateLoginUri = (body.initiateLoginUri as string) || null;
+  }
+  let nextDeviceThirdParty = client.deviceThirdPartyInitiateLogin === 1;
+  if (body.deviceThirdPartyInitiateLogin !== undefined) {
+    nextDeviceThirdParty = Boolean(body.deviceThirdPartyInitiateLogin);
+  }
+  if (!nextDeviceThirdParty) {
+    return null;
+  }
+  const uri = nextInitiateLoginUri?.trim();
+  if (!uri) {
+    return NextResponse.json(
+      {
+        error: "invalid_request",
+        error_description:
+          "Initiate login URI is required when device third-party login is enabled",
+      },
+      { status: 400 },
+    );
+  }
+  try {
+    validateInitiateLoginUri(uri);
+  } catch {
+    return NextResponse.json(
+      {
+        error: "invalid_request",
+        error_description:
+          "Initiate login URI must be a valid HTTPS URL (HTTP on localhost allowed in development)",
+      },
+      { status: 400 },
+    );
+  }
+  return null;
+}
+
+async function syncDomainWhitelistFromRedirects(
+  appId: string,
+  allRedirects: string[],
+) {
+  const origins = extractOrigins(allRedirects);
+  const existingDomains = await db
+    .select()
+    .from(appAllowedDomains)
+    .where(eq(appAllowedDomains.appId, appId));
+  const existingSet = new Set(existingDomains.map((d) => d.domain.toLowerCase()));
+
+  for (const origin of origins) {
+    const result = normalizeDomainWhitelist(origin);
+    if (!result.success) continue;
+    const normalized = result.normalized.toLowerCase();
+    if (existingSet.has(normalized)) continue;
+    await db.insert(appAllowedDomains).values({
+      id: uuidv4(),
+      appId,
+      domain: result.normalized,
+    });
+    existingSet.add(normalized);
+  }
+}
+
 export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -66,79 +191,12 @@ export async function PUT(
 
   const body = await request.json();
 
-  // Build update payload from allowed fields
-  const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
-
-  if (Array.isArray(body.redirectUris)) {
-    clientUpdates.redirectUris = body.redirectUris;
-  }
-  if (Array.isArray(body.postLogoutRedirectUris)) {
-    clientUpdates.postLogoutRedirectUris = body.postLogoutRedirectUris;
-  }
-  if (body.initiateLoginUri !== undefined) {
-    clientUpdates.initiateLoginUri = body.initiateLoginUri || null;
-  }
-  if (body.deviceThirdPartyInitiateLogin !== undefined) {
-    clientUpdates.deviceThirdPartyInitiateLogin = Boolean(
-      body.deviceThirdPartyInitiateLogin,
-    );
-  }
-  if (body.tokenEndpointAuthMethod !== undefined) {
-    clientUpdates.tokenEndpointAuthMethod = body.tokenEndpointAuthMethod;
+  const validationErr = validateDeviceThirdPartySettings(body, client);
+  if (validationErr) {
+    return validationErr;
   }
 
-  let nextInitiateLoginUri = client.initiateLoginUri;
-  if (body.initiateLoginUri !== undefined) {
-    nextInitiateLoginUri = body.initiateLoginUri || null;
-  }
-  let nextDeviceThirdParty =
-    client.deviceThirdPartyInitiateLogin === 1;
-  if (body.deviceThirdPartyInitiateLogin !== undefined) {
-    nextDeviceThirdParty = Boolean(body.deviceThirdPartyInitiateLogin);
-  }
-  if (nextDeviceThirdParty) {
-    const uri = nextInitiateLoginUri?.trim();
-    if (!uri) {
-      return NextResponse.json(
-        {
-          error: "invalid_request",
-          error_description:
-            "Initiate login URI is required when device third-party login is enabled",
-        },
-        { status: 400 },
-      );
-    }
-    try {
-      validateInitiateLoginUri(uri);
-    } catch {
-      return NextResponse.json(
-        {
-          error: "invalid_request",
-          error_description:
-            "Initiate login URI must be a valid HTTPS URL (HTTP on localhost allowed in development)",
-        },
-        { status: 400 },
-      );
-    }
-  }
-
-  if (nextDeviceThirdParty && nextInitiateLoginUri?.trim()) {
-    const grantTypes = client.grantTypes.split(",").filter(Boolean);
-    const hasDeviceCode = grantTypes.includes(DEVICE_CODE_GRANT);
-    if (hasDeviceCode) {
-      const allowedScopes = client.allowedScopes.split(/[,\s]+/).filter(Boolean);
-      if (!allowedScopes.includes("users:token")) {
-        clientUpdates.allowedScopes = [...allowedScopes, "users:token"].join(" ");
-      }
-    }
-  }
-
-  // Auto-sync branding from developerApps
-  clientUpdates.logoUri = app.logoLightUrl || null;
-  clientUpdates.clientUri = app.websiteUrl || null;
-  clientUpdates.policyUri = app.privacyPolicyUrl || null;
-  clientUpdates.tosUri = app.tosUrl || null;
-
+  const clientUpdates = buildSettingsClientUpdates(body, client, app);
   await updateClientConfig(client.clientId, clientUpdates);
 
   // Auto-populate domain whitelist from redirect URI origins
@@ -146,27 +204,7 @@ export async function PUT(
     ...(clientUpdates.redirectUris ?? JSON.parse(client.redirectUris) as string[]),
     ...(clientUpdates.postLogoutRedirectUris ?? []),
   ];
-  const origins = extractOrigins(allRedirects);
-
-  const existingDomains = await db
-    .select()
-    .from(appAllowedDomains)
-    .where(eq(appAllowedDomains.appId, app.id));
-  const existingSet = new Set(existingDomains.map((d) => d.domain.toLowerCase()));
-
-  for (const origin of origins) {
-    const result = normalizeDomainWhitelist(origin);
-    if (!result.success) continue;
-    const normalized = result.normalized.toLowerCase();
-    if (!existingSet.has(normalized)) {
-      await db.insert(appAllowedDomains).values({
-        id: uuidv4(),
-        appId: app.id,
-        domain: result.normalized,
-      });
-      existingSet.add(normalized);
-    }
-  }
+  await syncDomainWhitelistFromRedirects(app.id, allRedirects);
 
   // Reset provider so in-memory client cache picks up changes
   resetProvider();

--- a/src/app/api/v1/apps/route.ts
+++ b/src/app/api/v1/apps/route.ts
@@ -22,6 +22,89 @@ import { listAllAppsForAdmin, sortAppsByPriority } from "@/lib/user-apps";
 
 const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 const ADMIN_ROLES = new Set(["admin", "operator"]);
+const TOKEN_AUTH_METHODS = new Set([
+  "none",
+  "client_secret_post",
+  "client_secret_basic",
+]);
+
+function buildCreateAppClientUpdates(
+  body: Record<string, unknown>,
+  clientId: string,
+): Parameters<typeof updateClientConfig>[1] {
+  const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
+  const rawRedirectUris = body.redirectUris;
+  if (Array.isArray(rawRedirectUris) && rawRedirectUris.length > 0) {
+    const redirectUris = rawRedirectUris.filter(
+      (u: unknown): u is string => typeof u === "string" && u.trim().length > 0,
+    );
+    if (redirectUris.length > 0) {
+      clientUpdates.redirectUris = redirectUris.map((u) => u.trim());
+    }
+  }
+  if (
+    typeof body.tokenEndpointAuthMethod === "string" &&
+    TOKEN_AUTH_METHODS.has(body.tokenEndpointAuthMethod)
+  ) {
+    clientUpdates.tokenEndpointAuthMethod =
+      body.tokenEndpointAuthMethod as "none" | "client_secret_post" | "client_secret_basic";
+  }
+  if (typeof body.allowedScopes === "string" && body.allowedScopes.trim()) {
+    const validScopeValues = new Set(OIDC_SCOPES.map((s) => s.value));
+    const filtered = body.allowedScopes
+      .split(/[,\s]+/)
+      .filter((s: string) => s && validScopeValues.has(s))
+      .join(" ");
+    clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
+  }
+  // Resolve final redirect URIs early so we can sync authorization_code grant.
+  const finalRedirectUris = clientUpdates.redirectUris ?? [];
+
+  if (Array.isArray(body.grantTypes) && body.grantTypes.length > 0) {
+    const grantTypes = body.grantTypes.filter(
+      (v: unknown): v is string => typeof v === "string" && v.trim().length > 0,
+    );
+    if (grantTypes.length > 0) {
+      clientUpdates.grantTypes = syncPublicClientGrantTypes(grantTypes, finalRedirectUris, clientId);
+    }
+  }
+
+  // Always ensure the grant list is consistent with redirect URIs.
+  if (clientUpdates.grantTypes) {
+    clientUpdates.grantTypes = syncPublicClientGrantTypes(
+      clientUpdates.grantTypes,
+      finalRedirectUris,
+      clientId,
+    );
+  }
+
+  if (
+    body.deviceThirdPartyInitiateLogin === true &&
+    typeof body.initiateLoginUri === "string" &&
+    body.initiateLoginUri.trim() &&
+    (clientUpdates.grantTypes ?? ["refresh_token"]).includes(DEVICE_CODE_GRANT)
+  ) {
+    const allowedScopes = (clientUpdates.allowedScopes ?? DEFAULT_OIDC_SCOPES)
+      .split(/[,\s]+/)
+      .filter(Boolean);
+    if (!allowedScopes.includes("users:token")) {
+      clientUpdates.allowedScopes = [...allowedScopes, "users:token"].join(" ");
+    }
+  }
+  return clientUpdates;
+}
+
+async function syncStarterPlanToOpenMeterIfAvailable(appId: string) {
+  if (!isHostedAdminClientAvailable()) {
+    return;
+  }
+  try {
+    const starter = await getOrCreateStarterPlan(appId);
+    await syncPlanToOpenMeter(starter.id);
+  } catch (err) {
+    console.error("Starter plan OpenMeter sync failed for new app:", err);
+  }
+}
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -133,64 +216,7 @@ export async function POST(request: NextRequest) {
 
   const { id: oidcRowId, clientId } = await createAppClient(name.trim());
 
-  const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
-  const rawRedirectUris = body.redirectUris;
-  if (Array.isArray(rawRedirectUris) && rawRedirectUris.length > 0) {
-    const redirectUris = rawRedirectUris.filter(
-      (u: unknown): u is string => typeof u === "string" && u.trim().length > 0,
-    );
-    if (redirectUris.length > 0) {
-      clientUpdates.redirectUris = redirectUris.map((u) => u.trim());
-    }
-  }
-  if (
-    typeof body.tokenEndpointAuthMethod === "string" &&
-    ["none", "client_secret_post", "client_secret_basic"].includes(body.tokenEndpointAuthMethod)
-  ) {
-    clientUpdates.tokenEndpointAuthMethod = body.tokenEndpointAuthMethod;
-  }
-  if (typeof body.allowedScopes === "string" && body.allowedScopes.trim()) {
-    const validScopeValues = new Set(OIDC_SCOPES.map((s) => s.value));
-    const filtered = body.allowedScopes
-      .split(/[,\s]+/)
-      .filter((s: string) => s && validScopeValues.has(s))
-      .join(" ");
-    clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
-  }
-  // Resolve final redirect URIs early so we can sync authorization_code grant.
-  const finalRedirectUris = clientUpdates.redirectUris ?? [];
-
-  if (Array.isArray(body.grantTypes) && body.grantTypes.length > 0) {
-    const grantTypes = body.grantTypes.filter(
-      (v: unknown): v is string => typeof v === "string" && v.trim().length > 0,
-    );
-    if (grantTypes.length > 0) {
-      clientUpdates.grantTypes = syncPublicClientGrantTypes(grantTypes, finalRedirectUris, clientId);
-    }
-  }
-
-  // Always ensure the grant list is consistent with redirect URIs.
-  if (clientUpdates.grantTypes) {
-    clientUpdates.grantTypes = syncPublicClientGrantTypes(
-      clientUpdates.grantTypes,
-      finalRedirectUris,
-      clientId,
-    );
-  }
-
-  if (
-    body.deviceThirdPartyInitiateLogin === true &&
-    typeof body.initiateLoginUri === "string" &&
-    body.initiateLoginUri.trim() &&
-    (clientUpdates.grantTypes ?? ["refresh_token"]).includes(DEVICE_CODE_GRANT)
-  ) {
-    const allowedScopes = (clientUpdates.allowedScopes ?? DEFAULT_OIDC_SCOPES)
-      .split(/[,\s]+/)
-      .filter(Boolean);
-    if (!allowedScopes.includes("users:token")) {
-      clientUpdates.allowedScopes = [...allowedScopes, "users:token"].join(" ");
-    }
-  }
+  const clientUpdates = buildCreateAppClientUpdates(body, clientId);
   if (Object.keys(clientUpdates).length > 0) {
     await updateClientConfig(clientId, clientUpdates);
   }
@@ -231,14 +257,7 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  if (isHostedAdminClientAvailable()) {
-    try {
-      const starter = await getOrCreateStarterPlan(appId);
-      await syncPlanToOpenMeter(starter.id);
-    } catch (err) {
-      console.error("Starter plan OpenMeter sync failed for new app:", err);
-    }
-  }
+  await syncStarterPlanToOpenMeterIfAvailable(appId);
 
   resetProvider();
   await ensureProviderAdminMembership(userId, appId);

--- a/src/app/api/v1/oidc/[...oidc]/route.ts
+++ b/src/app/api/v1/oidc/[...oidc]/route.ts
@@ -50,6 +50,7 @@ const RESOURCE_REQUIRED_GRANTS = new Set([
 ]);
 
 const DEBUG_OIDC_LOGS = process.env.OIDC_DEBUG_LOGS === "1";
+const NO_STORE_HEADERS = { "Cache-Control": "no-store", Pragma: "no-cache" } as const;
 
 function requestedScopesFromParams(params: URLSearchParams): string[] {
   return (params.get("scope") || "")
@@ -72,6 +73,422 @@ function mintSignerTokenErrorResponse(err: unknown): NextResponse | null {
     );
   }
   return null;
+}
+
+function jsonNoStore(body: unknown, extraHeaders?: Record<string, string>): NextResponse {
+  return NextResponse.json(body, {
+    headers: { ...NO_STORE_HEADERS, ...extraHeaders },
+  });
+}
+
+async function handleMintSignerTokenGrant(
+  request: NextRequest,
+  exchangeParams: URLSearchParams,
+): Promise<NextResponse | null> {
+  if (!isMintUserSignerTokenRequest(exchangeParams)) {
+    return null;
+  }
+  const { clientId, clientSecret } = clientCredentialsFromTokenRequest(
+    request,
+    exchangeParams,
+  );
+  try {
+    assertSignJobNotMixedWithAdmin(requestedScopesFromParams(exchangeParams));
+    const result = await handleMintUserSignerToken({
+      clientId,
+      clientSecret,
+      externalUserId: exchangeParams.get("external_user_id") || "",
+      scope: exchangeParams.get("scope"),
+    });
+    return jsonNoStore(result);
+  } catch (err) {
+    const response = mintSignerTokenErrorResponse(err);
+    if (response) {
+      return response;
+    }
+    console.error("[OIDC] mint user signer token error:", err);
+    return NextResponse.json(
+      { error: "server_error", error_description: "Internal error during token mint" },
+      { status: 500 },
+    );
+  }
+}
+
+async function handleM2mOwnerSignJobGrant(
+  request: NextRequest,
+  exchangeParams: URLSearchParams,
+): Promise<NextResponse | null> {
+  if (!isM2mOwnerSignJobRequest(exchangeParams)) {
+    return null;
+  }
+  const { clientId, clientSecret } = clientCredentialsFromTokenRequest(
+    request,
+    exchangeParams,
+  );
+  try {
+    assertSignJobNotMixedWithAdmin(requestedScopesFromParams(exchangeParams));
+    const result = await handleM2mOwnerSignJob({
+      clientId,
+      clientSecret,
+    });
+    return jsonNoStore(result);
+  } catch (err) {
+    const response = mintSignerTokenErrorResponse(err);
+    if (response) {
+      return response;
+    }
+    console.error("[OIDC] M2M owner sign:job mint error:", err);
+    return NextResponse.json(
+      { error: "server_error", error_description: "Internal error during token mint" },
+      { status: 500 },
+    );
+  }
+}
+
+async function tryDeviceApprovalExchange(
+  clientId: string,
+  clientSecret: string,
+  exchangeParams: URLSearchParams,
+  grantType: string,
+  subjectTokenType: string,
+  resourceParam: string | null,
+): Promise<NextResponse | null> {
+  if (
+    !isDeviceApprovalTokenExchangeRequest({
+      grantType,
+      subjectTokenType,
+      resource: resourceParam,
+    })
+  ) {
+    return null;
+  }
+  const result = await handleDeviceApprovalTokenExchange({
+    clientId,
+    clientSecret,
+    subjectToken: exchangeParams.get("subject_token") || "",
+    subjectTokenType,
+    resource: resourceParam,
+    requestedTokenType: exchangeParams.get("requested_token_type"),
+    audience: exchangeParams.getAll("audience"),
+  });
+  return jsonNoStore(result);
+}
+
+async function trySignerJwtExchange(
+  clientId: string,
+  clientSecret: string,
+  exchangeParams: URLSearchParams,
+  grantType: string,
+  subjectTokenType: string,
+  resourceParam: string | null,
+): Promise<NextResponse | null> {
+  if (
+    !isSignerJwtTokenExchangeRequest({
+      grantType,
+      subjectTokenType,
+      resource: resourceParam,
+      audience: exchangeParams.getAll("audience"),
+    })
+  ) {
+    return null;
+  }
+  const result = await handleSignerJwtTokenExchange({
+    clientId,
+    clientSecret,
+    subjectToken: exchangeParams.get("subject_token") || "",
+    subjectTokenType,
+    resource: resourceParam,
+    audience: exchangeParams.getAll("audience"),
+  });
+  return jsonNoStore(result, {
+    Deprecation: "true",
+    Link: '</api/v1/apps/{clientId}/oidc/token>; rel="successor-version"',
+    Sunset: "2026-10-01",
+  });
+}
+
+async function tryGatewayExchange(
+  clientId: string,
+  clientSecret: string,
+  exchangeParams: URLSearchParams,
+  grantType: string,
+  subjectTokenType: string,
+  resourceParam: string | null,
+): Promise<NextResponse | null> {
+  if (
+    !isGatewayTokenExchangeRequest({
+      grantType,
+      clientId,
+      subjectTokenType,
+      resource: resourceParam,
+      audience: exchangeParams.getAll("audience"),
+    })
+  ) {
+    return null;
+  }
+  const result = await handleGatewayTokenExchange({
+    clientId,
+    clientSecret,
+    subjectToken: exchangeParams.get("subject_token") || "",
+    subjectTokenType,
+    resource: resourceParam,
+    requestedTokenType: exchangeParams.get("requested_token_type"),
+    audience: exchangeParams.getAll("audience"),
+  });
+  return jsonNoStore(result);
+}
+
+async function handleTokenExchangeGrants(
+  request: NextRequest,
+  exchangeParams: URLSearchParams,
+  grantType: string,
+): Promise<NextResponse | null> {
+  if (!isTokenExchangeGrant(grantType)) {
+    return null;
+  }
+  const { clientId, clientSecret } = clientCredentialsFromTokenRequest(
+    request,
+    exchangeParams,
+  );
+  const subjectTokenType = exchangeParams.get("subject_token_type") || "";
+  const resourceParam = exchangeParams.get("resource");
+  try {
+    const deviceApproval = await tryDeviceApprovalExchange(
+      clientId,
+      clientSecret,
+      exchangeParams,
+      grantType,
+      subjectTokenType,
+      resourceParam,
+    );
+    if (deviceApproval) {
+      return deviceApproval;
+    }
+
+    const signerJwt = await trySignerJwtExchange(
+      clientId,
+      clientSecret,
+      exchangeParams,
+      grantType,
+      subjectTokenType,
+      resourceParam,
+    );
+    if (signerJwt) {
+      return signerJwt;
+    }
+
+    const gateway = await tryGatewayExchange(
+      clientId,
+      clientSecret,
+      exchangeParams,
+      grantType,
+      subjectTokenType,
+      resourceParam,
+    );
+    if (gateway) {
+      return gateway;
+    }
+
+    const result = await handleTokenExchange({
+      clientId,
+      clientSecret,
+      subjectToken: exchangeParams.get("subject_token") || "",
+      subjectTokenType,
+      scope: exchangeParams.get("scope") || undefined,
+      resource: exchangeParams.get("resource") || undefined,
+    });
+    return jsonNoStore(result);
+  } catch (err) {
+    if (err instanceof TokenExchangeError) {
+      console.warn("[OIDC] token exchange rejected", {
+        code: err.code,
+        detail: err.message,
+      });
+      return NextResponse.json(
+        { error: err.code, error_description: err.publicDescription },
+        { status: 400 },
+      );
+    }
+    console.error("[OIDC] token exchange error:", err);
+    return NextResponse.json(
+      { error: "server_error", error_description: "Internal error during token exchange" },
+      { status: 500 },
+    );
+  }
+}
+
+async function maybeInterceptTokenEndpoint(
+  request: NextRequest,
+  path: string,
+  body: Buffer | null,
+): Promise<NextResponse | null> {
+  const contentType = request.headers.get("content-type") || "";
+  if (
+    request.method !== "POST" ||
+    path !== "/token" ||
+    !contentType.includes("application/x-www-form-urlencoded") ||
+    !body ||
+    body.length === 0
+  ) {
+    return null;
+  }
+
+  const exchangeParams = new URLSearchParams(body.toString("utf-8"));
+  const grantType = exchangeParams.get("grant_type") || "";
+
+  if (grantType === "refresh_token") {
+    const refreshToken = exchangeParams.get("refresh_token") || "";
+    const { clientId, clientSecret } = clientCredentialsFromTokenRequest(
+      request,
+      exchangeParams,
+    );
+    const refreshed = await rotateProgrammaticRefreshToken({
+      refreshToken,
+      clientId,
+      clientSecret,
+    });
+    if (refreshed) {
+      return jsonNoStore(refreshed);
+    }
+  }
+
+  const mintResponse = await handleMintSignerTokenGrant(request, exchangeParams);
+  if (mintResponse) {
+    return mintResponse;
+  }
+
+  const m2mResponse = await handleM2mOwnerSignJobGrant(request, exchangeParams);
+  if (m2mResponse) {
+    return m2mResponse;
+  }
+
+  return handleTokenExchangeGrants(request, exchangeParams, grantType);
+}
+
+function injectResourceIndicatorIfNeeded(
+  request: NextRequest,
+  path: string,
+  body: Buffer | null,
+): Buffer | null {
+  const contentType = request.headers.get("content-type") || "";
+  if (
+    request.method !== "POST" ||
+    !contentType.includes("application/x-www-form-urlencoded") ||
+    !body ||
+    body.length === 0 ||
+    (path !== "/device/auth" && path !== "/token")
+  ) {
+    return body;
+  }
+  const params = new URLSearchParams(body.toString("utf-8"));
+  const grantType = params.get("grant_type");
+  const needsResource =
+    path === "/device/auth" || (!!grantType && RESOURCE_REQUIRED_GRANTS.has(grantType));
+  if (needsResource && !params.has("resource")) {
+    params.set("resource", getIssuer());
+    return Buffer.from(params.toString(), "utf-8");
+  }
+  return body;
+}
+
+function copyNodeHeadersToWeb(rawHeaders: ReturnType<ServerResponse["getHeaders"]>): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(rawHeaders)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        headers.append(key, String(v));
+      }
+    } else {
+      headers.set(key, String(value));
+    }
+  }
+  return headers;
+}
+
+function buildRedirectOidcResponse(
+  statusCode: number,
+  location: string,
+  externalOrigin: string,
+  registeredRedirectOriginsList: Set<string>,
+  trustedOidcOriginsSet: Set<string>,
+  rawHeaders: ReturnType<ServerResponse["getHeaders"]>,
+): NextResponse {
+  const allowedOrigins = new Set([
+    new URL(externalOrigin).origin,
+    ...registeredRedirectOriginsList,
+    ...trustedOidcOriginsSet,
+  ]);
+  const redirectResponse = NextResponse.redirect(
+    resolveRedirectLocation(location, externalOrigin, allowedOrigins),
+    statusCode as 301 | 302 | 303 | 307 | 308,
+  );
+  const setCookies = rawHeaders["set-cookie"];
+  if (setCookies) {
+    const cookies = Array.isArray(setCookies) ? setCookies : [setCookies];
+    for (const cookie of cookies) {
+      redirectResponse.headers.append("Set-Cookie", cookie);
+    }
+  }
+
+  const redirectSecureHeaders = getSecureHeaders(false);
+  for (const [key, value] of Object.entries(redirectSecureHeaders)) {
+    redirectResponse.headers.set(key, value);
+  }
+  return redirectResponse;
+}
+
+function rewriteDeviceAuthVerificationUri(
+  responseBody: Buffer,
+  path: string,
+  headers: Headers,
+  body: Buffer | null,
+  externalOrigin: string,
+): Buffer | null {
+  let finalBody: Buffer | null = responseBody.length > 0 ? responseBody : null;
+  const ct = headers.get("content-type") || "";
+  if (
+    !finalBody ||
+    !ct.includes("application/json") ||
+    path !== "/device/auth"
+  ) {
+    return finalBody;
+  }
+  try {
+    const json = JSON.parse(finalBody.toString("utf-8"));
+    if (!json.verification_uri) {
+      return finalBody;
+    }
+    const deviceParams = new URLSearchParams();
+    if (json.user_code) {
+      deviceParams.set("user_code", json.user_code);
+    }
+    if (body && body.length > 0) {
+      try {
+        const form = new URLSearchParams(body.toString("utf-8"));
+        const deviceClientId = form.get("client_id");
+        if (deviceClientId) {
+          deviceParams.set("client_id", deviceClientId);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    deviceParams.set("iss", getIssuer());
+    const qs = deviceParams.toString();
+    const verificationBase = `${externalOrigin}/oidc/device`;
+    json.verification_uri = verificationBase;
+    if (json.user_code) {
+      json.verification_uri_complete = qs
+        ? `${verificationBase}?${qs}`
+        : verificationBase;
+    }
+    finalBody = Buffer.from(JSON.stringify(json), "utf-8");
+    headers.set("content-length", String(finalBody.length));
+  } catch {
+    /* non-JSON body, pass through */
+  }
+  return finalBody;
 }
 
 /**
@@ -100,222 +517,17 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
   path = normalizedPath;
 
   // Create a Node.js IncomingMessage from the NextRequest
-  let body = request.body ? Buffer.from(await request.arrayBuffer()) : null;
+  let body: Buffer | null = request.body ? Buffer.from(await request.arrayBuffer()) : null;
 
-  // Intercept RFC 8693 token exchange before node-oidc-provider
-  const contentType = request.headers.get("content-type") || "";
-  if (
-    request.method === "POST" &&
-    path === "/token" &&
-    contentType.includes("application/x-www-form-urlencoded") &&
-    body &&
-    body.length > 0
-  ) {
-    const exchangeParams = new URLSearchParams(body.toString("utf-8"));
-    const grantType = exchangeParams.get("grant_type") || "";
-
-    if (grantType === "refresh_token") {
-      const refreshToken = exchangeParams.get("refresh_token") || "";
-      const { clientId, clientSecret } = clientCredentialsFromTokenRequest(
-        request,
-        exchangeParams,
-      );
-      const refreshed = await rotateProgrammaticRefreshToken({
-        refreshToken,
-        clientId,
-        clientSecret,
-      });
-      if (refreshed) {
-        return NextResponse.json(refreshed, {
-          headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
-        });
-      }
-    }
-
-    if (isMintUserSignerTokenRequest(exchangeParams)) {
-      const { clientId, clientSecret } = clientCredentialsFromTokenRequest(
-        request,
-        exchangeParams,
-      );
-      try {
-        assertSignJobNotMixedWithAdmin(requestedScopesFromParams(exchangeParams));
-        const result = await handleMintUserSignerToken({
-          clientId,
-          clientSecret,
-          externalUserId: exchangeParams.get("external_user_id") || "",
-          scope: exchangeParams.get("scope"),
-        });
-        return NextResponse.json(result, {
-          headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
-        });
-      } catch (err) {
-        const response = mintSignerTokenErrorResponse(err);
-        if (response) {
-          return response;
-        }
-        console.error("[OIDC] mint user signer token error:", err);
-        return NextResponse.json(
-          { error: "server_error", error_description: "Internal error during token mint" },
-          { status: 500 },
-        );
-      }
-    }
-
-    if (isM2mOwnerSignJobRequest(exchangeParams)) {
-      const { clientId, clientSecret } = clientCredentialsFromTokenRequest(
-        request,
-        exchangeParams,
-      );
-      try {
-        assertSignJobNotMixedWithAdmin(requestedScopesFromParams(exchangeParams));
-        const result = await handleM2mOwnerSignJob({
-          clientId,
-          clientSecret,
-        });
-        return NextResponse.json(result, {
-          headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
-        });
-      } catch (err) {
-        const response = mintSignerTokenErrorResponse(err);
-        if (response) {
-          return response;
-        }
-        console.error("[OIDC] M2M owner sign:job mint error:", err);
-        return NextResponse.json(
-          { error: "server_error", error_description: "Internal error during token mint" },
-          { status: 500 },
-        );
-      }
-    }
-
-    if (isTokenExchangeGrant(grantType)) {
-      const { clientId, clientSecret } = clientCredentialsFromTokenRequest(
-        request,
-        exchangeParams,
-      );
-      const subjectTokenType = exchangeParams.get("subject_token_type") || "";
-      const resourceParam = exchangeParams.get("resource");
-      try {
-        if (
-          isDeviceApprovalTokenExchangeRequest({
-            grantType,
-            subjectTokenType,
-            resource: resourceParam,
-          })
-        ) {
-          const result = await handleDeviceApprovalTokenExchange({
-            clientId,
-            clientSecret,
-            subjectToken: exchangeParams.get("subject_token") || "",
-            subjectTokenType,
-            resource: resourceParam,
-            requestedTokenType: exchangeParams.get("requested_token_type"),
-            audience: exchangeParams.getAll("audience"),
-          });
-          return NextResponse.json(result, {
-            headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
-          });
-        }
-
-        if (
-          isSignerJwtTokenExchangeRequest({
-            grantType,
-            subjectTokenType,
-            resource: resourceParam,
-            audience: exchangeParams.getAll("audience"),
-          })
-        ) {
-          const result = await handleSignerJwtTokenExchange({
-            clientId,
-            clientSecret,
-            subjectToken: exchangeParams.get("subject_token") || "",
-            subjectTokenType,
-            resource: resourceParam,
-            audience: exchangeParams.getAll("audience"),
-          });
-          return NextResponse.json(result, {
-            headers: {
-              "Cache-Control": "no-store",
-              Pragma: "no-cache",
-              Deprecation: "true",
-              Link: '</api/v1/apps/{clientId}/oidc/token>; rel="successor-version"',
-              "Sunset": "2026-10-01",
-            },
-          });
-        }
-
-        if (
-          isGatewayTokenExchangeRequest({
-            grantType,
-            clientId,
-            subjectTokenType,
-            resource: resourceParam,
-            audience: exchangeParams.getAll("audience"),
-          })
-        ) {
-          const result = await handleGatewayTokenExchange({
-            clientId,
-            clientSecret,
-            subjectToken: exchangeParams.get("subject_token") || "",
-            subjectTokenType,
-            resource: resourceParam,
-            requestedTokenType: exchangeParams.get("requested_token_type"),
-            audience: exchangeParams.getAll("audience"),
-          });
-          return NextResponse.json(result, {
-            headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
-          });
-        }
-
-        const result = await handleTokenExchange({
-          clientId,
-          clientSecret,
-          subjectToken: exchangeParams.get("subject_token") || "",
-          subjectTokenType,
-          scope: exchangeParams.get("scope") || undefined,
-          resource: exchangeParams.get("resource") || undefined,
-        });
-        return NextResponse.json(result, {
-          headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
-        });
-      } catch (err) {
-        if (err instanceof TokenExchangeError) {
-          console.warn("[OIDC] token exchange rejected", {
-            code: err.code,
-            detail: err.message,
-          });
-          return NextResponse.json(
-            { error: err.code, error_description: err.publicDescription },
-            { status: 400 },
-          );
-        }
-        console.error("[OIDC] token exchange error:", err);
-        return NextResponse.json(
-          { error: "server_error", error_description: "Internal error during token exchange" },
-          { status: 500 },
-        );
-      }
-    }
+  const intercepted = await maybeInterceptTokenEndpoint(request, path, body);
+  if (intercepted) {
+    return intercepted;
   }
 
   // RFC 8707 strict mode: ensure resource indicator is present on token-issuing
   // endpoints so access tokens are always audience-bound JWTs.
-  if (
-    request.method === "POST" &&
-    contentType.includes("application/x-www-form-urlencoded") &&
-    body &&
-    body.length > 0 &&
-    (path === "/device/auth" || path === "/token")
-  ) {
-    const params = new URLSearchParams(body.toString("utf-8"));
-    const grantType = params.get("grant_type");
-    const needsResource =
-      path === "/device/auth" || (grantType && RESOURCE_REQUIRED_GRANTS.has(grantType));
-    if (needsResource && !params.has("resource")) {
-      params.set("resource", getIssuer());
-      body = Buffer.from(params.toString(), "utf-8");
-    }
-  }
+  body = injectResourceIndicatorIfNeeded(request, path, body);
+
   const socket = new Socket();
   const req = new IncomingMessage(socket);
   req.method = request.method;
@@ -368,113 +580,54 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
 
       const responseBody = Buffer.concat(chunks);
       const statusCode = res.statusCode || 200;
-      const headers = new Headers();
-
-      // Copy response headers
       const rawHeaders = res.getHeaders();
-      for (const [key, value] of Object.entries(rawHeaders)) {
-        if (value !== undefined) {
-          if (Array.isArray(value)) {
-            for (const v of value) {
-              headers.append(key, String(v));
-            }
-          } else {
-            headers.set(key, String(value));
-          }
-        }
-      }
+      const headers = copyNodeHeadersToWeb(rawHeaders);
 
       // Handle redirects — must forward Set-Cookie so the _interaction cookie reaches the browser
       if ([301, 302, 303, 307, 308].includes(statusCode)) {
         const location = headers.get("location");
         if (location) {
-          const allowedOrigins = new Set([
-            new URL(externalOrigin).origin,
-            ...registeredRedirectOriginsList,
-            ...trustedOidcOriginsSet,
-          ]);
-          const redirectResponse = NextResponse.redirect(
-            resolveRedirectLocation(location, externalOrigin, allowedOrigins),
-            statusCode as 301 | 302 | 303 | 307 | 308,
+          resolve(
+            buildRedirectOidcResponse(
+              statusCode,
+              location,
+              externalOrigin,
+              registeredRedirectOriginsList,
+              trustedOidcOriginsSet,
+              rawHeaders,
+            ),
           );
-          const setCookies = rawHeaders["set-cookie"];
-          if (setCookies) {
-            const cookies = Array.isArray(setCookies) ? setCookies : [setCookies];
-            for (const cookie of cookies) {
-              redirectResponse.headers.append("Set-Cookie", cookie);
-            }
-          }
-          
-          // Add security headers to redirect responses
-          const redirectSecureHeaders = getSecureHeaders(false);
-          for (const [key, value] of Object.entries(redirectSecureHeaders)) {
-            redirectResponse.headers.set(key, value);
-          }
-          
-          resolve(redirectResponse);
           return originalEnd(chunk, ...args);
         }
       }
 
       // Rewrite verification_uri in device auth responses to point to our
       // custom React UI instead of the provider's built-in HTML form.
-      let finalBody: Buffer | null = responseBody.length > 0 ? responseBody : null;
-      const ct = headers.get("content-type") || "";
-      if (
-        finalBody &&
-        ct.includes("application/json") &&
-        path === "/device/auth"
-      ) {
-        try {
-          const json = JSON.parse(finalBody.toString("utf-8"));
-          if (json.verification_uri) {
-            const deviceParams = new URLSearchParams();
-            if (json.user_code) {
-              deviceParams.set("user_code", json.user_code);
-            }
-            if (body && body.length > 0) {
-              try {
-                const form = new URLSearchParams(body.toString("utf-8"));
-                const deviceClientId = form.get("client_id");
-                if (deviceClientId) {
-                  deviceParams.set("client_id", deviceClientId);
-                }
-              } catch {
-                /* ignore */
-              }
-            }
-                       deviceParams.set("iss", getIssuer());
-            const qs = deviceParams.toString();
-            const verificationBase = `${externalOrigin}/oidc/device`;
-            json.verification_uri = verificationBase;
-            if (json.user_code) {
-              json.verification_uri_complete = qs
-                ? `${verificationBase}?${qs}`
-                : verificationBase;
-            }
-            finalBody = Buffer.from(JSON.stringify(json), "utf-8");
-            headers.set("content-length", String(finalBody.length));
-          }
-        } catch { /* non-JSON body, pass through */ }
-      }
+      const finalBody = rewriteDeviceAuthVerificationUri(
+        responseBody,
+        path,
+        headers,
+        body,
+        externalOrigin,
+      );
 
       // Determine if this is a custom domain request
       const requestHost = req.headers["x-forwarded-host"] || req.headers.host || "";
       const hostStr = Array.isArray(requestHost) ? requestHost[0] : requestHost;
       const isCustomDomain = await isVerifiedCustomDomain(hostStr);
-      
+
       // Add security headers
       const secureHeaders = getSecureHeaders(isCustomDomain);
       for (const [key, value] of Object.entries(secureHeaders)) {
         headers.set(key, value);
       }
 
-      const nextResponse = new NextResponse(
-        finalBody ? new Uint8Array(finalBody) : null,
-        { status: statusCode, headers },
+      resolve(
+        new NextResponse(finalBody ? new Uint8Array(finalBody) : null, {
+          status: statusCode,
+          headers,
+        }),
       );
-
-      resolve(nextResponse);
       return originalEnd(chunk, ...args);
     } as any;
 

--- a/src/app/api/v1/oidc/device/verify/route.ts
+++ b/src/app/api/v1/oidc/device/verify/route.ts
@@ -30,6 +30,124 @@ function errorResponse(
   );
 }
 
+function deviceCodeClientId(deviceCode: {
+  clientId?: unknown;
+  params?: { client_id?: unknown };
+}): string | null {
+  const clientId = deviceCode.clientId || deviceCode.params?.client_id;
+  return typeof clientId === "string" ? clientId : null;
+}
+
+function deviceCodeScope(deviceCode: {
+  scope?: unknown;
+  params?: { scope?: unknown };
+}): string {
+  if (typeof deviceCode.scope === "string") {
+    return deviceCode.scope;
+  }
+  if (typeof deviceCode.params?.scope === "string") {
+    return deviceCode.params.scope;
+  }
+  return "";
+}
+
+async function lookupImpliedDeviceConsent(clientId: string): Promise<boolean> {
+  const policyRows = await db
+    .select({
+      deviceThirdPartyInitiateLogin: oidcClients.deviceThirdPartyInitiateLogin,
+      clientSecretHash: oidcClients.clientSecretHash,
+    })
+    .from(oidcClients)
+    .where(eq(oidcClients.clientId, clientId))
+    .limit(1);
+  const policy = policyRows[0];
+  return policy?.deviceThirdPartyInitiateLogin === 1 && !!policy?.clientSecretHash;
+}
+
+async function handleDeviceLookup(deviceCode: {
+  clientId?: unknown;
+  scope?: unknown;
+  params?: { client_id?: unknown; scope?: unknown };
+}): Promise<NextResponse> {
+  const clientId = deviceCodeClientId(deviceCode);
+  const client = clientId ? await getClient(clientId) : null;
+  const branding = clientId ? await resolveAppBrandingByClientId(clientId) : null;
+  const scope = deviceCodeScope(deviceCode);
+  const impliedDeviceConsent = clientId
+    ? await lookupImpliedDeviceConsent(clientId)
+    : false;
+
+  return NextResponse.json({
+    client_name: client?.displayName || clientId || "Unknown Application",
+    scopes: scope.split(" ").filter(Boolean),
+    implied_device_consent: impliedDeviceConsent,
+    branding: branding
+      ? {
+          mode: branding.mode,
+          displayName: branding.displayName,
+          logoUrl: branding.logoUrl,
+          primaryColor: branding.primaryColor,
+        }
+      : null,
+  });
+}
+
+async function handleDeviceApprove(
+  deviceCode: {
+    clientId?: unknown;
+    params?: { client_id?: unknown };
+  },
+  normalizedUserCode: string,
+  userId: string,
+): Promise<NextResponse> {
+  const clientId = deviceCodeClientId(deviceCode);
+  if (!clientId) {
+    return errorResponse("server_error", "Device code is missing client binding", 500);
+  }
+
+  const accessCheck = await checkAppAccess(clientId, userId);
+  if (!accessCheck.allowed) {
+    return errorResponse(
+      "access_denied",
+      accessCheck.reason || "You do not have access to this application",
+      403,
+    );
+  }
+
+  const approved = await approveDeviceCodeForAccount(
+    normalizedUserCode,
+    clientId,
+    userId,
+  );
+  if (!approved.ok) {
+    return errorResponse(approved.error, approved.description, approved.status);
+  }
+
+  return NextResponse.json({ status: "authorized" });
+}
+
+async function handleDeviceDeny(
+  adapter: InstanceType<typeof SqliteAdapter>,
+  deviceCode: {
+    jti?: string;
+    exp?: number;
+    [key: string]: unknown;
+  },
+): Promise<NextResponse> {
+  const now = Math.floor(Date.now() / 1000);
+  const expiresIn = deviceCode.exp ? Math.max(deviceCode.exp - now, 1) : 600;
+  await adapter.upsert(
+    deviceCode.jti!,
+    {
+      ...deviceCode,
+      error: "access_denied",
+      errorDescription: "The user denied the authorization request",
+    },
+    expiresIn,
+  );
+  return NextResponse.json({ status: "denied" });
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const session = await getServerSession(authOptions);
   if (!session?.user) {
@@ -71,87 +189,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   if (action === "lookup") {
-    const clientId = deviceCode.clientId || deviceCode.params?.client_id;
-    const client =
-      typeof clientId === "string" ? await getClient(clientId) : null;
-    const branding =
-      typeof clientId === "string"
-        ? await resolveAppBrandingByClientId(clientId)
-        : null;
-    const scope =
-      typeof deviceCode.scope === "string"
-        ? deviceCode.scope
-        : typeof deviceCode.params?.scope === "string"
-          ? deviceCode.params.scope
-          : "";
-    let impliedDeviceConsent = false;
-    if (typeof clientId === "string") {
-      const policyRows = await db
-        .select({
-          deviceThirdPartyInitiateLogin: oidcClients.deviceThirdPartyInitiateLogin,
-          clientSecretHash: oidcClients.clientSecretHash,
-        })
-        .from(oidcClients)
-        .where(eq(oidcClients.clientId, clientId))
-        .limit(1);
-      const policy = policyRows[0];
-      impliedDeviceConsent =
-        policy?.deviceThirdPartyInitiateLogin === 1 && !!policy?.clientSecretHash;
-    }
-
-    return NextResponse.json({
-      client_name: client?.displayName || clientId || "Unknown Application",
-      scopes: scope.split(" ").filter(Boolean),
-      implied_device_consent: impliedDeviceConsent,
-      branding: branding ? {
-        mode: branding.mode,
-        displayName: branding.displayName,
-        logoUrl: branding.logoUrl,
-        primaryColor: branding.primaryColor,
-      } : null,
-    });
+    return handleDeviceLookup(deviceCode);
   }
-
   if (action === "approve") {
-    const clientId = deviceCode.clientId || deviceCode.params?.client_id;
-    if (typeof clientId !== "string" || !clientId) {
-      return errorResponse("server_error", "Device code is missing client binding", 500);
-    }
-
-    // Check app access before approving
-    const accessCheck = await checkAppAccess(clientId, userId);
-    if (!accessCheck.allowed) {
-      return errorResponse(
-        "access_denied",
-        accessCheck.reason || "You do not have access to this application",
-        403
-      );
-    }
-
-    const approved = await approveDeviceCodeForAccount(
-      normalizedUserCode,
-      clientId,
-      userId,
-    );
-    if (!approved.ok) {
-      return errorResponse(approved.error, approved.description, approved.status);
-    }
-
-    return NextResponse.json({ status: "authorized" });
+    return handleDeviceApprove(deviceCode, normalizedUserCode, userId);
   }
-
-  // action === "deny"
-  const now = Math.floor(Date.now() / 1000);
-  const expiresIn = deviceCode.exp ? Math.max(deviceCode.exp - now, 1) : 600;
-  await adapter.upsert(
-    deviceCode.jti!,
-    {
-      ...deviceCode,
-      error: "access_denied",
-      errorDescription: "The user denied the authorization request",
-    },
-    expiresIn,
-  );
-
-  return NextResponse.json({ status: "denied" });
+  return handleDeviceDeny(adapter, deviceCode);
 }

--- a/src/app/api/v1/oidc/interaction/[uid]/route.ts
+++ b/src/app/api/v1/oidc/interaction/[uid]/route.ts
@@ -51,6 +51,70 @@ function buildNodeRequest(
   return { req, res };
 }
 
+async function parseInteractionBody(
+  request: NextRequest,
+): Promise<{ action?: "approve" | "deny" }> {
+  try {
+    const contentType = request.headers.get("content-type") ?? "";
+    if (contentType.includes("application/x-www-form-urlencoded")) {
+      const formData = await request.formData();
+      const action = formData.get("action");
+      if (action === "approve" || action === "deny") {
+        return { action };
+      }
+      return {};
+    }
+    return await request.json();
+  } catch {
+    // Allow login interactions that do not provide a JSON body.
+    return {};
+  }
+}
+
+async function buildInteractionResult(
+  provider: Awaited<ReturnType<typeof getProvider>>,
+  details: { prompt: { name: string }; params: Record<string, unknown> },
+  userId: string,
+  body: { action?: "approve" | "deny" },
+): Promise<Record<string, unknown>> {
+  const { prompt } = details;
+  if (prompt.name === "login") {
+    return {
+      login: {
+        accountId: userId,
+        remember: true,
+      },
+    };
+  }
+  if (prompt.name !== "consent") {
+    return {};
+  }
+  if (body.action === "deny") {
+    return {
+      error: "access_denied",
+      error_description: "User denied the authorization request",
+    };
+  }
+  // Grant the requested scopes (OIDC + resource)
+  const grant = new provider.Grant();
+  grant.clientId = details.params.client_id as string;
+  grant.accountId = userId;
+
+  const requestedScopes = details.params.scope as string;
+  if (requestedScopes) {
+    grant.addOIDCScope(requestedScopes);
+    grant.addResourceScope(getIssuer(), requestedScopes);
+  }
+
+  await grant.save();
+
+  return {
+    consent: {
+      grantId: grant.jti,
+    },
+  };
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ uid: string }> },
@@ -86,21 +150,7 @@ export async function POST(
 ): Promise<NextResponse> {
   const { uid } = await params;
   const provider = await getProvider();
-  let body: { action?: "approve" | "deny" } = {};
-  try {
-    const contentType = request.headers.get("content-type") ?? "";
-    if (contentType.includes("application/x-www-form-urlencoded")) {
-      const formData = await request.formData();
-      const action = formData.get("action");
-      if (action === "approve" || action === "deny") {
-        body = { action };
-      }
-    } else {
-      body = await request.json();
-    }
-  } catch {
-    // Allow login interactions that do not provide a JSON body.
-  }
+  const body = await parseInteractionBody(request);
 
   // Require an authenticated NextAuth session for login/consent completion
   const session = await getServerSession(authOptions);
@@ -121,48 +171,8 @@ export async function POST(
 
   try {
     const { req, res } = buildNodeRequest("POST", uid, request);
-
     const details = await provider.interactionDetails(req, res);
-    const { prompt } = details;
-
-    let result: Record<string, unknown>;
-
-    if (prompt.name === "login") {
-      result = {
-        login: {
-          accountId: userId,
-          remember: true,
-        },
-      };
-    } else if (prompt.name === "consent") {
-      if (body.action === "deny") {
-        result = {
-          error: "access_denied",
-          error_description: "User denied the authorization request",
-        };
-      } else {
-        // Grant the requested scopes (OIDC + resource)
-        const grant = new provider.Grant();
-        grant.clientId = details.params.client_id as string;
-        grant.accountId = userId;
-
-        const requestedScopes = details.params.scope as string;
-        if (requestedScopes) {
-          grant.addOIDCScope(requestedScopes);
-          grant.addResourceScope(getIssuer(), requestedScopes);
-        }
-
-        await grant.save();
-
-        result = {
-          consent: {
-            grantId: grant.jti,
-          },
-        };
-      }
-    } else {
-      result = {};
-    }
+    const result = await buildInteractionResult(provider, details, userId, body);
 
     const redirectTo = await provider.interactionResult(req, res, result, {
       mergeWithLastSubmission: false,


### PR DESCRIPTION
## Summary
- Extract helpers to bring apps/OIDC API route handlers under Sonar cognitive-complexity limit (S3776)
- Part of Phase 4 Sonar cleanup (API batch)

## Test plan
- [ ] Apps CRUD / plans / billing / settings / discovery-profiles routes still behave
- [ ] OIDC catch-all + device verify + interaction routes still work
- [ ] CI tests pass
- [ ] Sonar S3776 clears on these files