### PR TITLE
fix(security): address CodeQL code scanning alerts

### DIFF
--- a/src/app/api/v1/apps/[id]/discovery-profiles/route.test.ts
+++ b/src/app/api/v1/apps/[id]/discovery-profiles/route.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import Module from "node:module";
 
 import { eq } from "drizzle-orm";
 import { db } from "@/db/index";

--- a/src/app/api/v1/apps/[id]/plans/route.ts
+++ b/src/app/api/v1/apps/[id]/plans/route.ts
@@ -78,26 +78,6 @@ function coerceJsonScalarString(raw: unknown, fallback = ""): string {
   return fallback;
 }
 
-function parseOptionalNonNegativeIntString(
-  raw: unknown,
-  fieldName: string,
-): { ok: true; value: string | null } | { ok: false; error: string } {
-  if (raw === undefined || raw === null) {
-    return { ok: true, value: null };
-  }
-  const s = coerceJsonScalarString(raw).trim();
-  if (s === "") {
-    return { ok: true, value: null };
-  }
-  if (!isNonNegativeIntegerString(s)) {
-    return {
-      ok: false,
-      error: `${fieldName} must be a non-negative integer string`,
-    };
-  }
-  return { ok: true, value: s };
-}
-
 function parseOptionalRetailRateUsd(
   raw: unknown,
   fieldName: string,

--- a/src/app/api/v1/apps/[id]/users/route.ts
+++ b/src/app/api/v1/apps/[id]/users/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/provider-apps";
 import { createCorrelationId, writeAuditLog } from "@/lib/audit";
 import { provisionAppUserBilling } from "@/lib/billing/provision-app-user";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
 
 async function canAccessUsers(request: NextRequest, clientId: string, requiredScope: string) {
   const app = await getProviderApp(clientId);
@@ -117,7 +118,10 @@ export async function POST(
       externalUserId,
     });
   } catch (err) {
-    console.error("provisionAppUserBilling failed on user upsert:", err);
+    console.error(
+      "provisionAppUserBilling failed on user upsert:",
+      sanitizeForLog(err instanceof Error ? err.message : err),
+    );
   }
 
   await writeAuditLog({

--- a/src/app/oidc/consent/page.tsx
+++ b/src/app/oidc/consent/page.tsx
@@ -176,8 +176,6 @@ export default async function ConsentPage({
     : null;
 
   const primaryColorStyle = { backgroundColor: branding.primaryColor };
-  const primaryBorderStyle = { borderColor: `${branding.primaryColor}33` };
-  const primaryBgStyle = { backgroundColor: `${branding.primaryColor}1a` };
 
   return (
     <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-6">

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -11,14 +11,6 @@ import DashboardLayout from "@/components/DashboardLayout";
 import UserTable from "@/components/UserTable";
 import CreateEndUserForm from "@/components/CreateEndUserForm";
 
-function formatWei(wei: string): string {
-  if (wei === "0") return "0 ETH";
-  const value = BigInt(wei);
-  const eth = Number(value) / 1e18;
-  if (eth < 0.001) return `${wei} wei`;
-  return `${eth.toFixed(6)} ETH`;
-}
-
 export default async function UsersPage() {
   const session = await getServerSession(authOptions);
   const userRole = (session?.user as Record<string, unknown> | undefined)

--- a/src/app/webhooks/turnkey-balance/route.ts
+++ b/src/app/webhooks/turnkey-balance/route.ts
@@ -11,6 +11,7 @@ import {
   getTurnkeyWebhookVerificationKeys,
   getTurnkeyWebhookVerificationKeysForKeyId,
 } from "@/lib/turnkey-webhook-jwks";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
 
 export const maxDuration = 300;
 
@@ -51,7 +52,7 @@ export async function POST(request: Request): Promise<Response> {
   const tag = "[turnkey-balance]";
   try {
     const rawBody = await request.text();
-    console.log(tag, "POST received, body length:", rawBody.length);
+    console.log(tag, "POST received, body length:", sanitizeForLog(rawBody.length));
 
     const verified = await verifyTurnkeyWebhook(request, rawBody);
     if (!verified.ok) {
@@ -87,7 +88,15 @@ export async function POST(request: Request): Promise<Response> {
       return Response.json({ status: "ignored", reason: decision.reason });
     }
 
-    console.log(tag, "decision: fund", decision.idempotencyKey, "amount:", decision.amountWei.toString(), "fund:", decision.fundWei.toString());
+    console.log(
+      tag,
+      "decision: fund",
+      sanitizeForLog(decision.idempotencyKey),
+      "amount:",
+      sanitizeForLog(decision.amountWei.toString()),
+      "fund:",
+      sanitizeForLog(decision.fundWei.toString()),
+    );
 
     const claim = await claimTurnkeyFundingEvent({
       idempotencyKey: decision.idempotencyKey,

--- a/src/lib/openmeter/constants.test.ts
+++ b/src/lib/openmeter/constants.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isKonnectMeteringUrl } from "./constants";
+
+test("isKonnectMeteringUrl accepts konghq.com host", () => {
+  assert.equal(isKonnectMeteringUrl("https://konghq.com/v3/openmeter"), true);
+});
+
+test("isKonnectMeteringUrl accepts *.konghq.com hosts", () => {
+  assert.equal(
+    isKonnectMeteringUrl("https://us.api.konghq.com/v3/openmeter"),
+    true,
+  );
+});
+
+test("isKonnectMeteringUrl rejects hosts that only contain konghq.com as a substring", () => {
+  assert.equal(
+    isKonnectMeteringUrl("https://evil-konghq.com.example/v3/openmeter"),
+    false,
+  );
+});
+
+test("isKonnectMeteringUrl falls back to kpat_/spat_ API key heuristics", () => {
+  assert.equal(isKonnectMeteringUrl("not a url", "kpat_abc"), true);
+  assert.equal(isKonnectMeteringUrl("http://127.0.0.1:48888", "spat_abc"), true);
+  assert.equal(isKonnectMeteringUrl("http://127.0.0.1:48888", "other"), false);
+  assert.equal(isKonnectMeteringUrl("http://127.0.0.1:48888"), false);
+});

--- a/src/lib/openmeter/constants.ts
+++ b/src/lib/openmeter/constants.ts
@@ -45,8 +45,13 @@ export function getHostedOpenMeterUrl(): string {
 }
 
 export function isKonnectMeteringUrl(url: string, apiKey?: string): boolean {
-  if (/konghq\.com/i.test(url)) {
-    return true;
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    if (hostname === "konghq.com" || hostname.endsWith(".konghq.com")) {
+      return true;
+    }
+  } catch {
+    // Non-URL strings fall through to API-key heuristics.
   }
   const key = apiKey?.trim() ?? "";
   return key.startsWith("kpat_") || key.startsWith("spat_");

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -7,6 +7,7 @@ import {
   buildOwnerCustomerKey,
   buildOwnerMeterSubjects,
 } from "@/lib/openmeter/customer-key";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
 import { getHostedOpenMeterUrl } from "./constants";
 import { isOpenMeterUlid } from "./konnect-routes";
 import { shouldUseKonnectRoutes } from "./route-mode";
@@ -118,9 +119,9 @@ async function ensureCustomerUsageAttribution(
     if (isSubjectKeyConflictError(err)) {
       console.warn(
         "openmeter: skip subject key update",
-        customer.key ?? customer.id,
-        missing.join(","),
-        err instanceof Error ? err.message : String(err),
+        sanitizeForLog(customer.key ?? customer.id),
+        sanitizeForLog(missing.join(",")),
+        sanitizeForLog(err instanceof Error ? err.message : String(err)),
       );
       return;
     }

--- a/src/lib/openmeter/signed-ticket-events.test.ts
+++ b/src/lib/openmeter/signed-ticket-events.test.ts
@@ -63,9 +63,6 @@ test("eventUsageSubject prefers data.external_user_id", () => {
 });
 
 test("eventUsageSubject falls back to subject suffix", () => {
-  const ev = sampleEvent({
-    data: { external_user_id: "", usage_subject: "" },
-  });
   // clear empty strings from data by rebuilding
   const bare = {
     event: {

--- a/src/lib/prices/public-exchange-spot.test.ts
+++ b/src/lib/prices/public-exchange-spot.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
-import { test, mock } from "node:test";
+import { test } from "node:test";
 
 // We need to mock global fetch before importing the module under test.
-// Using node:test's mock.method to patch globalThis.fetch.
 
 test("fetchEthUsdFromPublicExchanges: returns Binance result on success", async () => {
   const original = globalThis.fetch;

--- a/src/lib/sanitize-for-log.test.ts
+++ b/src/lib/sanitize-for-log.test.ts
@@ -12,7 +12,15 @@ test("sanitizeForLog coerces nullish to empty string", () => {
   assert.equal(sanitizeForLog(undefined), "");
 });
 
-test("sanitizeForLog stringifies non-strings", () => {
+test("sanitizeForLog stringifies primitives", () => {
   assert.equal(sanitizeForLog(42), "42");
   assert.equal(sanitizeForLog(true), "true");
+});
+
+test("sanitizeForLog uses Error message", () => {
+  assert.equal(sanitizeForLog(new Error("boom\nline")), "boomline");
+});
+
+test("sanitizeForLog JSON-stringifies plain objects", () => {
+  assert.equal(sanitizeForLog({ a: 1 }), '{"a":1}');
 });

--- a/src/lib/sanitize-for-log.test.ts
+++ b/src/lib/sanitize-for-log.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { sanitizeForLog } from "./sanitize-for-log";
+
+test("sanitizeForLog strips CR and LF", () => {
+  assert.equal(sanitizeForLog("a\nb\rc"), "abc");
+});
+
+test("sanitizeForLog coerces nullish to empty string", () => {
+  assert.equal(sanitizeForLog(null), "");
+  assert.equal(sanitizeForLog(undefined), "");
+});
+
+test("sanitizeForLog stringifies non-strings", () => {
+  assert.equal(sanitizeForLog(42), "42");
+  assert.equal(sanitizeForLog(true), "true");
+});

--- a/src/lib/sanitize-for-log.ts
+++ b/src/lib/sanitize-for-log.ts
@@ -2,5 +2,18 @@
  * Strip CR/LF so user-controlled values cannot forge additional log lines (CWE-117).
  */
 export function sanitizeForLog(value: unknown): string {
-  return String(value ?? "").replace(/[\n\r]/g, "");
+  if (value == null) {
+    return "";
+  }
+  if (typeof value === "object") {
+    if (value instanceof Error) {
+      return value.message.replace(/[\n\r]/g, "");
+    }
+    try {
+      return JSON.stringify(value).replace(/[\n\r]/g, "");
+    } catch {
+      return "[unserializable]";
+    }
+  }
+  return String(value).replace(/[\n\r]/g, "");
 }

--- a/src/lib/sanitize-for-log.ts
+++ b/src/lib/sanitize-for-log.ts
@@ -1,0 +1,6 @@
+/**
+ * Strip CR/LF so user-controlled values cannot forge additional log lines (CWE-117).
+ */
+export function sanitizeForLog(value: unknown): string {
+  return String(value ?? "").replace(/[\n\r]/g, "");
+}


### PR DESCRIPTION
## Summary
- Sanitize user-influenced values before logging (`sanitizeForLog`) to clear `js/log-injection` findings in app user upsert, Turnkey balance webhook, and OpenMeter customer subject-key updates.
- Replace the unanchored `/konghq\.com/` URL check with hostname parsing so Konnect detection cannot match arbitrary hosts (`js/regex/missing-regexp-anchor`).
- Remove unused imports/locals/functions flagged by `js/unused-local-variable` (plans route, consent page, users page, and related tests).

Closes CodeQL alerts: #77–#81, #86, #90–#91, #94, #96–#97, #99.

## Test plan
- [ ] Confirm CodeQL analysis on this PR clears the open alerts listed above
- [ ] Spot-check Turnkey balance webhook logs still include length / fund decision fields
- [ ] Spot-check Konnect URL detection for `*.konghq.com` hosts and `kpat_`/`spat_` API keys