### PR TITLE
fix(discovery): use discovery-service for network catalog

### DIFF
--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -57,9 +57,11 @@ OIDC_AUDIENCE=https://pymthouse.com/api/v1/oidc
 JWKS_URI=https://pymthouse.com/api/v1/oidc/jwks
 # Signer session exchange (RFC 8693 at POST /api/v1/apps/{clientId}/oidc/token)
 # SIGNER_TOKEN_AUDIENCE=   # optional; defaults to OIDC issuer URL
-# DISCOVERY_URL=           # Livepeer network discovery URL in SignerSession.discovery_url
-#                          # and livepeer-python-sdk --token (sdkToken on API key mint).
-#                          # If unset, ORCH_WEBHOOK_URL is used as the sdkToken discovery fallback.
+# DISCOVERY_URL=https://discovery-service-production-8955.up.railway.app
+#   Livepeer discovery service for SignerSession.discovery_url and
+#   livepeer-python-sdk --token (sdkToken on API key mint).
+#   Alias: DISCOVERY_SERVICE_URL. Origin or full `…/v1/discovery/raw` both work;
+#   code always embeds the raw endpoint. If unset, ORCH_WEBHOOK_URL is used.
 # Remote signer orchestrator pool (go-livepeer -orchWebhookUrl); requires SIGNER_REMOTE_DISCOVERY=1
 SIGNER_REMOTE_DISCOVERY=1
 ORCH_WEBHOOK_URL=https://discovery-service-production-8955.up.railway.app/v1/discovery/raw?serviceType=legacy

--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -57,11 +57,10 @@ OIDC_AUDIENCE=https://pymthouse.com/api/v1/oidc
 JWKS_URI=https://pymthouse.com/api/v1/oidc/jwks
 # Signer session exchange (RFC 8693 at POST /api/v1/apps/{clientId}/oidc/token)
 # SIGNER_TOKEN_AUDIENCE=   # optional; defaults to OIDC issuer URL
-# DISCOVERY_URL=https://discovery-service-production-8955.up.railway.app
-#   Livepeer discovery service for SignerSession.discovery_url and
-#   livepeer-python-sdk --token (sdkToken on API key mint).
-#   Alias: DISCOVERY_SERVICE_URL. Origin or full `…/v1/discovery/raw` both work;
-#   code always embeds the raw endpoint. If unset, ORCH_WEBHOOK_URL is used.
+# DISCOVERY_URL=https://discovery-service-production-8955.up.railway.app/v1/discovery/raw
+#   Full raw discovery endpoint (as-is) for SignerSession.discovery_url and
+#   livepeer-python-sdk --token. Alias: DISCOVERY_SERVICE_URL.
+#   If unset, ORCH_WEBHOOK_URL is used.
 # Remote signer orchestrator pool (go-livepeer -orchWebhookUrl); requires SIGNER_REMOTE_DISCOVERY=1
 SIGNER_REMOTE_DISCOVERY=1
 ORCH_WEBHOOK_URL=https://discovery-service-production-8955.up.railway.app/v1/discovery/raw?serviceType=legacy

--- a/src/lib/discovery-service-url.test.ts
+++ b/src/lib/discovery-service-url.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DISCOVERY_RAW_PATH,
+  getDiscoveryRawUrl,
+  getDiscoveryServiceBaseUrl,
+  normalizeDiscoveryServiceBaseUrl,
+  readConfiguredDiscoveryUrl,
+  resolveDiscoveryRawUrl,
+} from "@/lib/discovery-service-url";
+
+const ORIGIN = "https://discovery-service-production-8955.up.railway.app";
+const RAW = `${ORIGIN}${DISCOVERY_RAW_PATH}`;
+const RAW_LEGACY = `${RAW}?serviceType=legacy`;
+
+function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => void,
+) {
+  const prior: Record<string, string | undefined> = {};
+  for (const key of Object.keys(overrides)) {
+    prior[key] = process.env[key];
+    const next = overrides[key];
+    if (next === undefined) delete process.env[key];
+    else process.env[key] = next;
+  }
+  try {
+    fn();
+  } finally {
+    for (const key of Object.keys(overrides)) {
+      const value = prior[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test("normalizeDiscoveryServiceBaseUrl strips raw path and query", () => {
+  assert.equal(normalizeDiscoveryServiceBaseUrl(ORIGIN), ORIGIN);
+  assert.equal(normalizeDiscoveryServiceBaseUrl(`${ORIGIN}/`), ORIGIN);
+  assert.equal(normalizeDiscoveryServiceBaseUrl(RAW), ORIGIN);
+  assert.equal(normalizeDiscoveryServiceBaseUrl(RAW_LEGACY), ORIGIN);
+  assert.equal(
+    normalizeDiscoveryServiceBaseUrl(`${ORIGIN}/v1/discovery/capabilities`),
+    ORIGIN,
+  );
+});
+
+test("resolveDiscoveryRawUrl builds raw from origin or preserves raw query", () => {
+  assert.equal(resolveDiscoveryRawUrl(ORIGIN), RAW);
+  assert.equal(resolveDiscoveryRawUrl(`${ORIGIN}/`), RAW);
+  assert.equal(resolveDiscoveryRawUrl(RAW), RAW);
+  assert.equal(resolveDiscoveryRawUrl(RAW_LEGACY), RAW_LEGACY);
+});
+
+test("readConfiguredDiscoveryUrl prefers DISCOVERY_URL then aliases", () => {
+  withEnv(
+    {
+      DISCOVERY_URL: "https://a.example",
+      DISCOVERY_SERVICE_URL: "https://b.example",
+      LIVEPEER_DISCOVERY_SERVICE_URL: "https://c.example",
+      ORCH_WEBHOOK_URL: "https://d.example/v1/discovery/raw",
+    },
+    () => {
+      assert.equal(readConfiguredDiscoveryUrl(), "https://a.example");
+    },
+  );
+  withEnv(
+    {
+      DISCOVERY_URL: undefined,
+      DISCOVERY_SERVICE_URL: "https://b.example",
+      LIVEPEER_DISCOVERY_SERVICE_URL: "https://c.example",
+      ORCH_WEBHOOK_URL: "https://d.example/v1/discovery/raw",
+    },
+    () => {
+      assert.equal(readConfiguredDiscoveryUrl(), "https://b.example");
+    },
+  );
+  withEnv(
+    {
+      DISCOVERY_URL: undefined,
+      DISCOVERY_SERVICE_URL: undefined,
+      LIVEPEER_DISCOVERY_SERVICE_URL: undefined,
+      ORCH_WEBHOOK_URL: RAW_LEGACY,
+    },
+    () => {
+      assert.equal(readConfiguredDiscoveryUrl(), RAW_LEGACY);
+      assert.equal(getDiscoveryServiceBaseUrl(), ORIGIN);
+      assert.equal(getDiscoveryRawUrl(), RAW_LEGACY);
+    },
+  );
+});
+
+test("origin-only DISCOVERY_SERVICE_URL yields raw for tokens", () => {
+  withEnv(
+    {
+      DISCOVERY_URL: undefined,
+      DISCOVERY_SERVICE_URL: ORIGIN,
+      LIVEPEER_DISCOVERY_SERVICE_URL: undefined,
+      ORCH_WEBHOOK_URL: undefined,
+    },
+    () => {
+      assert.equal(getDiscoveryServiceBaseUrl(), ORIGIN);
+      assert.equal(getDiscoveryRawUrl(), RAW);
+    },
+  );
+});

--- a/src/lib/discovery-service-url.test.ts
+++ b/src/lib/discovery-service-url.test.ts
@@ -1,17 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import {
-  DISCOVERY_RAW_PATH,
-  getDiscoveryRawUrl,
-  getDiscoveryServiceBaseUrl,
-  normalizeDiscoveryServiceBaseUrl,
-  readConfiguredDiscoveryUrl,
-  resolveDiscoveryRawUrl,
-} from "@/lib/discovery-service-url";
+import { getDiscoveryRawUrl } from "@/lib/discovery-service-url";
 
-const ORIGIN = "https://discovery-service-production-8955.up.railway.app";
-const RAW = `${ORIGIN}${DISCOVERY_RAW_PATH}`;
+const RAW =
+  "https://discovery-service-production-8955.up.railway.app/v1/discovery/raw";
 const RAW_LEGACY = `${RAW}?serviceType=legacy`;
 
 function withEnv(
@@ -36,45 +29,29 @@ function withEnv(
   }
 }
 
-test("normalizeDiscoveryServiceBaseUrl strips raw path and query", () => {
-  assert.equal(normalizeDiscoveryServiceBaseUrl(ORIGIN), ORIGIN);
-  assert.equal(normalizeDiscoveryServiceBaseUrl(`${ORIGIN}/`), ORIGIN);
-  assert.equal(normalizeDiscoveryServiceBaseUrl(RAW), ORIGIN);
-  assert.equal(normalizeDiscoveryServiceBaseUrl(RAW_LEGACY), ORIGIN);
-  assert.equal(
-    normalizeDiscoveryServiceBaseUrl(`${ORIGIN}/v1/discovery/capabilities`),
-    ORIGIN,
-  );
-});
-
-test("resolveDiscoveryRawUrl builds raw from origin or preserves raw query", () => {
-  assert.equal(resolveDiscoveryRawUrl(ORIGIN), RAW);
-  assert.equal(resolveDiscoveryRawUrl(`${ORIGIN}/`), RAW);
-  assert.equal(resolveDiscoveryRawUrl(RAW), RAW);
-  assert.equal(resolveDiscoveryRawUrl(RAW_LEGACY), RAW_LEGACY);
-});
-
-test("readConfiguredDiscoveryUrl prefers DISCOVERY_URL then aliases", () => {
+test("getDiscoveryRawUrl returns configured URL as-is", () => {
   withEnv(
     {
-      DISCOVERY_URL: "https://a.example",
-      DISCOVERY_SERVICE_URL: "https://b.example",
-      LIVEPEER_DISCOVERY_SERVICE_URL: "https://c.example",
-      ORCH_WEBHOOK_URL: "https://d.example/v1/discovery/raw",
+      DISCOVERY_URL: RAW_LEGACY,
+      DISCOVERY_SERVICE_URL: "https://other.example/v1/discovery/raw",
+      ORCH_WEBHOOK_URL: undefined,
     },
     () => {
-      assert.equal(readConfiguredDiscoveryUrl(), "https://a.example");
+      assert.equal(getDiscoveryRawUrl(), RAW_LEGACY);
     },
   );
+});
+
+test("getDiscoveryRawUrl prefers DISCOVERY_URL then aliases", () => {
   withEnv(
     {
       DISCOVERY_URL: undefined,
-      DISCOVERY_SERVICE_URL: "https://b.example",
-      LIVEPEER_DISCOVERY_SERVICE_URL: "https://c.example",
-      ORCH_WEBHOOK_URL: "https://d.example/v1/discovery/raw",
+      DISCOVERY_SERVICE_URL: RAW,
+      LIVEPEER_DISCOVERY_SERVICE_URL: undefined,
+      ORCH_WEBHOOK_URL: RAW_LEGACY,
     },
     () => {
-      assert.equal(readConfiguredDiscoveryUrl(), "https://b.example");
+      assert.equal(getDiscoveryRawUrl(), RAW);
     },
   );
   withEnv(
@@ -85,24 +62,7 @@ test("readConfiguredDiscoveryUrl prefers DISCOVERY_URL then aliases", () => {
       ORCH_WEBHOOK_URL: RAW_LEGACY,
     },
     () => {
-      assert.equal(readConfiguredDiscoveryUrl(), RAW_LEGACY);
-      assert.equal(getDiscoveryServiceBaseUrl(), ORIGIN);
       assert.equal(getDiscoveryRawUrl(), RAW_LEGACY);
-    },
-  );
-});
-
-test("origin-only DISCOVERY_SERVICE_URL yields raw for tokens", () => {
-  withEnv(
-    {
-      DISCOVERY_URL: undefined,
-      DISCOVERY_SERVICE_URL: ORIGIN,
-      LIVEPEER_DISCOVERY_SERVICE_URL: undefined,
-      ORCH_WEBHOOK_URL: undefined,
-    },
-    () => {
-      assert.equal(getDiscoveryServiceBaseUrl(), ORIGIN);
-      assert.equal(getDiscoveryRawUrl(), RAW);
     },
   );
 });

--- a/src/lib/discovery-service-url.ts
+++ b/src/lib/discovery-service-url.ts
@@ -1,15 +1,10 @@
 /**
- * Canonical Livepeer discovery-service URL helpers.
+ * Livepeer discovery-service URL for SignerSession / python-gateway `--token`.
  *
- * Accepts either env name and either URL shape:
- * - origin/base: `https://discovery-service…up.railway.app`
- * - raw endpoint: `https://…/v1/discovery/raw` (optional query)
- *
- * Explore-style callers use the base and append `/v1/discovery/…`.
- * Gateway `--token` / SignerSession callers use the raw endpoint as-is.
+ * Configure the full raw endpoint (optional query), e.g.
+ * `https://discovery-service-production-8955.up.railway.app/v1/discovery/raw`
+ * Returned as-is (trimmed). No path rewriting.
  */
-
-export const DISCOVERY_RAW_PATH = "/v1/discovery/raw";
 
 const ENV_KEYS = [
   "DISCOVERY_URL",
@@ -18,8 +13,7 @@ const ENV_KEYS = [
   "ORCH_WEBHOOK_URL",
 ] as const;
 
-/** First non-empty configured discovery URL (any accepted shape). */
-export function readConfiguredDiscoveryUrl(
+export function getDiscoveryRawUrl(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
   for (const key of ENV_KEYS) {
@@ -27,54 +21,4 @@ export function readConfiguredDiscoveryUrl(
     if (value) return value;
   }
   return undefined;
-}
-
-/**
- * Normalize to discovery-service origin (no `/v1/discovery…`, no query/hash).
- * Trailing slashes on the origin path are stripped.
- */
-export function normalizeDiscoveryServiceBaseUrl(input: string): string {
-  const url = new URL(input.trim());
-  const discoveryIdx = url.pathname.indexOf("/v1/discovery");
-  if (discoveryIdx >= 0) {
-    url.pathname = url.pathname.slice(0, discoveryIdx) || "/";
-  }
-  url.search = "";
-  url.hash = "";
-  const path = url.pathname.replace(/\/+$/, "");
-  return path && path !== "/" ? `${url.origin}${path}` : url.origin;
-}
-
-/**
- * Full GET endpoint for orchestrator lists (python-gateway / orch webhook).
- * Preserves query string when the configured URL already targeted raw.
- */
-export function resolveDiscoveryRawUrl(input: string): string {
-  const trimmed = input.trim();
-  const parsed = new URL(trimmed);
-  const base = normalizeDiscoveryServiceBaseUrl(trimmed);
-  const path = parsed.pathname.replace(/\/+$/, "") || "/";
-  const search =
-    path === DISCOVERY_RAW_PATH || path.endsWith(DISCOVERY_RAW_PATH)
-      ? parsed.search
-      : "";
-  return `${base}${DISCOVERY_RAW_PATH}${search}`;
-}
-
-/** Base URL for appending `/v1/discovery/capabilities` etc. */
-export function getDiscoveryServiceBaseUrl(
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  const configured = readConfiguredDiscoveryUrl(env);
-  return configured ? normalizeDiscoveryServiceBaseUrl(configured) : undefined;
-}
-
-/**
- * Raw discovery endpoint for SignerSession.discovery_url and python-gateway tokens.
- */
-export function getDiscoveryRawUrl(
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  const configured = readConfiguredDiscoveryUrl(env);
-  return configured ? resolveDiscoveryRawUrl(configured) : undefined;
 }

--- a/src/lib/discovery-service-url.ts
+++ b/src/lib/discovery-service-url.ts
@@ -1,0 +1,80 @@
+/**
+ * Canonical Livepeer discovery-service URL helpers.
+ *
+ * Accepts either env name and either URL shape:
+ * - origin/base: `https://discovery-service…up.railway.app`
+ * - raw endpoint: `https://…/v1/discovery/raw` (optional query)
+ *
+ * Explore-style callers use the base and append `/v1/discovery/…`.
+ * Gateway `--token` / SignerSession callers use the raw endpoint as-is.
+ */
+
+export const DISCOVERY_RAW_PATH = "/v1/discovery/raw";
+
+const ENV_KEYS = [
+  "DISCOVERY_URL",
+  "DISCOVERY_SERVICE_URL",
+  "LIVEPEER_DISCOVERY_SERVICE_URL",
+  "ORCH_WEBHOOK_URL",
+] as const;
+
+/** First non-empty configured discovery URL (any accepted shape). */
+export function readConfiguredDiscoveryUrl(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  for (const key of ENV_KEYS) {
+    const value = env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Normalize to discovery-service origin (no `/v1/discovery…`, no query/hash).
+ * Trailing slashes on the origin path are stripped.
+ */
+export function normalizeDiscoveryServiceBaseUrl(input: string): string {
+  const url = new URL(input.trim());
+  const discoveryIdx = url.pathname.indexOf("/v1/discovery");
+  if (discoveryIdx >= 0) {
+    url.pathname = url.pathname.slice(0, discoveryIdx) || "/";
+  }
+  url.search = "";
+  url.hash = "";
+  const path = url.pathname.replace(/\/+$/, "");
+  return path && path !== "/" ? `${url.origin}${path}` : url.origin;
+}
+
+/**
+ * Full GET endpoint for orchestrator lists (python-gateway / orch webhook).
+ * Preserves query string when the configured URL already targeted raw.
+ */
+export function resolveDiscoveryRawUrl(input: string): string {
+  const trimmed = input.trim();
+  const parsed = new URL(trimmed);
+  const base = normalizeDiscoveryServiceBaseUrl(trimmed);
+  const path = parsed.pathname.replace(/\/+$/, "") || "/";
+  const search =
+    path === DISCOVERY_RAW_PATH || path.endsWith(DISCOVERY_RAW_PATH)
+      ? parsed.search
+      : "";
+  return `${base}${DISCOVERY_RAW_PATH}${search}`;
+}
+
+/** Base URL for appending `/v1/discovery/capabilities` etc. */
+export function getDiscoveryServiceBaseUrl(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const configured = readConfiguredDiscoveryUrl(env);
+  return configured ? normalizeDiscoveryServiceBaseUrl(configured) : undefined;
+}
+
+/**
+ * Raw discovery endpoint for SignerSession.discovery_url and python-gateway tokens.
+ */
+export function getDiscoveryRawUrl(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const configured = readConfiguredDiscoveryUrl(env);
+  return configured ? resolveDiscoveryRawUrl(configured) : undefined;
+}

--- a/src/lib/livepeer-python-sdk-token.test.ts
+++ b/src/lib/livepeer-python-sdk-token.test.ts
@@ -84,16 +84,34 @@ test("createLivepeerPythonSdkToken returns base64 string", () => {
   assert.equal(decoded.signer_headers.Authorization, "Bearer app_a_pmth_b");
 });
 
-test("getLivepeerPythonSdkDiscoveryUrl prefers DISCOVERY_URL over ORCH_WEBHOOK_URL", () => {
+test("getLivepeerPythonSdkDiscoveryUrl prefers DISCOVERY_URL and normalizes to raw", () => {
   withEnv(
     {
       DISCOVERY_URL: "https://discovery.example/preferred",
+      DISCOVERY_SERVICE_URL: "https://other.example",
       ORCH_WEBHOOK_URL: "https://orch.example/fallback",
     },
     () => {
       assert.equal(
         getLivepeerPythonSdkDiscoveryUrl(),
-        "https://discovery.example/preferred",
+        "https://discovery.example/preferred/v1/discovery/raw",
+      );
+    },
+  );
+});
+
+test("getLivepeerPythonSdkDiscoveryUrl accepts DISCOVERY_SERVICE_URL origin", () => {
+  withEnv(
+    {
+      DISCOVERY_URL: undefined,
+      DISCOVERY_SERVICE_URL:
+        "https://discovery-service-production-8955.up.railway.app",
+      ORCH_WEBHOOK_URL: undefined,
+    },
+    () => {
+      assert.equal(
+        getLivepeerPythonSdkDiscoveryUrl(),
+        "https://discovery-service-production-8955.up.railway.app/v1/discovery/raw",
       );
     },
   );
@@ -103,6 +121,8 @@ test("getLivepeerPythonSdkDiscoveryUrl falls back to ORCH_WEBHOOK_URL", () => {
   withEnv(
     {
       DISCOVERY_URL: undefined,
+      DISCOVERY_SERVICE_URL: undefined,
+      LIVEPEER_DISCOVERY_SERVICE_URL: undefined,
       ORCH_WEBHOOK_URL:
         "https://discovery-service-production-8955.up.railway.app/v1/discovery/raw?serviceType=legacy",
     },

--- a/src/lib/livepeer-python-sdk-token.test.ts
+++ b/src/lib/livepeer-python-sdk-token.test.ts
@@ -84,28 +84,28 @@ test("createLivepeerPythonSdkToken returns base64 string", () => {
   assert.equal(decoded.signer_headers.Authorization, "Bearer app_a_pmth_b");
 });
 
-test("getLivepeerPythonSdkDiscoveryUrl prefers DISCOVERY_URL and normalizes to raw", () => {
+test("getLivepeerPythonSdkDiscoveryUrl prefers DISCOVERY_URL as-is", () => {
   withEnv(
     {
-      DISCOVERY_URL: "https://discovery.example/preferred",
-      DISCOVERY_SERVICE_URL: "https://other.example",
-      ORCH_WEBHOOK_URL: "https://orch.example/fallback",
+      DISCOVERY_URL: "https://discovery.example/v1/discovery/raw",
+      DISCOVERY_SERVICE_URL: "https://other.example/v1/discovery/raw",
+      ORCH_WEBHOOK_URL: "https://orch.example/v1/discovery/raw",
     },
     () => {
       assert.equal(
         getLivepeerPythonSdkDiscoveryUrl(),
-        "https://discovery.example/preferred/v1/discovery/raw",
+        "https://discovery.example/v1/discovery/raw",
       );
     },
   );
 });
 
-test("getLivepeerPythonSdkDiscoveryUrl accepts DISCOVERY_SERVICE_URL origin", () => {
+test("getLivepeerPythonSdkDiscoveryUrl accepts DISCOVERY_SERVICE_URL", () => {
   withEnv(
     {
       DISCOVERY_URL: undefined,
       DISCOVERY_SERVICE_URL:
-        "https://discovery-service-production-8955.up.railway.app",
+        "https://discovery-service-production-8955.up.railway.app/v1/discovery/raw",
       ORCH_WEBHOOK_URL: undefined,
     },
     () => {

--- a/src/lib/livepeer-python-sdk-token.ts
+++ b/src/lib/livepeer-python-sdk-token.ts
@@ -1,3 +1,4 @@
+import { getDiscoveryRawUrl } from "@/lib/discovery-service-url";
 import { getClientSignerApiUrl } from "@/lib/signer-proxy";
 
 export type LivepeerPythonSdkTokenPayload = {
@@ -10,13 +11,11 @@ export type LivepeerPythonSdkTokenPayload = {
 
 /**
  * Discovery URL for livepeer-python-sdk `--token` payloads.
- * Prefer DISCOVERY_URL; fall back to ORCH_WEBHOOK_URL (production orch pool).
+ * Always the raw endpoint (`…/v1/discovery/raw`), normalized from
+ * DISCOVERY_URL / DISCOVERY_SERVICE_URL / ORCH_WEBHOOK_URL (any shape).
  */
 export function getLivepeerPythonSdkDiscoveryUrl(): string | undefined {
-  const discovery = process.env.DISCOVERY_URL?.trim();
-  if (discovery) return discovery;
-  const orch = process.env.ORCH_WEBHOOK_URL?.trim();
-  return orch || undefined;
+  return getDiscoveryRawUrl();
 }
 
 export function buildLivepeerPythonSdkTokenPayload(input: {

--- a/src/lib/livepeer-python-sdk-token.ts
+++ b/src/lib/livepeer-python-sdk-token.ts
@@ -11,8 +11,7 @@ export type LivepeerPythonSdkTokenPayload = {
 
 /**
  * Discovery URL for livepeer-python-sdk `--token` payloads.
- * Always the raw endpoint (`…/v1/discovery/raw`), normalized from
- * DISCOVERY_URL / DISCOVERY_SERVICE_URL / ORCH_WEBHOOK_URL (any shape).
+ * Full raw endpoint as configured (`…/v1/discovery/raw`), unchanged.
  */
 export function getLivepeerPythonSdkDiscoveryUrl(): string | undefined {
   return getDiscoveryRawUrl();

--- a/src/lib/oidc/app-scoped-signer-token-exchange.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.ts
@@ -74,7 +74,6 @@ export function getSignerTokenAudienceEnv(): string | null {
 }
 
 export function getSignerDiscoveryUrl(): string | undefined {
-  // Shared with SDK tokens: always `…/v1/discovery/raw` (see discovery-service-url).
   return getDiscoveryRawUrl();
 }
 

--- a/src/lib/oidc/app-scoped-signer-token-exchange.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.ts
@@ -2,6 +2,7 @@ import { hasScope } from "@/lib/auth";
 import {
   resolveActiveAppApiKey,
 } from "@/lib/app-api-keys";
+import { getDiscoveryRawUrl } from "@/lib/discovery-service-url";
 import { validateClientSecret } from "@/lib/oidc/clients";
 import {
   mintSignerJwtForExternalUser,
@@ -73,8 +74,8 @@ export function getSignerTokenAudienceEnv(): string | null {
 }
 
 export function getSignerDiscoveryUrl(): string | undefined {
-  const raw = process.env.DISCOVERY_URL?.trim();
-  return raw || undefined;
+  // Shared with SDK tokens: always `…/v1/discovery/raw` (see discovery-service-url).
+  return getDiscoveryRawUrl();
 }
 
 export function acceptedSignerAudiences(): Set<string> {

--- a/src/lib/openapi/schemas/credentials.ts
+++ b/src/lib/openapi/schemas/credentials.ts
@@ -65,7 +65,8 @@ export const SignerSessionSchema = z
       description: "Public remote-signer base URL.",
     }),
     discovery_url: z.string().url().optional().openapi({
-      description: "Livepeer network discovery URL (not OIDC issuer metadata).",
+      description:
+        "Livepeer discovery-service raw endpoint (…/v1/discovery/raw), not OIDC issuer metadata.",
     }),
     issued_token_type: z
       .literal("urn:ietf:params:oauth:token-type:access_token")


### PR DESCRIPTION
## Summary
- Single expected format: full `…/v1/discovery/raw` (optional query)
- `DISCOVERY_URL` / `DISCOVERY_SERVICE_URL` / aliases return that value **as-is** (no origin↔path rewriting)
- SignerSession + python-gateway `--token` embed the configured URL unchanged

## Test plan
- [ ] Unit tests for discovery-service-url + livepeer-python-sdk-token
- [ ] Env set to full raw URL; token/session `discovery` matches exactly
- [ ] Vercel/Railway uses full raw URL (not origin-only)