### PR TITLE
feat(apps): confine auth-code redirects to web_ + credentials client tabs

### DIFF
--- a/.claude/skills/pymthouse-integrations/SKILL.md
+++ b/.claude/skills/pymthouse-integrations/SKILL.md
@@ -26,10 +26,11 @@ Each developer app typically has **two** registered OIDC clients:
 
 | Role | `client_id` shape | Secret? | Used for |
 | --- | --- | --- | --- |
-| **Public** (SDK, browser, RFC 8628 device) | `app_…` | No (`token_endpoint_auth_method: none`) | Device/auth URLs, `client_id` in verification links, subject JWT must show this `client_id` |
+| **Public** (SDK, browser device, RFC 8628) | `app_…` | No (`token_endpoint_auth_method: none`) | Device/auth URLs, `client_id` in verification links, subject JWT must show this `client_id` — **no** authorization-code redirects |
 | **Confidential** (Builder / M2M) | `m2m_…` | Yes | `Authorization: Basic base64(m2m_id:secret)` on Builder routes and RFC 8693 token exchange |
+| **Confidential web RP** (portal SSO) | `web_…` | Yes | authorization_code + redirects (Kong Dev Portal, etc.) |
 
-They are siblings: `developer_apps.oidc_client_id` → public row; `developer_apps.m2m_oidc_client_id` → M2M row.
+They are siblings: `developer_apps.oidc_client_id` → public row; `developer_apps.m2m_oidc_client_id` → M2M row; `developer_apps.web_oidc_client_id` → web RP row.
 
 **Do not** put the M2M id in env vars meant for the public app (e.g. integrators must set **public** `app_…` wherever the device URL’s `client_id` or Builder path `{clientId}` is the public id).
 

--- a/.cursor/skills/pymthouse-integrations/SKILL.md
+++ b/.cursor/skills/pymthouse-integrations/SKILL.md
@@ -20,16 +20,17 @@ PymtHouse is the **sole OIDC issuer** for integrator apps. External backends tal
 | --- | --- |
 | Builder product (OIDC issuer, Builder API, Usage API, device + token exchange) | `docs/builder-api.md` || [docs.pymthouse.com](https://docs.pymthouse.com)
 
-## Two clients per interactive app
+## OIDC siblings per interactive app
 
-Each developer app typically has **two** registered OIDC clients:
+Each developer app typically registers **two or three** OIDC clients:
 
 | Role | `client_id` shape | Secret? | Used for |
 | --- | --- | --- | --- |
-| **Public** (SDK, browser, RFC 8628 device) | `app_…` | No (`token_endpoint_auth_method: none`) | Device/auth URLs, `client_id` in verification links, subject JWT must show this `client_id` |
+| **Public** (SDK, browser device, RFC 8628) | `app_…` | No (`token_endpoint_auth_method: none`) | Device/auth URLs, `client_id` in verification links, subject JWT must show this `client_id` — **no** authorization-code redirects |
 | **Confidential** (Builder / M2M) | `m2m_…` | Yes | `Authorization: Basic base64(m2m_id:secret)` on Builder routes and RFC 8693 token exchange |
+| **Confidential web RP** (portal SSO) | `web_…` | Yes | authorization_code + redirects (Kong Dev Portal, etc.) |
 
-They are siblings: `developer_apps.oidc_client_id` → public row; `developer_apps.m2m_oidc_client_id` → M2M row.
+They are siblings: `developer_apps.oidc_client_id` → public row; `developer_apps.m2m_oidc_client_id` → M2M row; `developer_apps.web_oidc_client_id` → web RP row.
 
 **Do not** put the M2M id in env vars meant for the public app (e.g. integrators must set **public** `app_…` wherever the device URL’s `client_id` or Builder path `{clientId}` is the public id).
 

--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -54,7 +54,7 @@ M2M secret rotation remains at `POST /api/v1/apps/{clientId}/credentials` (provi
 | Stored API key (`<prefix><hex>`) | Per-app-user **API key** (hashed at rest) | `subject_token` on `POST /api/v1/apps/{clientId}/oidc/token` |
 | `app_<24hex>_<secret>` | **Presented** API key (issuance + remote-signer Bearer) | Same secret material as the stored key; `app_*` segment routes the app-scoped exchange URL |
 | Client secret (`*_cs_*`) | Confidential client secret | HTTP Basic / `client_secret_post` with the matching client id (RFC 6749 §2.3.1) — never the API-key bearer exchange |
-| `app_…` | Public interactive client | Path params and token endpoint `client_id`; `token_endpoint_auth_method=none` (PKCE) |
+| `app_…` | Public interactive client | Path params and token endpoint `client_id`; `token_endpoint_auth_method=none` (device / SDK; **no** authorization-code redirects) |
 | `m2m_…` | Confidential M2M sibling | `client_credentials` only — Builder API / machine tokens |
 | `web_…` | Confidential web RP sibling | `authorization_code` + secret + redirects — portal SSO (e.g. Kong Dev Portal); **not** `client_credentials` |
 
@@ -62,9 +62,11 @@ M2M secret rotation remains at `POST /api/v1/apps/{clientId}/credentials` (provi
 
 | Shape | Client | Secret | Typical grants |
 | --- | --- | --- | --- |
-| Public interactive | `app_…`, auth method `none` | No | auth code (PKCE), refresh, device |
+| Public interactive | `app_…`, auth method `none` | No | refresh, device (no redirect URIs) |
 | M2M backend helper | `m2m_…` | Yes | `client_credentials` |
 | Confidential web RP | `web_…` | Yes | auth code + refresh |
+
+Authorization-code (browser / portal) login is registered **only** on the confidential `web_` sibling. The public `app_` client stays secretless for device flow, SDK `client_id`, and API-key routing.
 
 Enable **Confidential web RP** on App profile (same pattern as Confidential M2M backend). Rotate the `web_` secret with `POST /api/v1/apps/{clientId}/credentials?target=web`. Do not put portal SSO credentials on the public SDK client or the M2M helper.
 
@@ -318,11 +320,15 @@ sequenceDiagram
 
 ## Interactive login and machine access
 
-### Authorization code (interactive)
+### Authorization code (interactive / portal SSO)
 
-1. Redirect the user to `{issuer}/auth` with `response_type=code`, `client_id`, `redirect_uri`, `scope`, `state`.
-2. Exchange the code at `{issuer}/token` with `grant_type=authorization_code`, the same `redirect_uri`, and `client_id` + `client_secret` for confidential clients.
-3. Request only scopes allowed for that client. **Public clients:** PKCE is required. **Confidential clients:** client authentication is required.
+Use the confidential **`web_…`** sibling (not the public `app_…` client):
+
+1. Redirect the user to `{issuer}/auth` with `response_type=code`, `client_id` (`web_…`), `redirect_uri`, `scope`, `state`.
+2. Exchange the code at `{issuer}/token` with `grant_type=authorization_code`, the same `redirect_uri`, and `client_id` + `client_secret`.
+3. Request only scopes allowed for that client. Confidential clients must authenticate at the token endpoint.
+
+Public `app_…` clients do not register redirect URIs and do not advertise `authorization_code` — use device flow (RFC 8628) or API keys for interactive / end-user access on the public client.
 
 ### Client credentials (machine)
 

--- a/scripts/repair-client-grants.ts
+++ b/scripts/repair-client-grants.ts
@@ -1,12 +1,11 @@
 /**
- * Repair grant_types for all public (app_*) OIDC clients to enforce the
- * authorization_code ↔ redirect_uris invariant.
+ * Repair OIDC clients for the Option 1 product model:
+ *   - Public `app_*` clients never hold redirect URIs or authorization_code
+ *   - Confidential `web_*` clients sync authorization_code ↔ redirect_uris
+ *   - M2M `m2m_*` clients are left untouched
  *
- * Rule:
- *   - Client has redirect URIs  → authorization_code MUST be in grant_types
- *   - Client has no redirect URIs → authorization_code MUST NOT be in grant_types
- *
- * M2M clients (m2m_*) are left untouched.
+ * When an app has both a public client with legacy redirects and a web sibling
+ * with empty redirects, migrates those URIs onto the web sibling first.
  *
  * Usage:
  *   DATABASE_URL=... npx tsx scripts/repair-client-grants.ts
@@ -21,6 +20,17 @@ import * as schema from "../src/db/schema";
 
 const AUTHORIZATION_CODE = "authorization_code";
 
+function parseJsonArray(raw: string | null | undefined): string[] {
+  try {
+    const parsed = JSON.parse(raw ?? "[]") as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((u): u is string => typeof u === "string" && u.trim().length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 async function main() {
   const databaseUrl = process.env.DATABASE_URL?.trim();
   if (!databaseUrl) {
@@ -31,27 +41,87 @@ async function main() {
   const client = postgres(databaseUrl, { max: 1 });
   const db = drizzle(client, { schema });
 
-  const rows = await db.select().from(schema.oidcClients);
+  const apps = await db.select().from(schema.developerApps);
+  const clients = await db.select().from(schema.oidcClients);
+  const clientsByPk = new Map(clients.map((row) => [row.id, row]));
 
   let fixed = 0;
   let skipped = 0;
 
-  for (const row of rows) {
-    // Skip M2M clients — they never use redirect URIs or authorization_code.
-    if (row.clientId.startsWith("m2m_")) {
-      skipped++;
-      continue;
-    }
+  for (const app of apps) {
+    const pub = app.oidcClientId ? clientsByPk.get(app.oidcClientId) : undefined;
+    const web = app.webOidcClientId ? clientsByPk.get(app.webOidcClientId) : undefined;
 
-    const redirectUris: string[] = JSON.parse(row.redirectUris ?? "[]");
+    if (pub?.clientId.startsWith("app_")) {
+      const pubRedirects = parseJsonArray(pub.redirectUris);
+      const pubPostLogout = parseJsonArray(pub.postLogoutRedirectUris);
+      const pubGrants = pub.grantTypes
+        .split(",")
+        .map((g) => g.trim())
+        .filter(Boolean);
+
+      if (web && pubRedirects.length > 0) {
+        const webRedirects = parseJsonArray(web.redirectUris);
+        if (webRedirects.length === 0) {
+          const nextWebGrants = web.grantTypes
+            .split(",")
+            .map((g) => g.trim())
+            .filter((g) => g && g !== AUTHORIZATION_CODE);
+          nextWebGrants.unshift(AUTHORIZATION_CODE);
+          await db
+            .update(schema.oidcClients)
+            .set({
+              redirectUris: JSON.stringify(pubRedirects),
+              grantTypes: nextWebGrants.join(","),
+              ...(pubPostLogout.length > 0 && !parseJsonArray(web.postLogoutRedirectUris).length
+                ? { postLogoutRedirectUris: JSON.stringify(pubPostLogout) }
+                : {}),
+            })
+            .where(eq(schema.oidcClients.id, web.id));
+          console.log(
+            `[migrate] ${pub.clientId} → ${web.clientId}  redirects=${pubRedirects.length}`,
+          );
+          fixed++;
+        }
+      }
+
+      const nextPubGrants = pubGrants.filter((g) => g !== AUTHORIZATION_CODE);
+      const needsPubStrip =
+        pubRedirects.length > 0 ||
+        pubGrants.includes(AUTHORIZATION_CODE) ||
+        (pubPostLogout.length > 0 && Boolean(web));
+
+      if (needsPubStrip) {
+        await db
+          .update(schema.oidcClients)
+          .set({
+            redirectUris: JSON.stringify([]),
+            grantTypes: nextPubGrants.join(","),
+            ...(web && pubPostLogout.length > 0
+              ? { postLogoutRedirectUris: JSON.stringify([]) }
+              : {}),
+          })
+          .where(eq(schema.oidcClients.id, pub.id));
+        console.log(
+          `[strip]  ${pub.clientId}  cleared public redirects / authorization_code`,
+        );
+        fixed++;
+      } else {
+        skipped++;
+      }
+    }
+  }
+
+  for (const row of clients) {
+    if (!row.clientId.startsWith("web_")) continue;
+
+    const redirectUris = parseJsonArray(row.redirectUris);
     const grants = row.grantTypes
       .split(",")
       .map((g) => g.trim())
       .filter(Boolean);
-
     const hasRedirects = redirectUris.length > 0;
     const hasAuthCode = grants.includes(AUTHORIZATION_CODE);
-
     const needsAdd = hasRedirects && !hasAuthCode;
     const needsRemove = !hasRedirects && hasAuthCode;
 
@@ -60,18 +130,13 @@ async function main() {
       continue;
     }
 
-    let nextGrants: string[];
-    if (needsAdd) {
-      nextGrants = [AUTHORIZATION_CODE, ...grants];
-      console.log(
-        `[add]    ${row.clientId}  redirects=${redirectUris.length}  grants: ${grants.join(",")} → ${nextGrants.join(",")}`,
-      );
-    } else {
-      nextGrants = grants.filter((g) => g !== AUTHORIZATION_CODE);
-      console.log(
-        `[remove] ${row.clientId}  no redirects  grants: ${grants.join(",")} → ${nextGrants.join(",")}`,
-      );
-    }
+    const nextGrants = needsAdd
+      ? [AUTHORIZATION_CODE, ...grants.filter((g) => g !== AUTHORIZATION_CODE)]
+      : grants.filter((g) => g !== AUTHORIZATION_CODE);
+
+    console.log(
+      `[web]    ${row.clientId}  redirects=${redirectUris.length}  grants: ${grants.join(",")} → ${nextGrants.join(",")}`,
+    );
 
     await db
       .update(schema.oidcClients)
@@ -82,7 +147,7 @@ async function main() {
   }
 
   console.log(
-    `\n[repair-client-grants] Done. Fixed: ${fixed}, Skipped: ${skipped}, Total: ${rows.length}`,
+    `\n[repair-client-grants] Done. Fixed: ${fixed}, Skipped: ${skipped}, Clients: ${clients.length}`,
   );
 
   await client.end({ timeout: 5 });

--- a/scripts/repair-client-grants.ts
+++ b/scripts/repair-client-grants.ts
@@ -134,20 +134,11 @@ async function repairWebClientGrants(
   return "fixed";
 }
 
-async function main() {
-  const databaseUrl = process.env.DATABASE_URL?.trim();
-  if (!databaseUrl) {
-    console.error("[repair-client-grants] DATABASE_URL is not set.");
-    process.exit(1);
-  }
-
-  const client = postgres(databaseUrl, { max: 1 });
-  const db = drizzle(client, { schema });
-
-  const apps = await db.select().from(schema.developerApps);
-  const clients = await db.select().from(schema.oidcClients);
-  const clientsByPk = new Map(clients.map((row) => [row.id, row]));
-
+async function repairPublicAppClients(
+  db: Db,
+  apps: (typeof schema.developerApps.$inferSelect)[],
+  clientsByPk: Map<string, ClientRow>,
+): Promise<{ fixed: number; skipped: number }> {
   let fixed = 0;
   let skipped = 0;
 
@@ -164,6 +155,27 @@ async function main() {
     if (stripResult === "fixed") fixed++;
     else skipped++;
   }
+
+  return { fixed, skipped };
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    console.error("[repair-client-grants] DATABASE_URL is not set.");
+    process.exit(1);
+  }
+
+  const client = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(client, { schema });
+
+  const apps = await db.select().from(schema.developerApps);
+  const clients = await db.select().from(schema.oidcClients);
+  const clientsByPk = new Map(clients.map((row) => [row.id, row]));
+
+  const publicRepair = await repairPublicAppClients(db, apps, clientsByPk);
+  let fixed = publicRepair.fixed;
+  let skipped = publicRepair.skipped;
 
   for (const row of clients) {
     const result = await repairWebClientGrants(db, row);

--- a/scripts/repair-client-grants.ts
+++ b/scripts/repair-client-grants.ts
@@ -16,9 +16,13 @@ import "./load-env-first";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { eq } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import * as schema from "../src/db/schema";
 
 const AUTHORIZATION_CODE = "authorization_code";
+
+type Db = PostgresJsDatabase<typeof schema>;
+type ClientRow = typeof schema.oidcClients.$inferSelect;
 
 function parseJsonArray(raw: string | null | undefined): string[] {
   try {
@@ -29,6 +33,105 @@ function parseJsonArray(raw: string | null | undefined): string[] {
   } catch {
     return [];
   }
+}
+
+function parseGrants(grantTypes: string): string[] {
+  return grantTypes
+    .split(",")
+    .map((g) => g.trim())
+    .filter(Boolean);
+}
+
+async function migratePublicRedirectsToWeb(
+  db: Db,
+  pub: ClientRow,
+  web: ClientRow,
+): Promise<boolean> {
+  const pubRedirects = parseJsonArray(pub.redirectUris);
+  if (pubRedirects.length === 0) return false;
+  if (parseJsonArray(web.redirectUris).length > 0) return false;
+
+  const pubPostLogout = parseJsonArray(pub.postLogoutRedirectUris);
+  const nextWebGrants = parseGrants(web.grantTypes).filter((g) => g !== AUTHORIZATION_CODE);
+  nextWebGrants.unshift(AUTHORIZATION_CODE);
+
+  const webPostLogoutEmpty = parseJsonArray(web.postLogoutRedirectUris).length === 0;
+  await db
+    .update(schema.oidcClients)
+    .set({
+      redirectUris: JSON.stringify(pubRedirects),
+      grantTypes: nextWebGrants.join(","),
+      ...(pubPostLogout.length > 0 && webPostLogoutEmpty
+        ? { postLogoutRedirectUris: JSON.stringify(pubPostLogout) }
+        : {}),
+    })
+    .where(eq(schema.oidcClients.id, web.id));
+
+  console.log(
+    `[migrate] ${pub.clientId} → ${web.clientId}  redirects=${pubRedirects.length}`,
+  );
+  return true;
+}
+
+async function stripPublicAuthCode(
+  db: Db,
+  pub: ClientRow,
+  web: ClientRow | undefined,
+): Promise<"fixed" | "skipped"> {
+  const pubRedirects = parseJsonArray(pub.redirectUris);
+  const pubPostLogout = parseJsonArray(pub.postLogoutRedirectUris);
+  const pubGrants = parseGrants(pub.grantTypes);
+  const nextPubGrants = pubGrants.filter((g) => g !== AUTHORIZATION_CODE);
+  const needsPubStrip =
+    pubRedirects.length > 0 ||
+    pubGrants.includes(AUTHORIZATION_CODE) ||
+    (pubPostLogout.length > 0 && Boolean(web));
+
+  if (!needsPubStrip) return "skipped";
+
+  await db
+    .update(schema.oidcClients)
+    .set({
+      redirectUris: JSON.stringify([]),
+      grantTypes: nextPubGrants.join(","),
+      ...(web && pubPostLogout.length > 0
+        ? { postLogoutRedirectUris: JSON.stringify([]) }
+        : {}),
+    })
+    .where(eq(schema.oidcClients.id, pub.id));
+
+  console.log(
+    `[strip]  ${pub.clientId}  cleared public redirects / authorization_code`,
+  );
+  return "fixed";
+}
+
+async function repairWebClientGrants(
+  db: Db,
+  row: ClientRow,
+): Promise<"fixed" | "skipped"> {
+  if (!row.clientId.startsWith("web_")) return "skipped";
+
+  const redirectUris = parseJsonArray(row.redirectUris);
+  const grants = parseGrants(row.grantTypes);
+  const hasRedirects = redirectUris.length > 0;
+  const hasAuthCode = grants.includes(AUTHORIZATION_CODE);
+  if (hasRedirects === hasAuthCode) return "skipped";
+
+  const nextGrants = hasRedirects
+    ? [AUTHORIZATION_CODE, ...grants.filter((g) => g !== AUTHORIZATION_CODE)]
+    : grants.filter((g) => g !== AUTHORIZATION_CODE);
+
+  console.log(
+    `[web]    ${row.clientId}  redirects=${redirectUris.length}  grants: ${grants.join(",")} → ${nextGrants.join(",")}`,
+  );
+
+  await db
+    .update(schema.oidcClients)
+    .set({ grantTypes: nextGrants.join(",") })
+    .where(eq(schema.oidcClients.clientId, row.clientId));
+
+  return "fixed";
 }
 
 async function main() {
@@ -51,99 +154,21 @@ async function main() {
   for (const app of apps) {
     const pub = app.oidcClientId ? clientsByPk.get(app.oidcClientId) : undefined;
     const web = app.webOidcClientId ? clientsByPk.get(app.webOidcClientId) : undefined;
+    if (!pub?.clientId.startsWith("app_")) continue;
 
-    if (pub?.clientId.startsWith("app_")) {
-      const pubRedirects = parseJsonArray(pub.redirectUris);
-      const pubPostLogout = parseJsonArray(pub.postLogoutRedirectUris);
-      const pubGrants = pub.grantTypes
-        .split(",")
-        .map((g) => g.trim())
-        .filter(Boolean);
-
-      if (web && pubRedirects.length > 0) {
-        const webRedirects = parseJsonArray(web.redirectUris);
-        if (webRedirects.length === 0) {
-          const nextWebGrants = web.grantTypes
-            .split(",")
-            .map((g) => g.trim())
-            .filter((g) => g && g !== AUTHORIZATION_CODE);
-          nextWebGrants.unshift(AUTHORIZATION_CODE);
-          await db
-            .update(schema.oidcClients)
-            .set({
-              redirectUris: JSON.stringify(pubRedirects),
-              grantTypes: nextWebGrants.join(","),
-              ...(pubPostLogout.length > 0 && !parseJsonArray(web.postLogoutRedirectUris).length
-                ? { postLogoutRedirectUris: JSON.stringify(pubPostLogout) }
-                : {}),
-            })
-            .where(eq(schema.oidcClients.id, web.id));
-          console.log(
-            `[migrate] ${pub.clientId} → ${web.clientId}  redirects=${pubRedirects.length}`,
-          );
-          fixed++;
-        }
-      }
-
-      const nextPubGrants = pubGrants.filter((g) => g !== AUTHORIZATION_CODE);
-      const needsPubStrip =
-        pubRedirects.length > 0 ||
-        pubGrants.includes(AUTHORIZATION_CODE) ||
-        (pubPostLogout.length > 0 && Boolean(web));
-
-      if (needsPubStrip) {
-        await db
-          .update(schema.oidcClients)
-          .set({
-            redirectUris: JSON.stringify([]),
-            grantTypes: nextPubGrants.join(","),
-            ...(web && pubPostLogout.length > 0
-              ? { postLogoutRedirectUris: JSON.stringify([]) }
-              : {}),
-          })
-          .where(eq(schema.oidcClients.id, pub.id));
-        console.log(
-          `[strip]  ${pub.clientId}  cleared public redirects / authorization_code`,
-        );
-        fixed++;
-      } else {
-        skipped++;
-      }
+    if (web && (await migratePublicRedirectsToWeb(db, pub, web))) {
+      fixed++;
     }
+
+    const stripResult = await stripPublicAuthCode(db, pub, web);
+    if (stripResult === "fixed") fixed++;
+    else skipped++;
   }
 
   for (const row of clients) {
-    if (!row.clientId.startsWith("web_")) continue;
-
-    const redirectUris = parseJsonArray(row.redirectUris);
-    const grants = row.grantTypes
-      .split(",")
-      .map((g) => g.trim())
-      .filter(Boolean);
-    const hasRedirects = redirectUris.length > 0;
-    const hasAuthCode = grants.includes(AUTHORIZATION_CODE);
-    const needsAdd = hasRedirects && !hasAuthCode;
-    const needsRemove = !hasRedirects && hasAuthCode;
-
-    if (!needsAdd && !needsRemove) {
-      skipped++;
-      continue;
-    }
-
-    const nextGrants = needsAdd
-      ? [AUTHORIZATION_CODE, ...grants.filter((g) => g !== AUTHORIZATION_CODE)]
-      : grants.filter((g) => g !== AUTHORIZATION_CODE);
-
-    console.log(
-      `[web]    ${row.clientId}  redirects=${redirectUris.length}  grants: ${grants.join(",")} → ${nextGrants.join(",")}`,
-    );
-
-    await db
-      .update(schema.oidcClients)
-      .set({ grantTypes: nextGrants.join(",") })
-      .where(eq(schema.oidcClients.clientId, row.clientId));
-
-    fixed++;
+    const result = await repairWebClientGrants(db, row);
+    if (result === "fixed") fixed++;
+    else if (row.clientId.startsWith("web_")) skipped++;
   }
 
   console.log(

--- a/scripts/repair-client-grants.ts
+++ b/scripts/repair-client-grants.ts
@@ -24,12 +24,15 @@ const AUTHORIZATION_CODE = "authorization_code";
 type Db = PostgresJsDatabase<typeof schema>;
 type ClientRow = typeof schema.oidcClients.$inferSelect;
 
-function parseJsonArray(raw: string | null | undefined): string[] {
+/** Local copy — avoid importing oidc/clients (pulls app db) into this script. */
+function parseJsonStringArray(raw: string | null | undefined): string[] {
   try {
     const parsed = JSON.parse(raw ?? "[]") as unknown;
-    return Array.isArray(parsed)
-      ? parsed.filter((u): u is string => typeof u === "string" && u.trim().length > 0)
-      : [];
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((u): u is string => typeof u === "string")
+      .map((u) => u.trim())
+      .filter(Boolean);
   } catch {
     return [];
   }
@@ -47,15 +50,15 @@ async function migratePublicRedirectsToWeb(
   pub: ClientRow,
   web: ClientRow,
 ): Promise<boolean> {
-  const pubRedirects = parseJsonArray(pub.redirectUris);
+  const pubRedirects = parseJsonStringArray(pub.redirectUris);
   if (pubRedirects.length === 0) return false;
-  if (parseJsonArray(web.redirectUris).length > 0) return false;
+  if (parseJsonStringArray(web.redirectUris).length > 0) return false;
 
-  const pubPostLogout = parseJsonArray(pub.postLogoutRedirectUris);
+  const pubPostLogout = parseJsonStringArray(pub.postLogoutRedirectUris);
   const nextWebGrants = parseGrants(web.grantTypes).filter((g) => g !== AUTHORIZATION_CODE);
   nextWebGrants.unshift(AUTHORIZATION_CODE);
 
-  const webPostLogoutEmpty = parseJsonArray(web.postLogoutRedirectUris).length === 0;
+  const webPostLogoutEmpty = parseJsonStringArray(web.postLogoutRedirectUris).length === 0;
   await db
     .update(schema.oidcClients)
     .set({
@@ -78,8 +81,8 @@ async function stripPublicAuthCode(
   pub: ClientRow,
   web: ClientRow | undefined,
 ): Promise<"fixed" | "skipped"> {
-  const pubRedirects = parseJsonArray(pub.redirectUris);
-  const pubPostLogout = parseJsonArray(pub.postLogoutRedirectUris);
+  const pubRedirects = parseJsonStringArray(pub.redirectUris);
+  const pubPostLogout = parseJsonStringArray(pub.postLogoutRedirectUris);
   const pubGrants = parseGrants(pub.grantTypes);
   const nextPubGrants = pubGrants.filter((g) => g !== AUTHORIZATION_CODE);
   const needsPubStrip =
@@ -112,7 +115,7 @@ async function repairWebClientGrants(
 ): Promise<"fixed" | "skipped"> {
   if (!row.clientId.startsWith("web_")) return "skipped";
 
-  const redirectUris = parseJsonArray(row.redirectUris);
+  const redirectUris = parseJsonStringArray(row.redirectUris);
   const grants = parseGrants(row.grantTypes);
   const hasRedirects = redirectUris.length > 0;
   const hasAuthCode = grants.includes(AUTHORIZATION_CODE);

--- a/src/app/api/v1/apps/[id]/route.ts
+++ b/src/app/api/v1/apps/[id]/route.ts
@@ -286,7 +286,8 @@ export async function PUT(
     if (client) {
       const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
       if (body.name) clientUpdates.displayName = body.name;
-      if (body.redirectUris) clientUpdates.redirectUris = body.redirectUris;
+      // Public app_ never stores redirect URIs (authorization_code is on web_).
+      clientUpdates.redirectUris = [];
       if (body.tokenEndpointAuthMethod)
         clientUpdates.tokenEndpointAuthMethod = body.tokenEndpointAuthMethod;
       if (body.allowedScopes) {
@@ -299,16 +300,11 @@ export async function PUT(
       }
       if (body.grantTypes) clientUpdates.grantTypes = body.grantTypes;
 
-      // Resolve the final redirect URIs (updated or unchanged) and enforce the
-      // authorization_code ↔ redirect_uris invariant on every write.
-      const finalRedirectUris =
-        clientUpdates.redirectUris ??
-        (JSON.parse(client.redirectUris) as string[]);
       const baseGrants =
         clientUpdates.grantTypes ?? client.grantTypes.split(",").filter(Boolean);
       clientUpdates.grantTypes = syncPublicClientGrantTypes(
         baseGrants,
-        finalRedirectUris,
+        [],
         client.clientId,
       );
 
@@ -335,10 +331,7 @@ export async function PUT(
         resetProvider();
       }
 
-      if (
-        (app.m2mOidcClientId || app.webOidcClientId) &&
-        (await demotePublicClientWhenM2mSiblingExists(app.id))
-      ) {
+      if (await demotePublicClientWhenM2mSiblingExists(app.id)) {
         resetProvider();
       }
     }

--- a/src/app/api/v1/apps/[id]/settings/route.ts
+++ b/src/app/api/v1/apps/[id]/settings/route.ts
@@ -175,25 +175,17 @@ export async function PUT(
   // Auto-populate domain whitelist from confidential web redirect / post-logout origins
   let webRedirectUris: string[] = [];
   let webPostLogout: string[] = [];
-  if (app.webOidcClientId) {
-    const webRows = await db
-      .select({
-        redirectUris: oidcClients.redirectUris,
-        postLogoutRedirectUris: oidcClients.postLogoutRedirectUris,
-      })
-      .from(oidcClients)
-      .where(eq(oidcClients.id, app.webOidcClientId))
-      .limit(1);
-    if (webRows[0]?.redirectUris) {
+  if (webSummary) {
+    if (webSummary.redirectUris) {
       try {
-        webRedirectUris = JSON.parse(webRows[0].redirectUris) as string[];
+        webRedirectUris = JSON.parse(webSummary.redirectUris) as string[];
       } catch {
         webRedirectUris = [];
       }
     }
-    if (webRows[0]?.postLogoutRedirectUris) {
+    if (webSummary.postLogoutRedirectUris) {
       try {
-        webPostLogout = JSON.parse(webRows[0].postLogoutRedirectUris) as string[];
+        webPostLogout = JSON.parse(webSummary.postLogoutRedirectUris) as string[];
       } catch {
         webPostLogout = [];
       }

--- a/src/app/api/v1/apps/[id]/settings/route.ts
+++ b/src/app/api/v1/apps/[id]/settings/route.ts
@@ -66,14 +66,31 @@ export async function PUT(
 
   const body = await request.json();
 
-  // Build update payload from allowed fields
+  // Build update payload from allowed fields (public app_ never stores redirects).
   const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
+  clientUpdates.redirectUris = [];
 
-  if (Array.isArray(body.redirectUris)) {
-    clientUpdates.redirectUris = body.redirectUris;
-  }
+  const webSummary = app.webOidcClientId
+    ? await (async () => {
+        const webRows = await db
+          .select()
+          .from(oidcClients)
+          .where(eq(oidcClients.id, app.webOidcClientId!))
+          .limit(1);
+        return webRows[0] ?? null;
+      })()
+    : null;
+
   if (Array.isArray(body.postLogoutRedirectUris)) {
-    clientUpdates.postLogoutRedirectUris = body.postLogoutRedirectUris;
+    if (webSummary) {
+      // Portal SSO logout belongs on the confidential web_ client.
+      await updateClientConfig(webSummary.clientId, {
+        postLogoutRedirectUris: body.postLogoutRedirectUris,
+      });
+      clientUpdates.postLogoutRedirectUris = [];
+    } else {
+      clientUpdates.postLogoutRedirectUris = body.postLogoutRedirectUris;
+    }
   }
   if (body.initiateLoginUri !== undefined) {
     clientUpdates.initiateLoginUri = body.initiateLoginUri || null;
@@ -155,11 +172,15 @@ export async function PUT(
 
   await updateClientConfig(client.clientId, clientUpdates);
 
-  // Auto-populate domain whitelist from public + confidential web redirect origins
+  // Auto-populate domain whitelist from confidential web redirect / post-logout origins
   let webRedirectUris: string[] = [];
+  let webPostLogout: string[] = [];
   if (app.webOidcClientId) {
     const webRows = await db
-      .select({ redirectUris: oidcClients.redirectUris })
+      .select({
+        redirectUris: oidcClients.redirectUris,
+        postLogoutRedirectUris: oidcClients.postLogoutRedirectUris,
+      })
       .from(oidcClients)
       .where(eq(oidcClients.id, app.webOidcClientId))
       .limit(1);
@@ -170,11 +191,19 @@ export async function PUT(
         webRedirectUris = [];
       }
     }
+    if (webRows[0]?.postLogoutRedirectUris) {
+      try {
+        webPostLogout = JSON.parse(webRows[0].postLogoutRedirectUris) as string[];
+      } catch {
+        webPostLogout = [];
+      }
+    }
   }
   const allRedirects = [
-    ...(clientUpdates.redirectUris ?? JSON.parse(client.redirectUris) as string[]),
-    ...(clientUpdates.postLogoutRedirectUris ?? []),
     ...webRedirectUris,
+    ...(Array.isArray(body.postLogoutRedirectUris)
+      ? body.postLogoutRedirectUris
+      : webPostLogout),
   ];
   const origins = extractOrigins(allRedirects);
 

--- a/src/app/api/v1/apps/route.ts
+++ b/src/app/api/v1/apps/route.ts
@@ -135,15 +135,8 @@ export async function POST(request: NextRequest) {
   const { id: oidcRowId, clientId } = await createAppClient(name.trim());
 
   const clientUpdates: Parameters<typeof updateClientConfig>[1] = {};
-  const rawRedirectUris = body.redirectUris;
-  if (Array.isArray(rawRedirectUris) && rawRedirectUris.length > 0) {
-    const redirectUris = rawRedirectUris.filter(
-      (u: unknown): u is string => typeof u === "string" && u.trim().length > 0,
-    );
-    if (redirectUris.length > 0) {
-      clientUpdates.redirectUris = redirectUris.map((u) => u.trim());
-    }
-  }
+  // Public app_ never stores redirect URIs — authorization_code lives on web_.
+  clientUpdates.redirectUris = [];
   if (
     typeof body.tokenEndpointAuthMethod === "string" &&
     ["none", "client_secret_post", "client_secret_basic"].includes(body.tokenEndpointAuthMethod)
@@ -158,23 +151,27 @@ export async function POST(request: NextRequest) {
       .join(" ");
     clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
   }
-  // Resolve final redirect URIs early so we can sync authorization_code grant.
-  const finalRedirectUris = clientUpdates.redirectUris ?? [];
 
   if (Array.isArray(body.grantTypes) && body.grantTypes.length > 0) {
     const grantTypes = body.grantTypes.filter(
       (v: unknown): v is string => typeof v === "string" && v.trim().length > 0,
     );
     if (grantTypes.length > 0) {
-      clientUpdates.grantTypes = syncPublicClientGrantTypes(grantTypes, finalRedirectUris, clientId);
+      clientUpdates.grantTypes = syncPublicClientGrantTypes(grantTypes, [], clientId);
     }
   }
 
-  // Always ensure the grant list is consistent with redirect URIs.
+  // Always strip authorization_code from the public client.
   if (clientUpdates.grantTypes) {
     clientUpdates.grantTypes = syncPublicClientGrantTypes(
       clientUpdates.grantTypes,
-      finalRedirectUris,
+      [],
+      clientId,
+    );
+  } else {
+    clientUpdates.grantTypes = syncPublicClientGrantTypes(
+      ["refresh_token"],
+      [],
       clientId,
     );
   }

--- a/src/app/api/v1/apps/route.ts
+++ b/src/app/api/v1/apps/route.ts
@@ -152,29 +152,17 @@ export async function POST(request: NextRequest) {
     clientUpdates.allowedScopes = filtered || DEFAULT_OIDC_SCOPES;
   }
 
-  if (Array.isArray(body.grantTypes) && body.grantTypes.length > 0) {
-    const grantTypes = body.grantTypes.filter(
-      (v: unknown): v is string => typeof v === "string" && v.trim().length > 0,
-    );
-    if (grantTypes.length > 0) {
-      clientUpdates.grantTypes = syncPublicClientGrantTypes(grantTypes, [], clientId);
-    }
-  }
-
+  const requestedGrantTypes = Array.isArray(body.grantTypes)
+    ? body.grantTypes.filter(
+        (v: unknown): v is string => typeof v === "string" && v.trim().length > 0,
+      )
+    : [];
   // Always strip authorization_code from the public client.
-  if (clientUpdates.grantTypes) {
-    clientUpdates.grantTypes = syncPublicClientGrantTypes(
-      clientUpdates.grantTypes,
-      [],
-      clientId,
-    );
-  } else {
-    clientUpdates.grantTypes = syncPublicClientGrantTypes(
-      ["refresh_token"],
-      [],
-      clientId,
-    );
-  }
+  clientUpdates.grantTypes = syncPublicClientGrantTypes(
+    requestedGrantTypes.length > 0 ? requestedGrantTypes : ["refresh_token"],
+    [],
+    clientId,
+  );
 
   if (
     body.deviceThirdPartyInitiateLogin === true &&

--- a/src/app/apps/[id]/page.tsx
+++ b/src/app/apps/[id]/page.tsx
@@ -45,7 +45,7 @@ export default function AppDetailPage() {
             description: data.description || "",
             developerName: data.developerName || "",
             websiteUrl: data.websiteUrl || "",
-            redirectUris: data.oidcClient?.redirectUris || [],
+            redirectUris: [],
             allowedScopes: ensureOpenIdScope(
               data.oidcClient?.allowedScopes || DEFAULT_OIDC_SCOPES,
             ),
@@ -72,7 +72,10 @@ export default function AppDetailPage() {
               domain: d.domain,
             }),
           ),
-          postLogoutRedirectUris: data.oidcClient?.postLogoutRedirectUris || [],
+          postLogoutRedirectUris:
+            data.webOidcClient?.postLogoutRedirectUris ||
+            data.oidcClient?.postLogoutRedirectUris ||
+            [],
           initiateLoginUri: data.oidcClient?.initiateLoginUri ?? null,
           deviceThirdPartyInitiateLogin:
             data.oidcClient?.deviceThirdPartyInitiateLogin === true,

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -4,8 +4,9 @@ import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState }
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppInfoStep from "./steps/AppInfoStep";
 import AppModeStep from "./steps/AppModeStep";
-import AuthorizationCodeRedirectBlock from "./steps/AuthorizationCodeRedirectBlock";
-import TestingStep, { AuthCodeFlowTestSection } from "./steps/TestingStep";
+import TestingStep, {
+  type CredentialsClientTab,
+} from "./steps/TestingStep";
 import PlansTab from "./PlansTab";
 import PaymentsTab from "./PaymentsTab";
 import {
@@ -114,7 +115,8 @@ export default function AppSettingsScreen({
   const [postLogoutRedirectUris, setPostLogoutRedirectUris] = useState<string[]>(
     initialPostLogoutRedirectUris,
   );
-  const [newPostLogoutUri, setNewPostLogoutUri] = useState("");
+  const [credentialsClient, setCredentialsClient] =
+    useState<CredentialsClientTab>("public");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -137,6 +139,9 @@ export default function AppSettingsScreen({
         } else {
           nextParams.set("tab", section);
         }
+        if (section !== "credentials") {
+          nextParams.delete("client");
+        }
         const query = nextParams.toString();
         const nextUrl = query ? `${pathname}?${query}` : pathname;
         router.replace(nextUrl, { scroll: false });
@@ -146,6 +151,30 @@ export default function AppSettingsScreen({
     },
     [pathname, router, searchParams],
   );
+
+  const selectCredentialsClient = useCallback(
+    (client: CredentialsClientTab, updateUrl = true) => {
+      setCredentialsClient(client);
+      if (!updateUrl) return;
+      const nextParams = new URLSearchParams(searchParams.toString());
+      nextParams.set("tab", "credentials");
+      if (client === "public") {
+        nextParams.delete("client");
+      } else {
+        nextParams.set("client", client);
+      }
+      const query = nextParams.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  useEffect(() => {
+    const clientParam = searchParams.get("client");
+    if (clientParam === "m2m" || clientParam === "web" || clientParam === "public") {
+      setCredentialsClient(clientParam);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     const resolvedTab = resolveInitialTab(initialTab);
@@ -359,13 +388,6 @@ export default function AppSettingsScreen({
     }
   }, [appId, canDeleteApp, router]);
 
-  const addPostLogoutUri = () => {
-    const trimmed = newPostLogoutUri.trim();
-    if (!trimmed || postLogoutRedirectUris.includes(trimmed)) return;
-    updatePostLogoutRedirectUris((u) => [...u, trimmed]);
-    setNewPostLogoutUri("");
-  };
-
   const discoveryUrl =
     typeof window !== "undefined"
       ? `${window.location.origin}/.well-known/openid-configuration`
@@ -387,6 +409,19 @@ export default function AppSettingsScreen({
     formData.redirectUris,
     appState.clientId ?? "",
   ).includes(AUTHORIZATION_CODE_GRANT);
+
+  const showM2mCredentialsTab =
+    Boolean(formData.backendDeviceHelper) || Boolean(appState.backendHelper);
+  const showWebCredentialsTab =
+    Boolean(formData.confidentialWebHelper) || Boolean(appState.webHelper);
+
+  useEffect(() => {
+    if (credentialsClient === "m2m" && !showM2mCredentialsTab) {
+      setCredentialsClient("public");
+    } else if (credentialsClient === "web" && !showWebCredentialsTab) {
+      setCredentialsClient("public");
+    }
+  }, [credentialsClient, showM2mCredentialsTab, showWebCredentialsTab]);
 
   return (
     <div className="max-w-3xl">
@@ -510,151 +545,136 @@ export default function AppSettingsScreen({
           id="panel-credentials"
           role="tabpanel"
           aria-labelledby="tab-credentials"
-          className="space-y-10 pb-6"
+          className="space-y-8 pb-6"
         >
-          <section>
-            <TestingStep
-              appId={appId}
-              clientId={appState.clientId}
-              grantTypes={formData.grantTypes}
-              tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
-              redirectUris={formData.redirectUris}
-              allowedScopes={formData.allowedScopes}
-              hasSecret={appState.hasSecret}
-              backendHelper={appState.backendHelper}
-              backendDeviceHelper={formData.backendDeviceHelper}
-              webHelper={appState.webHelper}
-              confidentialWebHelper={formData.confidentialWebHelper}
-              confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
-              initiateLoginUri={formData.initiateLoginUri}
-              deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
-              domains={domains}
-              onChange={updateFormData}
-              onDomainsChange={setDomains}
-              onSecretGenerated={() => {
-                setAppState((s) => ({ ...s, hasSecret: true }));
-                updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
-              }}
-              onBackendSecretGenerated={() => {
-                setAppState((s) => ({
-                  ...s,
-                  backendHelper: s.backendHelper
-                    ? { ...s.backendHelper, hasSecret: true }
-                    : s.backendHelper,
-                }));
-              }}
-              onWebSecretGenerated={() => {
-                setAppState((s) => ({
-                  ...s,
-                  webHelper: s.webHelper
-                    ? { ...s.webHelper, hasSecret: true }
-                    : s.webHelper,
-                }));
-              }}
-              ownerExternalUserId={ownerExternalUserId}
-              readOnly={!canEdit}
-              hideRedirectUriEditor
-              hideAuthCodeFlowSection
-            />
-          </section>
-
-          <section className="space-y-4 border-t border-zinc-800 pt-10">
+          <div className="flex items-start justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-zinc-100">Sign-in URLs</h2>
-              <p className="text-sm text-zinc-500 mt-1">
-                Authorization Code + PKCE is enabled automatically when at least one
-                redirect URI is registered on the public client. Portal SSO redirect URIs
-                belong on the confidential web RP sibling. Device flow (CLI/SDK) works
-                without a public redirect URI.
+              <h2 className="text-lg font-semibold text-zinc-100 mb-1">
+                Credentials &amp; URLs
+              </h2>
+              <p className="text-sm text-zinc-500">
+                Manage each OIDC sibling separately: public SDK, M2M / Builder, and
+                confidential web RP.
               </p>
             </div>
-            <AuthorizationCodeRedirectBlock
-              appId={appState.id}
-              redirectUris={formData.redirectUris}
-              onRedirectUrisChange={handleRedirectUrisChange}
-              domains={domains}
-              onDomainsChange={setDomains}
-              readOnly={!canEdit}
-            />
+            <a
+              href="https://pymthouse.com/api/v1/docs"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0 inline-flex items-center gap-1 rounded-md border border-zinc-700 bg-zinc-800/50 px-2.5 py-1.5 text-xs font-medium text-zinc-400 hover:border-emerald-500/40 hover:text-emerald-400 transition-colors"
+            >
+              API Reference
+            </a>
+          </div>
 
-            {showPostLogoutRedirectUris ? (
-              <div className="space-y-3 pt-4 border-t border-zinc-800">
-                <div>
-                  <h3 className="text-sm font-semibold text-zinc-200">Post-logout redirects</h3>
-                  <p className="text-xs text-zinc-500 mt-1">
-                    URIs to redirect users to after sign-out. Saved with{" "}
-                    <strong className="text-zinc-400">Save changes</strong> below.
-                  </p>
-                </div>
-                <div>
-                  <label
-                    htmlFor="postLogoutUriInput"
-                    className="block text-sm font-medium text-zinc-300 mb-1.5"
+          <div
+            className="flex flex-wrap gap-1 rounded-lg bg-zinc-900/60 p-1 border border-zinc-800"
+            role="tablist"
+            aria-label="OIDC client credentials"
+          >
+            {(
+              [
+                {
+                  id: "public" as const,
+                  label: "Public / SDK",
+                  hint: "app_",
+                  show: true,
+                },
+                {
+                  id: "m2m" as const,
+                  label: "M2M / Builder",
+                  hint: "m2m_",
+                  show:
+                    Boolean(formData.backendDeviceHelper) ||
+                    Boolean(appState.backendHelper),
+                },
+                {
+                  id: "web" as const,
+                  label: "Web RP",
+                  hint: "web_",
+                  show:
+                    Boolean(formData.confidentialWebHelper) ||
+                    Boolean(appState.webHelper),
+                },
+              ] as const
+            )
+              .filter((tab) => tab.show)
+              .map((tab) => {
+                const selected = credentialsClient === tab.id;
+                return (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={selected}
+                    onClick={() => selectCredentialsClient(tab.id)}
+                    className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                      selected
+                        ? "bg-zinc-800 text-zinc-100 shadow-[inset_0_0_0_1px_rgba(63,63,70,0.9)]"
+                        : "text-zinc-500 hover:text-zinc-300"
+                    }`}
                   >
-                    Post-logout redirect URIs
-                  </label>
-                  <div className="flex gap-2 mb-2">
-                    <input
-                      id="postLogoutUriInput"
-                      type="text"
-                      value={newPostLogoutUri}
-                      onChange={(e) => setNewPostLogoutUri(e.target.value)}
-                      onKeyDown={(e) =>
-                        e.key === "Enter" && (e.preventDefault(), addPostLogoutUri())
-                      }
-                      placeholder="https://example.com/logout-complete"
-                      disabled={!canEdit}
-                      className="flex-1 px-3 py-1.5 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 focus:border-emerald-500/50 disabled:opacity-50 disabled:cursor-not-allowed"
-                    />
-                    <button
-                      type="button"
-                      onClick={addPostLogoutUri}
-                      disabled={!canEdit}
-                      className="px-4 py-1.5 rounded-md bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                    {tab.label}{" "}
+                    <code
+                      className={`font-mono text-xs ${
+                        selected ? "text-zinc-400" : "text-zinc-600"
+                      }`}
                     >
-                      Add
-                    </button>
-                  </div>
-                  <div className="space-y-1.5">
-                    {postLogoutRedirectUris.map((uri) => (
-                      <div
-                        key={uri}
-                        className="flex items-center justify-between rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2"
-                      >
-                        <code className="text-xs text-zinc-300">{uri}</code>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            updatePostLogoutRedirectUris((items) =>
-                              items.filter((item) => item !== uri),
-                            )
-                          }
-                          disabled={!canEdit}
-                          className="text-xs text-zinc-500 hover:text-red-400 disabled:opacity-40 disabled:cursor-not-allowed"
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            ) : null}
-          </section>
+                      {tab.hint}
+                    </code>
+                  </button>
+                );
+              })}
+          </div>
 
-          <AuthCodeFlowTestSection
-            appId={appState.id}
+          <TestingStep
+            appId={appId}
             clientId={appState.clientId}
             grantTypes={formData.grantTypes}
+            tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
             redirectUris={formData.redirectUris}
             allowedScopes={formData.allowedScopes}
+            hasSecret={appState.hasSecret}
+            backendHelper={appState.backendHelper}
             backendDeviceHelper={formData.backendDeviceHelper}
+            webHelper={appState.webHelper}
+            confidentialWebHelper={formData.confidentialWebHelper}
+            confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
             initiateLoginUri={formData.initiateLoginUri}
             deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
             domains={domains}
             onChange={updateFormData}
             onDomainsChange={setDomains}
+            onSecretGenerated={() => {
+              setAppState((s) => ({ ...s, hasSecret: true }));
+              updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
+            }}
+            onBackendSecretGenerated={() => {
+              setAppState((s) => ({
+                ...s,
+                backendHelper: s.backendHelper
+                  ? { ...s.backendHelper, hasSecret: true }
+                  : s.backendHelper,
+              }));
+            }}
+            onWebSecretGenerated={() => {
+              setAppState((s) => ({
+                ...s,
+                webHelper: s.webHelper
+                  ? { ...s.webHelper, hasSecret: true }
+                  : s.webHelper,
+              }));
+            }}
+            ownerExternalUserId={ownerExternalUserId}
             readOnly={!canEdit}
+            activeClient={credentialsClient}
+            hideHeader
+            onPublicRedirectUrisChange={handleRedirectUrisChange}
+            postLogoutRedirectUris={postLogoutRedirectUris}
+            onPostLogoutRedirectUrisChange={(uris) =>
+              updatePostLogoutRedirectUris(uris)
+            }
+            showPostLogoutRedirectUris={showPostLogoutRedirectUris}
           />
 
           <ReferenceEndpointsSection
@@ -691,9 +711,9 @@ export default function AppSettingsScreen({
       {integrationSection !== "plans" && integrationSection !== "payments" && (
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-6 border-t border-zinc-800">
         <p className="text-xs text-zinc-500 max-w-sm">
-          Redirect URIs and domains update immediately. Use{" "}
-          <strong className="text-zinc-400">Save changes</strong> for metadata,
-          auth mode, scopes, and OIDC fields.
+          Redirect URIs and domains update immediately. Post-logout redirects and
+          profile fields need{" "}
+          <strong className="text-zinc-400">Save changes</strong>.
         </p>
         <div className="flex items-center gap-3 shrink-0">
           {isDirty && !saving && (

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -543,8 +543,7 @@ export default function AppSettingsScreen({
                 Credentials &amp; URLs
               </h2>
               <p className="text-sm text-zinc-500">
-                Manage each OIDC sibling separately: public SDK, M2M / Builder, and
-                confidential web RP.
+                SDK, Builder, and portal credentials — each on its own tab.
               </p>
             </div>
             <a
@@ -711,8 +710,7 @@ export default function AppSettingsScreen({
       {integrationSection !== "plans" && integrationSection !== "payments" && (
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-6 border-t border-zinc-800">
         <p className="text-xs text-zinc-500 max-w-sm">
-          Redirect URIs (Web RP) and domains update immediately. Post-logout
-          redirects and profile fields need{" "}
+          Redirects and domains save immediately. Post-logout and profile need{" "}
           <strong className="text-zinc-400">Save changes</strong>.
         </p>
         <div className="flex items-center gap-3 shrink-0">

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppInfoStep from "./steps/AppInfoStep";
 import AppModeStep from "./steps/AppModeStep";
 import TestingStep, {
+  API_REFERENCE_URL,
   type CredentialsClientTab,
 } from "./steps/TestingStep";
 import PlansTab from "./PlansTab";
@@ -148,19 +149,25 @@ export default function AppSettingsScreen({
     [pathname, router, searchParams],
   );
 
+  const credentialsTabRefs = useRef<
+    Partial<Record<CredentialsClientTab, HTMLButtonElement | null>>
+  >({});
+
   const selectCredentialsClient = useCallback(
     (client: CredentialsClientTab, updateUrl = true) => {
       setCredentialsClient(client);
-      if (!updateUrl) return;
-      const nextParams = new URLSearchParams(searchParams.toString());
-      nextParams.set("tab", "credentials");
-      if (client === "public") {
-        nextParams.delete("client");
-      } else {
-        nextParams.set("client", client);
+      if (updateUrl) {
+        const nextParams = new URLSearchParams(searchParams.toString());
+        nextParams.set("tab", "credentials");
+        if (client === "public") {
+          nextParams.delete("client");
+        } else {
+          nextParams.set("client", client);
+        }
+        const query = nextParams.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
       }
-      const query = nextParams.toString();
-      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+      requestAnimationFrame(() => credentialsTabRefs.current[client]?.focus());
     },
     [pathname, router, searchParams],
   );
@@ -404,14 +411,71 @@ export default function AppSettingsScreen({
   const showWebCredentialsTab =
     Boolean(formData.confidentialWebHelper) || Boolean(appState.webHelper);
 
+  const credentialsClientTabs = useMemo(
+    () =>
+      (
+        [
+          {
+            id: "public" as const,
+            label: "Public / SDK",
+            hint: "app_",
+            show: true,
+          },
+          {
+            id: "m2m" as const,
+            label: "M2M / Builder",
+            hint: "m2m_",
+            show: showM2mCredentialsTab,
+          },
+          {
+            id: "web" as const,
+            label: "Web RP",
+            hint: "web_",
+            show: showWebCredentialsTab,
+          },
+        ] as const
+      ).filter((tab) => tab.show),
+    [showM2mCredentialsTab, showWebCredentialsTab],
+  );
+
+  const handleCredentialsClientTabKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, id: CredentialsClientTab) => {
+      const currentIndex = credentialsClientTabs.findIndex((tab) => tab.id === id);
+      if (currentIndex === -1) return;
+
+      let nextIndex: number | null = null;
+      if (event.key === "ArrowLeft") {
+        nextIndex =
+          (currentIndex - 1 + credentialsClientTabs.length) %
+          credentialsClientTabs.length;
+      } else if (event.key === "ArrowRight") {
+        nextIndex = (currentIndex + 1) % credentialsClientTabs.length;
+      } else if (event.key === "Home") {
+        nextIndex = 0;
+      } else if (event.key === "End") {
+        nextIndex = credentialsClientTabs.length - 1;
+      }
+
+      if (nextIndex === null) return;
+      event.preventDefault();
+      selectCredentialsClient(credentialsClientTabs[nextIndex].id);
+    },
+    [credentialsClientTabs, selectCredentialsClient],
+  );
+
   useEffect(() => {
     if (
       (credentialsClient === "m2m" && !showM2mCredentialsTab) ||
       (credentialsClient === "web" && !showWebCredentialsTab)
     ) {
-      setCredentialsClient("public");
+      selectCredentialsClient("public");
     }
-  }, [credentialsClient, showM2mCredentialsTab, showWebCredentialsTab]);
+  }, [
+    credentialsClient,
+    selectCredentialsClient,
+    showM2mCredentialsTab,
+    showWebCredentialsTab,
+  ]);
 
   return (
     <div className="max-w-3xl">
@@ -547,7 +611,7 @@ export default function AppSettingsScreen({
               </p>
             </div>
             <a
-              href="https://pymthouse.com/api/v1/docs"
+              href={API_REFERENCE_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="shrink-0 inline-flex items-center gap-1 rounded-md border border-zinc-700 bg-zinc-800/50 px-2.5 py-1.5 text-xs font-medium text-zinc-400 hover:border-emerald-500/40 hover:text-emerald-400 transition-colors"
@@ -562,34 +626,7 @@ export default function AppSettingsScreen({
               role="tablist"
               aria-label="OIDC client credentials"
             >
-              {(
-                [
-                  {
-                    id: "public" as const,
-                    label: "Public / SDK",
-                    hint: "app_",
-                    show: true,
-                  },
-                  {
-                    id: "m2m" as const,
-                    label: "M2M / Builder",
-                    hint: "m2m_",
-                    show:
-                      Boolean(formData.backendDeviceHelper) ||
-                      Boolean(appState.backendHelper),
-                  },
-                  {
-                    id: "web" as const,
-                    label: "Web RP",
-                    hint: "web_",
-                    show:
-                      Boolean(formData.confidentialWebHelper) ||
-                      Boolean(appState.webHelper),
-                  },
-                ] as const
-              )
-                .filter((tab) => tab.show)
-                .map((tab) => {
+              {credentialsClientTabs.map((tab) => {
                   const selected = credentialsClient === tab.id;
                   return (
                     <button
@@ -597,9 +634,16 @@ export default function AppSettingsScreen({
                       type="button"
                       role="tab"
                       id={`credentials-client-tab-${tab.id}`}
+                      ref={(node) => {
+                        credentialsTabRefs.current[tab.id] = node;
+                      }}
                       aria-selected={selected}
                       aria-controls={`credentials-client-panel-${tab.id}`}
+                      tabIndex={selected ? 0 : -1}
                       onClick={() => selectCredentialsClient(tab.id)}
+                      onKeyDown={(event) =>
+                        handleCredentialsClientTabKeyDown(event, tab.id)
+                      }
                       className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
                         selected
                           ? "border-emerald-500 text-zinc-100 bg-zinc-900/80"

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -405,9 +405,10 @@ export default function AppSettingsScreen({
     Boolean(formData.confidentialWebHelper) || Boolean(appState.webHelper);
 
   useEffect(() => {
-    if (credentialsClient === "m2m" && !showM2mCredentialsTab) {
-      setCredentialsClient("public");
-    } else if (credentialsClient === "web" && !showWebCredentialsTab) {
+    if (
+      (credentialsClient === "m2m" && !showM2mCredentialsTab) ||
+      (credentialsClient === "web" && !showWebCredentialsTab)
+    ) {
       setCredentialsClient("public");
     }
   }, [credentialsClient, showM2mCredentialsTab, showWebCredentialsTab]);
@@ -556,114 +557,125 @@ export default function AppSettingsScreen({
             </a>
           </div>
 
-          <div
-            className="flex flex-wrap gap-1 rounded-lg bg-zinc-900/60 p-1 border border-zinc-800"
-            role="tablist"
-            aria-label="OIDC client credentials"
-          >
-            {(
-              [
-                {
-                  id: "public" as const,
-                  label: "Public / SDK",
-                  hint: "app_",
-                  show: true,
-                },
-                {
-                  id: "m2m" as const,
-                  label: "M2M / Builder",
-                  hint: "m2m_",
-                  show:
-                    Boolean(formData.backendDeviceHelper) ||
-                    Boolean(appState.backendHelper),
-                },
-                {
-                  id: "web" as const,
-                  label: "Web RP",
-                  hint: "web_",
-                  show:
-                    Boolean(formData.confidentialWebHelper) ||
-                    Boolean(appState.webHelper),
-                },
-              ] as const
-            )
-              .filter((tab) => tab.show)
-              .map((tab) => {
-                const selected = credentialsClient === tab.id;
-                return (
-                  <button
-                    key={tab.id}
-                    type="button"
-                    role="tab"
-                    aria-selected={selected}
-                    onClick={() => selectCredentialsClient(tab.id)}
-                    className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                      selected
-                        ? "bg-zinc-800 text-zinc-100 shadow-[inset_0_0_0_1px_rgba(63,63,70,0.9)]"
-                        : "text-zinc-500 hover:text-zinc-300"
-                    }`}
-                  >
-                    {tab.label}{" "}
-                    <code
-                      className={`font-mono text-xs ${
-                        selected ? "text-zinc-400" : "text-zinc-600"
+          <div className="rounded-xl border border-zinc-800 bg-zinc-950/40 overflow-hidden">
+            <div
+              className="flex flex-wrap gap-0 border-b border-zinc-800 bg-zinc-900/50"
+              role="tablist"
+              aria-label="OIDC client credentials"
+            >
+              {(
+                [
+                  {
+                    id: "public" as const,
+                    label: "Public / SDK",
+                    hint: "app_",
+                    show: true,
+                  },
+                  {
+                    id: "m2m" as const,
+                    label: "M2M / Builder",
+                    hint: "m2m_",
+                    show:
+                      Boolean(formData.backendDeviceHelper) ||
+                      Boolean(appState.backendHelper),
+                  },
+                  {
+                    id: "web" as const,
+                    label: "Web RP",
+                    hint: "web_",
+                    show:
+                      Boolean(formData.confidentialWebHelper) ||
+                      Boolean(appState.webHelper),
+                  },
+                ] as const
+              )
+                .filter((tab) => tab.show)
+                .map((tab) => {
+                  const selected = credentialsClient === tab.id;
+                  return (
+                    <button
+                      key={tab.id}
+                      type="button"
+                      role="tab"
+                      id={`credentials-client-tab-${tab.id}`}
+                      aria-selected={selected}
+                      aria-controls={`credentials-client-panel-${tab.id}`}
+                      onClick={() => selectCredentialsClient(tab.id)}
+                      className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                        selected
+                          ? "border-emerald-500 text-zinc-100 bg-zinc-900/80"
+                          : "border-transparent text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900/40"
                       }`}
                     >
-                      {tab.hint}
-                    </code>
-                  </button>
-                );
-              })}
-          </div>
+                      {tab.label}{" "}
+                      <code
+                        className={`font-mono text-xs ${
+                          selected ? "text-zinc-400" : "text-zinc-600"
+                        }`}
+                      >
+                        {tab.hint}
+                      </code>
+                    </button>
+                  );
+                })}
+            </div>
 
-          <TestingStep
-            appId={appId}
-            clientId={appState.clientId}
-            grantTypes={formData.grantTypes}
-            tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
-            redirectUris={formData.redirectUris}
-            allowedScopes={formData.allowedScopes}
-            hasSecret={appState.hasSecret}
-            backendHelper={appState.backendHelper}
-            backendDeviceHelper={formData.backendDeviceHelper}
-            webHelper={appState.webHelper}
-            confidentialWebHelper={formData.confidentialWebHelper}
-            confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
-            initiateLoginUri={formData.initiateLoginUri}
-            deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
-            domains={domains}
-            onChange={updateFormData}
-            onDomainsChange={setDomains}
-            onSecretGenerated={() => {
-              setAppState((s) => ({ ...s, hasSecret: true }));
-              updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
-            }}
-            onBackendSecretGenerated={() => {
-              setAppState((s) => ({
-                ...s,
-                backendHelper: s.backendHelper
-                  ? { ...s.backendHelper, hasSecret: true }
-                  : s.backendHelper,
-              }));
-            }}
-            onWebSecretGenerated={() => {
-              setAppState((s) => ({
-                ...s,
-                webHelper: s.webHelper
-                  ? { ...s.webHelper, hasSecret: true }
-                  : s.webHelper,
-              }));
-            }}
-            ownerExternalUserId={ownerExternalUserId}
-            readOnly={!canEdit}
-            activeClient={credentialsClient}
-            hideHeader
-            postLogoutRedirectUris={postLogoutRedirectUris}
-            onPostLogoutRedirectUrisChange={(uris) =>
-              updatePostLogoutRedirectUris(uris)
-            }
-            showPostLogoutRedirectUris={showPostLogoutRedirectUris}
-          />
+            <div
+              id={`credentials-client-panel-${credentialsClient}`}
+              role="tabpanel"
+              aria-labelledby={`credentials-client-tab-${credentialsClient}`}
+              className="p-5 sm:p-6 space-y-8"
+            >
+              <TestingStep
+                appId={appId}
+                clientId={appState.clientId}
+                grantTypes={formData.grantTypes}
+                tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
+                redirectUris={formData.redirectUris}
+                allowedScopes={formData.allowedScopes}
+                hasSecret={appState.hasSecret}
+                backendHelper={appState.backendHelper}
+                backendDeviceHelper={formData.backendDeviceHelper}
+                webHelper={appState.webHelper}
+                confidentialWebHelper={formData.confidentialWebHelper}
+                confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
+                initiateLoginUri={formData.initiateLoginUri}
+                deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
+                domains={domains}
+                onChange={updateFormData}
+                onDomainsChange={setDomains}
+                onSecretGenerated={() => {
+                  setAppState((s) => ({ ...s, hasSecret: true }));
+                  updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
+                }}
+                onBackendSecretGenerated={() => {
+                  setAppState((s) => ({
+                    ...s,
+                    backendHelper: s.backendHelper
+                      ? { ...s.backendHelper, hasSecret: true }
+                      : s.backendHelper,
+                  }));
+                }}
+                onWebSecretGenerated={() => {
+                  setAppState((s) => ({
+                    ...s,
+                    webHelper: s.webHelper
+                      ? { ...s.webHelper, hasSecret: true }
+                      : s.webHelper,
+                  }));
+                }}
+                ownerExternalUserId={ownerExternalUserId}
+                readOnly={!canEdit}
+                activeClient={credentialsClient}
+                hideHeader
+                postLogoutRedirectUris={postLogoutRedirectUris}
+                onPostLogoutRedirectUrisChange={(uris) =>
+                  updatePostLogoutRedirectUris(uris)
+                }
+                showPostLogoutRedirectUris={showPostLogoutRedirectUris}
+              />
+            </div>
+          </div>
 
           <ReferenceEndpointsSection
             clientId={appState.clientId || ""}

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -14,10 +14,6 @@ import {
   type AppFormData,
   type AppState,
 } from "./AppWizard";
-import {
-  AUTHORIZATION_CODE_GRANT,
-  syncPublicClientGrantTypes,
-} from "@/lib/oidc/grants";
 
 interface Props {
   appId: string;
@@ -242,21 +238,6 @@ export default function AppSettingsScreen({
     [],
   );
 
-  const handleRedirectUrisChange = useCallback(
-    (uris: string[]) => {
-      setFormData((prev) => {
-        const nextGrantTypes = syncPublicClientGrantTypes(
-          prev.grantTypes,
-          uris,
-          appState.clientId ?? "",
-        );
-        return { ...prev, redirectUris: uris, grantTypes: nextGrantTypes };
-      });
-      setIsDirty(true);
-    },
-    [appState.clientId],
-  );
-
   const syncCredentialsFromServer = useCallback(async () => {
     const res = await fetch(`/api/v1/apps/${appId}`);
     if (!res.ok) {
@@ -268,8 +249,13 @@ export default function AppSettingsScreen({
         clientId: string;
         hasSecret: boolean;
         redirectUris: string[];
+        postLogoutRedirectUris?: string[];
       } | null;
-      oidcClient?: { hasSecret?: boolean; clientId?: string } | null;
+      oidcClient?: {
+        hasSecret?: boolean;
+        clientId?: string;
+        postLogoutRedirectUris?: string[];
+      } | null;
     };
     setAppState((s) => ({
       ...s,
@@ -280,10 +266,16 @@ export default function AppSettingsScreen({
     }));
     setFormData((prev) => ({
       ...prev,
+      redirectUris: [],
       backendDeviceHelper: Boolean(data.m2mOidcClient),
       confidentialWebHelper: Boolean(data.webOidcClient),
       confidentialWebRedirectUris: data.webOidcClient?.redirectUris ?? [],
     }));
+    setPostLogoutRedirectUris(
+      data.webOidcClient?.postLogoutRedirectUris ??
+        data.oidcClient?.postLogoutRedirectUris ??
+        [],
+    );
   }, [appId]);
 
   useEffect(() => {
@@ -302,7 +294,7 @@ export default function AppSettingsScreen({
       const res = await fetch(`/api/v1/apps/${appId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...formData }),
+        body: JSON.stringify({ ...formData, redirectUris: [] }),
       });
       const putJson = (await res.json()) as {
         success?: boolean;
@@ -404,11 +396,8 @@ export default function AppSettingsScreen({
     typeof window !== "undefined" && appState.clientId
       ? `${window.location.origin}/api/v1/apps/${encodeURIComponent(appState.clientId)}/oidc/token`
       : "";
-  const showPostLogoutRedirectUris = syncPublicClientGrantTypes(
-    formData.grantTypes,
-    formData.redirectUris,
-    appState.clientId ?? "",
-  ).includes(AUTHORIZATION_CODE_GRANT);
+  const showPostLogoutRedirectUris =
+    Boolean(formData.confidentialWebHelper) || Boolean(appState.webHelper);
 
   const showM2mCredentialsTab =
     Boolean(formData.backendDeviceHelper) || Boolean(appState.backendHelper);
@@ -669,7 +658,6 @@ export default function AppSettingsScreen({
             readOnly={!canEdit}
             activeClient={credentialsClient}
             hideHeader
-            onPublicRedirectUrisChange={handleRedirectUrisChange}
             postLogoutRedirectUris={postLogoutRedirectUris}
             onPostLogoutRedirectUrisChange={(uris) =>
               updatePostLogoutRedirectUris(uris)
@@ -711,8 +699,8 @@ export default function AppSettingsScreen({
       {integrationSection !== "plans" && integrationSection !== "payments" && (
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-6 border-t border-zinc-800">
         <p className="text-xs text-zinc-500 max-w-sm">
-          Redirect URIs and domains update immediately. Post-logout redirects and
-          profile fields need{" "}
+          Redirect URIs (Web RP) and domains update immediately. Post-logout
+          redirects and profile fields need{" "}
           <strong className="text-zinc-400">Save changes</strong>.
         </p>
         <div className="flex items-center gap-3 shrink-0">

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -198,6 +198,7 @@ export default function AppWizard({ initialData }: Readonly<Props>) {
 
       const payload: AppFormData = {
         ...formData,
+        redirectUris: [],
         allowedScopes: ensureOpenIdScope(formData.allowedScopes),
         confidentialWebRedirectUris: webRedirects,
         tokenEndpointAuthMethod: "none",

--- a/src/components/apps/steps/AppModeStep.tsx
+++ b/src/components/apps/steps/AppModeStep.tsx
@@ -186,7 +186,7 @@ export default function AppModeStep({
               {hasDeviceCode ? (
                 <p className="mt-2 text-xs text-zinc-500">
                   Configure the third-party initiate login URL on{" "}
-                  <strong className="text-zinc-400">Credentials &amp; URLs</strong>.
+                  <strong className="text-zinc-400">Credentials &amp; URLs → Public / SDK</strong>.
                 </p>
               ) : null}
             </div>
@@ -210,7 +210,7 @@ export default function AppModeStep({
               Provisions a confidential{" "}
               <code className="font-mono text-zinc-400">web_</code> sibling for portal
               SSO (auth code + secret + redirects). Configure redirect URIs and rotate
-              the secret on Credentials &amp; URLs.
+              the secret on Credentials &amp; URLs → Web RP.
             </p>
           </div>
         </label>

--- a/src/components/apps/steps/AppModeStep.tsx
+++ b/src/components/apps/steps/AppModeStep.tsx
@@ -209,8 +209,9 @@ export default function AppModeStep({
             <p className="text-xs text-zinc-500 mt-0.5">
               Provisions a confidential{" "}
               <code className="font-mono text-zinc-400">web_</code> sibling for portal
-              SSO (auth code + secret + redirects). Configure redirect URIs and rotate
-              the secret on Credentials &amp; URLs → Web RP.
+              SSO (auth code + secret + redirects). This is the only client that
+              registers redirect URIs — configure them on Credentials &amp; URLs →
+              Web RP.
             </p>
           </div>
         </label>

--- a/src/components/apps/steps/AuthorizationCodeRedirectBlock.tsx
+++ b/src/components/apps/steps/AuthorizationCodeRedirectBlock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
+import DomainAllowlistBlock, { parseDomainError } from "./DomainAllowlistBlock";
 
 interface Props {
   appId: string | null;
@@ -17,19 +18,15 @@ interface Props {
    * still uses `appId` when set.
    */
   persistRedirectUrisToPublicClient?: boolean;
-}
-
-async function parseDomainError(res: Response): Promise<string> {
-  const text = await res.text();
-  try {
-    const data = text ? JSON.parse(text) : {};
-    if (typeof data.error === "string" && data.error.trim()) {
-      return data.error.trim();
-    }
-  } catch {
-    /* keep fallback */
-  }
-  return text.trim() || res.statusText || `Domain request failed (${res.status})`;
+  /**
+   * When false, omit the domain allowlist editor (render it once at the Public tab).
+   * Redirect adds still auto-whitelist origins when `appId` is set.
+   */
+  showDomains?: boolean;
+  /** Optional label override (e.g. portal vs public redirects). */
+  label?: string;
+  /** Optional help text override. */
+  description?: string;
 }
 
 export default function AuthorizationCodeRedirectBlock({
@@ -41,10 +38,12 @@ export default function AuthorizationCodeRedirectBlock({
   readOnly = false,
   requireAtLeastOne = false,
   persistRedirectUrisToPublicClient = true,
+  showDomains = true,
+  label = "Redirect URIs",
+  description,
 }: Readonly<Props>) {
+  const inputId = useId();
   const [newUri, setNewUri] = useState("");
-  const [newDomain, setNewDomain] = useState("");
-  const [adding, setAdding] = useState(false);
   const [redirectPersistError, setRedirectPersistError] = useState<string | null>(null);
   const [redirectSaving, setRedirectSaving] = useState(false);
   const [domainError, setDomainError] = useState<string | null>(null);
@@ -82,6 +81,41 @@ export default function AuthorizationCodeRedirectBlock({
     }
   };
 
+  const autoWhitelistOrigin = async (uri: string) => {
+    if (!appId) return;
+    let normalizedOrigin: string;
+    try {
+      const origin = new URL(uri).origin;
+      if (origin === "null") return;
+      normalizedOrigin = origin.toLowerCase();
+    } catch {
+      /* invalid URL or wildcard — skip auto-whitelist */
+      return;
+    }
+
+    if (domains.some((d) => d.domain.toLowerCase() === normalizedOrigin)) return;
+
+    setDomainError(null);
+    try {
+      const res = await fetch(`/api/v1/apps/${appId}/domains`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domain: normalizedOrigin }),
+      });
+      if (!res.ok) {
+        setDomainError(await parseDomainError(res));
+        return;
+      }
+      const resData = await res.json();
+      onDomainsChange([...domains, { id: resData.id, domain: resData.domain }]);
+    } catch (err) {
+      console.error("Failed to auto-whitelist redirect URI domain.", err);
+      setDomainError(
+        err instanceof Error ? err.message : "Could not auto-whitelist redirect URI domain.",
+      );
+    }
+  };
+
   const addRedirectUri = async () => {
     if (readOnly) return;
     const uri = newUri.trim();
@@ -97,40 +131,7 @@ export default function AuthorizationCodeRedirectBlock({
         onRedirectUrisChange(previous);
         return;
       }
-    }
-
-    if (appId) {
-      let normalizedOrigin: string;
-      try {
-        const origin = new URL(uri).origin;
-        if (origin === "null") return;
-        normalizedOrigin = origin.toLowerCase();
-      } catch {
-        /* invalid URL or wildcard — skip auto-whitelist */
-        return;
-      }
-
-      if (domains.some((d) => d.domain.toLowerCase() === normalizedOrigin)) return;
-
-      setDomainError(null);
-      try {
-        const res = await fetch(`/api/v1/apps/${appId}/domains`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ domain: normalizedOrigin }),
-        });
-        if (!res.ok) {
-          setDomainError(await parseDomainError(res));
-          return;
-        }
-        const resData = await res.json();
-        onDomainsChange([...domains, { id: resData.id, domain: resData.domain }]);
-      } catch (err) {
-        console.error("Failed to auto-whitelist redirect URI domain.", err);
-        setDomainError(
-          err instanceof Error ? err.message : "Could not auto-whitelist redirect URI domain.",
-        );
-      }
+      await autoWhitelistOrigin(uri);
     }
   };
 
@@ -146,68 +147,30 @@ export default function AuthorizationCodeRedirectBlock({
     }
   };
 
-  const addDomain = async () => {
-    if (readOnly || !appId || !newDomain.trim()) return;
-    setAdding(true);
-    setDomainError(null);
-    try {
-      const res = await fetch(`/api/v1/apps/${appId}/domains`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ domain: newDomain.trim() }),
-      });
-      if (!res.ok) {
-        setDomainError(await parseDomainError(res));
-        return;
-      }
-      const resData = await res.json();
-      onDomainsChange([...domains, { id: resData.id, domain: resData.domain }]);
-      setNewDomain("");
-    } catch (err) {
-      setDomainError(err instanceof Error ? err.message : "Could not add domain.");
-    } finally {
-      setAdding(false);
-    }
-  };
-
-  const removeDomain = async (domainId: string) => {
-    if (readOnly || !appId) return;
-    setDomainError(null);
-    try {
-      const res = await fetch(
-        `/api/v1/apps/${appId}/domains?domainId=${encodeURIComponent(domainId)}`,
-        {
-          method: "DELETE",
-        },
-      );
-      if (!res.ok) {
-        setDomainError(await parseDomainError(res));
-        return;
-      }
-      onDomainsChange(domains.filter((d) => d.id !== domainId));
-    } catch (err) {
-      setDomainError(err instanceof Error ? err.message : "Could not remove domain.");
-    }
-  };
+  const helpText =
+    description ??
+    `URIs where PymtHouse can redirect after authorization. Wildcards (*) are supported.${
+      appId
+        ? " Each add or remove is saved immediately."
+        : " Save the app first, then add URIs here."
+    }`;
 
   return (
     <div className="space-y-5">
       <div className="space-y-2">
-        <label htmlFor="auth-code-new-redirect-uri" className="block text-sm font-medium text-zinc-300">
-          Redirect URIs
+        <label htmlFor={inputId} className="block text-sm font-medium text-zinc-300">
+          {label}
         </label>
-        <p className="text-xs text-zinc-500">
-          URIs where PymtHouse can redirect after authorization. Wildcards (*) are supported.
-          {appId
-            ? " Each add or remove is saved immediately."
-            : " Save the app first, then add URIs here."}
-        </p>
+        <p className="text-xs text-zinc-500">{helpText}</p>
         {redirectPersistError && (
           <p className="text-xs text-red-400">{redirectPersistError}</p>
         )}
+        {domainError && !showDomains ? (
+          <p className="text-xs text-red-400">{domainError}</p>
+        ) : null}
         <div className="flex gap-2 mb-2">
           <input
-            id="auth-code-new-redirect-uri"
+            id={inputId}
             type="text"
             value={newUri}
             onChange={(e) => setNewUri(e.target.value)}
@@ -245,7 +208,12 @@ export default function AuthorizationCodeRedirectBlock({
                   aria-label={`Remove ${uri}`}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
                   </svg>
                 </button>
               </div>
@@ -254,66 +222,17 @@ export default function AuthorizationCodeRedirectBlock({
         )}
       </div>
 
-      <div className="space-y-4">
-        <div>
-          <h4 className="text-sm font-medium text-zinc-300">Domain allowlist</h4>
-          <p className="text-xs text-zinc-500 mt-1">
-            Allowed origins for CORS and request validation. Redirect URIs above should match these
-            domains.
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={newDomain}
-            onChange={(e) => setNewDomain(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), void addDomain())}
-            placeholder="example.com"
-            disabled={readOnly}
-            className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-100 placeholder-zinc-500 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/40 disabled:opacity-50 disabled:cursor-not-allowed"
+      {showDomains ? (
+        <div className="space-y-2">
+          {domainError ? <p className="text-xs text-red-400">{domainError}</p> : null}
+          <DomainAllowlistBlock
+            appId={appId}
+            domains={domains}
+            onDomainsChange={onDomainsChange}
+            readOnly={readOnly}
           />
-          <button
-            type="button"
-            onClick={() => void addDomain()}
-            disabled={readOnly || adding || !newDomain.trim() || !appId}
-            className="px-4 py-2 bg-emerald-600 text-white rounded-lg text-sm hover:bg-emerald-500 disabled:opacity-40 transition-colors"
-          >
-            {adding ? "Adding..." : "Add domain"}
-          </button>
         </div>
-        {domainError && <p className="text-xs text-red-400">{domainError}</p>}
-        {domains.length > 0 ? (
-          <div className="space-y-2">
-            {domains.map((d) => (
-              <div
-                key={d.id}
-                className="flex items-center justify-between px-4 py-3 bg-zinc-800/50 rounded-lg border border-zinc-800"
-              >
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="w-2 h-2 rounded-full bg-emerald-500 shrink-0" />
-                  <code className="text-sm text-zinc-200 truncate">{d.domain}</code>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => void removeDomain(d.id)}
-                  disabled={readOnly}
-                  className="text-zinc-500 hover:text-red-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
-                  aria-label={`Remove domain ${d.domain}`}
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="text-center py-3 text-zinc-500 text-sm">
-            No domains yet. Add your app&apos;s origins above (adding a redirect URI may suggest
-            one automatically).
-          </div>
-        )}
-      </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/apps/steps/AuthorizationCodeRedirectBlock.tsx
+++ b/src/components/apps/steps/AuthorizationCodeRedirectBlock.tsx
@@ -85,7 +85,10 @@ export default function AuthorizationCodeRedirectBlock({
     if (!appId) return;
     let normalizedOrigin: string;
     try {
-      const origin = new URL(uri).origin;
+      if (uri.includes("*")) return;
+      const parsed = new URL(uri);
+      if (parsed.hostname.includes("*")) return;
+      const origin = parsed.origin;
       if (origin === "null") return;
       normalizedOrigin = origin.toLowerCase();
     } catch {

--- a/src/components/apps/steps/DomainAllowlistBlock.tsx
+++ b/src/components/apps/steps/DomainAllowlistBlock.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+
+export async function parseDomainError(res: Response): Promise<string> {
+  const text = await res.text();
+  try {
+    const data = text ? JSON.parse(text) : {};
+    if (typeof data.error === "string" && data.error.trim()) {
+      return data.error.trim();
+    }
+  } catch {
+    /* keep fallback */
+  }
+  return text.trim() || res.statusText || `Domain request failed (${res.status})`;
+}
+
+interface Props {
+  appId: string | null;
+  domains: { id: string; domain: string }[];
+  onDomainsChange: (domains: { id: string; domain: string }[]) => void;
+  readOnly?: boolean;
+}
+
+export default function DomainAllowlistBlock({
+  appId,
+  domains,
+  onDomainsChange,
+  readOnly = false,
+}: Readonly<Props>) {
+  const [newDomain, setNewDomain] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [domainError, setDomainError] = useState<string | null>(null);
+
+  const addDomain = async () => {
+    if (readOnly || !appId || !newDomain.trim()) return;
+    setAdding(true);
+    setDomainError(null);
+    try {
+      const res = await fetch(`/api/v1/apps/${appId}/domains`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domain: newDomain.trim() }),
+      });
+      if (!res.ok) {
+        setDomainError(await parseDomainError(res));
+        return;
+      }
+      const resData = await res.json();
+      onDomainsChange([...domains, { id: resData.id, domain: resData.domain }]);
+      setNewDomain("");
+    } catch (err) {
+      setDomainError(err instanceof Error ? err.message : "Could not add domain.");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const removeDomain = async (domainId: string) => {
+    if (readOnly || !appId) return;
+    setDomainError(null);
+    try {
+      const res = await fetch(
+        `/api/v1/apps/${appId}/domains?domainId=${encodeURIComponent(domainId)}`,
+        {
+          method: "DELETE",
+        },
+      );
+      if (!res.ok) {
+        setDomainError(await parseDomainError(res));
+        return;
+      }
+      onDomainsChange(domains.filter((d) => d.id !== domainId));
+    } catch (err) {
+      setDomainError(err instanceof Error ? err.message : "Could not remove domain.");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h4 className="text-sm font-medium text-zinc-300">Domain allowlist</h4>
+        <p className="text-xs text-zinc-500 mt-1">
+          Allowed origins for CORS and request validation. Shared across public and
+          confidential web redirect URIs — adding a redirect may suggest an origin
+          automatically.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={newDomain}
+          onChange={(e) => setNewDomain(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), void addDomain())}
+          placeholder="example.com"
+          disabled={readOnly}
+          className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-100 placeholder-zinc-500 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/40 disabled:opacity-50 disabled:cursor-not-allowed"
+        />
+        <button
+          type="button"
+          onClick={() => void addDomain()}
+          disabled={readOnly || adding || !newDomain.trim() || !appId}
+          className="px-4 py-2 bg-emerald-600 text-white rounded-lg text-sm hover:bg-emerald-500 disabled:opacity-40 transition-colors"
+        >
+          {adding ? "Adding..." : "Add domain"}
+        </button>
+      </div>
+      {domainError && <p className="text-xs text-red-400">{domainError}</p>}
+      {domains.length > 0 ? (
+        <div className="space-y-2">
+          {domains.map((d) => (
+            <div
+              key={d.id}
+              className="flex items-center justify-between px-4 py-3 bg-zinc-800/50 rounded-lg border border-zinc-800"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="w-2 h-2 rounded-full bg-emerald-500 shrink-0" />
+                <code className="text-sm text-zinc-200 truncate">{d.domain}</code>
+              </div>
+              <button
+                type="button"
+                onClick={() => void removeDomain(d.id)}
+                disabled={readOnly}
+                className="text-zinc-500 hover:text-red-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
+                aria-label={`Remove domain ${d.domain}`}
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-3 text-zinc-500 text-sm">
+          No domains yet. Add your app&apos;s origins above (adding a redirect URI may suggest
+          one automatically).
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/apps/steps/DomainAllowlistBlock.tsx
+++ b/src/components/apps/steps/DomainAllowlistBlock.tsx
@@ -85,9 +85,7 @@ export default function DomainAllowlistBlock({
         <div>
           <h4 className="text-sm font-medium text-zinc-300">Domain allowlist</h4>
           <p className="text-xs text-zinc-500 mt-1">
-            Allowed origins for CORS and request validation. Shared across siblings —
-            adding a portal redirect URI on the Web RP tab may suggest an origin
-            automatically.
+            Shared origins for CORS and request validation.
           </p>
         </div>
       )}

--- a/src/components/apps/steps/DomainAllowlistBlock.tsx
+++ b/src/components/apps/steps/DomainAllowlistBlock.tsx
@@ -81,8 +81,8 @@ export default function DomainAllowlistBlock({
       <div>
         <h4 className="text-sm font-medium text-zinc-300">Domain allowlist</h4>
         <p className="text-xs text-zinc-500 mt-1">
-          Allowed origins for CORS and request validation. Shared across public and
-          confidential web redirect URIs — adding a redirect may suggest an origin
+          Allowed origins for CORS and request validation. Shared across siblings —
+          adding a portal redirect URI on the Web RP tab may suggest an origin
           automatically.
         </p>
       </div>

--- a/src/components/apps/steps/DomainAllowlistBlock.tsx
+++ b/src/components/apps/steps/DomainAllowlistBlock.tsx
@@ -20,6 +20,8 @@ interface Props {
   domains: { id: string; domain: string }[];
   onDomainsChange: (domains: { id: string; domain: string }[]) => void;
   readOnly?: boolean;
+  /** When true, omit the built-in heading (parent already titled the section). */
+  hideHeading?: boolean;
 }
 
 export default function DomainAllowlistBlock({
@@ -27,6 +29,7 @@ export default function DomainAllowlistBlock({
   domains,
   onDomainsChange,
   readOnly = false,
+  hideHeading = false,
 }: Readonly<Props>) {
   const [newDomain, setNewDomain] = useState("");
   const [adding, setAdding] = useState(false);
@@ -78,14 +81,16 @@ export default function DomainAllowlistBlock({
 
   return (
     <div className="space-y-4">
-      <div>
-        <h4 className="text-sm font-medium text-zinc-300">Domain allowlist</h4>
-        <p className="text-xs text-zinc-500 mt-1">
-          Allowed origins for CORS and request validation. Shared across siblings —
-          adding a portal redirect URI on the Web RP tab may suggest an origin
-          automatically.
-        </p>
-      </div>
+      {hideHeading ? null : (
+        <div>
+          <h4 className="text-sm font-medium text-zinc-300">Domain allowlist</h4>
+          <p className="text-xs text-zinc-500 mt-1">
+            Allowed origins for CORS and request validation. Shared across siblings —
+            adding a portal redirect URI on the Web RP tab may suggest an origin
+            automatically.
+          </p>
+        </div>
+      )}
       <div className="flex gap-2">
         <input
           type="text"

--- a/src/components/apps/steps/DomainAllowlistBlock.tsx
+++ b/src/components/apps/steps/DomainAllowlistBlock.tsx
@@ -96,6 +96,7 @@ export default function DomainAllowlistBlock({
           onChange={(e) => setNewDomain(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), void addDomain())}
           placeholder="example.com"
+          aria-label="Domain to allowlist"
           disabled={readOnly}
           className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-100 placeholder-zinc-500 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/40 disabled:opacity-50 disabled:cursor-not-allowed"
         />

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -25,10 +25,13 @@ import {
   syncPublicClientGrantTypes,
 } from "@/lib/oidc/grants";
 import AuthorizationCodeRedirectBlock from "./AuthorizationCodeRedirectBlock";
+import DomainAllowlistBlock from "./DomainAllowlistBlock";
 import { mintOwnerApiKey } from "../mint-owner-api-key";
 import ApiKeyCredentialSwitcher from "@/components/apps/ApiKeyCredentialSwitcher";
 
 const API_REFERENCE_URL = "https://pymthouse.com/api/v1/docs";
+
+export type CredentialsClientTab = "public" | "m2m" | "web";
 
 interface Props {
   appId: string | null;
@@ -62,10 +65,19 @@ interface Props {
   onWebSecretGenerated?: () => void;
   ownerExternalUserId?: string | null;
   readOnly?: boolean;
-  /** When true, the redirect URI / domain editor is omitted (managed from Credentials & URLs tab). */
-  hideRedirectUriEditor?: boolean;
-  /** When true, the authorization-code test block is omitted (rendered separately below Sign-in URLs). */
-  hideAuthCodeFlowSection?: boolean;
+  /**
+   * When set, only render that sibling’s credentials + verify UI (used by the
+   * Credentials & URLs client sub-tabs). When null, render the legacy stacked layout.
+   */
+  activeClient?: CredentialsClientTab | null;
+  /** When true, omit the page title (parent renders it above client sub-tabs). */
+  hideHeader?: boolean;
+  /** Public redirect URI editor (Public tab). When omitted, redirects are not shown here. */
+  onPublicRedirectUrisChange?: (uris: string[]) => void;
+  /** Post-logout redirects (saved with Save changes). */
+  postLogoutRedirectUris?: string[];
+  onPostLogoutRedirectUrisChange?: (uris: string[]) => void;
+  showPostLogoutRedirectUris?: boolean;
 }
 
 function getDefaultRedirectUri(redirectUris: string[]) {
@@ -447,12 +459,21 @@ function getTokenTestActionLabel(
   return loading ? "Exchanging…" : "Exchange token";
 }
 
-function getCredentialsIntroText(isM2MOnly: boolean, hideAuthCodeFlowSection: boolean): string {
+function getCredentialsIntroText(
+  isM2MOnly: boolean,
+  activeClient: CredentialsClientTab | null,
+): string {
   if (isM2MOnly) return "Generate your client secret, then test your M2M token request.";
-  if (hideAuthCodeFlowSection) {
-    return "Generate and rotate credentials for confidential siblings, then test token exchange.";
+  if (activeClient === "public") {
+    return "Public SDK client ID, sign-in redirect URLs, domain allowlist, and authorization-code verification.";
   }
-  return "Configure redirect URLs, generate and rotate credentials, try a live authorization request, and copy reference endpoints.";
+  if (activeClient === "m2m") {
+    return "M2M / Builder credentials and client-credentials token exchange for server APIs.";
+  }
+  if (activeClient === "web") {
+    return "Confidential web RP credentials, portal redirect URIs, and authorization-code verification.";
+  }
+  return "Configure credentials and URLs per OIDC sibling, then verify each client’s auth flow.";
 }
 
 function scopesForInitiateLoginUri(allowedScopes: string, isValid: boolean): string {
@@ -1327,6 +1348,14 @@ export interface AuthCodeFlowTestSectionProps {
   onDomainsChange: (domains: { id: string; domain: string }[]) => void;
   readOnly?: boolean;
   showRedirectUriEditor?: boolean;
+  /** Skip grant-type inference (confidential web RP always supports auth code). */
+  forceAuthCodeFlow?: boolean;
+  /** Hide third-party initiate login (public/device only). */
+  showInitiateLogin?: boolean;
+  /** When editing redirects inline, whether to also show the shared domain allowlist. */
+  showDomainsInRedirectEditor?: boolean;
+  title?: string;
+  description?: string;
 }
 
 function DeviceInitiateLoginUriField({
@@ -1397,6 +1426,11 @@ export function AuthCodeFlowTestSection({
   onDomainsChange,
   readOnly = false,
   showRedirectUriEditor = false,
+  forceAuthCodeFlow = false,
+  showInitiateLogin = true,
+  showDomainsInRedirectEditor = true,
+  title = "Try the authorization code flow",
+  description = "Opens a new tab with a test authorization request using your configured redirect URI.",
 }: Readonly<AuthCodeFlowTestSectionProps>) {
   const [selectedRedirectUri, setSelectedRedirectUri] = useState(() =>
     getDefaultRedirectUri(redirectUris),
@@ -1406,7 +1440,8 @@ export function AuthCodeFlowTestSection({
     () => syncPublicClientGrantTypes(grantTypes, redirectUris, clientId ?? ""),
     [grantTypes, redirectUris, clientId],
   );
-  const hasAuthCodeFlow = effectiveGrantTypes.includes(AUTHORIZATION_CODE_GRANT);
+  const hasAuthCodeFlow =
+    forceAuthCodeFlow || effectiveGrantTypes.includes(AUTHORIZATION_CODE_GRANT);
   const hasDeviceCode = effectiveGrantTypes.includes(DEVICE_CODE_GRANT);
 
   const effectiveSelectedRedirectUri =
@@ -1435,6 +1470,8 @@ export function AuthCodeFlowTestSection({
 
   if (!hasAuthCodeFlow) return null;
 
+  const redirectSelectId = `testing-redirect-uri-${clientId ?? "client"}`;
+
   return (
     <div className="space-y-5 p-5 rounded-xl border border-zinc-800 bg-zinc-900/30">
       {showRedirectUriEditor && redirectUris.length === 0 ? (
@@ -1457,7 +1494,7 @@ export function AuthCodeFlowTestSection({
             />
           </svg>
           <div className="min-w-0 space-y-1">
-            <p className="text-sm font-medium text-zinc-200">Try the authorization code flow</p>
+            <p className="text-sm font-medium text-zinc-200">{title}</p>
             <p className="text-xs text-zinc-400">
               Add at least one redirect URI below. Once saved, you can open a live authorization
               request in a new tab to verify sign-in end to end.
@@ -1482,6 +1519,7 @@ export function AuthCodeFlowTestSection({
             domains={domains}
             onDomainsChange={onDomainsChange}
             readOnly={readOnly}
+            showDomains={showDomainsInRedirectEditor}
           />
         </>
       ) : null}
@@ -1489,21 +1527,19 @@ export function AuthCodeFlowTestSection({
       {testUrl ? (
         <div className={`space-y-3 ${showRedirectUriEditor ? "border-t border-zinc-800 pt-5" : ""}`}>
           <div>
-            <h4 className="text-sm font-semibold text-zinc-200">Try the authorization code flow</h4>
-            <p className="text-xs text-zinc-500 mt-1">
-              Opens a new tab with a test authorization request using your configured redirect URI.
-            </p>
+            <h4 className="text-sm font-semibold text-zinc-200">{title}</h4>
+            <p className="text-xs text-zinc-500 mt-1">{description}</p>
           </div>
           {redirectUriOptions.length > 1 ? (
             <div>
               <label
-                htmlFor="testing-redirect-uri"
+                htmlFor={redirectSelectId}
                 className="block text-xs font-medium text-zinc-400 mb-1"
               >
                 Redirect URI
               </label>
               <select
-                id="testing-redirect-uri"
+                id={redirectSelectId}
                 value={effectiveSelectedRedirectUri}
                 onChange={(e) => setSelectedRedirectUri(e.target.value)}
                 className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
@@ -1535,9 +1571,13 @@ export function AuthCodeFlowTestSection({
             <code className="text-zinc-400">{effectiveSelectedRedirectUri}</code>
           </p>
         </div>
+      ) : redirectUris.length === 0 && !showRedirectUriEditor ? (
+        <p className="text-xs text-zinc-500">
+          Add at least one redirect URI above to enable the live authorization test.
+        </p>
       ) : null}
 
-      {backendDeviceHelper && hasDeviceCode ? (
+      {showInitiateLogin && backendDeviceHelper && hasDeviceCode ? (
         <DeviceInitiateLoginUriField
           initiateLoginUri={initiateLoginUri}
           deviceThirdPartyInitiateLogin={deviceThirdPartyInitiateLogin}
@@ -1573,9 +1613,14 @@ export default function TestingStep({
   onWebSecretGenerated,
   ownerExternalUserId = null,
   readOnly = false,
-  hideRedirectUriEditor = false,
-  hideAuthCodeFlowSection = false,
+  activeClient = null,
+  hideHeader = false,
+  onPublicRedirectUrisChange,
+  postLogoutRedirectUris = [],
+  onPostLogoutRedirectUrisChange,
+  showPostLogoutRedirectUris = false,
 }: Readonly<Props>) {
+  const [newPostLogoutUri, setNewPostLogoutUri] = useState("");
   const [secret, setSecret] = useState<string | null>(null);
   const [backendSecret, setBackendSecret] = useState<string | null>(null);
   const [webSecret, setWebSecret] = useState<string | null>(null);
@@ -1774,51 +1819,78 @@ export default function TestingStep({
   const browserOrigin = getBrowserOrigin();
   const hasM2mBackend =
     Boolean(backendHelper?.clientId) || Boolean(clientId?.startsWith("m2m_"));
+  const showPublicPanel = activeClient == null || activeClient === "public";
+  const showM2mPanel = activeClient == null || activeClient === "m2m";
+  const showWebPanel = activeClient == null || activeClient === "web";
+
   const showRemoteSigningTab =
+    showPublicPanel &&
     !isM2MOnly &&
     Boolean(clientId?.startsWith("app_")) &&
     publicAppAllowsSignJob(allowedScopes ?? DEFAULT_OIDC_SCOPES);
-  const showAdminAccessTab = Boolean(backendHelper?.clientId);
-  const showAuthTestSection = showRemoteSigningTab || showAdminAccessTab;
-  const effectiveAuthTestTab = resolveEffectiveAuthTestTab(
-    authTestTab,
-    showAdminAccessTab,
-    showRemoteSigningTab,
-  );
+  const showAdminAccessTab = showM2mPanel && Boolean(backendHelper?.clientId);
+  // With client sub-tabs, remote vs admin live on separate panels — no nested switcher.
+  const useClientSubTabs = activeClient != null;
+  const showAuthTestSection =
+    useClientSubTabs
+      ? showRemoteSigningTab || showAdminAccessTab
+      : showRemoteSigningTab || showAdminAccessTab;
+  const effectiveAuthTestTab = useClientSubTabs
+    ? showAdminAccessTab && activeClient === "m2m"
+      ? "admin"
+      : "remote"
+    : resolveEffectiveAuthTestTab(
+        authTestTab,
+        showAdminAccessTab,
+        showRemoteSigningTab,
+      );
 
   useEffect(() => {
+    if (useClientSubTabs) return;
     if (authTestTab === "admin" && !showAdminAccessTab && showRemoteSigningTab) {
       setAuthTestTab("remote");
     }
-  }, [authTestTab, showAdminAccessTab, showRemoteSigningTab]);
+  }, [authTestTab, showAdminAccessTab, showRemoteSigningTab, useClientSubTabs]);
+
+  const showPrimaryCredentials =
+    showPublicPanel && (primaryIsConfidential || !isM2MOnly);
+  const showM2mCredentials = showM2mPanel && !isM2MOnly;
+  const showWebCredentials = showWebPanel && !isM2MOnly;
+  const showM2mOnlyExchange = showM2mPanel && isM2MOnly && Boolean(clientId);
+  const showPublicAuthCode =
+    showPublicPanel && !isM2MOnly && activeClient != null;
+  const showLegacyAuthCode = activeClient == null;
+  const showWebAuthCode = showWebPanel && Boolean(webHelper?.clientId);
 
   return (
     <div className="space-y-8">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-semibold text-zinc-100 mb-1">Credentials &amp; URLs</h2>
-          <p className="text-sm text-zinc-500">
-            {getCredentialsIntroText(isM2MOnly, hideAuthCodeFlowSection)}
-          </p>
+      {hideHeader ? null : (
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-zinc-100 mb-1">Credentials &amp; URLs</h2>
+            <p className="text-sm text-zinc-500">
+              {getCredentialsIntroText(isM2MOnly, activeClient)}
+            </p>
+          </div>
+          <a
+            href={API_REFERENCE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-1 rounded-md border border-zinc-700 bg-zinc-800/50 px-2.5 py-1.5 text-xs font-medium text-zinc-400 hover:border-emerald-500/40 hover:text-emerald-400 transition-colors"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+            </svg>
+            API Reference
+            <svg className="w-3 h-3 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </a>
         </div>
-        <a
-          href={API_REFERENCE_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="shrink-0 inline-flex items-center gap-1 rounded-md border border-zinc-700 bg-zinc-800/50 px-2.5 py-1.5 text-xs font-medium text-zinc-400 hover:border-emerald-500/40 hover:text-emerald-400 transition-colors"
-        >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-          </svg>
-          API Reference
-          <svg className="w-3 h-3 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-          </svg>
-        </a>
-      </div>
+      )}
       {copyError && <p className="text-xs text-red-400 mt-2">{copyError}</p>}
 
-      {primaryIsConfidential ? (
+      {showPrimaryCredentials && primaryIsConfidential ? (
         <>
           <div>
             <div className="block text-sm font-medium text-zinc-300 mb-1.5">
@@ -1884,237 +1956,378 @@ export default function TestingStep({
             )}
           </div>
         </>
-      ) : (
-        <>
+      ) : null}
+
+      {showPrimaryCredentials && !primaryIsConfidential ? (
+        <div>
+          <div className="block text-sm font-medium text-zinc-300 mb-1.5">
+            Public / SDK client ID
+          </div>
+          <p className="text-xs text-zinc-500 mb-2">
+            Use this in SDKs, CLIs, and the device authorization flow. It stays public
+            (no secret). Portal SSO needs the confidential{" "}
+            <code className="font-mono text-zinc-400">web_</code> sibling; Builder APIs
+            need the <code className="font-mono text-zinc-400">m2m_</code> sibling.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-emerald-400 text-sm font-mono">
+              {clientId || "Create app first"}
+            </code>
+            {clientId && (
+              <button
+                type="button"
+                onClick={() => copyToClipboard(clientId, "clientId")}
+                className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 transition-colors"
+              >
+                {copied === "clientId" ? "Copied!" : "Copy"}
+              </button>
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {showPublicPanel && onPublicRedirectUrisChange ? (
+        <section className="space-y-4 border-t border-zinc-800 pt-8">
           <div>
-            <div className="block text-sm font-medium text-zinc-300 mb-1.5">
-              Public / SDK client ID
-            </div>
-            <p className="text-xs text-zinc-500 mb-2">
-              Use this in SDKs, CLIs, and the device authorization flow. It stays public
-              (no secret). Portal SSO needs the confidential{" "}
-              <code className="font-mono text-zinc-400">web_</code> sibling; Builder APIs
-              need the <code className="font-mono text-zinc-400">m2m_</code> sibling.
+            <h3 className="text-base font-semibold text-zinc-100">Sign-in URLs</h3>
+            <p className="text-sm text-zinc-500 mt-1">
+              Authorization Code + PKCE is enabled automatically when at least one
+              redirect URI is registered on the public client. Portal SSO redirect URIs
+              belong on the Web RP tab. Device flow (CLI/SDK) works without a public
+              redirect URI.
             </p>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-emerald-400 text-sm font-mono">
-                {clientId || "Create app first"}
-              </code>
-              {clientId && (
+          </div>
+          <AuthorizationCodeRedirectBlock
+            appId={appId}
+            redirectUris={redirectUris}
+            onRedirectUrisChange={onPublicRedirectUrisChange}
+            domains={domains}
+            onDomainsChange={onDomainsChange}
+            readOnly={readOnly}
+            showDomains={false}
+          />
+          <DomainAllowlistBlock
+            appId={appId}
+            domains={domains}
+            onDomainsChange={onDomainsChange}
+            readOnly={readOnly}
+          />
+          {showPostLogoutRedirectUris && onPostLogoutRedirectUrisChange ? (
+            <div className="space-y-3 pt-4 border-t border-zinc-800">
+              <div>
+                <h4 className="text-sm font-semibold text-zinc-200">Post-logout redirects</h4>
+                <p className="text-xs text-zinc-500 mt-1">
+                  URIs to redirect users to after sign-out. Saved with{" "}
+                  <strong className="text-zinc-400">Save changes</strong> below.
+                </p>
+              </div>
+              <div className="flex gap-2 mb-2">
+                <input
+                  id="postLogoutUriInput"
+                  type="text"
+                  value={newPostLogoutUri}
+                  onChange={(e) => setNewPostLogoutUri(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key !== "Enter") return;
+                    e.preventDefault();
+                    const uri = newPostLogoutUri.trim();
+                    if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
+                    onPostLogoutRedirectUrisChange([...postLogoutRedirectUris, uri]);
+                    setNewPostLogoutUri("");
+                  }}
+                  placeholder="https://example.com/logout-complete"
+                  disabled={readOnly}
+                  className="flex-1 px-3 py-1.5 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 focus:border-emerald-500/50 disabled:opacity-50 disabled:cursor-not-allowed"
+                />
                 <button
                   type="button"
-                  onClick={() => copyToClipboard(clientId, "clientId")}
+                  onClick={() => {
+                    const uri = newPostLogoutUri.trim();
+                    if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
+                    onPostLogoutRedirectUrisChange([...postLogoutRedirectUris, uri]);
+                    setNewPostLogoutUri("");
+                  }}
+                  disabled={readOnly}
+                  className="px-4 py-1.5 rounded-md bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Add
+                </button>
+              </div>
+              <div className="space-y-1.5">
+                {postLogoutRedirectUris.map((uri) => (
+                  <div
+                    key={uri}
+                    className="flex items-center justify-between rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2"
+                  >
+                    <code className="text-xs text-zinc-300">{uri}</code>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onPostLogoutRedirectUrisChange(
+                          postLogoutRedirectUris.filter((item) => item !== uri),
+                        )
+                      }
+                      disabled={readOnly}
+                      className="text-xs text-zinc-500 hover:text-red-400 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {showPublicAuthCode || showLegacyAuthCode ? (
+        <AuthCodeFlowTestSection
+          appId={appId}
+          clientId={clientId}
+          grantTypes={grantTypes}
+          redirectUris={redirectUris}
+          allowedScopes={allowedScopes}
+          backendDeviceHelper={backendDeviceHelper}
+          initiateLoginUri={initiateLoginUri}
+          deviceThirdPartyInitiateLogin={deviceThirdPartyInitiateLogin}
+          domains={domains}
+          onChange={onChange}
+          onDomainsChange={onDomainsChange}
+          readOnly={readOnly}
+          showRedirectUriEditor={showLegacyAuthCode}
+          showDomainsInRedirectEditor={showLegacyAuthCode}
+        />
+      ) : null}
+
+      {showM2mCredentials ? (
+        backendHelper ? (
+          <div className="p-4 rounded-xl border border-cyan-500/20 bg-cyan-500/5 space-y-3">
+            <h3 className="text-sm font-semibold text-cyan-200/90">
+              M2M / Builder{" "}
+              <code className="font-mono text-cyan-300/80 font-normal">(m2m_)</code>
+            </h3>
+            <p className="text-xs text-zinc-500">
+              Use Basic auth with this client for Builder APIs and server-side device approval. Never embed in public apps.
+            </p>
+            <div>
+              <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-cyan-300 text-sm font-mono">
+                  {backendHelper.clientId}
+                </code>
+                <button
+                  type="button"
+                  onClick={() => copyToClipboard(backendHelper.clientId, "m2mClientId")}
                   className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 transition-colors"
                 >
-                  {copied === "clientId" ? "Copied!" : "Copy"}
+                  {copied === "m2mClientId" ? "Copied!" : "Copy"}
                 </button>
+              </div>
+            </div>
+            <div>
+              <div className="block text-xs font-medium text-zinc-400 mb-1">Client Secret</div>
+              {backendSecret ? (
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-amber-500/30 rounded-lg text-amber-400 text-sm font-mono break-all">
+                      {backendSecret}
+                    </code>
+                    <button
+                      type="button"
+                      onClick={() => copyToClipboard(backendSecret, "backendSecret")}
+                      className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 shrink-0"
+                    >
+                      {copied === "backendSecret" ? "Copied!" : "Copy"}
+                    </button>
+                  </div>
+                  <p className="text-xs text-amber-400/80">
+                    Store this secret securely. It will not be shown again.
+                  </p>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3 flex-wrap">
+                  {backendHelper.hasSecret && (
+                    <p className="text-sm text-zinc-500">
+                      A secret exists. Generate a new one to rotate.
+                    </p>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => void generateBackendSecret()}
+                    disabled={readOnly || generatingBackend || !appId}
+                    className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
+                  >
+                    {generatingBackend
+                      ? "Generating..."
+                      : backendHelper.hasSecret
+                        ? "Rotate Secret"
+                        : "Generate Secret"}
+                  </button>
+                </div>
+              )}
+              {backendSecretFetchError && (
+                <p className="text-xs text-red-400 mt-2">{backendSecretFetchError}</p>
               )}
             </div>
           </div>
-
-        </>
-      )}
-
-      {/*
-        Backend helper (confidential m2m_) — driven by server state
-        (`backendHelper` / `backendDeviceHelper`), refreshed when the
-        Credentials tab loads and after save.
-      */}
-      {backendHelper ? (
-        <div className="p-4 rounded-xl border border-cyan-500/20 bg-cyan-500/5 space-y-3">
-          <h3 className="text-sm font-semibold text-cyan-200/90">Backend helper (confidential)</h3>
-          <p className="text-xs text-zinc-500">
-            Use Basic auth with this client for Builder APIs and server-side device approval. Never embed in public apps.
+        ) : backendDeviceHelper ? (
+          <p className="text-sm text-zinc-500">
+            <strong className="text-zinc-400">Confidential M2M backend</strong> is enabled but not
+            yet provisioned. Use <strong className="text-zinc-400">Save changes</strong> to create
+            the <code className="font-mono text-zinc-400">m2m_</code> client, then return here.
           </p>
-          <div>
-            <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-cyan-300 text-sm font-mono">
-                {backendHelper.clientId}
-              </code>
-              <button
-                type="button"
-                onClick={() => copyToClipboard(backendHelper.clientId, "m2mClientId")}
-                className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 transition-colors"
-              >
-                {copied === "m2mClientId" ? "Copied!" : "Copy"}
-              </button>
-            </div>
-          </div>
-          <div>
-            <div className="block text-xs font-medium text-zinc-400 mb-1">Client Secret</div>
-            {backendSecret ? (
-              <div>
-                <div className="flex items-center gap-2 mb-2">
-                  <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-amber-500/30 rounded-lg text-amber-400 text-sm font-mono break-all">
-                    {backendSecret}
-                  </code>
-                  <button
-                    type="button"
-                    onClick={() => copyToClipboard(backendSecret, "backendSecret")}
-                    className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 shrink-0"
-                  >
-                    {copied === "backendSecret" ? "Copied!" : "Copy"}
-                  </button>
-                </div>
-                <p className="text-xs text-amber-400/80">
-                  Store this secret securely. It will not be shown again.
-                </p>
-              </div>
-            ) : (
-              <div className="flex items-center gap-3 flex-wrap">
-                {backendHelper.hasSecret && (
-                  <p className="text-sm text-zinc-500">
-                    A secret exists. Generate a new one to rotate.
-                  </p>
-                )}
-                <button
-                  type="button"
-                  onClick={() => void generateBackendSecret()}
-                  disabled={readOnly || generatingBackend || !appId}
-                  className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
-                >
-                  {generatingBackend
-                    ? "Generating..."
-                    : backendHelper.hasSecret
-                      ? "Rotate Secret"
-                      : "Generate Secret"}
-                </button>
-              </div>
-            )}
-            {backendSecretFetchError && (
-              <p className="text-xs text-red-400 mt-2">{backendSecretFetchError}</p>
-            )}
-          </div>
-        </div>
-      ) : !isM2MOnly && backendDeviceHelper ? (
-        <p className="text-sm text-zinc-500 mt-4">
-          <strong className="text-zinc-400">Backend device helper</strong> is enabled but not yet provisioned.
-          Save the app to provision the Backend device helper and create a confidential{" "}
-          <code className="font-mono text-zinc-400">m2m_</code> client for Builder APIs and NaaP-side device
-          approval, then return here.
-        </p>
-      ) : !isM2MOnly ? (
-        <p className="text-sm text-zinc-500 mt-4">
-          Confidential M2M backend is off on{" "}
-          <strong className="text-zinc-400">App profile</strong>. Turn on{" "}
-          <strong className="text-zinc-400">Confidential M2M backend</strong>{" "}
-          there to manage M2M credentials on this tab.
-        </p>
+        ) : (
+          <p className="text-sm text-zinc-500">
+            Confidential M2M backend is off on{" "}
+            <strong className="text-zinc-400">App profile</strong>. Turn on{" "}
+            <strong className="text-zinc-400">Confidential M2M backend</strong> there to manage M2M
+            credentials on this tab.
+          </p>
+        )
       ) : null}
 
-      {webHelper ? (
-        <div className="p-4 rounded-xl border border-violet-500/20 bg-violet-500/5 space-y-3">
-          <h3 className="text-sm font-semibold text-violet-200/90">
-            Confidential web RP
-          </h3>
-          <p className="text-xs text-zinc-500">
-            Use this <code className="font-mono text-zinc-400">web_</code> client ID +
-            secret in external portal SSO (e.g. Kong Dev Portal User authentication). Not
-            for Builder M2M.
-          </p>
-          <div>
-            <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-violet-300 text-sm font-mono">
-                {webHelper.clientId}
-              </code>
-              <button
-                type="button"
-                onClick={() => copyToClipboard(webHelper.clientId, "webClientId")}
-                className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 transition-colors"
-              >
-                {copied === "webClientId" ? "Copied!" : "Copy"}
-              </button>
-            </div>
-          </div>
-          <div>
-            <div className="block text-xs font-medium text-zinc-400 mb-1">
-              Redirect URIs
-            </div>
-            <AuthorizationCodeRedirectBlock
-              appId={appId}
-              redirectUris={confidentialWebRedirectUris}
-              onRedirectUrisChange={(uris) => void persistWebRedirectUris(uris)}
-              domains={domains}
-              onDomainsChange={onDomainsChange}
-              readOnly={readOnly}
-              requireAtLeastOne={confidentialWebRedirectUris.length > 0}
-              persistRedirectUrisToPublicClient={false}
-            />
-          </div>
-          <div>
-            <div className="block text-xs font-medium text-zinc-400 mb-1">Client Secret</div>
-            {webSecret ? (
-              <div>
-                <div className="flex items-center gap-2 mb-2">
-                  <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-amber-500/30 rounded-lg text-amber-400 text-sm font-mono break-all">
-                    {webSecret}
-                  </code>
-                  <button
-                    type="button"
-                    onClick={() => copyToClipboard(webSecret, "webSecret")}
-                    className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 shrink-0"
-                  >
-                    {copied === "webSecret" ? "Copied!" : "Copy"}
-                  </button>
-                </div>
-                <p className="text-xs text-amber-400/80">
-                  Store this secret securely. It will not be shown again.
-                </p>
-              </div>
-            ) : (
-              <div className="flex items-center gap-3 flex-wrap">
-                {webHelper.hasSecret && (
-                  <p className="text-sm text-zinc-500">
-                    A secret exists. Generate a new one to rotate.
-                  </p>
-                )}
+      {showWebCredentials ? (
+        webHelper ? (
+          <div className="p-4 rounded-xl border border-violet-500/20 bg-violet-500/5 space-y-3">
+            <h3 className="text-sm font-semibold text-violet-200/90">
+              Confidential web RP{" "}
+              <code className="font-mono text-violet-300/80 font-normal">(web_)</code>
+            </h3>
+            <p className="text-xs text-zinc-500">
+              Use this <code className="font-mono text-zinc-400">web_</code> client ID +
+              secret in external portal SSO (e.g. Kong Dev Portal User authentication). Not
+              for Builder M2M. Domain allowlist is shared — manage it on the Public / SDK tab.
+            </p>
+            <div>
+              <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-violet-300 text-sm font-mono">
+                  {webHelper.clientId}
+                </code>
                 <button
                   type="button"
-                  onClick={() => void generateWebSecret()}
-                  disabled={readOnly || generatingWeb || !appId}
-                  className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
+                  onClick={() => copyToClipboard(webHelper.clientId, "webClientId")}
+                  className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 transition-colors"
                 >
-                  {generatingWeb
-                    ? "Generating..."
-                    : webHelper.hasSecret
-                      ? "Rotate Secret"
-                      : "Generate Secret"}
+                  {copied === "webClientId" ? "Copied!" : "Copy"}
                 </button>
               </div>
-            )}
-            {webSecretFetchError && (
-              <p className="text-xs text-red-400 mt-2">{webSecretFetchError}</p>
-            )}
+            </div>
+            <div>
+              <AuthorizationCodeRedirectBlock
+                appId={appId}
+                redirectUris={confidentialWebRedirectUris}
+                onRedirectUrisChange={(uris) => void persistWebRedirectUris(uris)}
+                domains={domains}
+                onDomainsChange={onDomainsChange}
+                readOnly={readOnly}
+                requireAtLeastOne={confidentialWebRedirectUris.length > 0}
+                persistRedirectUrisToPublicClient={false}
+                showDomains={false}
+                label="Portal redirect URIs"
+                description="Callback URLs for the confidential web RP (portal SSO). Each add or remove is saved immediately. Origins are auto-added to the shared domain allowlist on the Public tab."
+              />
+            </div>
+            <div>
+              <div className="block text-xs font-medium text-zinc-400 mb-1">Client Secret</div>
+              {webSecret ? (
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-amber-500/30 rounded-lg text-amber-400 text-sm font-mono break-all">
+                      {webSecret}
+                    </code>
+                    <button
+                      type="button"
+                      onClick={() => copyToClipboard(webSecret, "webSecret")}
+                      className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 shrink-0"
+                    >
+                      {copied === "webSecret" ? "Copied!" : "Copy"}
+                    </button>
+                  </div>
+                  <p className="text-xs text-amber-400/80">
+                    Store this secret securely. It will not be shown again.
+                  </p>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3 flex-wrap">
+                  {webHelper.hasSecret && (
+                    <p className="text-sm text-zinc-500">
+                      A secret exists. Generate a new one to rotate.
+                    </p>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => void generateWebSecret()}
+                    disabled={readOnly || generatingWeb || !appId}
+                    className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
+                  >
+                    {generatingWeb
+                      ? "Generating..."
+                      : webHelper.hasSecret
+                        ? "Rotate Secret"
+                        : "Generate Secret"}
+                  </button>
+                </div>
+              )}
+              {webSecretFetchError && (
+                <p className="text-xs text-red-400 mt-2">{webSecretFetchError}</p>
+              )}
+            </div>
           </div>
-        </div>
-      ) : confidentialWebHelper ? (
-        <p className="text-sm text-zinc-500 mt-4">
-          <strong className="text-zinc-400">Confidential web RP</strong> is enabled but not
-          yet provisioned. Save the app to create the{" "}
-          <code className="font-mono text-zinc-400">web_</code> sibling, then return here.
-        </p>
-      ) : (
-        <p className="text-sm text-zinc-500 mt-4">
-          Confidential web RP is off on{" "}
-          <strong className="text-zinc-400">App profile</strong>. Turn it on there for
-          portal SSO (Kong Dev Portal, etc.).
-        </p>
-      )}
+        ) : confidentialWebHelper ? (
+          <p className="text-sm text-zinc-500">
+            <strong className="text-zinc-400">Confidential web RP</strong> is enabled but not
+            yet provisioned. Use <strong className="text-zinc-400">Save changes</strong> to create
+            the <code className="font-mono text-zinc-400">web_</code> sibling, then return here.
+          </p>
+        ) : (
+          <p className="text-sm text-zinc-500">
+            Confidential web RP is off on{" "}
+            <strong className="text-zinc-400">App profile</strong>. Turn it on there for
+            portal SSO (Kong Dev Portal, etc.).
+          </p>
+        )
+      ) : null}
+
+      {showWebAuthCode ? (
+        <AuthCodeFlowTestSection
+          appId={appId}
+          clientId={webHelper!.clientId}
+          grantTypes={[AUTHORIZATION_CODE_GRANT]}
+          redirectUris={confidentialWebRedirectUris}
+          allowedScopes={allowedScopes}
+          backendDeviceHelper={false}
+          initiateLoginUri=""
+          deviceThirdPartyInitiateLogin={false}
+          domains={domains}
+          onChange={onChange}
+          onDomainsChange={onDomainsChange}
+          readOnly={readOnly}
+          forceAuthCodeFlow
+          showInitiateLogin={false}
+          title="Try the portal authorization code flow"
+          description="Opens a test authorization request using the confidential web_ client ID and a portal redirect URI."
+        />
+      ) : null}
 
       {showAuthTestSection ? (
         <div className="p-4 rounded-xl border border-zinc-800 bg-zinc-900/30 space-y-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0">
-              <h3 className="text-sm font-semibold text-zinc-200">Test authentication</h3>
+              <h3 className="text-sm font-semibold text-zinc-200">
+                {useClientSubTabs
+                  ? effectiveAuthTestTab === "remote"
+                    ? "Verify remote signing"
+                    : "Verify administrative access"
+                  : "Test authentication"}
+              </h3>
               <p className="text-xs text-zinc-500 mt-1">
                 {effectiveAuthTestTab === "remote"
                   ? "Bearer API key for direct signing, or mint + exchange for a signer JWT. Device code login remains the end-user path."
-                  : "Client-credentials token exchange with the Backend helper for Builder APIs, user provisioning, and device approval."}
+                  : "Client-credentials token exchange with the M2M / Builder client for Builder APIs, user provisioning, and device approval."}
               </p>
             </div>
-            {showRemoteSigningTab && showAdminAccessTab ? (
+            {!useClientSubTabs && showRemoteSigningTab && showAdminAccessTab ? (
               <div
                 className="flex shrink-0 items-center gap-1 self-start rounded-lg bg-black/20 p-0.5"
                 role="tablist"
@@ -2186,15 +2399,15 @@ export default function TestingStep({
         </div>
       ) : null}
 
-      {isM2MOnly && clientId ? (
+      {showM2mOnlyExchange ? (
         <div className="space-y-4 p-5 rounded-xl border border-zinc-800 bg-zinc-900/30">
           <div className="flex items-center gap-2">
             <div className="w-2 h-2 rounded-full bg-cyan-500" />
             <h3 className="text-sm font-semibold text-zinc-200">M2M token exchange</h3>
           </div>
           <M2mTokenTestPanel
-            clientId={clientId}
-            publicClientId={clientId.startsWith("app_") ? clientId : null}
+            clientId={clientId!}
+            publicClientId={clientId!.startsWith("app_") ? clientId : null}
             ownerExternalUserId={ownerExternalUserId}
             generatedSecret={m2mSecretForTests}
             allowedScopes={allowedScopes ?? DEFAULT_OIDC_SCOPES}
@@ -2208,24 +2421,6 @@ export default function TestingStep({
         </div>
       ) : null}
 
-      {hideAuthCodeFlowSection ? null : (
-        <AuthCodeFlowTestSection
-          appId={appId}
-          clientId={clientId}
-          grantTypes={grantTypes}
-          redirectUris={redirectUris}
-          allowedScopes={allowedScopes}
-          backendDeviceHelper={backendDeviceHelper}
-          initiateLoginUri={initiateLoginUri}
-          deviceThirdPartyInitiateLogin={deviceThirdPartyInitiateLogin}
-          domains={domains}
-          onChange={onChange}
-          onDomainsChange={onDomainsChange}
-          readOnly={readOnly}
-          showRedirectUriEditor={!hideRedirectUriEditor}
-        />
-      )}
     </div>
   );
 }
-

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -426,9 +426,9 @@ function getM2mIntroText(showFlowPicker: boolean, showRemoteSigning: boolean): s
 
 function getSigningFormatHint(format: SigningTokenFormat): string {
   if (format === "bearer") {
-    return "Get API Key for a long-lived Bearer token";
+    return "Long-lived Bearer API key.";
   }
-  return "Mint an owner API key with your session, then exchange it for a short-lived signer JWT. End users can instead use device code login.";
+  return "Short-lived signer JWT via mint + exchange.";
 }
 
 function resolveOwnerSigningFormatHint(

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -469,13 +469,13 @@ function getCredentialsIntroText(
 ): string {
   if (isM2MOnly) return "Generate your client secret, then test your M2M token request.";
   if (activeClient === "public") {
-    return "Public SDK client ID, shared domain allowlist, and device / remote-signing verification. Authorization-code login lives on the Web RP tab.";
+    return "Public client for SDKs, CLIs, and device login.";
   }
   if (activeClient === "m2m") {
-    return "M2M / Builder credentials and client-credentials token exchange for server APIs.";
+    return "Server credentials for Builder APIs.";
   }
   if (activeClient === "web") {
-    return "Confidential web RP credentials, portal redirect URIs, and authorization-code verification.";
+    return "Confidential client for portal SSO.";
   }
   return "Configure credentials and URLs per OIDC sibling, then verify each client’s auth flow.";
 }
@@ -939,7 +939,7 @@ function M2mFlowSelection({
                 Administrative access
               </span>
               <span className="mt-1 block text-[11px] leading-snug text-zinc-500">
-                Builder APIs, user provisioning, and device approval
+                Builder APIs and device approval
               </span>
             </button>
           ) : null}
@@ -958,7 +958,7 @@ function M2mFlowSelection({
                 Remote signing
               </span>
               <span className="mt-1 block text-[11px] leading-snug text-zinc-500">
-                Bearer API key, or mint + exchange for a signer JWT (device code is the end-user path)
+                API key or signer JWT
               </span>
             </button>
           ) : null}
@@ -1399,11 +1399,8 @@ function DeviceInitiateLoginUriField({
           className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-sm text-zinc-100 placeholder:text-zinc-600 disabled:opacity-50 disabled:cursor-not-allowed"
         />
         <p className="text-xs text-zinc-500">
-          OIDC <code className="font-mono text-zinc-400">initiate_login_uri</code>. When set,
-          unauthenticated device verification redirects here with{" "}
-          <code className="font-mono text-zinc-400">iss</code> and{" "}
-          <code className="font-mono text-zinc-400">target_link_uri</code>. Your app must return
-          users to <code className="font-mono text-zinc-400">target_link_uri</code> after login.
+          Optional login page for unauthenticated device verification. After login, return
+          users to <code className="font-mono text-zinc-400">target_link_uri</code>.
         </p>
         {initiateLoginUri.trim() && !deviceThirdPartyInitiateLogin ? (
           <p className="text-xs text-amber-300">
@@ -1948,8 +1945,8 @@ export default function TestingStep({
   }
   const authTestDescription =
     effectiveAuthTestTab === "remote"
-      ? "Bearer API key for direct signing, or mint + exchange for a signer JWT. Device code login remains the end-user path."
-      : "Client-credentials token exchange with the M2M / Builder client for Builder APIs, user provisioning, and device approval.";
+      ? "Test remote signing with an API key or signer JWT."
+      : "Test a client-credentials token for Builder APIs.";
 
   return (
     <div className="space-y-8">
@@ -2061,10 +2058,7 @@ export default function TestingStep({
               <code className="font-mono text-emerald-300/80 font-normal">(app_)</code>
             </h3>
             <p className="text-xs text-zinc-500 mt-1">
-              Use this in SDKs, CLIs, and the device authorization flow. It stays public
-              (no secret). Portal SSO needs the confidential{" "}
-              <code className="font-mono text-zinc-400">web_</code> sibling; Builder APIs
-              need the <code className="font-mono text-zinc-400">m2m_</code> sibling.
+              For SDKs, CLIs, and device login. No secret — public only.
             </p>
           </div>
 
@@ -2092,8 +2086,7 @@ export default function TestingStep({
             <div>
               <h4 className="text-xs font-semibold text-zinc-200">Domain allowlist</h4>
               <p className="text-xs text-zinc-500 mt-1">
-                Shared origins for CORS and request validation. Authorization-code redirect
-                URIs live on the Web RP tab. Device flow does not need a redirect URI.
+                Shared origins for CORS and request validation.
               </p>
             </div>
             <DomainAllowlistBlock
@@ -2142,7 +2135,7 @@ export default function TestingStep({
               <code className="font-mono text-cyan-300/80 font-normal">(m2m_)</code>
             </h3>
             <p className="text-xs text-zinc-500">
-              Use Basic auth with this client for Builder APIs and server-side device approval. Never embed in public apps.
+              For Builder APIs and server-side device approval. Keep the secret off public apps.
             </p>
             <div>
               <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
@@ -2224,9 +2217,7 @@ export default function TestingStep({
               <code className="font-mono text-violet-300/80 font-normal">(web_)</code>
             </h3>
             <p className="text-xs text-zinc-500">
-              Use this <code className="font-mono text-zinc-400">web_</code> client ID +
-              secret in external portal SSO (e.g. Kong Dev Portal User authentication). Not
-              for Builder M2M. Domain allowlist is shared — manage it on the Public / SDK tab.
+              For portal SSO (auth code + secret). Redirects live here; domains on Public / SDK.
             </p>
             <div>
               <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
@@ -2255,7 +2246,7 @@ export default function TestingStep({
                 persistRedirectUrisToPublicClient={false}
                 showDomains={false}
                 label="Portal redirect URIs"
-                description="Callback URLs for the confidential web_ client (portal SSO / authorization code). Each add or remove is saved immediately. Origins are auto-added to the shared domain allowlist."
+                description="Portal SSO callback URLs. Saved immediately; origins are added to the shared domain allowlist."
               />
             </div>
             {showPostLogoutRedirectUris && onPostLogoutRedirectUrisChange ? (
@@ -2263,8 +2254,8 @@ export default function TestingStep({
                 <div>
                   <h4 className="text-xs font-semibold text-zinc-200">Post-logout redirects</h4>
                   <p className="text-xs text-zinc-500 mt-1">
-                    URIs to redirect users to after sign-out. Saved with{" "}
-                    <strong className="text-zinc-400">Save changes</strong> below.
+                    Where users go after sign-out. Saved with{" "}
+                    <strong className="text-zinc-400">Save changes</strong>.
                   </p>
                 </div>
                 <div className="flex gap-2 mb-2">
@@ -2372,7 +2363,7 @@ export default function TestingStep({
       {showWebCredentials && !webHelper && !confidentialWebHelper ? (
           <SiblingDisabledMessage
             label="Confidential web RP"
-            detail="Turn it on there for portal SSO (Kong Dev Portal, etc.)."
+            detail="Turn it on there for portal SSO."
           />
       ) : null}
 
@@ -2393,7 +2384,7 @@ export default function TestingStep({
           forceAuthCodeFlow
           showInitiateLogin={false}
           title="Try the portal authorization code flow"
-          description="Opens a test authorization request using the confidential web_ client ID and a portal redirect URI."
+          description="Opens a test portal authorization request with this web_ client."
         />
       ) : null}
 

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -72,9 +72,7 @@ interface Props {
   activeClient?: CredentialsClientTab | null;
   /** When true, omit the page title (parent renders it above client sub-tabs). */
   hideHeader?: boolean;
-  /** Public redirect URI editor (Public tab). When omitted, redirects are not shown here. */
-  onPublicRedirectUrisChange?: (uris: string[]) => void;
-  /** Post-logout redirects (saved with Save changes). */
+  /** Post-logout redirects on the web_ client (saved with Save changes). */
   postLogoutRedirectUris?: string[];
   onPostLogoutRedirectUrisChange?: (uris: string[]) => void;
   showPostLogoutRedirectUris?: boolean;
@@ -465,7 +463,7 @@ function getCredentialsIntroText(
 ): string {
   if (isM2MOnly) return "Generate your client secret, then test your M2M token request.";
   if (activeClient === "public") {
-    return "Public SDK client ID, sign-in redirect URLs, domain allowlist, and authorization-code verification.";
+    return "Public SDK client ID, shared domain allowlist, and device / remote-signing verification. Authorization-code login lives on the Web RP tab.";
   }
   if (activeClient === "m2m") {
     return "M2M / Builder credentials and client-credentials token exchange for server APIs.";
@@ -1615,7 +1613,6 @@ export default function TestingStep({
   readOnly = false,
   activeClient = null,
   hideHeader = false,
-  onPublicRedirectUrisChange,
   postLogoutRedirectUris = [],
   onPostLogoutRedirectUrisChange,
   showPostLogoutRedirectUris = false,
@@ -1857,9 +1854,7 @@ export default function TestingStep({
   const showM2mCredentials = showM2mPanel && !isM2MOnly;
   const showWebCredentials = showWebPanel && !isM2MOnly;
   const showM2mOnlyExchange = showM2mPanel && isM2MOnly && Boolean(clientId);
-  const showPublicAuthCode =
-    showPublicPanel && !isM2MOnly && activeClient != null;
-  const showLegacyAuthCode = activeClient == null;
+  // Authorization code + redirects live only on web_ (Option 1).
   const showWebAuthCode = showWebPanel && Boolean(webHelper?.clientId);
 
   return (
@@ -1986,117 +1981,35 @@ export default function TestingStep({
         </div>
       ) : null}
 
-      {showPublicPanel && onPublicRedirectUrisChange ? (
+      {showPublicPanel ? (
         <section className="space-y-4 border-t border-zinc-800 pt-8">
           <div>
-            <h3 className="text-base font-semibold text-zinc-100">Sign-in URLs</h3>
+            <h3 className="text-base font-semibold text-zinc-100">Domain allowlist</h3>
             <p className="text-sm text-zinc-500 mt-1">
-              Authorization Code + PKCE is enabled automatically when at least one
-              redirect URI is registered on the public client. Portal SSO redirect URIs
-              belong on the Web RP tab. Device flow (CLI/SDK) works without a public
-              redirect URI.
+              Shared origins for CORS and request validation across all siblings.
+              Authorization-code redirect URIs are configured on the{" "}
+              <strong className="text-zinc-400">Web RP</strong> tab (confidential{" "}
+              <code className="font-mono text-zinc-400">web_</code> client). Device
+              flow does not need a redirect URI.
             </p>
           </div>
-          <AuthorizationCodeRedirectBlock
-            appId={appId}
-            redirectUris={redirectUris}
-            onRedirectUrisChange={onPublicRedirectUrisChange}
-            domains={domains}
-            onDomainsChange={onDomainsChange}
-            readOnly={readOnly}
-            showDomains={false}
-          />
           <DomainAllowlistBlock
             appId={appId}
             domains={domains}
             onDomainsChange={onDomainsChange}
             readOnly={readOnly}
           />
-          {showPostLogoutRedirectUris && onPostLogoutRedirectUrisChange ? (
-            <div className="space-y-3 pt-4 border-t border-zinc-800">
-              <div>
-                <h4 className="text-sm font-semibold text-zinc-200">Post-logout redirects</h4>
-                <p className="text-xs text-zinc-500 mt-1">
-                  URIs to redirect users to after sign-out. Saved with{" "}
-                  <strong className="text-zinc-400">Save changes</strong> below.
-                </p>
-              </div>
-              <div className="flex gap-2 mb-2">
-                <input
-                  id="postLogoutUriInput"
-                  type="text"
-                  value={newPostLogoutUri}
-                  onChange={(e) => setNewPostLogoutUri(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key !== "Enter") return;
-                    e.preventDefault();
-                    const uri = newPostLogoutUri.trim();
-                    if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
-                    onPostLogoutRedirectUrisChange([...postLogoutRedirectUris, uri]);
-                    setNewPostLogoutUri("");
-                  }}
-                  placeholder="https://example.com/logout-complete"
-                  disabled={readOnly}
-                  className="flex-1 px-3 py-1.5 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 focus:border-emerald-500/50 disabled:opacity-50 disabled:cursor-not-allowed"
-                />
-                <button
-                  type="button"
-                  onClick={() => {
-                    const uri = newPostLogoutUri.trim();
-                    if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
-                    onPostLogoutRedirectUrisChange([...postLogoutRedirectUris, uri]);
-                    setNewPostLogoutUri("");
-                  }}
-                  disabled={readOnly}
-                  className="px-4 py-1.5 rounded-md bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  Add
-                </button>
-              </div>
-              <div className="space-y-1.5">
-                {postLogoutRedirectUris.map((uri) => (
-                  <div
-                    key={uri}
-                    className="flex items-center justify-between rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2"
-                  >
-                    <code className="text-xs text-zinc-300">{uri}</code>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        onPostLogoutRedirectUrisChange(
-                          postLogoutRedirectUris.filter((item) => item !== uri),
-                        )
-                      }
-                      disabled={readOnly}
-                      className="text-xs text-zinc-500 hover:text-red-400 disabled:opacity-40 disabled:cursor-not-allowed"
-                    >
-                      Remove
-                    </button>
-                  </div>
-                ))}
-              </div>
-            </div>
+          {backendDeviceHelper &&
+          grantTypes.includes(DEVICE_CODE_GRANT) ? (
+            <DeviceInitiateLoginUriField
+              initiateLoginUri={initiateLoginUri}
+              deviceThirdPartyInitiateLogin={deviceThirdPartyInitiateLogin}
+              allowedScopes={allowedScopes}
+              readOnly={readOnly}
+              onChange={onChange}
+            />
           ) : null}
         </section>
-      ) : null}
-
-      {showPublicAuthCode || showLegacyAuthCode ? (
-        <AuthCodeFlowTestSection
-          appId={appId}
-          clientId={clientId}
-          grantTypes={grantTypes}
-          redirectUris={redirectUris}
-          allowedScopes={allowedScopes}
-          backendDeviceHelper={backendDeviceHelper}
-          initiateLoginUri={initiateLoginUri}
-          deviceThirdPartyInitiateLogin={deviceThirdPartyInitiateLogin}
-          domains={domains}
-          onChange={onChange}
-          onDomainsChange={onDomainsChange}
-          readOnly={readOnly}
-          showRedirectUriEditor={showLegacyAuthCode}
-          showDomainsInRedirectEditor={showLegacyAuthCode}
-        />
       ) : null}
 
       {showM2mCredentials ? (
@@ -2225,9 +2138,74 @@ export default function TestingStep({
                 persistRedirectUrisToPublicClient={false}
                 showDomains={false}
                 label="Portal redirect URIs"
-                description="Callback URLs for the confidential web RP (portal SSO). Each add or remove is saved immediately. Origins are auto-added to the shared domain allowlist on the Public tab."
+                description="Callback URLs for the confidential web_ client (portal SSO / authorization code). Each add or remove is saved immediately. Origins are auto-added to the shared domain allowlist."
               />
             </div>
+            {showPostLogoutRedirectUris && onPostLogoutRedirectUrisChange ? (
+              <div className="space-y-3 pt-2 border-t border-violet-500/15">
+                <div>
+                  <h4 className="text-xs font-semibold text-zinc-200">Post-logout redirects</h4>
+                  <p className="text-xs text-zinc-500 mt-1">
+                    URIs to redirect users to after sign-out. Saved with{" "}
+                    <strong className="text-zinc-400">Save changes</strong> below.
+                  </p>
+                </div>
+                <div className="flex gap-2 mb-2">
+                  <input
+                    id="postLogoutUriInput"
+                    type="text"
+                    value={newPostLogoutUri}
+                    onChange={(e) => setNewPostLogoutUri(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key !== "Enter") return;
+                      e.preventDefault();
+                      const uri = newPostLogoutUri.trim();
+                      if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
+                      onPostLogoutRedirectUrisChange([...postLogoutRedirectUris, uri]);
+                      setNewPostLogoutUri("");
+                    }}
+                    placeholder="https://example.com/logout-complete"
+                    disabled={readOnly}
+                    className="flex-1 px-3 py-1.5 bg-zinc-900 border border-zinc-700 rounded-md text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 focus:border-emerald-500/50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const uri = newPostLogoutUri.trim();
+                      if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
+                      onPostLogoutRedirectUrisChange([...postLogoutRedirectUris, uri]);
+                      setNewPostLogoutUri("");
+                    }}
+                    disabled={readOnly}
+                    className="px-4 py-1.5 rounded-md bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Add
+                  </button>
+                </div>
+                <div className="space-y-1.5">
+                  {postLogoutRedirectUris.map((uri) => (
+                    <div
+                      key={uri}
+                      className="flex items-center justify-between rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2"
+                    >
+                      <code className="text-xs text-zinc-300">{uri}</code>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          onPostLogoutRedirectUrisChange(
+                            postLogoutRedirectUris.filter((item) => item !== uri),
+                          )
+                        }
+                        disabled={readOnly}
+                        className="text-xs text-zinc-500 hover:text-red-400 disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
             <div>
               <div className="block text-xs font-medium text-zinc-400 mb-1">Client Secret</div>
               {webSecret ? (

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -1376,9 +1376,9 @@ function DeviceInitiateLoginUriField({
   onChange: (updates: Partial<AppFormData>) => void;
 }>): ReactNode {
   return (
-    <div className="border-t border-zinc-800 pt-5">
+    <div className="border-t border-emerald-500/15 pt-4">
       <div className="space-y-2">
-        <label htmlFor="device-initiate-login-uri" className="block text-sm font-medium text-zinc-300">
+        <label htmlFor="device-initiate-login-uri" className="block text-xs font-semibold text-zinc-200">
           Third-party initiate login URI
         </label>
         <input
@@ -1980,11 +1980,19 @@ export default function TestingStep({
       {copyError && <p className="text-xs text-red-400 mt-2">{copyError}</p>}
 
       {showPrimaryCredentials && primaryIsConfidential ? (
-        <>
+        <div className="p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-4">
           <div>
-            <div className="block text-sm font-medium text-zinc-300 mb-1.5">
-              Client ID
-            </div>
+            <h3 className="text-sm font-semibold text-emerald-200/90">
+              Public / SDK{" "}
+              <code className="font-mono text-emerald-300/80 font-normal">(app_)</code>
+            </h3>
+            <p className="text-xs text-zinc-500 mt-1">
+              Legacy confidential primary client. Prefer enabling M2M / Web siblings on App
+              profile for new integrations.
+            </p>
+          </div>
+          <div>
+            <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
             <div className="flex items-center gap-2">
               <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-emerald-400 text-sm font-mono">
                 {clientId || "Create app first"}
@@ -2002,9 +2010,7 @@ export default function TestingStep({
           </div>
 
           <div>
-            <div className="block text-sm font-medium text-zinc-300 mb-1.5">
-              Client Secret
-            </div>
+            <div className="block text-xs font-medium text-zinc-400 mb-1">Client Secret</div>
             {secret ? (
               <div>
                 <div className="flex items-center gap-2 mb-2">
@@ -2044,57 +2050,62 @@ export default function TestingStep({
               <p className="text-xs text-red-400 mt-2">{secretFetchError}</p>
             )}
           </div>
-        </>
-      ) : null}
-
-      {showPrimaryCredentials && !primaryIsConfidential ? (
-        <div>
-          <div className="block text-sm font-medium text-zinc-300 mb-1.5">
-            Public / SDK client ID
-          </div>
-          <p className="text-xs text-zinc-500 mb-2">
-            Use this in SDKs, CLIs, and the device authorization flow. It stays public
-            (no secret). Portal SSO needs the confidential{" "}
-            <code className="font-mono text-zinc-400">web_</code> sibling; Builder APIs
-            need the <code className="font-mono text-zinc-400">m2m_</code> sibling.
-          </p>
-          <div className="flex items-center gap-2">
-            <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-emerald-400 text-sm font-mono">
-              {clientId || "Create app first"}
-            </code>
-            {clientId && (
-              <button
-                type="button"
-                onClick={() => copyToClipboard(clientId, "clientId")}
-                className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 transition-colors"
-              >
-                {copied === "clientId" ? "Copied!" : "Copy"}
-              </button>
-            )}
-          </div>
         </div>
       ) : null}
 
-      {showPublicPanel ? (
-        <section className="space-y-4 border-t border-zinc-800 pt-8">
+      {showPublicPanel && !primaryIsConfidential ? (
+        <div className="p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-5">
           <div>
-            <h3 className="text-base font-semibold text-zinc-100">Domain allowlist</h3>
-            <p className="text-sm text-zinc-500 mt-1">
-              Shared origins for CORS and request validation across all siblings.
-              Authorization-code redirect URIs are configured on the{" "}
-              <strong className="text-zinc-400">Web RP</strong> tab (confidential{" "}
-              <code className="font-mono text-zinc-400">web_</code> client). Device
-              flow does not need a redirect URI.
+            <h3 className="text-sm font-semibold text-emerald-200/90">
+              Public / SDK{" "}
+              <code className="font-mono text-emerald-300/80 font-normal">(app_)</code>
+            </h3>
+            <p className="text-xs text-zinc-500 mt-1">
+              Use this in SDKs, CLIs, and the device authorization flow. It stays public
+              (no secret). Portal SSO needs the confidential{" "}
+              <code className="font-mono text-zinc-400">web_</code> sibling; Builder APIs
+              need the <code className="font-mono text-zinc-400">m2m_</code> sibling.
             </p>
           </div>
-          <DomainAllowlistBlock
-            appId={appId}
-            domains={domains}
-            onDomainsChange={onDomainsChange}
-            readOnly={readOnly}
-          />
-          {backendDeviceHelper &&
-          grantTypes.includes(DEVICE_CODE_GRANT) ? (
+
+          {showPrimaryCredentials ? (
+            <div>
+              <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-emerald-400 text-sm font-mono">
+                  {clientId || "Create app first"}
+                </code>
+                {clientId && (
+                  <button
+                    type="button"
+                    onClick={() => copyToClipboard(clientId, "clientId")}
+                    className="px-3 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 transition-colors"
+                  >
+                    {copied === "clientId" ? "Copied!" : "Copy"}
+                  </button>
+                )}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="space-y-3 border-t border-emerald-500/15 pt-4">
+            <div>
+              <h4 className="text-xs font-semibold text-zinc-200">Domain allowlist</h4>
+              <p className="text-xs text-zinc-500 mt-1">
+                Shared origins for CORS and request validation. Authorization-code redirect
+                URIs live on the Web RP tab. Device flow does not need a redirect URI.
+              </p>
+            </div>
+            <DomainAllowlistBlock
+              appId={appId}
+              domains={domains}
+              onDomainsChange={onDomainsChange}
+              readOnly={readOnly}
+              hideHeading
+            />
+          </div>
+
+          {backendDeviceHelper && grantTypes.includes(DEVICE_CODE_GRANT) ? (
             <DeviceInitiateLoginUriField
               initiateLoginUri={initiateLoginUri}
               deviceThirdPartyInitiateLogin={deviceThirdPartyInitiateLogin}
@@ -2103,7 +2114,25 @@ export default function TestingStep({
               onChange={onChange}
             />
           ) : null}
-        </section>
+        </div>
+      ) : null}
+
+      {showPublicPanel && primaryIsConfidential ? (
+        <div className="p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-4">
+          <div>
+            <h4 className="text-xs font-semibold text-zinc-200">Domain allowlist</h4>
+            <p className="text-xs text-zinc-500 mt-1">
+              Shared origins for CORS and request validation across siblings.
+            </p>
+          </div>
+          <DomainAllowlistBlock
+            appId={appId}
+            domains={domains}
+            onDomainsChange={onDomainsChange}
+            readOnly={readOnly}
+            hideHeading
+          />
+        </div>
       ) : null}
 
       {showM2mCredentials && backendHelper ? (

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -30,6 +31,8 @@ import { mintOwnerApiKey } from "../mint-owner-api-key";
 import ApiKeyCredentialSwitcher from "@/components/apps/ApiKeyCredentialSwitcher";
 
 const API_REFERENCE_URL = "https://pymthouse.com/api/v1/docs";
+
+export { API_REFERENCE_URL };
 
 export type CredentialsClientTab = "public" | "m2m" | "web";
 
@@ -1698,6 +1701,7 @@ export default function TestingStep({
   showPostLogoutRedirectUris = false,
 }: Readonly<Props>) {
   const [newPostLogoutUri, setNewPostLogoutUri] = useState("");
+  const postLogoutUriInputId = useId();
   const [secret, setSecret] = useState<string | null>(null);
   const [backendSecret, setBackendSecret] = useState<string | null>(null);
   const [webSecret, setWebSecret] = useState<string | null>(null);
@@ -1711,6 +1715,13 @@ export default function TestingStep({
   const [authTestTab, setAuthTestTab] = useState<"remote" | "admin">("remote");
   const [copyError, setCopyError] = useState<string | null>(null);
   const copyResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const addPostLogoutUri = () => {
+    const uri = newPostLogoutUri.trim();
+    if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
+    onPostLogoutRedirectUrisChange?.([...postLogoutRedirectUris, uri]);
+    setNewPostLogoutUri("");
+  };
 
   const effectiveGrantTypes = useMemo(
     () => syncPublicClientGrantTypes(grantTypes, redirectUris, clientId ?? ""),
@@ -2252,7 +2263,12 @@ export default function TestingStep({
             {showPostLogoutRedirectUris && onPostLogoutRedirectUrisChange ? (
               <div className="space-y-3 pt-2 border-t border-violet-500/15">
                 <div>
-                  <h4 className="text-xs font-semibold text-zinc-200">Post-logout redirects</h4>
+                  <label
+                    htmlFor={postLogoutUriInputId}
+                    className="block text-xs font-semibold text-zinc-200"
+                  >
+                    Post-logout redirects
+                  </label>
                   <p className="text-xs text-zinc-500 mt-1">
                     Where users go after sign-out. Saved with{" "}
                     <strong className="text-zinc-400">Save changes</strong>.
@@ -2260,17 +2276,14 @@ export default function TestingStep({
                 </div>
                 <div className="flex gap-2 mb-2">
                   <input
-                    id="postLogoutUriInput"
+                    id={postLogoutUriInputId}
                     type="text"
                     value={newPostLogoutUri}
                     onChange={(e) => setNewPostLogoutUri(e.target.value)}
                     onKeyDown={(e) => {
                       if (e.key !== "Enter") return;
                       e.preventDefault();
-                      const uri = newPostLogoutUri.trim();
-                      if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
-                      onPostLogoutRedirectUrisChange([...postLogoutRedirectUris, uri]);
-                      setNewPostLogoutUri("");
+                      addPostLogoutUri();
                     }}
                     placeholder="https://example.com/logout-complete"
                     disabled={readOnly}
@@ -2278,12 +2291,7 @@ export default function TestingStep({
                   />
                   <button
                     type="button"
-                    onClick={() => {
-                      const uri = newPostLogoutUri.trim();
-                      if (!uri || postLogoutRedirectUris.includes(uri) || readOnly) return;
-                      onPostLogoutRedirectUrisChange([...postLogoutRedirectUris, uri]);
-                      setNewPostLogoutUri("");
-                    }}
+                    onClick={addPostLogoutUri}
                     disabled={readOnly}
                     className="px-4 py-1.5 rounded-md bg-zinc-700 text-zinc-200 text-sm hover:bg-zinc-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                   >

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -1473,6 +1473,94 @@ function AuthCodeMissingRedirectHint({
   );
 }
 
+function resolveAuthCodeScopes(allowedScopes: string): {
+  effectiveScopes: string;
+  selectedScopes: string[];
+} {
+  const validScopeValues = new Set(OIDC_SCOPES.map((s) => s.value));
+  const effectiveScopes = allowedScopes
+    .split(/[,\s]+/)
+    .filter((s) => s && validScopeValues.has(s))
+    .join(" ");
+  const selectedScopes = effectiveScopes
+    .split(/[,\s]+/)
+    .filter(Boolean)
+    .map((scope) => getScopeDefinition(scope)?.label || scope);
+  return { effectiveScopes, selectedScopes };
+}
+
+function AuthCodeLiveTestPanel({
+  title,
+  description,
+  testUrl,
+  redirectUriOptions,
+  effectiveSelectedRedirectUri,
+  onSelectRedirectUri,
+  selectedScopes,
+  showTopBorder,
+  clientId,
+}: Readonly<{
+  title: string;
+  description: string;
+  testUrl: string;
+  redirectUriOptions: string[];
+  effectiveSelectedRedirectUri: string;
+  onSelectRedirectUri: (uri: string) => void;
+  selectedScopes: string[];
+  showTopBorder: boolean;
+  clientId: string | null;
+}>): ReactNode {
+  const redirectSelectId = `testing-redirect-uri-${clientId ?? "client"}`;
+  return (
+    <div className={`space-y-3 ${showTopBorder ? "border-t border-zinc-800 pt-5" : ""}`}>
+      <div>
+        <h4 className="text-sm font-semibold text-zinc-200">{title}</h4>
+        <p className="text-xs text-zinc-500 mt-1">{description}</p>
+      </div>
+      {redirectUriOptions.length > 1 ? (
+        <div>
+          <label
+            htmlFor={redirectSelectId}
+            className="block text-xs font-medium text-zinc-400 mb-1"
+          >
+            Redirect URI
+          </label>
+          <select
+            id={redirectSelectId}
+            value={effectiveSelectedRedirectUri}
+            onChange={(e) => onSelectRedirectUri(e.target.value)}
+            className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+          >
+            {redirectUriOptions.map((uri) => (
+              <option key={uri} value={uri}>
+                {uri}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => {
+          const newWin = globalThis.window?.open(testUrl, "_blank", "noopener,noreferrer");
+          if (newWin) newWin.opener = null;
+        }}
+        className="px-4 py-2 bg-emerald-600 text-white rounded-lg text-sm hover:bg-emerald-500 transition-colors"
+      >
+        Open Test Flow
+      </button>
+      <p className="text-xs text-zinc-500">
+        Requested scopes:{" "}
+        <span className="text-zinc-400">{selectedScopes.join(", ")}</span>
+      </p>
+      <p className="text-xs text-zinc-500">
+        Using redirect URI:{" "}
+        <code className="text-zinc-400">{effectiveSelectedRedirectUri}</code>
+      </p>
+    </div>
+  );
+}
+
 export function AuthCodeFlowTestSection({
   appId,
   clientId,
@@ -1510,19 +1598,7 @@ export function AuthCodeFlowTestSection({
       ? selectedRedirectUri
       : getDefaultRedirectUri(redirectUris);
 
-  const redirectUriOptions = useMemo(() => redirectUris, [redirectUris]);
-
-  const validScopeValues = new Set(OIDC_SCOPES.map((s) => s.value));
-  const effectiveScopes = allowedScopes
-    .split(/[,\s]+/)
-    .filter((s) => s && validScopeValues.has(s))
-    .join(" ");
-
-  const selectedScopes = effectiveScopes
-    .split(/[,\s]+/)
-    .filter(Boolean)
-    .map((scope) => getScopeDefinition(scope)?.label || scope);
-
+  const { effectiveScopes, selectedScopes } = resolveAuthCodeScopes(allowedScopes);
   const browserOrigin = getBrowserOrigin();
   const testUrl =
     clientId && effectiveSelectedRedirectUri && browserOrigin
@@ -1531,7 +1607,6 @@ export function AuthCodeFlowTestSection({
 
   if (!hasAuthCodeFlow) return null;
 
-  const redirectSelectId = `testing-redirect-uri-${clientId ?? "client"}`;
   const showEmptyRedirectHint = showRedirectUriEditor && redirectUris.length === 0;
   const showMissingRedirectMessage =
     !testUrl && redirectUris.length === 0 && !showRedirectUriEditor;
@@ -1564,52 +1639,17 @@ export function AuthCodeFlowTestSection({
       ) : null}
 
       {testUrl ? (
-        <div className={`space-y-3 ${showRedirectUriEditor ? "border-t border-zinc-800 pt-5" : ""}`}>
-          <div>
-            <h4 className="text-sm font-semibold text-zinc-200">{title}</h4>
-            <p className="text-xs text-zinc-500 mt-1">{description}</p>
-          </div>
-          {redirectUriOptions.length > 1 ? (
-            <div>
-              <label
-                htmlFor={redirectSelectId}
-                className="block text-xs font-medium text-zinc-400 mb-1"
-              >
-                Redirect URI
-              </label>
-              <select
-                id={redirectSelectId}
-                value={effectiveSelectedRedirectUri}
-                onChange={(e) => setSelectedRedirectUri(e.target.value)}
-                className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 rounded-lg text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-              >
-                {redirectUriOptions.map((uri) => (
-                  <option key={uri} value={uri}>
-                    {uri}
-                  </option>
-                ))}
-              </select>
-            </div>
-          ) : null}
-          <button
-            type="button"
-            onClick={() => {
-              const newWin = globalThis.window?.open(testUrl, "_blank", "noopener,noreferrer");
-              if (newWin) newWin.opener = null;
-            }}
-            className="px-4 py-2 bg-emerald-600 text-white rounded-lg text-sm hover:bg-emerald-500 transition-colors"
-          >
-            Open Test Flow
-          </button>
-          <p className="text-xs text-zinc-500">
-            Requested scopes:{" "}
-            <span className="text-zinc-400">{selectedScopes.join(", ")}</span>
-          </p>
-          <p className="text-xs text-zinc-500">
-            Using redirect URI:{" "}
-            <code className="text-zinc-400">{effectiveSelectedRedirectUri}</code>
-          </p>
-        </div>
+        <AuthCodeLiveTestPanel
+          title={title}
+          description={description}
+          testUrl={testUrl}
+          redirectUriOptions={redirectUris}
+          effectiveSelectedRedirectUri={effectiveSelectedRedirectUri}
+          onSelectRedirectUri={setSelectedRedirectUri}
+          selectedScopes={selectedScopes}
+          showTopBorder={showRedirectUriEditor}
+          clientId={clientId}
+        />
       ) : null}
 
       {showMissingRedirectMessage ? (

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -82,6 +82,12 @@ function getDefaultRedirectUri(redirectUris: string[]) {
   return redirectUris.find((uri) => /^https?:\/\//i.test(uri)) ?? redirectUris[0] ?? "";
 }
 
+function secretActionLabel(generating: boolean, hasSecret: boolean): string {
+  if (generating) return "Generating...";
+  if (hasSecret) return "Rotate Secret";
+  return "Generate Secret";
+}
+
 function isValidInitiateLoginUri(uri: string): boolean {
   const trimmed = uri.trim();
   if (!trimmed.length) return false;
@@ -1410,6 +1416,63 @@ function DeviceInitiateLoginUriField({
   );
 }
 
+function SiblingNotProvisionedMessage({
+  label,
+  clientPrefix,
+}: Readonly<{ label: string; clientPrefix: string }>): ReactNode {
+  return (
+    <p className="text-sm text-zinc-500">
+      <strong className="text-zinc-400">{label}</strong> is enabled but not yet provisioned. Use{" "}
+      <strong className="text-zinc-400">Save changes</strong> to create the{" "}
+      <code className="font-mono text-zinc-400">{clientPrefix}</code> client, then return here.
+    </p>
+  );
+}
+
+function SiblingDisabledMessage({
+  label,
+  detail,
+}: Readonly<{ label: string; detail: ReactNode }>): ReactNode {
+  return (
+    <p className="text-sm text-zinc-500">
+      {label} is off on <strong className="text-zinc-400">App profile</strong>. {detail}
+    </p>
+  );
+}
+
+function AuthCodeMissingRedirectHint({
+  title,
+}: Readonly<{ title: string }>): ReactNode {
+  return (
+    <div
+      className="flex gap-3 rounded-lg border border-blue-500/25 bg-blue-500/5 px-3 py-3"
+      role="status"
+    >
+      <svg
+        className="w-4 h-4 mt-0.5 shrink-0 text-blue-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+      <div className="min-w-0 space-y-1">
+        <p className="text-sm font-medium text-zinc-200">{title}</p>
+        <p className="text-xs text-zinc-400">
+          Add at least one redirect URI below. Once saved, you can open a live authorization
+          request in a new tab to verify sign-in end to end.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export function AuthCodeFlowTestSection({
   appId,
   clientId,
@@ -1469,37 +1532,15 @@ export function AuthCodeFlowTestSection({
   if (!hasAuthCodeFlow) return null;
 
   const redirectSelectId = `testing-redirect-uri-${clientId ?? "client"}`;
+  const showEmptyRedirectHint = showRedirectUriEditor && redirectUris.length === 0;
+  const showMissingRedirectMessage =
+    !testUrl && redirectUris.length === 0 && !showRedirectUriEditor;
+  const showInitiateLoginField =
+    showInitiateLogin && backendDeviceHelper && hasDeviceCode;
 
   return (
     <div className="space-y-5 p-5 rounded-xl border border-zinc-800 bg-zinc-900/30">
-      {showRedirectUriEditor && redirectUris.length === 0 ? (
-        <div
-          className="flex gap-3 rounded-lg border border-blue-500/25 bg-blue-500/5 px-3 py-3"
-          role="status"
-        >
-          <svg
-            className="w-4 h-4 mt-0.5 shrink-0 text-blue-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-          <div className="min-w-0 space-y-1">
-            <p className="text-sm font-medium text-zinc-200">{title}</p>
-            <p className="text-xs text-zinc-400">
-              Add at least one redirect URI below. Once saved, you can open a live authorization
-              request in a new tab to verify sign-in end to end.
-            </p>
-          </div>
-        </div>
-      ) : null}
+      {showEmptyRedirectHint ? <AuthCodeMissingRedirectHint title={title} /> : null}
 
       {showRedirectUriEditor ? (
         <>
@@ -1569,13 +1610,15 @@ export function AuthCodeFlowTestSection({
             <code className="text-zinc-400">{effectiveSelectedRedirectUri}</code>
           </p>
         </div>
-      ) : redirectUris.length === 0 && !showRedirectUriEditor ? (
+      ) : null}
+
+      {showMissingRedirectMessage ? (
         <p className="text-xs text-zinc-500">
           Add at least one redirect URI above to enable the live authorization test.
         </p>
       ) : null}
 
-      {showInitiateLogin && backendDeviceHelper && hasDeviceCode ? (
+      {showInitiateLoginField ? (
         <DeviceInitiateLoginUriField
           initiateLoginUri={initiateLoginUri}
           deviceThirdPartyInitiateLogin={deviceThirdPartyInitiateLogin}
@@ -1828,19 +1871,18 @@ export default function TestingStep({
   const showAdminAccessTab = showM2mPanel && Boolean(backendHelper?.clientId);
   // With client sub-tabs, remote vs admin live on separate panels — no nested switcher.
   const useClientSubTabs = activeClient != null;
-  const showAuthTestSection =
-    useClientSubTabs
-      ? showRemoteSigningTab || showAdminAccessTab
-      : showRemoteSigningTab || showAdminAccessTab;
-  const effectiveAuthTestTab = useClientSubTabs
-    ? showAdminAccessTab && activeClient === "m2m"
-      ? "admin"
-      : "remote"
-    : resolveEffectiveAuthTestTab(
-        authTestTab,
-        showAdminAccessTab,
-        showRemoteSigningTab,
-      );
+  const showAuthTestSection = showRemoteSigningTab || showAdminAccessTab;
+  let effectiveAuthTestTab: "remote" | "admin";
+  if (useClientSubTabs) {
+    effectiveAuthTestTab =
+      showAdminAccessTab && activeClient === "m2m" ? "admin" : "remote";
+  } else {
+    effectiveAuthTestTab = resolveEffectiveAuthTestTab(
+      authTestTab,
+      showAdminAccessTab,
+      showRemoteSigningTab,
+    );
+  }
 
   useEffect(() => {
     if (useClientSubTabs) return;
@@ -1856,6 +1898,18 @@ export default function TestingStep({
   const showM2mOnlyExchange = showM2mPanel && isM2MOnly && Boolean(clientId);
   // Authorization code + redirects live only on web_ (Option 1).
   const showWebAuthCode = showWebPanel && Boolean(webHelper?.clientId);
+
+  let authTestTitle = "Test authentication";
+  if (useClientSubTabs) {
+    authTestTitle =
+      effectiveAuthTestTab === "remote"
+        ? "Verify remote signing"
+        : "Verify administrative access";
+  }
+  const authTestDescription =
+    effectiveAuthTestTab === "remote"
+      ? "Bearer API key for direct signing, or mint + exchange for a signer JWT. Device code login remains the end-user path."
+      : "Client-credentials token exchange with the M2M / Builder client for Builder APIs, user provisioning, and device approval.";
 
   return (
     <div className="space-y-8">
@@ -1942,7 +1996,7 @@ export default function TestingStep({
                   disabled={readOnly || generating || !appId}
                   className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
                 >
-                  {generating ? "Generating..." : hasSecret ? "Rotate Secret" : "Generate Secret"}
+                  {secretActionLabel(generating, hasSecret)}
                 </button>
               </div>
             )}
@@ -2012,9 +2066,8 @@ export default function TestingStep({
         </section>
       ) : null}
 
-      {showM2mCredentials ? (
-        backendHelper ? (
-          <div className="p-4 rounded-xl border border-cyan-500/20 bg-cyan-500/5 space-y-3">
+      {showM2mCredentials && backendHelper ? (
+        <div className="p-4 rounded-xl border border-cyan-500/20 bg-cyan-500/5 space-y-3">
             <h3 className="text-sm font-semibold text-cyan-200/90">
               M2M / Builder{" "}
               <code className="font-mono text-cyan-300/80 font-normal">(m2m_)</code>
@@ -2070,11 +2123,7 @@ export default function TestingStep({
                     disabled={readOnly || generatingBackend || !appId}
                     className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
                   >
-                    {generatingBackend
-                      ? "Generating..."
-                      : backendHelper.hasSecret
-                        ? "Rotate Secret"
-                        : "Generate Secret"}
+                    {secretActionLabel(generatingBackend, backendHelper.hasSecret)}
                   </button>
                 </div>
               )}
@@ -2083,25 +2132,24 @@ export default function TestingStep({
               )}
             </div>
           </div>
-        ) : backendDeviceHelper ? (
-          <p className="text-sm text-zinc-500">
-            <strong className="text-zinc-400">Confidential M2M backend</strong> is enabled but not
-            yet provisioned. Use <strong className="text-zinc-400">Save changes</strong> to create
-            the <code className="font-mono text-zinc-400">m2m_</code> client, then return here.
-          </p>
-        ) : (
-          <p className="text-sm text-zinc-500">
-            Confidential M2M backend is off on{" "}
-            <strong className="text-zinc-400">App profile</strong>. Turn on{" "}
-            <strong className="text-zinc-400">Confidential M2M backend</strong> there to manage M2M
-            credentials on this tab.
-          </p>
-        )
+      ) : null}
+      {showM2mCredentials && !backendHelper && backendDeviceHelper ? (
+          <SiblingNotProvisionedMessage label="Confidential M2M backend" clientPrefix="m2m_" />
+      ) : null}
+      {showM2mCredentials && !backendHelper && !backendDeviceHelper ? (
+          <SiblingDisabledMessage
+            label="Confidential M2M backend"
+            detail={
+              <>
+                Turn on <strong className="text-zinc-400">Confidential M2M backend</strong> there to
+                manage M2M credentials on this tab.
+              </>
+            }
+          />
       ) : null}
 
-      {showWebCredentials ? (
-        webHelper ? (
-          <div className="p-4 rounded-xl border border-violet-500/20 bg-violet-500/5 space-y-3">
+      {showWebCredentials && webHelper ? (
+        <div className="p-4 rounded-xl border border-violet-500/20 bg-violet-500/5 space-y-3">
             <h3 className="text-sm font-semibold text-violet-200/90">
               Confidential web RP{" "}
               <code className="font-mono text-violet-300/80 font-normal">(web_)</code>
@@ -2239,11 +2287,7 @@ export default function TestingStep({
                     disabled={readOnly || generatingWeb || !appId}
                     className="px-4 py-2 bg-zinc-700 text-zinc-200 rounded-lg text-sm hover:bg-zinc-600 disabled:opacity-40 transition-colors"
                   >
-                    {generatingWeb
-                      ? "Generating..."
-                      : webHelper.hasSecret
-                        ? "Rotate Secret"
-                        : "Generate Secret"}
+                    {secretActionLabel(generatingWeb, webHelper.hasSecret)}
                   </button>
                 </div>
               )}
@@ -2252,19 +2296,15 @@ export default function TestingStep({
               )}
             </div>
           </div>
-        ) : confidentialWebHelper ? (
-          <p className="text-sm text-zinc-500">
-            <strong className="text-zinc-400">Confidential web RP</strong> is enabled but not
-            yet provisioned. Use <strong className="text-zinc-400">Save changes</strong> to create
-            the <code className="font-mono text-zinc-400">web_</code> sibling, then return here.
-          </p>
-        ) : (
-          <p className="text-sm text-zinc-500">
-            Confidential web RP is off on{" "}
-            <strong className="text-zinc-400">App profile</strong>. Turn it on there for
-            portal SSO (Kong Dev Portal, etc.).
-          </p>
-        )
+      ) : null}
+      {showWebCredentials && !webHelper && confidentialWebHelper ? (
+          <SiblingNotProvisionedMessage label="Confidential web RP" clientPrefix="web_" />
+      ) : null}
+      {showWebCredentials && !webHelper && !confidentialWebHelper ? (
+          <SiblingDisabledMessage
+            label="Confidential web RP"
+            detail="Turn it on there for portal SSO (Kong Dev Portal, etc.)."
+          />
       ) : null}
 
       {showWebAuthCode ? (
@@ -2293,17 +2333,9 @@ export default function TestingStep({
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0">
               <h3 className="text-sm font-semibold text-zinc-200">
-                {useClientSubTabs
-                  ? effectiveAuthTestTab === "remote"
-                    ? "Verify remote signing"
-                    : "Verify administrative access"
-                  : "Test authentication"}
+                {authTestTitle}
               </h3>
-              <p className="text-xs text-zinc-500 mt-1">
-                {effectiveAuthTestTab === "remote"
-                  ? "Bearer API key for direct signing, or mint + exchange for a signer JWT. Device code login remains the end-user path."
-                  : "Client-credentials token exchange with the M2M / Builder client for Builder APIs, user provisioning, and device approval."}
-              </p>
+              <p className="text-xs text-zinc-500 mt-1">{authTestDescription}</p>
             </div>
             {!useClientSubTabs && showRemoteSigningTab && showAdminAccessTab ? (
               <div

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -593,6 +593,56 @@ export async function loadM2mOidcClientSummary(
   };
 }
 
+function parseJsonStringArray(raw: string | null | undefined): string[] {
+  try {
+    const parsed = JSON.parse(raw ?? "[]") as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((u): u is string => typeof u === "string")
+      .map((u) => u.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function updateExistingConfidentialWebClient(input: {
+  existing: {
+    id: string;
+    clientId: string;
+    allowedScopes: string;
+    grantTypes: string;
+  };
+  redirectUris?: string[];
+}): Promise<{ id: string; clientId: string }> {
+  const { existing } = input;
+  const nextScopes = ensureConfidentialWebIdentityScopes(
+    existing.allowedScopes || DEFAULT_OIDC_SCOPES,
+  );
+  const scopeNeedsUpdate =
+    normalizeScopeListString(nextScopes) !==
+    normalizeScopeListString(existing.allowedScopes);
+
+  if (input.redirectUris !== undefined) {
+    const redirectUris = input.redirectUris.map((u) => u.trim()).filter(Boolean);
+    const grantTypes = syncConfidentialWebGrantTypes(
+      existing.grantTypes.split(",").filter(Boolean),
+      redirectUris,
+    );
+    await updateClientConfig(existing.clientId, {
+      redirectUris,
+      grantTypes,
+      ...(scopeNeedsUpdate ? { allowedScopes: nextScopes } : {}),
+    });
+  } else if (scopeNeedsUpdate) {
+    await updateClientConfig(existing.clientId, {
+      allowedScopes: nextScopes,
+    });
+  }
+
+  return { id: existing.id, clientId: existing.clientId };
+}
+
 /**
  * Ensures a confidential web RP OIDC row exists for portal SSO / server-side
  * authorization_code without turning the public client confidential.
@@ -619,31 +669,10 @@ export async function ensureConfidentialWebClient(params: {
       .where(eq(oidcClients.id, app.webOidcClientId))
       .limit(1);
     if (existing[0]) {
-      const nextScopes = ensureConfidentialWebIdentityScopes(
-        existing[0].allowedScopes || DEFAULT_OIDC_SCOPES,
-      );
-      const scopeNeedsUpdate =
-        normalizeScopeListString(nextScopes) !==
-        normalizeScopeListString(existing[0].allowedScopes);
-      if (params.redirectUris !== undefined) {
-        const redirectUris = params.redirectUris
-          .map((u) => u.trim())
-          .filter(Boolean);
-        const grantTypes = syncConfidentialWebGrantTypes(
-          existing[0].grantTypes.split(",").filter(Boolean),
-          redirectUris,
-        );
-        await updateClientConfig(existing[0].clientId, {
-          redirectUris,
-          grantTypes,
-          ...(scopeNeedsUpdate ? { allowedScopes: nextScopes } : {}),
-        });
-      } else if (scopeNeedsUpdate) {
-        await updateClientConfig(existing[0].clientId, {
-          allowedScopes: nextScopes,
-        });
-      }
-      return { id: existing[0].id, clientId: existing[0].clientId };
+      return updateExistingConfidentialWebClient({
+        existing: existing[0],
+        redirectUris: params.redirectUris,
+      });
     }
   }
 
@@ -657,22 +686,8 @@ export async function ensureConfidentialWebClient(params: {
     .where(eq(oidcClients.id, app.oidcClientId))
     .limit(1);
   const publicScopes = pubRows[0]?.allowedScopes ?? DEFAULT_OIDC_SCOPES;
-
-  let legacyPublicRedirects: string[] = [];
-  try {
-    legacyPublicRedirects = JSON.parse(pubRows[0]?.redirectUris ?? "[]") as string[];
-  } catch {
-    legacyPublicRedirects = [];
-  }
-  legacyPublicRedirects = legacyPublicRedirects.map((u) => u.trim()).filter(Boolean);
-
-  let legacyPostLogout: string[] = [];
-  try {
-    legacyPostLogout = JSON.parse(pubRows[0]?.postLogoutRedirectUris ?? "[]") as string[];
-  } catch {
-    legacyPostLogout = [];
-  }
-  legacyPostLogout = legacyPostLogout.map((u) => u.trim()).filter(Boolean);
+  const legacyPublicRedirects = parseJsonStringArray(pubRows[0]?.redirectUris);
+  const legacyPostLogout = parseJsonStringArray(pubRows[0]?.postLogoutRedirectUris);
 
   const redirectUris =
     params.redirectUris !== undefined

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -282,8 +282,8 @@ export async function createAppClient(displayName: string): Promise<{
   const id = uuidv4();
   const clientId = generateClientId();
 
-  // New apps start with no redirect URIs, so authorization_code is absent.
-  // It will be added by syncAuthorizationCodeGrant when the first redirect URI is registered.
+  // New apps start with no redirect URIs and no authorization_code — portal
+  // SSO redirects are registered on the confidential web_ sibling instead.
   await db.insert(oidcClients).values({
     id,
     clientId,
@@ -380,8 +380,9 @@ export async function syncBackendM2mAllowedScopesFromPublicApp(
 }
 
 /**
- * When a confidential m2m_ or web_ sibling exists, the primary app_ row must remain public.
- * Repairs legacy rows that still have a secret or client_credentials on app_.
+ * Public `app_` never holds authorization_code or redirect URIs — those belong on
+ * the confidential `web_` sibling. Always strips auth-code + redirects; when a
+ * confidential sibling exists, also clears any legacy secret / client_credentials.
  */
 export async function demotePublicClientWhenM2mSiblingExists(
   appInternalId: string,
@@ -392,7 +393,7 @@ export async function demotePublicClientWhenM2mSiblingExists(
     .where(eq(developerApps.id, appInternalId))
     .limit(1);
   const app = appRows[0];
-  if (!app?.oidcClientId || (!app.m2mOidcClientId && !app.webOidcClientId)) {
+  if (!app?.oidcClientId) {
     return false;
   }
 
@@ -406,12 +407,27 @@ export async function demotePublicClientWhenM2mSiblingExists(
     return false;
   }
 
+  const hasSibling = Boolean(app.m2mOidcClientId || app.webOidcClientId);
   const grants = pub.grantTypes.split(",").filter(Boolean);
-  const nextGrants = grants.filter((g) => g !== "client_credentials");
+  let nextGrants = grants.filter((g) => g !== "authorization_code");
+  if (hasSibling) {
+    nextGrants = nextGrants.filter((g) => g !== "client_credentials");
+  }
+
+  let redirectUris: string[] = [];
+  try {
+    redirectUris = JSON.parse(pub.redirectUris ?? "[]") as string[];
+  } catch {
+    redirectUris = [];
+  }
+
   const needsUpdate =
-    pub.clientSecretHash != null ||
-    pub.tokenEndpointAuthMethod !== "none" ||
-    grants.length !== nextGrants.length;
+    redirectUris.length > 0 ||
+    grants.includes("authorization_code") ||
+    (hasSibling &&
+      (pub.clientSecretHash != null ||
+        pub.tokenEndpointAuthMethod !== "none" ||
+        grants.includes("client_credentials")));
 
   if (!needsUpdate) {
     return false;
@@ -420,8 +436,13 @@ export async function demotePublicClientWhenM2mSiblingExists(
   await db
     .update(oidcClients)
     .set({
-      clientSecretHash: null,
-      tokenEndpointAuthMethod: "none",
+      redirectUris: JSON.stringify([]),
+      ...(hasSibling
+        ? {
+            clientSecretHash: null,
+            tokenEndpointAuthMethod: "none",
+          }
+        : {}),
       grantTypes: nextGrants.join(","),
     })
     .where(eq(oidcClients.id, app.oidcClientId));
@@ -627,15 +648,36 @@ export async function ensureConfidentialWebClient(params: {
   }
 
   const pubRows = await db
-    .select({ allowedScopes: oidcClients.allowedScopes })
+    .select({
+      allowedScopes: oidcClients.allowedScopes,
+      redirectUris: oidcClients.redirectUris,
+      postLogoutRedirectUris: oidcClients.postLogoutRedirectUris,
+    })
     .from(oidcClients)
     .where(eq(oidcClients.id, app.oidcClientId))
     .limit(1);
   const publicScopes = pubRows[0]?.allowedScopes ?? DEFAULT_OIDC_SCOPES;
 
-  const redirectUris = (params.redirectUris ?? [])
-    .map((u) => u.trim())
-    .filter(Boolean);
+  let legacyPublicRedirects: string[] = [];
+  try {
+    legacyPublicRedirects = JSON.parse(pubRows[0]?.redirectUris ?? "[]") as string[];
+  } catch {
+    legacyPublicRedirects = [];
+  }
+  legacyPublicRedirects = legacyPublicRedirects.map((u) => u.trim()).filter(Boolean);
+
+  let legacyPostLogout: string[] = [];
+  try {
+    legacyPostLogout = JSON.parse(pubRows[0]?.postLogoutRedirectUris ?? "[]") as string[];
+  } catch {
+    legacyPostLogout = [];
+  }
+  legacyPostLogout = legacyPostLogout.map((u) => u.trim()).filter(Boolean);
+
+  const redirectUris =
+    params.redirectUris !== undefined
+      ? params.redirectUris.map((u) => u.trim()).filter(Boolean)
+      : legacyPublicRedirects;
   const grantTypes = syncConfidentialWebGrantTypes(
     [...DEFAULT_CONFIDENTIAL_WEB_GRANT_TYPES],
     redirectUris,
@@ -652,6 +694,8 @@ export async function ensureConfidentialWebClient(params: {
     clientSecretHash: null,
     displayName: `${display} - confidential web`,
     redirectUris: JSON.stringify(redirectUris),
+    postLogoutRedirectUris:
+      legacyPostLogout.length > 0 ? JSON.stringify(legacyPostLogout) : null,
     allowedScopes: ensureConfidentialWebIdentityScopes(publicScopes),
     grantTypes: grantTypes.join(","),
     tokenEndpointAuthMethod: "client_secret_post",
@@ -664,8 +708,14 @@ export async function ensureConfidentialWebClient(params: {
     .set({ webOidcClientId: id })
     .where(eq(developerApps.id, params.appInternalId));
 
-  // Keep the primary interactive client public when any confidential sibling exists.
+  // Keep the primary interactive client public; strip legacy auth-code redirects.
   await demotePublicClientWhenM2mSiblingExists(params.appInternalId);
+  if (legacyPostLogout.length > 0) {
+    await db
+      .update(oidcClients)
+      .set({ postLogoutRedirectUris: JSON.stringify([]) })
+      .where(eq(oidcClients.id, app.oidcClientId));
+  }
 
   return { id, clientId };
 }
@@ -713,6 +763,7 @@ export async function loadConfidentialWebOidcClientSummary(
   clientId: string;
   hasSecret: boolean;
   redirectUris: string[];
+  postLogoutRedirectUris: string[];
 } | null> {
   const appRows = await db
     .select({ webOidcClientId: developerApps.webOidcClientId })
@@ -729,6 +780,7 @@ export async function loadConfidentialWebOidcClientSummary(
       clientId: oidcClients.clientId,
       clientSecretHash: oidcClients.clientSecretHash,
       redirectUris: oidcClients.redirectUris,
+      postLogoutRedirectUris: oidcClients.postLogoutRedirectUris,
     })
     .from(oidcClients)
     .where(eq(oidcClients.id, webPk))
@@ -745,10 +797,20 @@ export async function loadConfidentialWebOidcClientSummary(
     redirectUris = [];
   }
 
+  let postLogoutRedirectUris: string[] = [];
+  try {
+    postLogoutRedirectUris = web.postLogoutRedirectUris
+      ? (JSON.parse(web.postLogoutRedirectUris) as string[])
+      : [];
+  } catch {
+    postLogoutRedirectUris = [];
+  }
+
   return {
     clientId: web.clientId,
     hasSecret: !!web.clientSecretHash,
     redirectUris,
+    postLogoutRedirectUris,
   };
 }
 

--- a/src/lib/oidc/clients.ts
+++ b/src/lib/oidc/clients.ts
@@ -414,12 +414,7 @@ export async function demotePublicClientWhenM2mSiblingExists(
     nextGrants = nextGrants.filter((g) => g !== "client_credentials");
   }
 
-  let redirectUris: string[] = [];
-  try {
-    redirectUris = JSON.parse(pub.redirectUris ?? "[]") as string[];
-  } catch {
-    redirectUris = [];
-  }
+  let redirectUris = parseJsonStringArray(pub.redirectUris);
 
   const needsUpdate =
     redirectUris.length > 0 ||
@@ -805,21 +800,8 @@ export async function loadConfidentialWebOidcClientSummary(
     return null;
   }
 
-  let redirectUris: string[] = [];
-  try {
-    redirectUris = JSON.parse(web.redirectUris) as string[];
-  } catch {
-    redirectUris = [];
-  }
-
-  let postLogoutRedirectUris: string[] = [];
-  try {
-    postLogoutRedirectUris = web.postLogoutRedirectUris
-      ? (JSON.parse(web.postLogoutRedirectUris) as string[])
-      : [];
-  } catch {
-    postLogoutRedirectUris = [];
-  }
+  const redirectUris = parseJsonStringArray(web.redirectUris);
+  const postLogoutRedirectUris = parseJsonStringArray(web.postLogoutRedirectUris);
 
   return {
     clientId: web.clientId,

--- a/src/lib/oidc/grants.ts
+++ b/src/lib/oidc/grants.ts
@@ -8,8 +8,8 @@ export const CLIENT_CREDENTIALS_GRANT = "client_credentials";
 
 /**
  * Default grant types for a newly created public app with no redirect URIs.
- * `authorization_code` is intentionally absent — it is added automatically
- * by {@link syncAuthorizationCodeGrant} once a redirect URI is registered.
+ * Authorization code lives on the confidential `web_` sibling (portal SSO), not
+ * on the public `app_` client (device / SDK / API-key routing).
  */
 export const DEFAULT_PUBLIC_GRANT_TYPES = [
   REFRESH_TOKEN_GRANT,
@@ -17,6 +17,10 @@ export const DEFAULT_PUBLIC_GRANT_TYPES = [
 
 function isM2mClientId(clientId: string): boolean {
   return clientId.startsWith("m2m_");
+}
+
+function isPublicAppClientId(clientId: string): boolean {
+  return clientId.startsWith("app_");
 }
 
 export function parseGrantTypes(grantTypes: string): string[] {
@@ -45,12 +49,19 @@ export function syncAuthorizationCodeGrant(
   return [AUTHORIZATION_CODE_GRANT, ...without];
 }
 
-/** Pass-through for M2M clients; apply {@link syncAuthorizationCodeGrant} for public ones. */
+/**
+ * Public `app_` clients never advertise authorization_code — browser / portal
+ * redirect login uses the confidential `web_` sibling. M2M clients are unchanged.
+ * Non-app / non-m2m ids (legacy) still sync auth code from redirect URIs.
+ */
 export function syncPublicClientGrantTypes(
   grants: string[],
   redirectUris: string[],
   clientId: string,
 ): string[] {
   if (isM2mClientId(clientId)) return grants;
+  if (isPublicAppClientId(clientId)) {
+    return grants.filter((g) => g !== AUTHORIZATION_CODE_GRANT);
+  }
   return syncAuthorizationCodeGrant(grants, redirectUris.length > 0);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Splits Credentials &amp; URLs into Public / M2M / Web RP client tabs, keeps auth-code + redirects on `web_` only, and shortens the purpose copy so each tab states its job in one line.

## UX
- Tab bar + panel share one bordered container
- Public / SDK, M2M / Builder, and Web RP cards use matching outlined treatment
- Descriptions trimmed to purpose-only lines (e.g. “For SDKs, CLIs, and device login”)

## Backend
- Strip `app_` redirects / auth-code on write
- Migrate legacy public redirects onto `web_` when provisioning
- Settings write post-logout to `web_` when present

## Test plan
- [ ] Public tab: client ID + domains; no redirect editor
- [ ] Web RP: redirects, secret, portal auth-code test
- [ ] M2M: credentials + token exchange
- [ ] Copy on each tab reads as a short “what this is for” line
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01909bb1-053d-400f-820c-fc585de62da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01909bb1-053d-400f-820c-fc585de62da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Public/SDK, M2M, and Web RP credential tabs.
  * Added support for confidential Web RP clients for authorization-code login, redirects, and portal SSO.
  * Added domain allowlist management with inline validation and removal controls.
  * Expanded testing tools for device, client-credentials, and authorization-code flows.

* **Bug Fixes**
  * Public clients no longer accept redirect URIs or authorization-code grants.
  * Redirect and logout URI settings are now consistently managed by the Web RP client.
  * Added migration and repair handling for existing client configurations.

* **Documentation**
  * Updated integration and API guidance for the new client roles and redirect configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->