### PR TITLE
feat(portal): Kong Dev Portal OpenAPI packaging

### DIFF
--- a/docs/kong-dev-portal.md
+++ b/docs/kong-dev-portal.md
@@ -1,0 +1,44 @@
+# Kong Dev Portal (optional)
+
+Publish sliced OpenAPI specs from this repo to a Kong Konnect Dev Portal so
+integrators can browse Control + Discovery APIs (and Livepeer MCP connect
+metadata) without exposing billing/admin surfaces.
+
+## Specs
+
+| File | Use |
+| --- | --- |
+| [`openapi/livepeer-control.openapi.json`](../openapi/livepeer-control.openapi.json) | PymtHouse Builder slice: apps, signing, catalog, `/api/v1/mcp` |
+| [`openapi/discovery-service.openapi.yaml`](../openapi/discovery-service.openapi.yaml) | Standalone discovery-service API |
+
+These files are **portal packaging only** — they do not change the runtime API.
+
+## Auth
+
+Use a Konnect **application auth strategy** pointed at the PymtHouse OIDC issuer:
+
+- Issuer: `https://pymthouse.com/api/v1/oidc`
+- Discovery: `https://pymthouse.com/api/v1/oidc/.well-known/openid-configuration`
+
+Portal login / application registration should issue tokens callers can pass to
+PymtHouse as `Authorization: Bearer …` (including Livepeer MCP at `/api/v1/mcp`).
+
+## Publish checklist
+
+1. Create or select a Kong Dev Portal in Konnect.
+2. Attach the PymtHouse OIDC application auth strategy (e.g. `pymthouse-oidc-prod`).
+3. Upload / link both OpenAPI documents as portal API products (or portal pages).
+4. Add a Connect page for Livepeer MCP:
+   - URL: `https://pymthouse.com/api/v1/mcp`
+   - Auth: Bearer API key or JWT from the portal strategy
+5. Smoke-test: open the portal, sign in, hit Control health + MCP metadata GET.
+
+## Local preview of specs
+
+```bash
+# Control (JSON)
+jq '.info, (.paths | keys)' openapi/livepeer-control.openapi.json
+
+# Discovery (YAML)
+python3 -c 'import yaml; print(yaml.safe_load(open("openapi/discovery-service.openapi.yaml"))["info"])'
+```

--- a/openapi/discovery-service.openapi.yaml
+++ b/openapi/discovery-service.openapi.yaml
@@ -1,0 +1,456 @@
+openapi: 3.1.0
+info:
+  title: Discovery Service API
+  description: |
+    Standalone orchestrator discovery service. Aggregates subgraph, ClickHouse,
+    discover API, and optional sources into a materialized Postgres dataset.
+    Clients send filters, sort, and topN at query time — no server-side discovery plans.
+  version: 1.0.0
+  contact:
+    name: Livepeer Discovery Service
+servers:
+  - url: "https://discovery-service-production-8955.up.railway.app"
+    description: Current deployment
+
+tags:
+  - name: Health
+  - name: Discovery
+  - name: Dataset
+
+paths:
+  /healthz:
+    get:
+      tags: [Health]
+      summary: Liveness probe
+      operationId: healthz
+      responses:
+        "200":
+          description: Service is alive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /v1/discovery/health:
+    get:
+      tags: [Health]
+      summary: Discovery health alias
+      operationId: discoveryHealth
+      responses:
+        "200":
+          description: Service is alive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /v1/discovery/freshness:
+    get:
+      tags: [Discovery]
+      summary: Materialized dataset freshness
+      operationId: getFreshness
+      responses:
+        "200":
+          description: Dataset stats
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FreshnessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/discovery/capabilities:
+    get:
+      tags: [Discovery]
+      summary: List capabilities in the materialized dataset
+      operationId: listCapabilities
+      parameters:
+        - name: serviceType
+          in: query
+          description: Filter by service class (`live-video-to-video`, `live-runner`, `modules`, `batch`). Omit for live-video-to-video + live-runner.
+          schema:
+            type: string
+            enum: [live-video-to-video, live-runner, modules, batch]
+      responses:
+        "200":
+          description: Capability names
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CapabilitiesResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/discovery/query:
+    post:
+      tags: [Discovery]
+      summary: Query orchestrators with client-driven filters
+      description: |
+        Filter, rank, and return orchestrators per capability from the materialized dataset.
+        Plan definitions live in the client; pass filters, sortBy, slaWeights, and topN per request.
+      operationId: discoveryQuery
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueryRequest"
+      responses:
+        "200":
+          description: Ranked results per capability
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/discovery/raw:
+    get:
+      tags: [Discovery]
+      summary: Webhook-compatible orchestrator list
+      description: |
+        Returns `{address, score, capabilities}[]` for go-livepeer gateway `-orchWebhookUrl` compatibility.
+        `caps` accepts classic pipeline/model filters (also matched as bare model names) and
+        live-runner app IDs such as `transcode/ffmpeg` discovered via orch `/discovery` probes.
+      operationId: discoveryRaw
+      parameters:
+        - name: caps
+          in: query
+          description: |
+            Capability or live-runner app filter (repeat for multiple).
+            Live-video and batch pipeline/model values also match bare model names.
+            Live-runner app IDs (e.g. `transcode/ffmpeg`) are matched exactly
+            and also matched by their bare app name (e.g. `ffmpeg`).
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: capability
+          in: query
+          description: Alias for caps
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: serviceType
+          in: query
+          description: Filter by service class (`live-video-to-video`, `live-runner`, `modules`, `batch`). Omit for live-video-to-video + live-runner.
+          schema:
+            type: string
+            enum: [live-video-to-video, live-runner, modules, batch]
+      responses:
+        "200":
+          description: Webhook-shaped orchestrator list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WebhookOrchestrator"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/discovery/dataset/refresh:
+    post:
+      tags: [Dataset]
+      summary: Refresh materialized dataset from upstream sources
+      description: |
+        Fetches all enabled sources in parallel, resolves conflicts, and replaces the Postgres dataset.
+        Requires `Authorization: Bearer <CRON_SECRET>` or `X-Cron-Secret` header when CRON_SECRET is configured.
+      operationId: refreshDataset
+      security:
+        - CronBearer: []
+        - CronHeader: []
+      parameters:
+        - name: X-Refreshed-By
+          in: header
+          schema:
+            type: string
+          description: Audit label for who triggered the refresh
+      responses:
+        "200":
+          description: Refresh completed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RefreshResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  securitySchemes:
+    CronBearer:
+      type: http
+      scheme: bearer
+      description: Set to CRON_SECRET value
+    CronHeader:
+      type: apiKey
+      in: header
+      name: X-Cron-Secret
+      description: Alternative to Bearer auth for cron jobs
+
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Unauthorized:
+      description: Missing or invalid cron secret
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    InternalError:
+      description: Server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+
+    FreshnessResponse:
+      type: object
+      properties:
+        populated:
+          type: boolean
+        refreshedAt:
+          type: integer
+          format: int64
+          description: Unix epoch milliseconds
+        refreshedBy:
+          type: string
+        ageMs:
+          type: integer
+          format: int64
+        totalRows:
+          type: integer
+        capabilityCount:
+          type: integer
+
+    CapabilitiesResponse:
+      type: object
+      properties:
+        capabilities:
+          type: array
+          items:
+            type: string
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/CapabilityEntry"
+
+    CapabilityEntry:
+      type: object
+      properties:
+        serviceType:
+          type: string
+          enum: [live-video-to-video, live-runner, modules, batch]
+        capability:
+          type: string
+        offeringIds:
+          type: array
+          items:
+            type: string
+
+    Filters:
+      type: object
+      properties:
+        gpuRamGbMin:
+          type: number
+          format: double
+        gpuRamGbMax:
+          type: number
+          format: double
+        priceMax:
+          type: number
+          format: double
+        maxAvgLatencyMs:
+          type: number
+          format: double
+        maxSwapRatio:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+
+    SLAWeights:
+      type: object
+      properties:
+        latency:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+        swapRate:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+        price:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+
+    QueryRequest:
+      type: object
+      required: [capabilities]
+      properties:
+        capabilities:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          example: ["streamdiffusion-sdxl"]
+        serviceTypes:
+          type: array
+          items:
+            type: string
+            enum: [live-video-to-video, live-runner, modules, batch]
+          description: Filter dataset rows by service class. Omit for live-video-to-video + live-runner (excludes batch and modules).
+        topN:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 10
+        filters:
+          $ref: "#/components/schemas/Filters"
+        slaWeights:
+          $ref: "#/components/schemas/SLAWeights"
+        slaMinScore:
+          type: number
+          format: double
+        sortBy:
+          type: string
+          enum: [slaScore, latency, price, swapRate, avail]
+          default: slaScore
+
+    DatasetRow:
+      type: object
+      properties:
+        serviceType:
+          type: string
+          enum: [live-video-to-video, live-runner, modules, batch]
+        ethAddress:
+          type: string
+        offeringId:
+          type: string
+        interactionMode:
+          type: string
+        workUnit:
+          type: string
+        pricePerUnitWei:
+          type: string
+        orchUri:
+          type: string
+        gpuName:
+          type: string
+        gpuGb:
+          type: number
+        avail:
+          type: number
+        totalCap:
+          type: number
+        pricePerUnit:
+          type: number
+        bestLatMs:
+          type: number
+          nullable: true
+        avgLatMs:
+          type: number
+          nullable: true
+        swapRatio:
+          type: number
+          nullable: true
+        avgAvail:
+          type: number
+          nullable: true
+        score:
+          type: number
+        slaScore:
+          type: number
+          nullable: true
+
+    QueryResponse:
+      type: object
+      properties:
+        results:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/DatasetRow"
+        datasetVersion:
+          type: integer
+          format: int64
+        queryTimeMs:
+          type: integer
+          format: int64
+        sourceFreshness:
+          $ref: "#/components/schemas/SourceFreshness"
+
+    SourceFreshness:
+      type: object
+      properties:
+        refreshedAt:
+          type: integer
+          format: int64
+        refreshedBy:
+          type: string
+        ageMs:
+          type: integer
+          format: int64
+        capabilityCount:
+          type: integer
+
+    WebhookOrchestrator:
+      type: object
+      properties:
+        address:
+          type: string
+          description: Orchestrator service URL
+        score:
+          type: number
+          format: float
+        capabilities:
+          type: array
+          items:
+            type: string
+
+    RefreshResult:
+      type: object
+      properties:
+        refreshed:
+          type: boolean
+        capabilities:
+          type: integer
+        orchestrators:
+          type: integer
+        durationMs:
+          type: integer
+          format: int64

--- a/openapi/livepeer-control.openapi.json
+++ b/openapi/livepeer-control.openapi.json
@@ -1,0 +1,1701 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Livepeer Control Plane",
+    "version": "1.0.0",
+    "description": "Sliced PymtHouse Builder API for Livepeer Dev Portal: apps, signing, catalog, MCP metadata. Excludes billing/OpenMeter/admin."
+  },
+  "servers": [
+    {
+      "url": "https://pymthouse.com",
+      "description": "PymtHouse API origin"
+    }
+  ],
+  "paths": {
+    "/api/v1/apps/{clientId}": {
+      "delete": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Delete developer app",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Get developer app",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Update developer app",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/apps/{clientId}/users": {
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Deactivate provisioned user",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "List provisioned users",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Upsert provisioned user",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Update provisioned user",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/apps/{clientId}/users/{externalUserId}/keys": {
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Revoke user API key",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Integrator-defined stable user id."
+            },
+            "required": true,
+            "description": "Integrator-defined stable user id.",
+            "name": "externalUserId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "List user API keys",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Integrator-defined stable user id."
+            },
+            "required": true,
+            "description": "Integrator-defined stable user id.",
+            "name": "externalUserId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Create user API key",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Integrator-defined stable user id."
+            },
+            "required": true,
+            "description": "Integrator-defined stable user id.",
+            "name": "externalUserId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/apps/{clientId}/manifest": {
+      "get": {
+        "tags": [
+          "Discovery"
+        ],
+        "summary": "App manifest",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Discovery"
+        ],
+        "summary": "Update app manifest",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/apps/{clientId}/signer/routing": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Signer routing config",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/health": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "Service healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pipeline-catalog": {
+      "get": {
+        "tags": [
+          "Discovery"
+        ],
+        "summary": "Pipeline capability catalog",
+        "responses": {
+          "200": {
+            "description": "Catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/apps/{clientId}/oidc/token": {
+      "post": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "RFC 8693 signer session token exchange",
+        "description": "Exchanges a user access JWT (device code / authorization code) or per-app-user API key (`pmth_*`) for a short-lived signer JWT. The `{clientId}` path segment is the public OAuth app client id. Authenticate with the end-user `subject_token`; optional HTTP Basic with the M2M client is supported for server-side callers.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenExchangeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signer session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignerSession"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request, grant, target, or unsupported token type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid client credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "App not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/apps/{clientId}/users/{externalUserId}/token": {
+      "post": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Mint programmatic user JWT (M2M)",
+        "description": "Confidential client (`m2m_*` + secret) mints a user-scoped access token. Subject-token acquisition strategy for RFC 8693 signer exchange at `POST /api/v1/apps/{clientId}/oidc/token`.",
+        "security": [
+          {
+            "m2mBasic": []
+          },
+          {
+            "bearerUserJwt": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^app_[a-f0-9]+$",
+              "description": "Public Builder app client id (`app_\u2026`).",
+              "examples": [
+                "app_3b386c81a1db1169fd2c3986"
+              ]
+            },
+            "required": true,
+            "description": "Public Builder app client id (`app_\u2026`).",
+            "name": "clientId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Integrator-defined stable user id."
+            },
+            "required": true,
+            "description": "Integrator-defined stable user id.",
+            "name": "externalUserId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProgrammaticUserTokenRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Programmatic user token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProgrammaticTokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid scope or request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "M2M authentication failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden (scope or cross-app).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "App or user not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/oidc/token": {
+      "post": {
+        "skipCompletenessCheck": true,
+        "tags": [
+          "OIDC"
+        ],
+        "summary": "OIDC provider token endpoint",
+        "description": "Served by oidc-provider at `/api/v1/oidc/token`. Standard OAuth/OIDC grants: `authorization_code`, `refresh_token`, `client_credentials`, device code, and pymthouse-specific exchanges (device approval, gateway session). Signer session exchange uses `POST /api/v1/apps/{clientId}/oidc/token` instead. See OpenID Configuration for the full parameter matrix.",
+        "responses": {
+          "200": {
+            "description": "Token response per OAuth/OIDC."
+          },
+          "400": {
+            "description": "OAuth error."
+          }
+        }
+      }
+    },
+    "/api/v1/mcp": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Livepeer MCP connect metadata",
+        "responses": {
+          "200": {
+            "description": "MCP metadata"
+          }
+        },
+        "description": "Public metadata for the hosted Livepeer MCP (URL, issuer, tools). No secrets. Tool calls require Bearer API key/JWT or Basic M2M."
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GenericJsonObject": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": {
+          "nullable": true
+        }
+      },
+      "OAuthError": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "OAuth 2.0 error code (RFC 6749 \u00a75.2).",
+            "examples": [
+              "invalid_request",
+              "invalid_client",
+              "invalid_scope"
+            ]
+          },
+          "error_description": {
+            "type": "string",
+            "description": "Human-readable error description."
+          },
+          "correlation_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Request correlation id for support and audit."
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "correlation_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Request correlation id for support and audit."
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "SignerSession": {
+        "type": "object",
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "description": "Short-lived signer JWT (RFC 8693)."
+          },
+          "token_type": {
+            "type": "string",
+            "enum": [
+              "Bearer"
+            ]
+          },
+          "expires_in": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "scope": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Space-delimited OAuth scopes.",
+            "examples": [
+              "sign:job"
+            ]
+          },
+          "balanceUsdMicros": {
+            "type": "string",
+            "description": "PymtHouse extension: remaining balance in USD micros."
+          },
+          "lifetimeGrantedUsdMicros": {
+            "type": "string",
+            "description": "PymtHouse extension: lifetime granted balance in USD micros."
+          },
+          "signer_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Public remote-signer base URL."
+          },
+          "discovery_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Livepeer network discovery URL (not OIDC issuer metadata)."
+          },
+          "issued_token_type": {
+            "type": "string",
+            "enum": [
+              "urn:ietf:params:oauth:token-type:access_token"
+            ],
+            "description": "RFC 8693 issued_token_type when sourced from /token."
+          },
+          "correlation_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Request correlation id for support and audit."
+          }
+        },
+        "required": [
+          "access_token",
+          "token_type",
+          "expires_in",
+          "scope"
+        ]
+      },
+      "TokenExchangeRequest": {
+        "type": "object",
+        "properties": {
+          "grant_type": {
+            "type": "string",
+            "enum": [
+              "urn:ietf:params:oauth:grant-type:token-exchange"
+            ],
+            "description": "RFC 8693 token exchange grant type."
+          },
+          "subject_token": {
+            "type": "string",
+            "description": "User access JWT, opaque API-key secret, or composite `app_<24hex>_<secret>`."
+          },
+          "subject_token_type": {
+            "type": "string",
+            "enum": [
+              "urn:ietf:params:oauth:token-type:access_token"
+            ],
+            "description": "Subject token type for signer session exchange."
+          },
+          "requested_token_type": {
+            "type": "string",
+            "enum": [
+              "urn:ietf:params:oauth:token-type:access_token"
+            ]
+          },
+          "audience": {
+            "type": "string",
+            "description": "Must match configured signer audience when provided."
+          },
+          "resource": {
+            "type": "string",
+            "description": "Must match configured signer audience when provided."
+          }
+        },
+        "required": [
+          "grant_type",
+          "subject_token",
+          "subject_token_type"
+        ]
+      },
+      "ProgrammaticTokenResponse": {
+        "type": "object",
+        "properties": {
+          "access_token": {
+            "type": "string"
+          },
+          "refresh_token": {
+            "type": "string"
+          },
+          "token_type": {
+            "type": "string",
+            "enum": [
+              "Bearer"
+            ]
+          },
+          "expires_in": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "scope": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Space-delimited OAuth scopes.",
+            "examples": [
+              "sign:job"
+            ]
+          },
+          "subject_type": {
+            "type": "string",
+            "enum": [
+              "app_user"
+            ]
+          },
+          "externalUserId": {
+            "type": "string"
+          },
+          "correlation_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Request correlation id for support and audit."
+          }
+        },
+        "required": [
+          "access_token",
+          "token_type",
+          "expires_in",
+          "scope"
+        ]
+      },
+      "ProgrammaticUserTokenRequest": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Space-delimited OAuth scopes.",
+            "examples": [
+              "sign:job"
+            ]
+          }
+        }
+      },
+      "C0ValidateResponse": {
+        "type": "object",
+        "properties": {
+          "valid": {
+            "type": "boolean"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "sub": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sub"
+            ]
+          },
+          "billing_account": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "providerSlug": {
+                "type": "string"
+              },
+              "billingMode": {
+                "type": "string",
+                "enum": [
+                  "delegated",
+                  "prepay"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "providerSlug",
+              "billingMode"
+            ]
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "quota": {
+            "nullable": true
+          },
+          "subscriptionRef": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "valid"
+        ]
+      },
+      "C0ValidateRequest": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "key"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "m2mBasic": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "Confidential M2M client (`m2m_\u2026` + `pmth_cs_\u2026` secret). RFC 6749 client authentication."
+      },
+      "bearerUserJwt": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Short-lived user access token minted by Builder API or OIDC."
+      },
+      "adminSession": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Dashboard admin session or admin-scoped platform token."
+      }
+    }
+  }
+}

--- a/scripts/bootstrap-dev-portal.sh
+++ b/scripts/bootstrap-dev-portal.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Print Kong Dev Portal packaging checklist (OpenAPI slices in openapi/).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+cat <<EOF
+Kong Dev Portal packaging (optional):
+
+  Specs:
+    ${ROOT}/openapi/livepeer-control.openapi.json
+    ${ROOT}/openapi/discovery-service.openapi.yaml
+
+  Docs:
+    ${ROOT}/docs/kong-dev-portal.md
+
+  Auth strategy issuer:
+    https://pymthouse.com/api/v1/oidc
+
+  MCP metadata (after Livepeer MCP is deployed):
+    GET https://pymthouse.com/api/v1/mcp
+EOF


### PR DESCRIPTION
## Summary
- Add optional Kong Dev Portal packaging: Livepeer control OpenAPI slice + discovery-service OpenAPI
- Document publish/auth checklist (`docs/kong-dev-portal.md`) and a small bootstrap helper
- Kept separate from the Livepeer MCP runtime PR so portal specs do not inflate that diff

## Test plan
- [ ] `jq '.info, (.paths | keys)' openapi/livepeer-control.openapi.json` looks correct
- [ ] Discovery YAML parses and `info.title` is Discovery Service API
- [ ] Follow `docs/kong-dev-portal.md` against a Konnect portal (OIDC strategy → upload specs → MCP connect page)