### PR TITLE
build(deps): bump next-auth from 4.24.14 to 4.24.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "drizzle-orm": "^0.45.2",
         "jose": "^6.2.1",
         "next": "16.2.11",
-        "next-auth": "^4.24.0",
+        "next-auth": "^4.24.15",
         "oidc-provider": "^9.7.0",
         "postgres": "^3.4.5",
         "protobufjs": "^7.6.3",
@@ -8860,9 +8860,9 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.14",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.14.tgz",
-      "integrity": "sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==",
+      "version": "4.24.15",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.15.tgz",
+      "integrity": "sha512-NnjYtjrSOAx/TIVFGTX4IfI/9yHnNpi4B7FuLUwuV20v2Zxgr2OGP/YN0ynJuI7y8QOnTBPitfOdEXZrVvhIuA==",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -8873,7 +8873,7 @@
         "openid-client": "^5.4.0",
         "preact": "^10.6.3",
         "preact-render-to-string": "^5.1.19",
-        "uuid": "^8.3.2"
+        "uuid": "^11.1.1"
       },
       "peerDependencies": {
         "@auth/core": "0.34.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "drizzle-orm": "^0.45.2",
     "jose": "^6.2.1",
     "next": "16.2.11",
-    "next-auth": "^4.24.0",
+    "next-auth": "^4.24.15",
     "oidc-provider": "^9.7.0",
     "postgres": "^3.4.5",
     "protobufjs": "^7.6.3",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Same dependency bump as Dependabot [#303](https://github.com/pymthouse/pymthouse/pull/303), landed on a same-repo branch so CI secrets (Sonar/Snyk/Vercel) are available.

Bumps `next-auth` from `4.24.14` → `4.24.15` (security patch on the 4.x line).

## Compatibility
Reviewed against current Auth.js usage (`src/lib/next-auth-options.ts`, `src/proxy.ts`):

- Only Credentials providers (`token`, `turnkey-wallet`) — OAuth state/nonce/PKCE cookie binding change does not apply
- No Email provider — NFKC email normalization N/A
- `getToken()` null-on-malformed-Bearer is compatible with existing proxy try/catch
- Explicit `NEXTAUTH_URL` precedence aligns with issuer URL usage
- Nested `uuid@11.1.1` matches the existing `overrides.next-auth.uuid`

## Verification
- `npm ci --ignore-scripts` — clean install, `npm audit` reports 0 vulnerabilities
- Resolved `next-auth@4.24.15` with nested `uuid@11.1.1`
- `npx tsc --noEmit` — same 2 pre-existing errors in `src/lib/openmeter/openmeter.test.ts` as on `main` (unrelated)
- CI on this PR: **test, SonarQube, Snyk, CodeQL, deploy-vercel all green**

## Notes
Recommend closing [#303](https://github.com/pymthouse/pymthouse/pull/303) once this merges (Dependabot fork CI was blocked by missing secrets / Docker Hub flakiness, not by the bump itself).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13966fce-3a6d-4717-bdbf-64d72f77e658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13966fce-3a6d-4717-bdbf-64d72f77e658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

