### PR TITLE
fix(deps): bump postcss to >=8.5.18 (SNYK-JS-POSTCSS-18313038)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "drizzle-kit": "^0.31.10",
         "eslint": "^9.39.5",
         "eslint-config-next": "16.2.3",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.18",
         "tailwindcss": "^4.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.7.0"
@@ -8757,9 +8757,9 @@
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -9492,9 +9492,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -9511,7 +9511,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       "uuid": "^11.1.1"
     },
     "js-yaml": "4.3.0",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "undici": "^7.28.0",
     "ws": "8.21.1",
     "sharp": "0.35.0"
@@ -89,7 +89,7 @@
     "drizzle-kit": "^0.31.10",
     "eslint": "^9.39.5",
     "eslint-config-next": "16.2.3",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "tailwindcss": "^4.0.0",
     "tsx": "^4.21.0",
     "typescript": "^5.7.0"


### PR DESCRIPTION
## Summary
- Raises the `postcss` override and direct dependency from `^8.5.10` to `^8.5.18` so the lockfile resolves to a fixed release (`8.5.23`).
- Closes [code scanning alert #105](https://github.com/pymthouse/pymthouse/security/code-scanning/105) ([SNYK-JS-POSTCSS-18313038](https://security.snyk.io/vuln/SNYK-JS-POSTCSS-18313038) Directory Traversal, High).

## Test plan
- [x] `npx snyk test --file=package-lock.json --severity-threshold=high` → no vulnerable paths
- [x] `npm ls postcss` → `postcss@8.5.23`
- [ ] CI Snyk Open Source (SCA) passes once quota allows / on this PR