### PR TITLE
fix: UsageLineChart Y-scale guards and login copy

### DIFF
--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -173,7 +173,7 @@ function LoginStartCtaPanel({
           New here?
         </p>
         <p className="mt-2 text-xl font-semibold text-zinc-50 sm:text-2xl">
-          Explore or Build
+          Explore and Build
         </p>
         <p className="mt-2 max-w-md text-sm leading-relaxed text-zinc-300 sm:text-base">
           Explore the Livepeer network and build your own AI platform!

--- a/src/components/UsageLineChart.test.ts
+++ b/src/components/UsageLineChart.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildYTicks, chartYScaleMax } from "./UsageLineChart";
+
+test("buildYTicks returns identity ticks when max is zero or invalid", () => {
+  assert.deepEqual(buildYTicks(0), [0, 1, 2, 3, 4]);
+  assert.deepEqual(buildYTicks(-1), [0, 1, 2, 3, 4]);
+  assert.deepEqual(buildYTicks(Number.NaN), [0, 1, 2, 3, 4]);
+});
+
+test("chartYScaleMax is at least 1 when ticks are all zero", () => {
+  assert.equal(chartYScaleMax([0]), 1);
+});
+
+test("chartYScaleMax uses top tick when positive", () => {
+  assert.equal(chartYScaleMax([0, 25, 50]), 50);
+});

--- a/src/components/UsageLineChart.tsx
+++ b/src/components/UsageLineChart.tsx
@@ -52,7 +52,7 @@ function sanitizeChartValue(value: number): number {
 }
 
 /** Y-axis top ≈ 20% above the peak so the line fills ~80% of the plot height. */
-function buildYTicks(maxValue: number, tickCount = 4): number[] {
+export function buildYTicks(maxValue: number, tickCount = 4): number[] {
   if (!Number.isFinite(maxValue) || maxValue <= 0) {
     return Array.from({ length: tickCount + 1 }, (_, i) => i);
   }
@@ -64,6 +64,12 @@ function buildYTicks(maxValue: number, tickCount = 4): number[] {
     ticks.push(v);
   }
   return ticks;
+}
+
+/** Y-axis scale maximum; never zero (avoids NaN in SVG coordinates). */
+export function chartYScaleMax(yTicks: number[]): number {
+  const top = yTicks.at(-1) ?? 0;
+  return Number.isFinite(top) && top > 0 ? top : 1;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Export `buildYTicks` / `chartYScaleMax` with zero/NaN guards and unit tests.
- Align login CTA copy to "Explore and Build".

Split out of draft #124 (misc standalone fixes). Does not include OIDC activation mapping (that lands with the activation-gate PR).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (suite green)
- [x] Snyk MCP code scan on changed component paths
- [x] Sonar snippet analysis on Y-scale helpers