### PR TITLE
chore(deploy): require OPENMETER_APPS_BASE_URL for OpenMeter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,8 @@ OPENMETER_URL=http://127.0.0.1:48888
 # - self_hosted: use OpenMeter SDK /api/v1 routes
 # - hosted: use hosted Konnect-style routes (no /api/v1 prefix)
 OPENMETER_ROUTE_MODE=auto
+# Self-hosted OpenMeter only: public URL for Stripe app OAuth (defaults to OPENMETER_URL in Railway scripts).
+# OPENMETER_APPS_BASE_URL=http://127.0.0.1:48888
 # Optional for local docker; required for OpenMeter Cloud / auth-enabled installs.
 OPENMETER_API_KEY=
 # Optional collector-only ingest key. Falls back to OPENMETER_API_KEY when unset.

--- a/config/railway/production.env.example
+++ b/config/railway/production.env.example
@@ -30,6 +30,29 @@
 # | SIGNER_ETH_ADDR | pymthouse (optional 0x pin) |
 
 # --- kafka service ---
+
+# --- Shared OpenMeter (set on postgres, openmeter, sink-worker, balance-worker) ---
+OPENMETER_POSTGRES_PASSWORD=
+
+# --- openmeter-postgres ---
+POSTGRES_USER=postgres
+POSTGRES_DB=postgres
+POSTGRES_PASSWORD=${OPENMETER_POSTGRES_PASSWORD}
+
+# --- openmeter-clickhouse ---
+CLICKHOUSE_USER=default
+CLICKHOUSE_DB=openmeter
+CLICKHOUSE_PASSWORD=
+
+# --- openmeter (API only; generate public domain in Railway) ---
+OPENMETER_API_KEY=
+# Public OpenMeter URL (required for Stripe marketplace OAuth — same host as OPENMETER_URL on Vercel)
+OPENMETER_APPS_BASE_URL=https://openmeter-production-xxxx.up.railway.app
+
+# --- openmeter-redis (production uses openmeter-redis-prod; preview uses openmeter-redis) ---
+# OPENMETER_REDIS_ADDRESS=openmeter-redis-prod.railway.internal:6379
+
+# --- openmeter-kafka (match docker-compose.openmeter.railway.yml) ---
 CLUSTER_ID=ca497efe-9f82-4b84-890b-d9969a9a2e1c
 
 # --- openmeter-collector service ---
@@ -63,7 +86,9 @@ JWKS_URI=https://pymthouse.com/api/v1/oidc/jwks
 #   If unset, ORCH_WEBHOOK_URL is used.
 # Remote signer orchestrator pool (go-livepeer -orchWebhookUrl); requires SIGNER_REMOTE_DISCOVERY=1
 SIGNER_REMOTE_DISCOVERY=1
-ORCH_WEBHOOK_URL=https://discovery-service-production-8955.up.railway.app/v1/discovery/raw?serviceType=legacy
+ORCH_WEBHOOK_URL=https://discovery-service-production-8955.up.railway.app/v1/discovery/raw?serviceType=live-video-to-video
+# Plans UI / manifest catalog (defaults to production discovery-service if unset)
+# DISCOVERY_SERVICE_URL=https://discovery-service-production-8955.up.railway.app
 LIVE_AI_CAP_REPORT_INTERVAL=5m
 REMOTE_SIGNER_WEBHOOK_URL=https://pymthouse.com/webhooks/remote-signer
 WEBHOOK_SECRET=

--- a/deploy/openmeter/entrypoint.sh
+++ b/deploy/openmeter/entrypoint.sh
@@ -5,8 +5,15 @@ set -eu
 CONFIG_OUT="/tmp/openmeter.config.yaml"
 PASS="${OPENMETER_POSTGRES_PASSWORD:-postgres}"
 REDIS_ADDR="${OPENMETER_REDIS_ADDRESS:-openmeter-redis.railway.internal:6379}"
+APPS_BASE_URL="${OPENMETER_APPS_BASE_URL:-}"
+if [ -z "$APPS_BASE_URL" ]; then
+  echo "entrypoint: OPENMETER_APPS_BASE_URL is required (public OpenMeter URL, no trailing slash)" >&2
+  exit 1
+fi
+APPS_BASE_URL="${APPS_BASE_URL%/}"
 sed -e "s|\${OPENMETER_POSTGRES_PASSWORD}|${PASS}|g" \
   -e "s|\${OPENMETER_REDIS_ADDRESS}|${REDIS_ADDR}|g" \
+  -e "s|\${OPENMETER_APPS_BASE_URL}|${APPS_BASE_URL}|g" \
   /etc/openmeter/config.railway.yaml >"${CONFIG_OUT}"
 
 CMD="${1:-openmeter}"

--- a/docker/openmeter/config.railway.yaml
+++ b/docker/openmeter/config.railway.yaml
@@ -37,6 +37,15 @@ telemetry:
   log:
     level: info
 
+billing:
+  advancementStrategy: foreground
+
+credits:
+  enabled: true
+
+apps:
+  baseURL: ${OPENMETER_APPS_BASE_URL}
+
 meters:
   - slug: network_fee_usd_micros
     description: Livepeer signed-ticket network fee (USD micros)

--- a/docker/openmeter/config.yaml
+++ b/docker/openmeter/config.yaml
@@ -37,6 +37,17 @@ telemetry:
   log:
     level: info
 
+# Required for Stripe marketplace OAuth, billing profiles, and invoicing apps.
+billing:
+  advancementStrategy: foreground
+
+credits:
+  enabled: true
+
+apps:
+  # Local compose publishes API on host port 48888 (see docker-compose.openmeter.yml).
+  baseURL: http://127.0.0.1:48888
+
 meters:
   - slug: network_fee_usd_micros
     description: Livepeer signed-ticket network fee (USD micros)

--- a/docs/openmeter-railway.md
+++ b/docs/openmeter-railway.md
@@ -78,8 +78,11 @@ On the **openmeter** project (or per-service), set:
 | `OPENMETER_POSTGRES_PASSWORD` | postgres + openmeter + both workers | `openssl rand -hex 24` |
 | `OPENMETER_CLICKHOUSE_SECRET` | openmeter-clickhouse | `openssl rand -hex 24` |
 | `OPENMETER_API_KEY` | optional; set on OM if you enable auth | random secret |
+| `OPENMETER_APPS_BASE_URL` | openmeter + both workers | Same as the **public** OpenMeter domain from step 4 (no trailing slash) |
 
 Use the **same** `OPENMETER_POSTGRES_PASSWORD` on `openmeter-postgres`, `openmeter`, `openmeter-sink-worker`, and `openmeter-balance-worker`.
+
+`OPENMETER_APPS_BASE_URL` is required for **Stripe Connect** (per-app merchant billing in PymtHouse). Without it, `GET …/marketplace/listings/stripe/install/oauth2` returns **501 Unimplemented**. Set it to the OpenMeter API origin (e.g. `https://openmeter-production-xxxx.up.railway.app`), not the PymtHouse URL. If unset, use the same value as `OPENMETER_URL` on `openmeter` and both workers.
 
 ## 4. Public URL for the API
 

--- a/scripts/openmeter-bootstrap.ts
+++ b/scripts/openmeter-bootstrap.ts
@@ -187,6 +187,37 @@ async function ensureSelfHostedFeature(
   }
 }
 
+async function probeStripeOAuth(
+  baseUrl: string,
+  apiKey: string | undefined,
+  appsBaseUrl: string,
+): Promise<void> {
+  try {
+    const installResp = await fetchWithTimeout(
+      `${baseUrl}/api/v1/marketplace/listings/stripe/install/oauth2`,
+      {
+        headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      },
+    );
+    if (installResp.status === 501) {
+      console.warn(
+        "[openmeter-bootstrap] Stripe Connect unavailable (501). Set apps.baseURL on OpenMeter " +
+          `(OPENMETER_APPS_BASE_URL=${appsBaseUrl}) and redeploy.`,
+      );
+      return;
+    }
+    if (!installResp.ok) {
+      console.warn(
+        `[openmeter-bootstrap] Stripe install probe returned ${installResp.status} (apps.baseURL should be ${appsBaseUrl})`,
+      );
+      return;
+    }
+    console.log("[openmeter-bootstrap] Stripe marketplace OAuth is available");
+  } catch (err) {
+    console.warn("[openmeter-bootstrap] Stripe install probe skipped:", err);
+  }
+}
+
 async function bootstrapSelfHosted(
   baseUrl: string,
   apiKey: string | undefined,
@@ -199,6 +230,8 @@ async function bootstrapSelfHosted(
   console.log(
     "[openmeter-bootstrap] Per-customer trial grants are created at user provision time via customers.entitlements.createGrant (self-hosted)",
   );
+  const appsBaseUrl = process.env.OPENMETER_APPS_BASE_URL?.trim() || baseUrl;
+  await probeStripeOAuth(baseUrl, apiKey, appsBaseUrl);
 }
 
 function requireBootstrapTarget(): { rawBaseUrl: string; apiKey: string | undefined } {


### PR DESCRIPTION
## Summary
- Require `OPENMETER_APPS_BASE_URL` in the OpenMeter Railway entrypoint and wire `apps.baseURL` in config.
- Document the env var (`.env.example`, Railway examples, `docs/openmeter-railway.md`).
- Probe Stripe marketplace OAuth availability during self-hosted bootstrap.

Split out of draft #124 (deployment config only). No Stripe Connect app/merchant code.

## Test plan
- [x] `npx tsc --noEmit`
- [ ] Confirm Railway openmeter deploy fails closed without `OPENMETER_APPS_BASE_URL`
- [ ] Confirm bootstrap logs Stripe OAuth probe result when OpenMeter is reachable