### PR TITLE
feat(billing): Stripe Connect merchant onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,10 @@ OPENMETER_API_KEY=
 OPENMETER_INGEST_API_KEY=
 # Platform Stripe secret key for the SAME account installed in Konnect/OpenMeter.
 # STRIPE_SECRET_KEY=sk_live_…
+# After hard cutover, force Connect-only checkout globally (optional; prefer per-app connectPaymentsOnly)
+# STRIPE_CONNECT_PAYMENTS_ONLY=0
+# Connect webhook signing secret (Dashboard → Webhooks → endpoint for /webhooks/stripe, include account.updated)
+# STRIPE_WEBHOOK_SECRET=whsec_…
 # Optional override for the shared owners Stripe billing profile id
 # OPENMETER_OWNERS_BILLING_PROFILE_ID=
 # Deprecated: sandbox free profile — Starter now uses Stripe profiles + included usage.

--- a/.env.example
+++ b/.env.example
@@ -150,27 +150,33 @@ OPENMETER_URL=http://127.0.0.1:48888
 # - self_hosted: use OpenMeter SDK /api/v1 routes
 # - hosted: use hosted Konnect-style routes (no /api/v1 prefix)
 OPENMETER_ROUTE_MODE=auto
-# ISO 3166-1 alpha-2 country on per-app billing profile supplier (default US)
-# OPENMETER_BILLING_SUPPLIER_COUNTRY=US
-# Konnect only: pin a specific org Stripe app when multiple are installed
-# OPENMETER_STRIPE_APP_ID=01G65Z755AFWAKHE12NY0CQ9FH
 # Optional for local docker; required for OpenMeter Cloud / auth-enabled installs.
 OPENMETER_API_KEY=
 # Optional collector-only ingest key. Falls back to OPENMETER_API_KEY when unset.
 OPENMETER_INGEST_API_KEY=
-# Platform Stripe secret key for the SAME account installed in Konnect/OpenMeter.
-# STRIPE_SECRET_KEY=sk_live_…
-# After hard cutover, force Connect-only checkout globally (optional; prefer per-app connectPaymentsOnly)
-# STRIPE_CONNECT_PAYMENTS_ONLY=0
-# Connect webhook signing secret (Dashboard → Webhooks → endpoint for /webhooks/stripe, include account.updated)
-# STRIPE_WEBHOOK_SECRET=whsec_…
-# Optional override for the shared owners Stripe billing profile id
-# OPENMETER_OWNERS_BILLING_PROFILE_ID=
-# Deprecated: sandbox free profile — Starter now uses Stripe profiles + included usage.
-# OPENMETER_FREE_BILLING_PROFILE_ID=
 OPENMETER_TRIAL_FEATURE_KEY=network_spend
 # Default included usage (USD micros) when seeding per-app Starter plan (5000000 = $5)
 OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS=5000000
+
+# ---------- Plane A: OpenMeter Stripe app (platform cost rail) ----------
+# Developers pay PymtHouse for network usage via Kong/OM billing profiles.
+# ISO 3166-1 alpha-2 country on per-app billing profile supplier (default US)
+# OPENMETER_BILLING_SUPPLIER_COUNTRY=US
+# Konnect only: pin a specific org Stripe app when multiple are installed
+# OPENMETER_STRIPE_APP_ID=01G65Z755AFWAKHE12NY0CQ9FH
+# Platform Stripe secret key for the SAME account installed in Konnect/OpenMeter
+# (used to mint cus_… for OM customer app_data).
+# STRIPE_SECRET_KEY=sk_live_…
+# Optional override for the shared owners Stripe billing profile id
+# OPENMETER_OWNERS_BILLING_PROFILE_ID=
+
+# ---------- Plane B: Merchant Stripe Connect (revenue rail) ----------
+# Builders collect from end users on Connected Accounts; PymtHouse takes application_fee_bps.
+# Connect webhook signing secret (Dashboard → Webhooks → connected-account events → /webhooks/stripe)
+# STRIPE_WEBHOOK_SECRET=whsec_…
+# After hard cutover, force Connect-only checkout globally (optional; prefer per-app connectPaymentsOnly)
+# STRIPE_CONNECT_PAYMENTS_ONLY=0
+
 # Required for usage totals, allowance balance, and signed-ticket metering
 # OPENMETER_URL=http://127.0.0.1:48888
 

--- a/docs/adr-stripe-connect-openmeter-webhooks.md
+++ b/docs/adr-stripe-connect-openmeter-webhooks.md
@@ -157,7 +157,8 @@ Verify `Stripe-Signature` over the raw body (`src/lib/stripe/webhook.ts`).
 | `invoice.paid` (Connect) | Recurring retail on connected account | Advance local subscription cache; do **not** also charge via OM Stripe app |
 | `customer.subscription.deleted` (optional) | Merchant cancelled retail sub | Align OM subscription cancel / phase-out |
 
-**Readiness predicate** (activation gate): `charges_enabled && details_submitted`.
+**Readiness predicate** (merchant checkout / activation gate): Connected Account id
+present, `charges_enabled`, and `details_submitted`.
 `payouts_enabled` is recorded but **not** required (see activation-gate.md).
 
 **Idempotency:** store processed Stripe `event.id` (or rely on natural upserts keyed

--- a/docs/adr-stripe-connect-openmeter-webhooks.md
+++ b/docs/adr-stripe-connect-openmeter-webhooks.md
@@ -1,0 +1,262 @@
+# ADR: Stripe Connect + OpenMeter via two webhook planes
+
+Status: **accepted** (design binding for stacked billing PRs).  
+Supersedes the ambiguous “Stripe Connect” naming in the OpenMeter Stripe **app
+install** path. Companion to [`activation-gate.md`](./activation-gate.md).
+
+| Stack | PR | Role |
+|---|---|---|
+| OpenMeter Stripe billing foundations | [#321](https://github.com/pymthouse/pymthouse/pull/321) | Platform OM Stripe app, billing profiles, customer Stripe app data |
+| Merchant Connect onboarding | [#322](https://github.com/pymthouse/pymthouse/pull/322) | Account Links, Connect webhook, connected Checkout |
+| Plans / phase-out | [#323](https://github.com/pymthouse/pymthouse/pull/323) | Progressive billing, subscription change |
+| Cutover scripts | [#324](https://github.com/pymthouse/pymthouse/pull/324) | Sandbox → Stripe / Connect cutover tooling |
+| Activation gate | [#325](https://github.com/pymthouse/pymthouse/pull/325) | Cost vs revenue rails; readiness predicate |
+
+## Context
+
+OpenMeter’s Stripe **app** (marketplace install / API key / Konnect org Stripe
+app) integrates with a **normal Stripe account**: Tax, Invoicing, Payments, and
+Checkout. On install it registers Stripe webhooks (notably
+`setup_intent.succeeded`) so Checkout can attach a default payment method to an
+OpenMeter customer.
+
+That product is **not** Stripe Connect. It does not onboard Express/Standard
+connected accounts, does not emit Account Links, and does not document
+destination charges or `application_fee_amount` on connected-account payments.
+
+PymtHouse needs both:
+
+1. **Cost rail** — app owners pay PymtHouse for network usage (always on).
+2. **Revenue rail** — Builders optionally collect from their own end users, with
+   PymtHouse taking `application_fee_bps`.
+
+Conflating “connect Stripe to OpenMeter” with “Stripe Connect for merchants”
+produced oversized PR #124 and incorrect product assumptions. This ADR fixes the
+architecture and the vocabulary.
+
+## Decision
+
+**Use two independent Stripe webhook planes and never ask the OpenMeter Stripe
+app to charge on connected accounts.**
+
+| Plane | Stripe account scope | Owner | Purpose |
+|---|---|---|---|
+| **A — OpenMeter Stripe app** | Platform (or Konnect org) Stripe account | OpenMeter / Konnect (auto-installed) | Cost-rail Checkout, invoice sync, PM attach for **owners** |
+| **B — PymtHouse Connect** | Connected accounts (`events from Connect`) | `POST /webhooks/stripe` | Merchant readiness, end-user Checkout completion, deauth |
+
+OpenMeter remains the **metering and entitlement brain** for both rails. For
+merchant end users it must **meter without auto-collecting** on the platform
+Stripe app (Sandbox / non-charging profile, or subscription created only after
+Connect payment with no chargeable PM in OM).
+
+### Vocabulary (use in UI and docs)
+
+| Say | Mean |
+|---|---|
+| **Connect Stripe billing** / OpenMeter Stripe app | Install OM’s Stripe app on the platform account |
+| **Merchant Stripe Connect** / connected account | Builder Express/Standard account via Account Links |
+| Do **not** say “Stripe Connect” for OM app install | Causes the confusion this ADR kills |
+
+## Architecture
+
+```
+ Network usage ──► OpenMeter (plans, entitlements, invoices)
+                         │
+                         │ Plane A: OM Stripe app webhooks
+                         │ (platform account only)
+                         ▼
+                   Platform Stripe
+                   • Owner Checkout / invoices
+                   • setup_intent.succeeded → OM attaches PM
+
+ Builder onboarding ──► Account Links (acct_…)
+ End-user retail pay ──► Checkout / PaymentIntent
+                         (destination or stripeAccount
+                          + application_fee_amount)
+                         │
+                         │ Plane B: /webhooks/stripe
+                         │ (Connect events; event.account)
+                         ▼
+                   PymtHouse
+                   • account.updated → readiness flags
+                   • checkout.session.completed → ensure OM
+                     customer + subscription (meter only)
+                   • deauthorized → clear connectReady
+```
+
+### Sequence — merchant sells a paid plan
+
+```mermaid
+sequenceDiagram
+  participant B as Builder
+  participant PH as PymtHouse
+  participant S as Stripe (Connect)
+  participant OM as OpenMeter
+
+  B->>PH: Start Account Link onboarding
+  PH->>S: accounts.create + accountLinks.create
+  S-->>B: Hosted onboarding
+  S->>PH: webhook account.updated (Plane B)
+  PH->>PH: Persist charges_enabled, details_submitted
+
+  Note over PH: canSellPaidPlans when connectReady
+
+  B->>PH: Activate priced plan / create checkout
+  PH->>S: Checkout Session on connected account<br/>metadata: clientId, externalUserId, planId
+  S-->>B: Hosted Checkout
+  S->>PH: webhook checkout.session.completed (Plane B)
+  PH->>OM: Ensure customer + create/change subscription<br/>(non-charging billing profile)
+  OM-->>PH: subscription id
+  PH->>PH: Cache subscription / audit payment
+
+  Note over OM: Usage events still settle cost rail<br/>to owner wallet via platform Stripe (Plane A)
+```
+
+### Sequence — owner cost rail (unchanged OM path)
+
+```mermaid
+sequenceDiagram
+  participant O as App owner
+  participant PH as PymtHouse
+  participant OM as OpenMeter
+  participant S as Platform Stripe
+
+  O->>PH: Top-up / attach payment method
+  PH->>OM: apps.stripe.createCheckoutSession (setup)
+  OM->>S: Checkout (platform account)
+  S->>OM: setup_intent.succeeded (Plane A — OM webhook)
+  OM->>OM: Attach cus_ + default PM
+  Note over OM,S: Later invoices charge_automatically<br/>on platform account for network usage
+```
+
+## Event catalogue
+
+### Plane A — OpenMeter-owned (do not duplicate)
+
+Registered when the OM Stripe app is installed. PymtHouse must **not** steal these
+handlers for the same objects unless OM is unreachable and we have an explicit
+failover design.
+
+| Event | Consumer | Effect |
+|---|---|---|
+| `setup_intent.succeeded` | OpenMeter Stripe app | Bind Stripe customer + default PM to OM customer |
+| Invoice / payment sync events | OpenMeter Stripe app | Collect platform invoices for owners |
+
+### Plane B — PymtHouse Connect endpoint
+
+Dashboard: **Developers → Webhooks → Listen to events on Connected accounts**.  
+Env: `STRIPE_WEBHOOK_SECRET` (`whsec_…`), endpoint `POST /webhooks/stripe`.  
+Verify `Stripe-Signature` over the raw body (`src/lib/stripe/webhook.ts`).
+
+| Event | Handler intent | Neon / OM effect |
+|---|---|---|
+| `account.updated` | `applyConnectedAccountWebhookUpdate` | Refresh `stripe_charges_enabled`, `stripe_details_submitted`, `stripe_payouts_enabled`; set `stripe_connect_status` |
+| `account.application.deauthorized` | Clear merchant link | `connectReady=false`; block new paid checkouts; keep metering |
+| `checkout.session.completed` | Retail payment success | Idempotent: map metadata → ensure OM customer + subscription; write `app_user_stripe_customers` |
+| `payment_intent.succeeded` | Alternate / one-shot retail | Same as above when Checkout is not used |
+| `invoice.paid` (Connect) | Recurring retail on connected account | Advance local subscription cache; do **not** also charge via OM Stripe app |
+| `customer.subscription.deleted` (optional) | Merchant cancelled retail sub | Align OM subscription cancel / phase-out |
+
+**Readiness predicate** (activation gate): `charges_enabled && details_submitted`.
+`payouts_enabled` is recorded but **not** required (see activation-gate.md).
+
+**Idempotency:** store processed Stripe `event.id` (or rely on natural upserts keyed
+by `client_id` + `external_user_id` + `openmeter_subscription_id`). Retries are
+normal.
+
+## Anti-patterns (rejected)
+
+1. **OM Checkout for merchant end users on the platform Stripe app** — money lands
+   in the wrong merchant-of-record; Connect fees and branding are wrong.
+2. **Installing one OM Stripe app per Builder** — works for a few partners, not a
+   marketplace; not Connect.
+3. **Charging on Connect and also `charge_automatically` in OM for the same
+   customer** — double charge. Merchant end users must sit on a non-collecting OM
+   billing profile (or have no chargeable PM in OM).
+4. **Gating end-user provisioning on Connect readiness** — cost rail is owner
+   solvency; Connect only gates priced-plan activation and retail Checkout
+   ([activation-gate.md](./activation-gate.md)).
+5. **Treating `application_fee_bps` as cost recovery** — retail can be $0; network
+   cost must always meter to the owner wallet.
+
+## Design decisions and trade-offs
+
+| Decision | Trade-off |
+|---|---|
+| Two webhook planes | Operational clarity; two secrets / two destinations to monitor |
+| OM meters, Connect collects (revenue) | PymtHouse owns Checkout UX and tax edge cases for merchants; OM invoice UI for end users is secondary |
+| Platform OM Stripe app only | Simpler Konnect ops; cannot use OM’s multi-Stripe-app routing for Builders |
+| Account Links only (no OAuth Connect) | Aligns with current `merchant-connect.ts`; OAuth remains legacy path for OM self-hosted API-key install only |
+| Keep OM install API named carefully in UI | Module renamed to `stripe-app-install.ts`; HTTP routes under `/billing/stripe/connect` remain for merchant Connect |
+
+## MoonPay (admin-only; not a user funding rail)
+
+MoonPay / Turnkey on-ramp (`FundAccountOnRampPanel`, `POST …/onramp/sessions`) is
+**platform-admin tooling** for signer refill experiments. It is **not** the developer
+funding UX. Owners attach a payment method on `/billing` via Plane A
+(`POST /api/v1/me/billing/payment-method` → OM `apps.stripe.createCheckoutSession`
+setup). Non-admins receive 403 on on-ramp APIs.
+
+## Future: x402 / stablecoin payments via Stripe
+
+eth/usdc (and other crypto/stablecoin) settlement via Stripe is a **future payment-method
+type** on the existing planes — not a third webhook plane:
+
+| Rail | Where it lands |
+|---|---|
+| Owner cost top-up / PM | Plane A (platform Stripe account + OM Stripe app) |
+| Merchant retail | Plane B (Connected Account Checkout / PaymentIntents) |
+
+No implementation in the current stack. When Stripe exposes the product surface we need
+for x402-style flows, wire it as an additional `payment_method_types` / Checkout option
+and keep the same OM metering + Connect readiness model.
+
+## Related code
+
+- OM app install / Konnect link: `src/lib/openmeter/stripe-app-install.ts`
+- Billing profiles / owners profile: `src/lib/openmeter/billing-profiles.ts`
+- Customer Stripe app data: `src/lib/openmeter/stripe-customer-data.ts`
+- Owner PM attach: `src/lib/openmeter/owner-payment-method.ts`,
+  `POST /api/v1/me/billing/payment-method`
+- Merchant Account Links + Checkout: `src/lib/stripe/merchant-connect.ts`,
+  `src/lib/stripe/connect-accounts.ts`
+- Connect webhook verify / `account.updated`: `src/lib/stripe/webhook.ts`,
+  `src/app/webhooks/stripe/route.ts`
+- Activation gate: `src/lib/activation/app-activation.ts`,
+  [`docs/activation-gate.md`](./activation-gate.md)
+
+## Implementation tasks
+
+### Done or in-flight (stacked PRs)
+
+- [x] Platform OM Stripe app + billing profile foundations (#321)
+- [x] Account Links onboarding + `account.updated` webhook (#322)
+- [x] Connected Checkout helpers (#322)
+- [x] Activation gate separating cost / revenue (#325)
+- [x] Rename OM install module → `stripe-app-install.ts`; expose `billingReady`
+- [x] Payments tab copy: “Merchant Stripe Connect” vs OpenMeter Stripe billing
+- [x] Owner Stripe payment-method attach on `/billing` (Plane A)
+- [x] MoonPay gated to platform admin only
+
+### Remaining
+
+- [ ] Stripe Dashboard: dedicated Connect webhook endpoint (connected-account
+      events) pointed at production `/webhooks/stripe`; document secret rotation.
+- [ ] Expand Plane B beyond `account.updated`: `checkout.session.completed`,
+      `account.application.deauthorized`, and idempotent event ledger.
+- [ ] Guarantee merchant end-user OM customers use a **non-charging** billing
+      profile (assert in `prepareAppCustomerStripeBilling` when
+      `billing_mode=merchant`).
+- [ ] Cutover audit (#324): flag apps where OM would auto-charge the same
+      customer that Connect already bills.
+- [ ] x402 / stablecoin payment methods on Plane A and Plane B (design above).
+
+## Success criteria
+
+1. Owner network invoices collect only via Plane A (platform Stripe + OM app).
+2. Builder retail payments collect only via Plane B (connected account).
+3. No end user is charged twice for the same plan period.
+4. `canSellPaidPlans` tracks Connect readiness from Plane B webhooks, not OM app
+   install status (`billingReady`).
+5. Engineers and UI never call OM app install “Stripe Connect.”
+6. MoonPay is never presented as the primary owner funding path.

--- a/docs/openmeter-railway.md
+++ b/docs/openmeter-railway.md
@@ -162,31 +162,47 @@ Redeploy Vercel. Usage, balance, and allowances return **503** without `OPENMETE
 
 Dashboard / builder-sdk apps use PymtHouse BFF routes; they do not call OpenMeter directly.
 
-### Stripe billing (per developer app)
+### Stripe billing (dual plane)
 
-Starter is a **real synced OpenMeter plan** on a **Stripe billing profile**. Included usage/credits let users start without a payment method. PymtHouse provisions a Stripe Customer (`cus_…`) via `STRIPE_SECRET_KEY` (same Stripe account as Konnect) and upserts Konnect customer billing app-data — no card required for Starter.
+See [`adr-stripe-connect-openmeter-webhooks.md`](./adr-stripe-connect-openmeter-webhooks.md).
 
-Sandbox billing profiles are **not** used at runtime; migrate legacy Sandbox-linked customers with the cutover scripts (separate PR).
+**Plane A — OpenMeter Stripe app (platform cost rail):** Starter is a real synced
+OpenMeter plan on a Stripe billing profile. Included usage/credits let users start
+without a payment method. PymtHouse provisions a Stripe Customer (`cus_…`) via
+`STRIPE_SECRET_KEY` (same Stripe account as Konnect) and upserts Konnect customer
+billing app-data. Owners attach a card from **`/billing` → Add payment method**
+(`POST /api/v1/me/billing/payment-method` → OM Checkout setup) so overage invoices
+can `charge_automatically`.
 
-PymtHouse **Payments** tab → **Connect Stripe** (optional; Starter auto-ensures the app Stripe profile) stores a per-app billing profile in `app_billing_config`.
+**Plane B — Merchant Stripe Connect:** app **Settings → Payments → Merchant Stripe
+Connect** uses Account Links + `/webhooks/stripe` for end-user retail collection.
+Never charges through the OM Stripe app.
+
+**MoonPay:** admin-only signer-refill tooling (`POST …/onramp/sessions` requires
+platform admin). Not shown on owner `/billing` for non-admins.
+
+Sandbox billing profiles are **not** used at runtime; migrate legacy Sandbox-linked
+customers with the cutover scripts (separate PR).
 
 **Konnect (production):**
 
 1. Install Stripe once in [Konnect → Metering & Billing → Settings → Stripe](https://developer.konghq.com/metering-and-billing/stripe-integration/) (API key + billing profile wizard).
 2. Set `OPENMETER_URL`, `OPENMETER_API_KEY`, and `STRIPE_SECRET_KEY` (same Stripe account) on Vercel.
 3. Bootstrap should log `Konnect Stripe app is ready` (not a missing-app warning).
-4. Starter provision auto-creates the per-app Stripe billing profile when missing. Optional: **Settings → Payments → Connect Stripe** or mid-cycle invoicing settings.
+4. Starter provision auto-creates the per-app Stripe billing profile when missing.
 5. Optional: `OPENMETER_STRIPE_APP_ID` when multiple Stripe apps exist in the org.
+6. Configure a Connect webhook (connected-account events) → `/webhooks/stripe` with `STRIPE_WEBHOOK_SECRET`.
 
 **Self-hosted (Railway/OSS):**
 
 1. Ensure `OPENMETER_APPS_BASE_URL` is set on Railway OpenMeter (see §3) and redeploy **openmeter**.
 2. Bootstrap should log `Stripe marketplace OAuth is available` (not a 501 warning).
-3. Set `STRIPE_SECRET_KEY` for customer provisioning. Install Stripe via Connect (OAuth or `{ "stripeSecretKey": "sk_…" }`) so a Stripe app exists in OpenMeter.
-4. After the Stripe app exists, Starter provision auto-ensures the per-app billing profile; invoices/checkout use that profile.
-5. Publish paid plans (OpenMeter plan sync) and use checkout via `POST …/billing/checkout` for end users (collects payment method).
+3. Set `STRIPE_SECRET_KEY` for customer provisioning. Install the OM Stripe app via marketplace API key or OAuth so a Stripe app exists in OpenMeter.
+4. After the Stripe app exists, Starter provision auto-ensures the per-app billing profile; owner PM attach and invoices use that profile.
+5. Publish paid plans (OpenMeter plan sync). Merchant end-user checkout uses Connect (Plane B), not OM Checkout on the platform account.
 
-Stripe redirect URI for each app: `{NEXTAUTH_URL}/api/v1/apps/{clientId}/billing/stripe/callback`.
+Legacy OM Stripe app OAuth callback (self-hosted install): `{NEXTAUTH_URL}/api/v1/apps/{clientId}/billing/stripe/callback`.
+Merchant Connect Account Links use `{NEXTAUTH_URL}/api/v1/apps/{clientId}/billing/stripe/…` Account Link routes.
 
 ## 8. Signer (`pymthouse` Railway service)
 

--- a/drizzle/0033_stripe_connect_merchant.sql
+++ b/drizzle/0033_stripe_connect_merchant.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "stripe_connected_account_id" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "stripe_onboarding_method" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "stripe_charges_enabled" boolean NOT NULL DEFAULT false;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "stripe_payouts_enabled" boolean NOT NULL DEFAULT false;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "stripe_details_submitted" boolean NOT NULL DEFAULT false;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "application_fee_bps" integer NOT NULL DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "connect_payments_only" boolean NOT NULL DEFAULT false;--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "app_user_stripe_customers" (
+  "id" text PRIMARY KEY NOT NULL,
+  "client_id" text NOT NULL,
+  "external_user_id" text NOT NULL,
+  "stripe_connected_account_id" text NOT NULL,
+  "stripe_customer_id" text NOT NULL,
+  "openmeter_customer_id" text,
+  "openmeter_customer_key" text,
+  "created_at" text NOT NULL,
+  "updated_at" text NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_app_user_stripe_customers_unique"
+  ON "app_user_stripe_customers" ("client_id","external_user_id");

--- a/drizzle/0033_stripe_connect_merchant.sql
+++ b/drizzle/0033_stripe_connect_merchant.sql
@@ -16,5 +16,13 @@ CREATE TABLE IF NOT EXISTS "app_user_stripe_customers" (
   "created_at" text NOT NULL,
   "updated_at" text NOT NULL
 );--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "app_user_stripe_customers"
+    ADD CONSTRAINT "app_user_stripe_customers_client_id_developer_apps_id_fk"
+    FOREIGN KEY ("client_id") REFERENCES "public"."developer_apps"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "idx_app_user_stripe_customers_unique"
   ON "app_user_stripe_customers" ("client_id","external_user_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1785400000000,
       "tag": "0032_app_billing_progressive_threshold",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1785500000000,
+      "tag": "0033_stripe_connect_merchant",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/v1/apps/[id]/billing/stripe/account-link/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/account-link/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  canManageMerchantBilling,
+  getAuthorizedProviderApp,
+  merchantBillingForbiddenResponse,
+} from "@/lib/provider-apps";
+import { getAppOpenMeterConfigRow } from "@/lib/openmeter/client-factory";
+import { refreshMerchantAccountLink } from "@/lib/stripe/merchant-connect";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: clientId } = await params;
+  const auth = await getAuthorizedProviderApp(clientId, request);
+  if (!auth) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (!(await canManageMerchantBilling(auth))) {
+    return merchantBillingForbiddenResponse();
+  }
+
+  const omConfig = await getAppOpenMeterConfigRow(auth.app.id);
+  if ((omConfig?.mode || "pymthouse_hosted") !== "pymthouse_hosted") {
+    return NextResponse.json(
+      { error: "Billing connect requires pymthouse_hosted OpenMeter mode" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await refreshMerchantAccountLink(auth.app.id);
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/v1/apps/[id]/billing/stripe/account-link/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/account-link/route.ts
@@ -5,7 +5,9 @@ import {
   merchantBillingForbiddenResponse,
 } from "@/lib/provider-apps";
 import { getAppOpenMeterConfigRow } from "@/lib/openmeter/client-factory";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
 import { refreshMerchantAccountLink } from "@/lib/stripe/merchant-connect";
+import { merchantConnectOAuthErrorCode } from "@/lib/stripe/webhook";
 
 export async function POST(
   request: NextRequest,
@@ -33,6 +35,14 @@ export async function POST(
     return NextResponse.json(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 400 });
+    console.error(
+      "[stripe-account-link]",
+      "refreshMerchantAccountLink failed:",
+      sanitizeForLog(message),
+    );
+    return NextResponse.json(
+      { error: merchantConnectOAuthErrorCode(err) },
+      { status: 400 },
+    );
   }
 }

--- a/src/app/api/v1/apps/[id]/billing/stripe/callback/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthorizedProviderApp } from "@/lib/provider-apps";
-import { completeStripeOAuthCallback } from "@/lib/openmeter/stripe-connect";
+import { completeStripeOAuthCallback } from "@/lib/openmeter/stripe-app-install";
 import { getPublicOrigin } from "@/lib/oidc/issuer-urls";
 
 export async function GET(

--- a/src/app/api/v1/apps/[id]/billing/stripe/connect/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/connect/route.ts
@@ -4,8 +4,11 @@ import {
   getAuthorizedProviderApp,
   merchantBillingForbiddenResponse,
 } from "@/lib/provider-apps";
-import { createStripeOAuthState } from "@/lib/openmeter/stripe-connect";
 import { getAppOpenMeterConfigRow } from "@/lib/openmeter/client-factory";
+import {
+  startMerchantConnect,
+  type MerchantConnectMode,
+} from "@/lib/stripe/merchant-connect";
 
 export async function POST(
   request: NextRequest,
@@ -28,14 +31,44 @@ export async function POST(
     );
   }
 
+  let body: Record<string, unknown> = {};
   try {
-    const { url } = await createStripeOAuthState({
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    body = {};
+  }
+
+  const modeRaw = typeof body.mode === "string" ? body.mode.trim() : "account_link";
+  if (modeRaw === "oauth") {
+    return NextResponse.json(
+      {
+        error:
+          'Standard Connect OAuth is no longer supported. Use mode "account_link" (Stripe Account Links).',
+      },
+      { status: 400 },
+    );
+  }
+  if (modeRaw !== "account_link") {
+    return NextResponse.json(
+      { error: 'mode must be "account_link"' },
+      { status: 400 },
+    );
+  }
+  const mode = modeRaw as MerchantConnectMode;
+
+  try {
+    const result = await startMerchantConnect({
       clientId: auth.app.id,
       userId: auth.userId,
+      mode,
+      email: typeof body.email === "string" ? body.email : undefined,
+      displayName:
+        typeof body.displayName === "string" ? body.displayName : undefined,
     });
-    return NextResponse.json({ url });
+    return NextResponse.json(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    const status = message.includes("STRIPE_") ? 400 : 502;
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/v1/apps/[id]/billing/stripe/connect/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/connect/route.ts
@@ -5,10 +5,12 @@ import {
   merchantBillingForbiddenResponse,
 } from "@/lib/provider-apps";
 import { getAppOpenMeterConfigRow } from "@/lib/openmeter/client-factory";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
 import {
   startMerchantConnect,
   type MerchantConnectMode,
 } from "@/lib/stripe/merchant-connect";
+import { merchantConnectOAuthErrorCode } from "@/lib/stripe/webhook";
 
 export async function POST(
   request: NextRequest,
@@ -68,7 +70,13 @@ export async function POST(
     return NextResponse.json(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const status = message.includes("STRIPE_") ? 400 : 502;
-    return NextResponse.json({ error: message }, { status });
+    console.error(
+      "[stripe-connect]",
+      "startMerchantConnect failed:",
+      sanitizeForLog(message),
+    );
+    const code = merchantConnectOAuthErrorCode(err);
+    const status = code === "connect_misconfigured" ? 400 : 502;
+    return NextResponse.json({ error: code }, { status });
   }
 }

--- a/src/app/api/v1/apps/[id]/billing/stripe/oauth/callback/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/oauth/callback/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPublicOrigin } from "@/lib/oidc/issuer-urls";
+import { completeMerchantConnectOAuth } from "@/lib/stripe/merchant-connect";
+import {
+  merchantConnectOAuthErrorCode,
+  sanitizeStripeOAuthProviderError,
+} from "@/lib/stripe/webhook";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: clientId } = await params;
+  const origin = getPublicOrigin();
+  const paymentsUrl = `${origin}/apps/${encodeURIComponent(clientId)}/settings?tab=payments`;
+
+  const code = request.nextUrl.searchParams.get("code")?.trim() || "";
+  const state = request.nextUrl.searchParams.get("state")?.trim() || "";
+  const oauthError = request.nextUrl.searchParams.get("error")?.trim();
+
+  if (oauthError) {
+    return NextResponse.redirect(
+      `${paymentsUrl}&error=${encodeURIComponent(
+        sanitizeStripeOAuthProviderError(oauthError),
+      )}`,
+    );
+  }
+  if (!code || !state) {
+    return NextResponse.redirect(
+      `${paymentsUrl}&error=${encodeURIComponent("missing_oauth_params")}`,
+    );
+  }
+
+  try {
+    await completeMerchantConnectOAuth({ clientId, state, code });
+    return NextResponse.redirect(`${paymentsUrl}&connected=1`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      "[stripe-connect-oauth]",
+      "callback failed:",
+      sanitizeForLog(message),
+    );
+    return NextResponse.redirect(
+      `${paymentsUrl}&error=${encodeURIComponent(
+        merchantConnectOAuthErrorCode(err),
+      )}`,
+    );
+  }
+}

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -5,6 +5,13 @@ import {
   merchantBillingForbiddenResponse,
 } from "@/lib/provider-apps";
 import {
+  updateAppBillingProfileSettings,
+} from "@/lib/openmeter/billing-profiles";
+import {
+  parseInvoiceThresholdUsdMicrosInput,
+  parseProgressiveBillingInput,
+} from "@/lib/openmeter/billing-profile-settings";
+import {
   disconnectStripeConnect,
   getStripeConnectStatus,
 } from "@/lib/openmeter/stripe-connect";
@@ -38,6 +45,100 @@ export async function GET(
 
   const status = await getStripeConnectStatus(access.auth.app.id);
   return NextResponse.json({ clientId: access.auth.app.id, ...status });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: clientId } = await params;
+  const access = await requireHostedBillingApp(clientId);
+  if (!access) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (access.error) {
+    return access.error;
+  }
+  if (!(await canManageMerchantBilling(access.auth))) {
+    return merchantBillingForbiddenResponse();
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (
+    body.progressiveBilling === undefined &&
+    body.invoiceThresholdUsdMicros === undefined &&
+    body.applicationFeeBps === undefined
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "Provide progressiveBilling, invoiceThresholdUsdMicros, and/or applicationFeeBps to update",
+      },
+      { status: 400 },
+    );
+  }
+
+  let progressiveBilling: boolean | undefined;
+  if (body.progressiveBilling !== undefined) {
+    const parsed = parseProgressiveBillingInput(body.progressiveBilling);
+    if (!parsed.ok) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+    progressiveBilling = parsed.value;
+  }
+
+  let invoiceThresholdUsdMicros: string | null | undefined;
+  if (body.invoiceThresholdUsdMicros !== undefined) {
+    const parsed = parseInvoiceThresholdUsdMicrosInput(body.invoiceThresholdUsdMicros);
+    if (!parsed.ok) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+    invoiceThresholdUsdMicros = parsed.value;
+  }
+
+  let applicationFeeBps: number | undefined;
+  if (body.applicationFeeBps !== undefined) {
+    const n =
+      typeof body.applicationFeeBps === "number"
+        ? body.applicationFeeBps
+        : Number.parseInt(String(body.applicationFeeBps), 10);
+    if (!Number.isInteger(n) || n < 0 || n > 10_000) {
+      return NextResponse.json(
+        { error: "applicationFeeBps must be an integer from 0 to 10000" },
+        { status: 400 },
+      );
+    }
+    applicationFeeBps = n;
+  }
+
+  try {
+    const updated = await updateAppBillingProfileSettings({
+      clientId: access.auth.app.id,
+      progressiveBilling,
+      invoiceThresholdUsdMicros,
+      applicationFeeBps,
+    });
+    const status = await getStripeConnectStatus(access.auth.app.id);
+    return NextResponse.json({
+      clientId: access.auth.app.id,
+      ...status,
+      ...updated,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const httpStatus = message.includes("not configured")
+      ? 400
+      : message.includes("Cannot reach OpenMeter")
+        ? 503
+        : 502;
+    return NextResponse.json({ error: message }, { status: httpStatus });
+  }
 }
 
 export async function DELETE(

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -14,7 +14,7 @@ import {
 import {
   disconnectStripeConnect,
   getStripeConnectStatus,
-} from "@/lib/openmeter/stripe-connect";
+} from "@/lib/openmeter/stripe-app-install";
 import { getAppOpenMeterConfigRow } from "@/lib/openmeter/client-factory";
 
 async function requireHostedBillingApp(clientId: string) {

--- a/src/app/api/v1/apps/[id]/onramp/sessions/[sessionId]/settle/route.ts
+++ b/src/app/api/v1/apps/[id]/onramp/sessions/[sessionId]/settle/route.ts
@@ -1,24 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  canManageMerchantBilling,
-  getAuthorizedProviderApp,
-} from "@/lib/provider-apps";
+import { getAdminUser } from "@/lib/admin-auth";
+import { getAuthorizedProviderApp } from "@/lib/provider-apps";
 import { settleOnRampSession } from "@/lib/onramp/sessions";
 
+/**
+ * MoonPay settle — platform-admin only (signer refill tooling).
+ */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; sessionId: string }> },
 ) {
+  const admin = await getAdminUser(request);
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Only a platform admin can settle MoonPay on-ramp sessions." },
+      { status: 403 },
+    );
+  }
+
   const { id: clientId, sessionId } = await params;
   const access = await getAuthorizedProviderApp(clientId, request);
   if (!access) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-  if (!(await canManageMerchantBilling(access))) {
-    return NextResponse.json(
-      { error: "Only the app owner or platform admin can settle prepaid credits." },
-      { status: 403 },
-    );
   }
 
   try {

--- a/src/app/api/v1/apps/[id]/onramp/sessions/route.ts
+++ b/src/app/api/v1/apps/[id]/onramp/sessions/route.ts
@@ -37,7 +37,7 @@ export async function POST(
       : undefined;
 
   // Admin refill credits the signed-in admin's owner wallet for this app context.
-  const externalUserId = access.userId;
+  const externalUserId = admin.id;
   const fiatCurrencyCode = "USD";
   const fiatAmount = SANDBOX_ONRAMP_USD_AMOUNT;
 

--- a/src/app/api/v1/apps/[id]/onramp/sessions/route.ts
+++ b/src/app/api/v1/apps/[id]/onramp/sessions/route.ts
@@ -1,25 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  canManageMerchantBilling,
-  getAuthorizedProviderApp,
-} from "@/lib/provider-apps";
+import { getAdminUser } from "@/lib/admin-auth";
+import { getAuthorizedProviderApp } from "@/lib/provider-apps";
 import { createOnRampSession } from "@/lib/onramp/sessions";
 import { SANDBOX_ONRAMP_USD_AMOUNT } from "@/lib/onramp/amount";
 
+/**
+ * MoonPay / Turnkey prepaid on-ramp — platform-admin only (signer refill tooling).
+ * Owner funding uses Stripe payment-method attach on /billing instead.
+ */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const admin = await getAdminUser(request);
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Only a platform admin can create MoonPay on-ramp sessions." },
+      { status: 403 },
+    );
+  }
+
   const { id: clientId } = await params;
   const access = await getAuthorizedProviderApp(clientId, request);
   if (!access) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-  if (!(await canManageMerchantBilling(access))) {
-    return NextResponse.json(
-      { error: "Only the app owner or platform admin can fund prepaid credits." },
-      { status: 403 },
-    );
   }
 
   const body = await request.json().catch(() => ({}));
@@ -32,9 +36,8 @@ export async function POST(
       ? body.turnkeyOrganizationId.trim()
       : undefined;
 
-  // Owner-funding only: credit the signed-in owner, never a client-chosen subject.
+  // Admin refill credits the signed-in admin's owner wallet for this app context.
   const externalUserId = access.userId;
-  // Amount is fixed server-side for the sandbox demo (Turnkey status API has no amount).
   const fiatCurrencyCode = "USD";
   const fiatAmount = SANDBOX_ONRAMP_USD_AMOUNT;
 

--- a/src/app/api/v1/me/billing/payment-method/route.ts
+++ b/src/app/api/v1/me/billing/payment-method/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/next-auth-options";
+import { createOwnerPaymentMethodCheckout } from "@/lib/openmeter/owner-payment-method";
+
+/**
+ * Start Stripe Checkout (setup) so the signed-in owner can attach a payment
+ * method for platform cost-rail invoices (OpenMeter Stripe app / Plane A).
+ */
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const sessionUser = session?.user as Record<string, unknown> | undefined;
+  const userId = typeof sessionUser?.id === "string" ? sessionUser.id : undefined;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    body = {};
+  }
+
+  try {
+    const result = await createOwnerPaymentMethodCheckout({
+      ownerUserId: userId,
+      successUrl:
+        typeof body.successUrl === "string" ? body.successUrl : undefined,
+      cancelUrl: typeof body.cancelUrl === "string" ? body.cancelUrl : undefined,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    let status = 502;
+    if (
+      message.includes("STRIPE_") ||
+      message.includes("OPENMETER_") ||
+      message.includes("No ready Stripe") ||
+      message.includes("No Stripe app")
+    ) {
+      status = 400;
+    } else if (message.includes("Cannot reach OpenMeter")) {
+      status = 503;
+    }
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,9 +1,12 @@
 export const dynamic = "force-dynamic";
 
 import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
 
 import FundAccountOnRampPanel from "@/components/apps/FundAccountOnRampPanel";
 import OwnerBillingView from "@/components/OwnerBillingView";
+import OwnerPaymentMethodButton from "@/components/OwnerPaymentMethodButton";
+import { authOptions } from "@/lib/next-auth-options";
 import { getOwnerBillingData } from "@/lib/owner-billing-data";
 
 function isTurnkeyFundingConfigured(): boolean {
@@ -35,12 +38,15 @@ export default async function BillingPage() {
   }
 
   const { data } = result;
+  const session = await getServerSession(authOptions);
+  const sessionUser = session?.user as Record<string, unknown> | undefined;
+  const isAdmin = sessionUser?.role === "admin";
   const fundingClientId = data.fundingClientId?.trim() || null;
-  const fundingAvailable = Boolean(
-    isTurnkeyFundingConfigured() && fundingClientId && data.userId,
+  const adminFundAvailable = Boolean(
+    isAdmin && isTurnkeyFundingConfigured() && fundingClientId && data.userId,
   );
-  const fundPanel =
-    fundingAvailable && fundingClientId ? (
+  const adminFundPanel =
+    adminFundAvailable && fundingClientId ? (
       <FundAccountOnRampPanel
         clientId={fundingClientId}
         ownerExternalUserId={data.userId}
@@ -50,8 +56,10 @@ export default async function BillingPage() {
   return (
     <OwnerBillingView
       data={data}
-      fundPanel={fundPanel}
-      fundingAvailable={fundingAvailable}
+      paymentMethodPanel={
+        data.openMeterConfigured ? <OwnerPaymentMethodButton /> : null
+      }
+      adminFundPanel={adminFundPanel}
     />
   );
 }

--- a/src/app/webhooks/stripe/route.ts
+++ b/src/app/webhooks/stripe/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { applyConnectedAccountWebhookUpdate } from "@/lib/stripe/merchant-connect";
+import {
+  parseStripeAccountUpdated,
+  requireStripeWebhookSecret,
+  verifyStripeWebhookSignature,
+} from "@/lib/stripe/webhook";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
+
+export const runtime = "nodejs";
+
+/**
+ * Stripe Connect platform webhook.
+ * Configure in Dashboard → Developers → Webhooks (Connect events):
+ *   POST {PUBLIC_ORIGIN}/webhooks/stripe
+ * Subscribe at least to `account.updated`.
+ */
+export async function POST(request: Request): Promise<Response> {
+  const tag = "[stripe-webhook]";
+  let secret: string;
+  try {
+    secret = requireStripeWebhookSecret();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(tag, "misconfigured:", sanitizeForLog(message));
+    return NextResponse.json({ error: "webhook_misconfigured" }, { status: 503 });
+  }
+
+  const rawBody = await request.text();
+  const signatureHeader = request.headers.get("stripe-signature");
+  if (
+    !verifyStripeWebhookSignature({
+      rawBody,
+      signatureHeader,
+      secret,
+    })
+  ) {
+    console.warn(tag, "signature rejected");
+    return NextResponse.json({ error: "invalid_signature" }, { status: 401 });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody) as unknown;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  const type =
+    parsed && typeof parsed === "object" && "type" in parsed
+      ? String((parsed as { type?: unknown }).type ?? "")
+      : "";
+
+  if (type !== "account.updated") {
+    return NextResponse.json({ received: true, ignored: type || "unknown" });
+  }
+
+  const account = parseStripeAccountUpdated(rawBody);
+  if (!account) {
+    return NextResponse.json({ received: true, ignored: "malformed_account" });
+  }
+
+  try {
+    const result = await applyConnectedAccountWebhookUpdate(account);
+    return NextResponse.json({
+      received: true,
+      updated: result.updated,
+      clientId: result.clientId ?? null,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(tag, "account.updated failed:", sanitizeForLog(message));
+    return NextResponse.json({ error: "handler_failed" }, { status: 500 });
+  }
+}

--- a/src/components/OwnerBillingView.tsx
+++ b/src/components/OwnerBillingView.tsx
@@ -77,7 +77,7 @@ function SubscriptionCard({
       ) : (
         <p className="mt-3 text-xs text-zinc-600">
           No included usage allowance on this plan — cycle usage settles against prepaid
-          credits.
+          credits or your Stripe payment method.
         </p>
       )}
 
@@ -87,7 +87,7 @@ function SubscriptionCard({
           <span className="font-mono tabular-nums">
             {formatUsdMicrosDisplay(overage.toString())}
           </span>{" "}
-          overage burns prepaid credits
+          overage burns prepaid credits, then invoices your Stripe payment method
         </p>
       ) : null}
 
@@ -102,23 +102,30 @@ function SubscriptionCard({
 
 export default function OwnerBillingView({
   data,
-  fundPanel,
-  fundingAvailable = false,
+  paymentMethodPanel,
+  adminFundPanel,
 }: Readonly<{
   data: OwnerBillingPayload;
-  /** MoonPay on-ramp (credits prepaid balance for your account). */
-  fundPanel?: ReactNode;
-  /** True when Turnkey is configured and an owned app can host on-ramp APIs. */
-  fundingAvailable?: boolean;
+  /** Stripe Checkout (setup) to attach a card for platform overage invoices. */
+  paymentMethodPanel?: ReactNode;
+  /** Admin-only MoonPay signer refill tooling (hidden from normal owners). */
+  adminFundPanel?: ReactNode;
 }>) {
+  const billingActions =
+    paymentMethodPanel || adminFundPanel ? (
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {paymentMethodPanel}
+        {adminFundPanel}
+      </div>
+    ) : null;
+
   return (
     <DashboardLayout>
       <div className="mb-6 sm:mb-8">
         <h1 className="text-xl sm:text-2xl font-bold text-zinc-100">Billing</h1>
         <p className="mt-1 text-xs sm:text-sm text-zinc-500">
           Prepaid credits, active subscriptions, and platform invoices for your account.
-          Plan allowances are tracked per billing cycle; prepaid credits burn only after the
-          allowance is exhausted.
+          Attach a Stripe payment method so overage invoices can charge automatically.
         </p>
         {data.openMeterConfigured ? (
           <p className="mt-2 text-xs text-zinc-600">
@@ -142,12 +149,15 @@ export default function OwnerBillingView({
       {!data.openMeterConfigured ? null : (
         <>
           <section className="mb-8">
-            <div className="mb-3 flex flex-wrap items-center gap-2">
-              <h2 className="text-sm font-semibold text-zinc-200">Prepaid credits</h2>
-              <InfoTooltip
-                label="Credits for your account — usable across all apps you own. Separate from per-cycle plan allowances."
-                wide
-              />
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-sm font-semibold text-zinc-200">Payment &amp; credits</h2>
+                <InfoTooltip
+                  label="Add a Stripe card for automatic overage invoices. Prepaid credits (when present) burn first under credit_then_invoice settlement."
+                  wide
+                />
+              </div>
+              {billingActions}
             </div>
             {hasDisplayablePrepaidCredit(data.creditAllowance) && data.creditAllowance ? (
               <AllowanceStrip
@@ -158,35 +168,14 @@ export default function OwnerBillingView({
                   (sum, row) => sum + row.requestCount,
                   0,
                 )}
-                actions={fundPanel}
               />
             ) : (
-              <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-5">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="min-w-0 flex-1 text-sm text-zinc-500">
-                    <p>
-                      No prepaid credit balance yet. Starter included usage comes from your
-                      plan allowance; this balance stays empty until you top up.
-                    </p>
-                    <p className="mt-2">
-                      {fundingAvailable ? (
-                        <>
-                          Use <span className="text-zinc-300">Fund with MoonPay</span> to add
-                          sandbox prepaid credits — they cover pay-per-use plans with no
-                          allowance, and burn after any plan allowance is exhausted.
-                        </>
-                      ) : (
-                        <>
-                          Prepaid credits appear here after a top-up. MoonPay funding requires
-                          Turnkey Wallet Kit configuration and at least one owned app.
-                        </>
-                      )}
-                    </p>
-                  </div>
-                  {fundPanel ? (
-                    <div className="shrink-0 sm:pt-0.5">{fundPanel}</div>
-                  ) : null}
-                </div>
+              <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-5 text-sm text-zinc-500">
+                <p>
+                  No prepaid credit balance yet. Starter included usage comes from your plan
+                  allowance. Attach a payment method so usage beyond the allowance can be
+                  invoiced on Stripe.
+                </p>
               </div>
             )}
           </section>
@@ -195,7 +184,8 @@ export default function OwnerBillingView({
             <h2 className="mb-3 text-sm font-semibold text-zinc-200">Active subscriptions</h2>
             <p className="mb-4 text-xs text-zinc-600">
               Usage toward each plan&apos;s included allowance for the current cycle. Overage
-              after the allowance burns prepaid credits.
+              after the allowance burns prepaid credits, then charges your Stripe payment
+              method.
             </p>
             {data.subscriptions.length === 0 ? (
               <div className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-6 text-center">
@@ -218,7 +208,7 @@ export default function OwnerBillingView({
             <div className="mb-3 flex flex-wrap items-center gap-2">
               <h2 className="text-sm font-semibold text-zinc-200">Platform invoices</h2>
               <InfoTooltip
-                label="Invoices from PymtHouse to your developer account (prepaid top-ups and overage). End-user invoices billed through your Stripe Connect account appear on each app’s Payments tab."
+                label="Invoices from PymtHouse to your developer account (overage and top-ups). End-user invoices billed through your Merchant Stripe Connect account appear on each app’s Payments tab."
                 wide
               />
             </div>

--- a/src/components/OwnerPaymentMethodButton.tsx
+++ b/src/components/OwnerPaymentMethodButton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Owner billing: start OpenMeter Stripe Checkout (setup) to attach a card for
+ * platform overage invoices.
+ */
+export default function OwnerPaymentMethodButton() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function startCheckout() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/me/billing/payment-method", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        checkoutUrl?: string;
+        error?: string;
+      };
+      if (!res.ok) {
+        throw new Error(body.error || "Could not start Stripe Checkout");
+      }
+      if (!body.checkoutUrl) {
+        throw new Error("Checkout URL missing");
+      }
+      window.location.assign(body.checkoutUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
+        disabled={busy}
+        onClick={() => void startCheckout()}
+      >
+        {busy ? "Opening Stripe…" : "Add payment method"}
+      </button>
+      {error ? (
+        <p className="max-w-xs text-right text-xs text-red-400">{error}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -10,6 +10,7 @@ import { paymentsTabErrorMessage } from "@/lib/stripe/payments-tab-errors";
 
 type StripeStatus = {
   status: string;
+  billingReady?: boolean;
   openmeterStripeAppId: string | null;
   openmeterBillingProfileId: string | null;
   defaultCurrency: string;
@@ -236,11 +237,12 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
       <div className="rounded-lg border p-4 space-y-3">
         <div className="flex items-center justify-between gap-4">
           <div>
-            <h3 className="text-base font-semibold">Stripe Connect</h3>
+            <h3 className="text-base font-semibold">Merchant Stripe Connect</h3>
             <p className="text-sm text-muted-foreground">
-              OpenMeter meters usage and subscriptions. End-user payments go through your
-              merchant Connected Account (direct charges). Complete Stripe-hosted onboarding
-              (Account Links) to create and verify your Connected Account.
+              Collect from your end users on a Stripe Connected Account (Plane B).
+              OpenMeter Stripe billing (Plane A) meters usage and invoices you for
+              network cost separately. Complete Stripe-hosted onboarding (Account Links)
+              to create and verify your Connected Account.
             </p>
           </div>
           <span
@@ -281,6 +283,16 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
             <div>
               <dt className="text-muted-foreground">Payouts</dt>
               <dd>{status?.stripePayoutsEnabled ? "Enabled" : "Paused / pending"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">OpenMeter Stripe billing</dt>
+              <dd>
+                {status?.billingReady
+                  ? "Ready"
+                  : status?.openmeterBillingProfileId
+                    ? "Partial"
+                    : "Not provisioned"}
+              </dd>
             </div>
             <div>
               <dt className="text-muted-foreground">OM billing profile</dt>

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import {
+  sanitizeUsdCentsInput,
+  usdCentsDisplayToMicros,
+  usdMicrosToCentsDisplay,
+} from "@/lib/format-usd-micros";
+import { paymentsTabErrorMessage } from "@/lib/stripe/payments-tab-errors";
 
 type StripeStatus = {
   status: string;
@@ -8,6 +14,15 @@ type StripeStatus = {
   openmeterBillingProfileId: string | null;
   defaultCurrency: string;
   connectedAt: string | null;
+  progressiveBilling?: boolean;
+  invoiceThresholdUsdMicros?: string | null;
+  stripeConnectedAccountId?: string | null;
+  stripeOnboardingMethod?: string | null;
+  stripeChargesEnabled?: boolean;
+  stripePayoutsEnabled?: boolean;
+  stripeDetailsSubmitted?: boolean;
+  applicationFeeBps?: number;
+  connectPaymentsOnly?: boolean;
 };
 
 type InvoiceRow = {
@@ -17,6 +32,7 @@ type InvoiceRow = {
   currency: string;
   totalAmount: string;
   issuedAt?: string;
+  customerKey?: string;
 };
 
 type Props = {
@@ -24,12 +40,37 @@ type Props = {
   canManageBilling: boolean;
 };
 
+/** Only allow redirect to Stripe-hosted Connect / Account Link URLs. */
+function redirectToStripeConnectUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("Invalid Connect URL");
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error("Invalid Connect URL");
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (host !== "connect.stripe.com" && !host.endsWith(".stripe.com")) {
+    throw new Error("Connect URL must be a Stripe host");
+  }
+  // Rebuild from validated host + URL-parser path/query (no open redirect).
+  globalThis.location.assign(
+    `https://${host}${parsed.pathname}${parsed.search}${parsed.hash}`,
+  );
+}
+
 export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>) {
   const [status, setStatus] = useState<StripeStatus | null>(null);
   const [invoices, setInvoices] = useState<InvoiceRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [applicationFeeBps, setApplicationFeeBps] = useState("0");
+  const [progressiveBilling, setProgressiveBilling] = useState(true);
+  const [thresholdDisplay, setThresholdDisplay] = useState("");
+  const [settingsSaved, setSettingsSaved] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -42,7 +83,15 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
       if (!statusRes.ok) {
         throw new Error("Failed to load billing status");
       }
-      setStatus(await statusRes.json());
+      const nextStatus = (await statusRes.json()) as StripeStatus;
+      setStatus(nextStatus);
+      setProgressiveBilling(nextStatus.progressiveBilling ?? true);
+      setApplicationFeeBps(String(nextStatus.applicationFeeBps ?? 0));
+      setThresholdDisplay(
+        nextStatus.invoiceThresholdUsdMicros
+          ? usdMicrosToCentsDisplay(nextStatus.invoiceThresholdUsdMicros)
+          : "",
+      );
       if (invoicesRes.ok) {
         const body = await invoicesRes.json();
         setInvoices(body.items ?? []);
@@ -56,20 +105,53 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
 
   useEffect(() => {
     load().catch(() => undefined);
+    if (globalThis.window !== undefined) {
+      const params = new URLSearchParams(globalThis.location.search);
+      if (params.get("error")) {
+        setError(paymentsTabErrorMessage(params.get("error")));
+      }
+      if (params.get("connected") === "1" || params.get("connect") === "refresh") {
+        load().catch(() => undefined);
+      }
+    }
   }, [load]);
 
-  async function connectStripe() {
+  async function startMerchantOnboarding() {
     setBusy(true);
     setError(null);
     try {
       const res = await fetch(`/api/v1/apps/${appId}/billing/stripe/connect`, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "account_link" }),
       });
       const body = await res.json();
-      if (!res.ok || !body.url) {
+      if (!res.ok) {
         throw new Error(body.error || "Connect failed");
       }
-      globalThis.location.href = body.url;
+      if (!body.url) {
+        throw new Error(body.error || "Connect URL missing");
+      }
+      redirectToStripeConnectUrl(body.url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+    }
+  }
+
+  async function refreshAccountLink() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/v1/apps/${appId}/billing/stripe/account-link`,
+        { method: "POST" },
+      );
+      const body = await res.json();
+      if (!res.ok || !body.url) {
+        throw new Error(body.error || "Account Link failed");
+      }
+      redirectToStripeConnectUrl(body.url);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       setBusy(false);
@@ -98,11 +180,56 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
     }
   }
 
+  async function saveBillingProfileSettings() {
+    setBusy(true);
+    setError(null);
+    setSettingsSaved(null);
+    try {
+      const trimmed = thresholdDisplay.trim();
+      let invoiceThresholdUsdMicros: string | null = null;
+      if (trimmed !== "") {
+        const micros = usdCentsDisplayToMicros(trimmed);
+        if (micros == null) {
+          throw new Error("Invoice threshold must be a valid dollar amount");
+        }
+        invoiceThresholdUsdMicros = micros;
+      }
+      const res = await fetch(`/api/v1/apps/${appId}/billing/stripe`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          progressiveBilling,
+          invoiceThresholdUsdMicros,
+          applicationFeeBps: Number.parseInt(applicationFeeBps, 10) || 0,
+        }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        throw new Error(body.error || "Failed to save billing settings");
+      }
+      setStatus((prev) => (prev ? { ...prev, ...body } : body));
+      setSettingsSaved("Saved");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   if (loading) {
     return <p className="text-sm text-muted-foreground">Loading payments…</p>;
   }
 
-  const connected = status?.status === "connected";
+  const hasAccount = Boolean(status?.stripeConnectedAccountId?.trim());
+  /** Merchant Connect ready (acct_… + charges). Not legacy OM Stripe-app install. */
+  const merchantReady =
+    hasAccount && Boolean(status?.stripeChargesEnabled);
+  const pendingOnboarding = hasAccount && !merchantReady;
+  const hasLegacyOmLink = Boolean(
+    status?.openmeterStripeAppId || status?.openmeterBillingProfileId,
+  );
+  /** Allow clearing legacy OM link and/or merchant Connect account. */
+  const canDisconnect = hasAccount || hasLegacyOmLink;
 
   return (
     <div className="space-y-6">
@@ -111,22 +238,52 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
           <div>
             <h3 className="text-base font-semibold">Stripe Connect</h3>
             <p className="text-sm text-muted-foreground">
-              Connect your Stripe account to bill end users via OpenMeter.
+              OpenMeter meters usage and subscriptions. End-user payments go through your
+              merchant Connected Account (direct charges). Complete Stripe-hosted onboarding
+              (Account Links) to create and verify your Connected Account.
             </p>
           </div>
           <span
             className={`text-xs font-medium px-2 py-1 rounded ${
-              connected ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-700"
+              merchantReady
+                ? "bg-green-100 text-green-800"
+                : pendingOnboarding
+                  ? "bg-amber-100 text-amber-900"
+                  : "bg-gray-100 text-gray-700"
             }`}
           >
-            {status?.status ?? "disconnected"}
+            {hasAccount
+              ? merchantReady
+                ? "connected"
+                : "pending"
+              : hasLegacyOmLink
+                ? "needs merchant connect"
+                : (status?.status ?? "disconnected")}
           </span>
         </div>
 
-        {connected && (
+        {(hasAccount || hasLegacyOmLink || status?.connectedAt) && (
           <dl className="text-sm grid grid-cols-1 sm:grid-cols-2 gap-2">
             <div>
-              <dt className="text-muted-foreground">Billing profile</dt>
+              <dt className="text-muted-foreground">Connected account</dt>
+              <dd className="font-mono text-xs break-all">
+                {status?.stripeConnectedAccountId ?? "—"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Onboarding</dt>
+              <dd>{status?.stripeOnboardingMethod ?? "—"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Charges</dt>
+              <dd>{status?.stripeChargesEnabled ? "Enabled" : "Paused / pending"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Payouts</dt>
+              <dd>{status?.stripePayoutsEnabled ? "Enabled" : "Paused / pending"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">OM billing profile</dt>
               <dd className="font-mono text-xs break-all">
                 {status?.openmeterBillingProfileId ?? "—"}
               </dd>
@@ -139,8 +296,28 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
         )}
 
         {canManageBilling && (
-          <div className="flex gap-2">
-            {connected ? (
+          <div className="flex flex-wrap gap-2">
+            {!hasAccount && (
+              <button
+                type="button"
+                className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
+                disabled={busy}
+                onClick={() => void startMerchantOnboarding()}
+              >
+                Complete onboarding
+              </button>
+            )}
+            {pendingOnboarding && (
+              <button
+                type="button"
+                className="rounded-md border px-3 py-2 text-sm disabled:opacity-50"
+                disabled={busy}
+                onClick={() => void refreshAccountLink()}
+              >
+                Refresh Account Link
+              </button>
+            )}
+            {canDisconnect && (
               <button
                 type="button"
                 className="rounded-md border px-3 py-2 text-sm disabled:opacity-50"
@@ -149,30 +326,138 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
               >
                 Disconnect
               </button>
-            ) : (
+            )}
+          </div>
+        )}
+
+        {canManageBilling && (
+          <div className="pt-2 border-t space-y-3">
+            <label className="block text-sm">
+              <span className="text-muted-foreground">Platform application fee (bps)</span>
+              <input
+                type="number"
+                min={0}
+                max={10000}
+                className="mt-1 w-40 rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+                value={applicationFeeBps}
+                onChange={(e) => setApplicationFeeBps(e.target.value)}
+                disabled={busy}
+              />
+            </label>
+            <p className="text-xs text-muted-foreground">
+              100 bps = 1%. Applied on Connect payment intents / invoices.
+            </p>
+            <div className="flex items-center gap-3">
               <button
                 type="button"
                 className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
                 disabled={busy}
-                onClick={() => void connectStripe()}
+                onClick={() => void saveBillingProfileSettings()}
               >
-                Connect Stripe
+                Save billing settings
               </button>
-            )}
+              {settingsSaved ? (
+                <span className="text-xs text-emerald-600">{settingsSaved}</span>
+              ) : null}
+            </div>
           </div>
         )}
       </div>
 
+      {merchantReady && (
+        <div className="rounded-lg border p-4 space-y-3">
+          <div>
+            <h3 className="text-base font-semibold">Mid-cycle invoicing</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Progressive billing allows OpenMeter to invoice unpaid usage before the
+              billing cycle ends. Set an optional dollar threshold; the clearinghouse
+              worker charges when gathering invoices reach that amount.
+            </p>
+          </div>
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={progressiveBilling}
+              disabled={!canManageBilling || busy}
+              onChange={(e) => {
+                setProgressiveBilling(e.target.checked);
+                setSettingsSaved(null);
+              }}
+            />
+            <span>
+              Enable progressive billing
+              <span className="block text-xs text-muted-foreground">
+                Synced to this app&apos;s OpenMeter billing profile.
+              </span>
+            </span>
+          </label>
+          <div>
+            <label htmlFor="invoice-threshold" className="block text-xs text-muted-foreground mb-1">
+              Invoice when unpaid usage reaches (USD)
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">$</span>
+              <input
+                id="invoice-threshold"
+                type="text"
+                inputMode="decimal"
+                placeholder="e.g. 10.00 (leave blank to disable)"
+                disabled={!canManageBilling || busy || !progressiveBilling}
+                value={thresholdDisplay}
+                onChange={(e) => {
+                  setThresholdDisplay(sanitizeUsdCentsInput(e.target.value));
+                  setSettingsSaved(null);
+                }}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30 disabled:opacity-50"
+              />
+            </div>
+          </div>
+          {canManageBilling && (
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
+                disabled={busy}
+                onClick={() => void saveBillingProfileSettings()}
+              >
+                Save invoicing settings
+              </button>
+              {settingsSaved ? (
+                <span className="text-xs text-emerald-600">{settingsSaved}</span>
+              ) : null}
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="rounded-lg border p-4 space-y-3">
-        <h3 className="text-base font-semibold">Recent invoices</h3>
+        <div>
+          <h3 className="text-base font-semibold">Customer invoices</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            End users billed through this app&apos;s Stripe Connect account. Platform invoices
+            for your developer prepaid wallet are on{" "}
+            <a href="/billing" className="text-emerald-500 hover:text-emerald-400">
+              Billing
+            </a>
+            .
+          </p>
+        </div>
         {invoices.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No invoices yet.</p>
+          <p className="text-sm text-muted-foreground">No customer invoices yet.</p>
         ) : (
           <ul className="divide-y text-sm">
             {invoices.map((inv) => (
               <li key={inv.id} className="py-2 flex justify-between gap-4">
-                <span className="font-mono">{inv.number ?? inv.id}</span>
-                <span>
+                <div className="min-w-0">
+                  <span className="font-mono">{inv.number ?? inv.id}</span>
+                  {inv.customerKey ? (
+                    <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                      {inv.customerKey}
+                    </p>
+                  ) : null}
+                </div>
+                <span className="shrink-0">
                   {inv.totalAmount} {inv.currency} · {inv.status}
                 </span>
               </li>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -559,6 +559,17 @@ export const appBillingConfig = pgTable(
      * clearinghouse threshold worker via invoicePendingLines — not by OpenMeter alone.
      */
     invoiceThresholdUsdMicros: text("invoice_threshold_usd_micros"),
+    /** Merchant Stripe Connected Account id (`acct_…`). */
+    stripeConnectedAccountId: text("stripe_connected_account_id"),
+    /** How the merchant linked: account_link | oauth */
+    stripeOnboardingMethod: text("stripe_onboarding_method"),
+    stripeChargesEnabled: boolean("stripe_charges_enabled").notNull().default(false),
+    stripePayoutsEnabled: boolean("stripe_payouts_enabled").notNull().default(false),
+    stripeDetailsSubmitted: boolean("stripe_details_submitted").notNull().default(false),
+    /** Platform application fee in basis points (0 = none). */
+    applicationFeeBps: integer("application_fee_bps").notNull().default(0),
+    /** After hard cutover: refuse OM Stripe checkout fallback. */
+    connectPaymentsOnly: boolean("connect_payments_only").notNull().default(false),
     connectedAt: text("connected_at"),
     createdAt: text("created_at")
       .notNull()
@@ -587,6 +598,34 @@ export const appBillingOauthStates = pgTable(
       .$defaultFn(() => new Date().toISOString()),
   },
   (t) => [index("idx_app_billing_oauth_states_expires").on(t.expiresAt)],
+);
+
+/** Maps end-users to merchant-owned Stripe customers on Connected Accounts. */
+export const appUserStripeCustomers = pgTable(
+  "app_user_stripe_customers",
+  {
+    id: text("id").primaryKey(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => developerApps.id),
+    externalUserId: text("external_user_id").notNull(),
+    stripeConnectedAccountId: text("stripe_connected_account_id").notNull(),
+    stripeCustomerId: text("stripe_customer_id").notNull(),
+    openmeterCustomerId: text("openmeter_customer_id"),
+    openmeterCustomerKey: text("openmeter_customer_key"),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    updatedAt: text("updated_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (t) => [
+    uniqueIndex("idx_app_user_stripe_customers_unique").on(
+      t.clientId,
+      t.externalUserId,
+    ),
+  ],
 );
 
 /** Idempotency audit for OpenMeter signed-ticket ingest (not balance source). */

--- a/src/lib/openmeter/billing-profiles.test.ts
+++ b/src/lib/openmeter/billing-profiles.test.ts
@@ -3,9 +3,28 @@ import test from "node:test";
 import type { OpenMeter } from "@openmeter/sdk";
 import {
   ensureOwnersBillingProfile,
+  isAppBillingReady,
   resetOwnersBillingProfileCacheForTests,
 } from "./billing-profiles";
 import { __testSetHostedOpenMeterClient, resetHostedOpenMeterClientForTests } from "./client";
+
+test("isAppBillingReady requires Stripe app id and billing profile id", () => {
+  assert.equal(isAppBillingReady(null), false);
+  assert.equal(
+    isAppBillingReady({
+      openmeterStripeAppId: "app",
+      openmeterBillingProfileId: null,
+    }),
+    false,
+  );
+  assert.equal(
+    isAppBillingReady({
+      openmeterStripeAppId: "app",
+      openmeterBillingProfileId: "profile",
+    }),
+    true,
+  );
+});
 
 test("ensureOwnersBillingProfile returns OPENMETER_OWNERS_BILLING_PROFILE_ID when set", async (t) => {
   resetOwnersBillingProfileCacheForTests();

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -149,14 +149,26 @@ export async function getAppBillingConfig(clientId: string) {
   return rows[0] ?? null;
 }
 
-/** Stripe Connect completed and wired into OpenMeter billing profiles. */
+/**
+ * Platform OpenMeter Stripe billing is ready (Plane A): org Stripe app +
+ * tenant billing profile. Distinct from merchant Stripe Connect readiness.
+ */
+export function isAppBillingReady(
+  config: {
+    openmeterStripeAppId?: string | null;
+    openmeterBillingProfileId?: string | null;
+  } | null | undefined,
+): boolean {
+  return (
+    Boolean(config?.openmeterStripeAppId?.trim()) &&
+    Boolean(config?.openmeterBillingProfileId?.trim())
+  );
+}
+
+/** @deprecated Prefer {@link isAppBillingReady}; name kept for existing call sites. */
 export async function isStripeBillingEnabledForApp(clientId: string): Promise<boolean> {
   const config = await getAppBillingConfig(clientId);
-  return (
-    config?.stripeConnectStatus === "connected" &&
-    Boolean(config.openmeterStripeAppId?.trim()) &&
-    Boolean(config.openmeterBillingProfileId?.trim())
-  );
+  return isAppBillingReady(config);
 }
 
 export async function ensureTenantBillingProfile(input: {
@@ -237,14 +249,12 @@ export async function ensureAppStripeBillingReady(input: {
   openmeterBillingProfileId: string;
 }> {
   const existing = await getAppBillingConfig(input.clientId);
-  if (
-    existing?.stripeConnectStatus === "connected" &&
-    existing.openmeterStripeAppId?.trim() &&
-    existing.openmeterBillingProfileId?.trim()
-  ) {
+  const existingStripeAppId = existing?.openmeterStripeAppId?.trim();
+  const existingProfileId = existing?.openmeterBillingProfileId?.trim();
+  if (existingStripeAppId && existingProfileId) {
     return {
-      openmeterStripeAppId: existing.openmeterStripeAppId,
-      openmeterBillingProfileId: existing.openmeterBillingProfileId,
+      openmeterStripeAppId: existingStripeAppId,
+      openmeterBillingProfileId: existingProfileId,
     };
   }
 

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -504,9 +504,11 @@ export async function updateAppBillingProfileSettings(input: {
   clientId: string;
   progressiveBilling?: boolean;
   invoiceThresholdUsdMicros?: string | null;
+  applicationFeeBps?: number;
 }): Promise<{
   progressiveBilling: boolean;
   invoiceThresholdUsdMicros: string | null;
+  applicationFeeBps: number;
 }> {
   let existing = await getAppBillingConfig(input.clientId);
   if (!existing) {
@@ -525,6 +527,10 @@ export async function updateAppBillingProfileSettings(input: {
     input.invoiceThresholdUsdMicros === undefined
       ? existing.invoiceThresholdUsdMicros
       : input.invoiceThresholdUsdMicros;
+  const applicationFeeBps =
+    input.applicationFeeBps === undefined
+      ? (existing.applicationFeeBps ?? 0)
+      : input.applicationFeeBps;
 
   const progressiveChanged =
     input.progressiveBilling !== undefined &&
@@ -544,11 +550,13 @@ export async function updateAppBillingProfileSettings(input: {
   await upsertAppBillingConfig(input.clientId, {
     progressiveBilling,
     invoiceThresholdUsdMicros,
+    applicationFeeBps,
   });
 
   return {
     progressiveBilling,
     invoiceThresholdUsdMicros: invoiceThresholdUsdMicros ?? null,
+    applicationFeeBps,
   };
 }
 

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -546,15 +546,14 @@ export async function updateAppBillingProfileSettings(input: {
     input.progressiveBilling !== undefined &&
     input.progressiveBilling !== existing.progressiveBilling;
 
-  if (
-    progressiveChanged &&
-    existing.stripeConnectStatus === "connected" &&
-    existing.openmeterBillingProfileId?.trim()
-  ) {
-    await syncProgressiveBillingToOpenMeterProfile({
-      profileId: existing.openmeterBillingProfileId,
-      progressiveBilling,
-    });
+  if (progressiveChanged && isAppBillingReady(existing)) {
+    const profileId = existing.openmeterBillingProfileId?.trim();
+    if (profileId) {
+      await syncProgressiveBillingToOpenMeterProfile({
+        profileId,
+        progressiveBilling,
+      });
+    }
   }
 
   await upsertAppBillingConfig(input.clientId, {

--- a/src/lib/openmeter/invoices.ts
+++ b/src/lib/openmeter/invoices.ts
@@ -68,12 +68,10 @@ async function resolveOwnerCustomerIdsByUserId(
     buildOwnerCustomerKey(ownerId),
     buildOwnerWireSubject(ownerId),
   ];
-  const ids: string[] = [];
-  for (const key of keys) {
-    const id = await findCustomerIdByExactKey(client, key);
-    if (id) ids.push(id);
-  }
-  return [...new Set(ids)];
+  const ids = await Promise.all(
+    keys.map((key) => findCustomerIdByExactKey(client, key)),
+  );
+  return [...new Set(ids.filter((id): id is string => Boolean(id)))];
 }
 
 async function resolveOwnerCustomerIdsForApp(

--- a/src/lib/openmeter/konnect-billing-profiles.test.ts
+++ b/src/lib/openmeter/konnect-billing-profiles.test.ts
@@ -17,7 +17,7 @@ import {
 import {
   createStripeOAuthState,
   StripeOAuthUnavailableError,
-} from "./stripe-connect";
+} from "./stripe-app-install";
 
 test("buildKonnectCreateBillingProfileBody uses Konnect snake_case supplier address", () => {
   const body = buildKonnectCreateBillingProfileBody({

--- a/src/lib/openmeter/owner-payment-method.ts
+++ b/src/lib/openmeter/owner-payment-method.ts
@@ -53,6 +53,7 @@ export async function createOwnerPaymentMethodCheckout(input: {
     options: {
       successURL: success,
       cancelURL: cancel,
+      currency: "USD",
     },
   });
   if (!checkout?.url) {

--- a/src/lib/openmeter/owner-payment-method.ts
+++ b/src/lib/openmeter/owner-payment-method.ts
@@ -1,0 +1,68 @@
+import { getPublicOrigin } from "@/lib/oidc/issuer-urls";
+import { getHostedAdminClient } from "./admin-client";
+import { prepareOwnerCustomerStripeBilling } from "./billing-profiles";
+import {
+  ensureOwnerCustomer,
+  listOwnedPublicClientIds,
+} from "./customers";
+import { getKonnectDefaultPaymentMethodId } from "./stripe-customer-data";
+
+export type OwnerPaymentMethodCheckoutResult = {
+  checkoutUrl: string;
+  sessionId: string | null;
+  customerId: string;
+  /** True when Konnect already has a default payment method on file. */
+  hasDefaultPaymentMethod: boolean;
+};
+
+/**
+ * Start an OpenMeter Stripe Checkout session (always setup mode) so the owner
+ * can attach a card for Plane A overage invoices (charge_automatically).
+ */
+export async function createOwnerPaymentMethodCheckout(input: {
+  ownerUserId: string;
+  successUrl?: string;
+  cancelUrl?: string;
+}): Promise<OwnerPaymentMethodCheckoutResult> {
+  const ownerUserId = input.ownerUserId.trim();
+  if (!ownerUserId) {
+    throw new Error("ownerUserId is required");
+  }
+
+  const client = getHostedAdminClient();
+  const publicClientIds = await listOwnedPublicClientIds(ownerUserId);
+  const customer = await ensureOwnerCustomer(
+    client,
+    ownerUserId,
+    publicClientIds,
+  );
+  await prepareOwnerCustomerStripeBilling({
+    client,
+    customerId: customer.id,
+    customerKey: customer.key,
+  });
+
+  const defaultPm = await getKonnectDefaultPaymentMethodId(customer.id);
+  const origin = getPublicOrigin();
+  const success =
+    input.successUrl?.trim() || `${origin}/billing?pm=attached`;
+  const cancel = input.cancelUrl?.trim() || `${origin}/billing`;
+
+  const checkout = await client.apps.stripe.createCheckoutSession({
+    customer: { id: customer.id },
+    options: {
+      successURL: success,
+      cancelURL: cancel,
+    },
+  });
+  if (!checkout?.url) {
+    throw new Error("Stripe checkout session URL unavailable");
+  }
+
+  return {
+    checkoutUrl: checkout.url,
+    sessionId: checkout.sessionId ?? null,
+    customerId: customer.id,
+    hasDefaultPaymentMethod: Boolean(defaultPm),
+  };
+}

--- a/src/lib/openmeter/stripe-app-install.test.ts
+++ b/src/lib/openmeter/stripe-app-install.test.ts
@@ -17,7 +17,7 @@ import {
   getStripeConnectStatus,
   parseStripeAccountIdFromConflict,
   purgeExpiredOAuthStates,
-} from "./stripe-connect";
+} from "./stripe-app-install";
 import { test } from "@/test-utils/db-guard";
 import {
   cleanupTestApp,
@@ -249,6 +249,7 @@ test("getStripeConnectStatus defaults to disconnected when no config row", async
   t.after(() => cleanupTestApp(seeded));
   const status = await getStripeConnectStatus(seeded.clientId);
   assert.equal(status.status, "disconnected");
+  assert.equal(status.billingReady, false);
   assert.equal(status.defaultCurrency, "USD");
 });
 
@@ -271,6 +272,7 @@ test("getStripeConnectStatus uses merchant account flags, not legacy OM status",
 
   let status = await getStripeConnectStatus(seeded.clientId);
   assert.equal(status.status, "disconnected");
+  assert.equal(status.billingReady, true);
   assert.equal(status.stripeConnectedAccountId, null);
   assert.equal(status.openmeterStripeAppId, "om_legacy");
 

--- a/src/lib/openmeter/stripe-app-install.ts
+++ b/src/lib/openmeter/stripe-app-install.ts
@@ -15,6 +15,14 @@ import { isOpenMeterConflictError } from "./plan-errors";
 import { shouldUseKonnectRoutes } from "./route-mode";
 import type { OpenMeter } from "@openmeter/sdk";
 
+/**
+ * OpenMeter / Konnect Stripe **app** install helpers (Plane A — platform cost rail).
+ *
+ * Renamed from `stripe-connect.ts` to avoid conflating this with merchant Stripe
+ * Connect Account Links (Plane B — `src/lib/stripe/merchant-connect.ts`).
+ * HTTP routes under `/billing/stripe/connect` remain for Connect onboarding.
+ */
+
 const OAUTH_STATE_TTL_MS = 15 * 60 * 1000;
 
 function stripeConnectCallbackUrl(clientId: string): string {
@@ -383,10 +391,18 @@ export async function getStripeConnectStatus(clientId: string) {
       : "pending"
     : "disconnected";
 
+  const openmeterStripeAppId = config?.openmeterStripeAppId ?? null;
+  const openmeterBillingProfileId = config?.openmeterBillingProfileId ?? null;
+  // Plane A readiness — independent of merchant Connect (Plane B).
+  const billingReady = Boolean(
+    openmeterStripeAppId?.trim() && openmeterBillingProfileId?.trim(),
+  );
+
   return {
     status,
-    openmeterStripeAppId: config?.openmeterStripeAppId ?? null,
-    openmeterBillingProfileId: config?.openmeterBillingProfileId ?? null,
+    billingReady,
+    openmeterStripeAppId,
+    openmeterBillingProfileId,
     defaultCurrency: config?.defaultCurrency ?? "USD",
     connectedAt: config?.connectedAt ?? null,
     progressiveBilling: config?.progressiveBilling ?? true,

--- a/src/lib/openmeter/stripe-connect.test.ts
+++ b/src/lib/openmeter/stripe-connect.test.ts
@@ -150,7 +150,9 @@ test("connectStripeWithApiKey installs Stripe app and writes billing config", as
 
   assert.equal(installedName, `pymthouse-${seeded.clientId}`);
   const status = await getStripeConnectStatus(seeded.clientId);
-  assert.equal(status.status, "connected");
+  // Legacy OM Stripe-app install is not merchant Connect-ready.
+  assert.equal(status.status, "disconnected");
+  assert.equal(status.stripeConnectedAccountId, null);
   assert.equal(status.openmeterStripeAppId, "om_stripe_1");
   assert.equal(status.openmeterBillingProfileId, "om_profile_1");
   assert.ok(status.connectedAt);
@@ -195,7 +197,8 @@ test("connectStripeWithApiKey reuses existing Stripe app on OpenMeter conflict",
 
   const status = await getStripeConnectStatus(seeded.clientId);
   assert.equal(status.openmeterStripeAppId, "om_existing_stripe");
-  assert.equal(status.status, "connected");
+  assert.equal(status.status, "disconnected");
+  assert.equal(status.stripeConnectedAccountId, null);
 });
 
 test("disconnectStripeConnect clears config and uninstalls on self-hosted", async (t) => {
@@ -249,7 +252,7 @@ test("getStripeConnectStatus defaults to disconnected when no config row", async
   assert.equal(status.defaultCurrency, "USD");
 });
 
-test("getStripeConnectStatus returns OpenMeter billing profile connection status", async (t) => {
+test("getStripeConnectStatus uses merchant account flags, not legacy OM status", async (t) => {
   const seeded = await seedDeveloperAppWithClient();
   t.after(() => cleanupTestApp(seeded));
 
@@ -266,11 +269,32 @@ test("getStripeConnectStatus returns OpenMeter billing profile connection status
     updatedAt: now,
   });
 
-  const status = await getStripeConnectStatus(seeded.clientId);
-  assert.equal(status.status, "connected");
+  let status = await getStripeConnectStatus(seeded.clientId);
+  assert.equal(status.status, "disconnected");
+  assert.equal(status.stripeConnectedAccountId, null);
   assert.equal(status.openmeterStripeAppId, "om_legacy");
-  assert.equal(status.openmeterBillingProfileId, "om_profile_legacy");
-  assert.equal(status.progressiveBilling, true);
+
+  await db
+    .update(appBillingConfig)
+    .set({
+      stripeConnectedAccountId: "acct_pending",
+      stripeChargesEnabled: false,
+      stripeOnboardingMethod: "account_link",
+    })
+    .where(eq(appBillingConfig.clientId, seeded.clientId));
+
+  status = await getStripeConnectStatus(seeded.clientId);
+  assert.equal(status.status, "pending");
+  assert.equal(status.stripeConnectedAccountId, "acct_pending");
+
+  await db
+    .update(appBillingConfig)
+    .set({ stripeChargesEnabled: true })
+    .where(eq(appBillingConfig.clientId, seeded.clientId));
+
+  status = await getStripeConnectStatus(seeded.clientId);
+  assert.equal(status.status, "connected");
+  assert.equal(status.stripeChargesEnabled, true);
 });
 
 test("purgeExpiredOAuthStates deletes only expired rows", async (t) => {
@@ -393,7 +417,8 @@ test("connectStripeOnKonnect finalizes via org Stripe app id", async (t) => {
 
   await connectStripeOnKonnect({ clientId: seeded.clientId, name: "Acme" });
   const status = await getStripeConnectStatus(seeded.clientId);
-  assert.equal(status.status, "connected");
+  assert.equal(status.status, "disconnected");
+  assert.equal(status.stripeConnectedAccountId, null);
   assert.equal(status.openmeterStripeAppId, "01KONNECTSTRIPE000000000001");
   assert.equal(status.openmeterBillingProfileId, "01KONNECTPROFILE0000000001");
 });

--- a/src/lib/openmeter/stripe-connect.ts
+++ b/src/lib/openmeter/stripe-connect.ts
@@ -345,6 +345,12 @@ export async function disconnectStripeConnect(clientId: string): Promise<void> {
     openmeterStripeAppId: null,
     openmeterBillingProfileId: null,
     connectedAt: null,
+    stripeConnectedAccountId: null,
+    stripeOnboardingMethod: null,
+    stripeChargesEnabled: false,
+    stripePayoutsEnabled: false,
+    stripeDetailsSubmitted: false,
+    connectPaymentsOnly: false,
   });
 }
 
@@ -354,19 +360,43 @@ export async function purgeExpiredOAuthStates(): Promise<void> {
 }
 
 export async function getStripeConnectStatus(clientId: string) {
+  const { syncMerchantConnectStatus } = await import(
+    "@/lib/stripe/merchant-connect"
+  );
+  try {
+    await syncMerchantConnectStatus(clientId);
+  } catch {
+    /* best-effort refresh */
+  }
   const row = await db
     .select()
     .from(appBillingConfig)
     .where(eq(appBillingConfig.clientId, clientId))
     .limit(1);
   const config = row[0];
+  const accountId = config?.stripeConnectedAccountId?.trim() || null;
+  // Merchant Connect only — do not treat legacy OpenMeter Stripe-app installs
+  // (stripe_connect_status=connected, no acct_…) as merchant-ready.
+  const status = accountId
+    ? config?.stripeChargesEnabled
+      ? "connected"
+      : "pending"
+    : "disconnected";
+
   return {
-    status: config?.stripeConnectStatus ?? "disconnected",
+    status,
     openmeterStripeAppId: config?.openmeterStripeAppId ?? null,
     openmeterBillingProfileId: config?.openmeterBillingProfileId ?? null,
     defaultCurrency: config?.defaultCurrency ?? "USD",
     connectedAt: config?.connectedAt ?? null,
     progressiveBilling: config?.progressiveBilling ?? true,
     invoiceThresholdUsdMicros: config?.invoiceThresholdUsdMicros ?? null,
+    stripeConnectedAccountId: accountId,
+    stripeOnboardingMethod: config?.stripeOnboardingMethod ?? null,
+    stripeChargesEnabled: config?.stripeChargesEnabled ?? false,
+    stripePayoutsEnabled: config?.stripePayoutsEnabled ?? false,
+    stripeDetailsSubmitted: config?.stripeDetailsSubmitted ?? false,
+    applicationFeeBps: config?.applicationFeeBps ?? 0,
+    connectPaymentsOnly: config?.connectPaymentsOnly ?? false,
   };
 }

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -180,6 +180,12 @@ export async function createEndUserCheckout(input: {
   });
 
   const billingConfig = await getAppBillingConfig(input.clientId);
+  const merchantReady = isMerchantConnectPaymentsReady(billingConfig);
+  if (!merchantReady && connectPaymentsOnlyEnabled(billingConfig)) {
+    throw new Error(
+      "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
+    );
+  }
 
   const planKey = buildOpenMeterPlanKey(input.clientId, plan.id);
   const subscription = await client.subscriptions.create({
@@ -203,7 +209,7 @@ export async function createEndUserCheckout(input: {
   let checkoutUrl: string;
   let stripeCheckoutSessionId: string | null = null;
 
-  if (isMerchantConnectPaymentsReady(billingConfig)) {
+  if (merchantReady) {
     const connectCheckout = await createMerchantConnectCheckoutForUser({
       clientId: input.clientId,
       externalUserId: input.externalUserId,
@@ -214,10 +220,6 @@ export async function createEndUserCheckout(input: {
     });
     checkoutUrl = connectCheckout.checkoutUrl;
     stripeCheckoutSessionId = connectCheckout.sessionId;
-  } else if (connectPaymentsOnlyEnabled(billingConfig)) {
-    throw new Error(
-      "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
-    );
   } else {
     const checkout = await client.apps.stripe.createCheckoutSession({
       customer: { id: customer.id },

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -23,6 +23,11 @@ import {
   resolveLocalPlanIdFromOpenMeterSubscription,
 } from "./subscription-read";
 import { getKonnectDefaultPaymentMethodId } from "./stripe-customer-data";
+import {
+  connectPaymentsOnlyEnabled,
+  createMerchantConnectCheckoutForUser,
+  isMerchantConnectPaymentsReady,
+} from "@/lib/stripe/merchant-connect";
 
 function parsePlanPriceAmount(raw: string | null | undefined): number {
   const n = Number.parseFloat(String(raw ?? "0").trim() || "0");
@@ -198,18 +203,35 @@ export async function createEndUserCheckout(input: {
   let checkoutUrl: string;
   let stripeCheckoutSessionId: string | null = null;
 
-  const checkout = await client.apps.stripe.createCheckoutSession({
-    customer: { id: customer.id },
-    options: {
-      successURL: success,
-      cancelURL: cancel,
-    },
-  });
-  if (!checkout?.url) {
-    throw new Error("Stripe checkout session URL unavailable");
+  if (isMerchantConnectPaymentsReady(billingConfig)) {
+    const connectCheckout = await createMerchantConnectCheckoutForUser({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+      successUrl: success,
+      cancelUrl: cancel,
+      openmeterCustomerId: customer.id,
+      openmeterCustomerKey: customer.key,
+    });
+    checkoutUrl = connectCheckout.checkoutUrl;
+    stripeCheckoutSessionId = connectCheckout.sessionId;
+  } else if (connectPaymentsOnlyEnabled(billingConfig)) {
+    throw new Error(
+      "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
+    );
+  } else {
+    const checkout = await client.apps.stripe.createCheckoutSession({
+      customer: { id: customer.id },
+      options: {
+        successURL: success,
+        cancelURL: cancel,
+      },
+    });
+    if (!checkout?.url) {
+      throw new Error("Stripe checkout session URL unavailable");
+    }
+    checkoutUrl = checkout.url;
+    stripeCheckoutSessionId = checkout.sessionId ?? null;
   }
-  checkoutUrl = checkout.url;
-  stripeCheckoutSessionId = checkout.sessionId ?? null;
 
   await upsertNeonSubscriptionCache({
     clientId: input.clientId,
@@ -343,20 +365,38 @@ export async function changeAppUserSubscriptionPlan(input: {
       billingConfig?.checkoutCancelUrl ||
       `${origin}/apps/${input.clientId}/settings?tab=payments`;
 
-    const paymentMethodId = await getKonnectDefaultPaymentMethodId(customer.id);
-    if (!paymentMethodId) {
-      const checkout = await client.apps.stripe.createCheckoutSession({
-        customer: { id: customer.id },
-        options: {
-          successURL: success,
-          cancelURL: cancel,
-        },
+    if (isMerchantConnectPaymentsReady(billingConfig)) {
+      const connectCheckout = await createMerchantConnectCheckoutForUser({
+        clientId: input.clientId,
+        externalUserId: input.externalUserId,
+        successUrl: success,
+        cancelUrl: cancel,
+        openmeterCustomerId: customer.id,
+        openmeterCustomerKey: customer.key,
       });
-      if (!checkout?.url) {
-        throw new Error("Stripe checkout session URL unavailable");
+      checkoutUrl = connectCheckout.checkoutUrl;
+      stripeCheckoutSessionId = connectCheckout.sessionId;
+    } else {
+      const paymentMethodId = await getKonnectDefaultPaymentMethodId(customer.id);
+      if (!paymentMethodId) {
+        if (connectPaymentsOnlyEnabled(billingConfig)) {
+          throw new Error(
+            "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
+          );
+        }
+        const checkout = await client.apps.stripe.createCheckoutSession({
+          customer: { id: customer.id },
+          options: {
+            successURL: success,
+            cancelURL: cancel,
+          },
+        });
+        if (!checkout?.url) {
+          throw new Error("Stripe checkout session URL unavailable");
+        }
+        checkoutUrl = checkout.url;
+        stripeCheckoutSessionId = checkout.sessionId ?? null;
       }
-      checkoutUrl = checkout.url;
-      stripeCheckoutSessionId = checkout.sessionId ?? null;
     }
   }
 

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -339,6 +339,48 @@ async function resolvePlanName(input: {
   };
 }
 
+async function loadPlanKeyToLocalId(): Promise<Map<string, string>> {
+  const allPlans = await db
+    .select({
+      id: plans.id,
+      clientId: plans.clientId,
+    })
+    .from(plans);
+  const index = new Map<string, string>();
+  for (const plan of allPlans) {
+    index.set(buildOpenMeterPlanKey(plan.clientId, plan.id), plan.id);
+  }
+  return index;
+}
+
+function withSoftTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T,
+  label: string,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      console.warn(`owner-billing: ${label} timed out after ${ms}ms`);
+      resolve(fallback);
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        console.warn(
+          `owner-billing: ${label} failed`,
+          err instanceof Error ? err.message : String(err),
+        );
+        resolve(fallback);
+      },
+    );
+  });
+}
+
 async function mapSubscriptionRow(input: {
   client: OpenMeter;
   subscription: OpenMeterSubscriptionView;
@@ -346,6 +388,7 @@ async function mapSubscriptionRow(input: {
   cycle: { start: string; end: string };
   ownerUserId: string;
   ownedApps: OwnedApp[];
+  planKeyToLocalId: Map<string, string>;
 }): Promise<OwnerBillingSubscriptionRow> {
   const localPlanId = input.candidate.appPublicClientId
     ? await resolveLocalPlanIdFromOpenMeterSubscription(
@@ -357,18 +400,8 @@ async function mapSubscriptionRow(input: {
   // Owner-wallet subscriptions may still map via plan key across owned apps.
   let resolvedLocalPlanId = localPlanId;
   if (!resolvedLocalPlanId && input.subscription.planKey) {
-    const allPlans = await db
-      .select({
-        id: plans.id,
-        clientId: plans.clientId,
-      })
-      .from(plans);
-    for (const plan of allPlans) {
-      if (buildOpenMeterPlanKey(plan.clientId, plan.id) === input.subscription.planKey) {
-        resolvedLocalPlanId = plan.id;
-        break;
-      }
-    }
+    resolvedLocalPlanId =
+      input.planKeyToLocalId.get(input.subscription.planKey) ?? null;
   }
 
   const { planName, isStarterDefault } = await resolvePlanName({
@@ -488,37 +521,56 @@ export async function listOwnerActiveSubscriptions(
   const client = getHostedAdminClient();
   const cycleBounds = calendarMonthBoundsUtc(new Date());
   const cycle = { start: cycleBounds.start, end: cycleBounds.end };
-  const ownedApps = await listOwnedApps(trimmed);
+  const [ownedApps, planKeyToLocalId] = await Promise.all([
+    listOwnedApps(trimmed),
+    loadPlanKeyToLocalId(),
+  ]);
   const candidates = buildCustomerCandidates(trimmed, ownedApps);
 
+  const perCandidate = await Promise.all(
+    candidates.map(async (candidate) => {
+      const customerId = await resolveCustomerIdForCandidate({ client, candidate });
+      if (!customerId) {
+        return [] as Array<{
+          candidate: CustomerCandidate;
+          subscription: OpenMeterSubscriptionView;
+        }>;
+      }
+      const active = await listActiveSubscriptionsForCustomer({
+        client,
+        customerId,
+        customerKey: candidate.customerKey,
+      });
+      return active.map((subscription) => ({ candidate, subscription }));
+    }),
+  );
+
   const seenSubscriptionIds = new Set<string>();
-  const subscriptions: OwnerBillingSubscriptionRow[] = [];
-
-  for (const candidate of candidates) {
-    const customerId = await resolveCustomerIdForCandidate({ client, candidate });
-    if (!customerId) continue;
-
-    const active = await listActiveSubscriptionsForCustomer({
-      client,
-      customerId,
-      customerKey: candidate.customerKey,
-    });
-
-    for (const subscription of active) {
-      if (seenSubscriptionIds.has(subscription.id)) continue;
-      seenSubscriptionIds.add(subscription.id);
-      subscriptions.push(
-        await mapSubscriptionRow({
-          client,
-          subscription,
-          candidate,
-          cycle,
-          ownerUserId: trimmed,
-          ownedApps,
-        }),
-      );
+  const unique: Array<{
+    candidate: CustomerCandidate;
+    subscription: OpenMeterSubscriptionView;
+  }> = [];
+  for (const group of perCandidate) {
+    for (const entry of group) {
+      if (seenSubscriptionIds.has(entry.subscription.id)) continue;
+      seenSubscriptionIds.add(entry.subscription.id);
+      unique.push(entry);
     }
   }
+
+  const subscriptions = await Promise.all(
+    unique.map(({ candidate, subscription }) =>
+      mapSubscriptionRow({
+        client,
+        subscription,
+        candidate,
+        cycle,
+        ownerUserId: trimmed,
+        ownedApps,
+        planKeyToLocalId,
+      }),
+    ),
+  );
 
   subscriptions.sort((a, b) => {
     const usedA = BigInt(a.usedUsdMicros);
@@ -550,6 +602,9 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
   }
 
   const adminClient = getHostedAdminClient();
+  // Invoices hit Konnect /billing/invoices (often multi-second). Soft-timeout so
+  // first paint is not blocked when the invoice index is large or slow.
+  const emptyInvoices = { items: [] as TenantInvoiceDto[] };
   const [creditAllowance, subscriptions, ownedApps, invoicesResult] =
     await Promise.all([
       getOwnerPrepaidCreditBalance(userId).catch((err) => {
@@ -559,20 +614,24 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
         );
         return null;
       }),
-      listOwnerActiveSubscriptions(userId),
+      withSoftTimeout(
+        listOwnerActiveSubscriptions(userId),
+        8_000,
+        [] as OwnerBillingSubscriptionRow[],
+        "subscription lookup",
+      ),
       listOwnedApps(userId),
-      listOwnerWalletInvoices({
-        client: adminClient,
-        ownerUserId: userId,
-        page: 1,
-        pageSize: 10,
-      }).catch((err) => {
-        console.warn(
-          "owner-billing: invoice lookup failed",
-          err instanceof Error ? err.message : String(err),
-        );
-        return { items: [] as TenantInvoiceDto[] };
-      }),
+      withSoftTimeout(
+        listOwnerWalletInvoices({
+          client: adminClient,
+          ownerUserId: userId,
+          page: 1,
+          pageSize: 10,
+        }),
+        2_500,
+        emptyInvoices,
+        "invoice lookup",
+      ),
     ]);
 
   return {

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { getServerSession } from "next-auth";
 import type { OpenMeter } from "@openmeter/sdk";
 
@@ -339,15 +339,21 @@ async function resolvePlanName(input: {
   };
 }
 
-async function loadPlanKeyToLocalId(): Promise<Map<string, string>> {
-  const allPlans = await db
+async function loadPlanKeyToLocalId(
+  clientIds: string[],
+): Promise<Map<string, string>> {
+  const index = new Map<string, string>();
+  if (clientIds.length === 0) {
+    return index;
+  }
+  const scopedPlans = await db
     .select({
       id: plans.id,
       clientId: plans.clientId,
     })
-    .from(plans);
-  const index = new Map<string, string>();
-  for (const plan of allPlans) {
+    .from(plans)
+    .where(inArray(plans.clientId, clientIds));
+  for (const plan of scopedPlans) {
     index.set(buildOpenMeterPlanKey(plan.clientId, plan.id), plan.id);
   }
   return index;
@@ -521,10 +527,10 @@ export async function listOwnerActiveSubscriptions(
   const client = getHostedAdminClient();
   const cycleBounds = calendarMonthBoundsUtc(new Date());
   const cycle = { start: cycleBounds.start, end: cycleBounds.end };
-  const [ownedApps, planKeyToLocalId] = await Promise.all([
-    listOwnedApps(trimmed),
-    loadPlanKeyToLocalId(),
-  ]);
+  const ownedApps = await listOwnedApps(trimmed);
+  const planKeyToLocalId = await loadPlanKeyToLocalId(
+    ownedApps.map((app) => app.developerAppId),
+  );
   const candidates = buildCustomerCandidates(trimmed, ownedApps);
 
   const perCandidate = await Promise.all(

--- a/src/lib/stripe/connect-accounts.test.ts
+++ b/src/lib/stripe/connect-accounts.test.ts
@@ -1,0 +1,379 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  applicationFeeAmountCents,
+  buildConnectOAuthAuthorizeUrl,
+  connectAccountLinkUrls,
+  connectOAuthCallbackUrl,
+  createAccountOnboardingLink,
+  createConnectedCheckoutSession,
+  createConnectedCustomer,
+  createConnectedInvoice,
+  createMerchantConnectedAccount,
+  exchangeConnectOAuthCode,
+  refreshConnectedAccountStatus,
+} from "./connect-accounts";
+
+const ENV_KEYS = [
+  "STRIPE_SECRET_KEY",
+  "STRIPE_API_KEY",
+  "STRIPE_CONNECT_CLIENT_ID",
+  "NEXTAUTH_URL",
+] as const;
+
+function withEnv(
+  t: test.TestContext,
+  values: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>>,
+): void {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+  }
+  for (const key of ENV_KEYS) {
+    const next = values[key];
+    if (next === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = next;
+    }
+  }
+  t.after(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("applicationFeeAmountCents computes bps fee", () => {
+  assert.equal(
+    applicationFeeAmountCents({ amountCents: 10_000, applicationFeeBps: 250 }),
+    250,
+  );
+  assert.equal(
+    applicationFeeAmountCents({ amountCents: 99, applicationFeeBps: 100 }),
+    0,
+  );
+  assert.equal(
+    applicationFeeAmountCents({ amountCents: 1000, applicationFeeBps: 0 }),
+    0,
+  );
+});
+
+test("connectAccountLinkUrls and connectOAuthCallbackUrl use public origin", (t) => {
+  withEnv(t, { NEXTAUTH_URL: "https://builder.example" });
+  assert.deepEqual(connectAccountLinkUrls("app_1"), {
+    refreshUrl:
+      "https://builder.example/apps/app_1/settings?tab=payments&connect=refresh",
+    returnUrl:
+      "https://builder.example/apps/app_1/settings?tab=payments&connected=1",
+  });
+  assert.equal(
+    connectOAuthCallbackUrl("app_1"),
+    "https://builder.example/api/v1/apps/app_1/billing/stripe/oauth/callback",
+  );
+});
+
+test("buildConnectOAuthAuthorizeUrl encodes params", (t) => {
+  withEnv(t, {
+    STRIPE_SECRET_KEY: "sk_test_unit",
+    STRIPE_CONNECT_CLIENT_ID: "ca_test_client",
+  });
+  const url = new URL(
+    buildConnectOAuthAuthorizeUrl({
+      state: "csrf",
+      redirectUri: "https://builder.example/callback",
+    }),
+  );
+  assert.equal(url.origin + url.pathname, "https://connect.stripe.com/oauth/authorize");
+  assert.equal(url.searchParams.get("client_id"), "ca_test_client");
+  assert.equal(url.searchParams.get("state"), "csrf");
+  assert.equal(url.searchParams.get("redirect_uri"), "https://builder.example/callback");
+});
+
+test("buildConnectOAuthAuthorizeUrl requires client id", (t) => {
+  withEnv(t, {
+    STRIPE_SECRET_KEY: "sk_test_unit",
+    STRIPE_CONNECT_CLIENT_ID: undefined,
+  });
+  assert.throws(
+    () =>
+      buildConnectOAuthAuthorizeUrl({
+        state: "x",
+        redirectUri: "https://example/cb",
+      }),
+    /STRIPE_CONNECT_CLIENT_ID/,
+  );
+});
+
+test("createMerchantConnectedAccount falls back to Express v1 when v2 fails", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  const calls: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push(`${init?.method ?? "GET"} ${url}`);
+    if (url.includes("/v2/core/accounts")) {
+      return jsonResponse({ error: { message: "v2 unavailable" } }, 400);
+    }
+    if (url.includes("/v1/accounts") && init?.method === "POST") {
+      const body = String(init.body ?? "");
+      assert.match(body, /type=express/);
+      assert.match(body, /metadata%5Bpymthouse_client_id%5D=app_abc/);
+      return jsonResponse({ id: "acct_express_1" });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+  const id = await createMerchantConnectedAccount({
+    clientId: "app_abc",
+    email: "owner@example.com",
+    displayName: "Acme",
+  });
+  assert.equal(id, "acct_express_1");
+  assert.equal(calls.length, 2);
+});
+
+test("createMerchantConnectedAccount uses v2 id when available", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+    if (String(input).includes("/v2/core/accounts")) {
+      return jsonResponse({ id: "acct_v2_ready" });
+    }
+    throw new Error(`Unexpected fetch: ${String(input)}`);
+  });
+  assert.equal(
+    await createMerchantConnectedAccount({ clientId: "app_1" }),
+    "acct_v2_ready",
+  );
+});
+
+test("createMerchantConnectedAccount rejects missing secret", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: undefined, STRIPE_API_KEY: undefined });
+  await assert.rejects(
+    () => createMerchantConnectedAccount({ clientId: "app_1" }),
+    /STRIPE_SECRET_KEY/,
+  );
+});
+
+test("createMerchantConnectedAccount rejects invalid account id", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async () => jsonResponse({ id: "not_an_acct" }));
+  await assert.rejects(
+    () => createMerchantConnectedAccount({ clientId: "app_1" }),
+    /did not return a Connected Account id/,
+  );
+});
+
+test("createAccountOnboardingLink and refreshConnectedAccountStatus", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes("/v1/account_links")) {
+      assert.equal(init?.method, "POST");
+      return jsonResponse({ url: "https://connect.stripe.com/setup/e/xxx" });
+    }
+    if (url.includes("/v1/accounts/acct_1")) {
+      return jsonResponse({
+        id: "acct_1",
+        charges_enabled: true,
+        payouts_enabled: false,
+        details_submitted: true,
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+  assert.equal(
+    await createAccountOnboardingLink({
+      accountId: "acct_1",
+      refreshUrl: "https://x/refresh",
+      returnUrl: "https://x/return",
+    }),
+    "https://connect.stripe.com/setup/e/xxx",
+  );
+  assert.deepEqual(await refreshConnectedAccountStatus("acct_1"), {
+    id: "acct_1",
+    chargesEnabled: true,
+    payoutsEnabled: false,
+    detailsSubmitted: true,
+  });
+});
+
+test("createAccountOnboardingLink fails when Stripe omits url", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async () => jsonResponse({}));
+  await assert.rejects(
+    () =>
+      createAccountOnboardingLink({
+        accountId: "acct_1",
+        refreshUrl: "https://x/r",
+        returnUrl: "https://x/t",
+      }),
+    /Account Link URL unavailable/,
+  );
+});
+
+test("exchangeConnectOAuthCode returns stripe_user_id", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    assert.match(String(input), /\/v1\/oauth\/token$/);
+    assert.equal(init?.method, "POST");
+    return jsonResponse({ stripe_user_id: "acct_oauth_9" });
+  });
+  assert.equal(await exchangeConnectOAuthCode("auth_code"), "acct_oauth_9");
+});
+
+test("exchangeConnectOAuthCode rejects missing stripe_user_id", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async () => jsonResponse({}));
+  await assert.rejects(
+    () => exchangeConnectOAuthCode("bad"),
+    /did not return stripe_user_id/,
+  );
+});
+
+test("createConnectedCustomer posts to Connected Account", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    assert.equal(headers.get("Stripe-Account"), "acct_merchant");
+    return jsonResponse({ id: "cus_connected_1" });
+  });
+  assert.equal(
+    await createConnectedCustomer({
+      accountId: "acct_merchant",
+      name: "User",
+      email: "u@example.com",
+      metadata: { external_user_id: "u1" },
+    }),
+    "cus_connected_1",
+  );
+});
+
+test("createConnectedCustomer rejects invalid customer id", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async () => jsonResponse({ id: "bad" }));
+  await assert.rejects(
+    () => createConnectedCustomer({ accountId: "acct_1" }),
+    /did not return a customer id/,
+  );
+});
+
+test("createConnectedCheckoutSession setup and payment modes", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  const bodies: string[] = [];
+  t.mock.method(globalThis, "fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+    bodies.push(String(init?.body ?? ""));
+    return jsonResponse({ id: "cs_test_1", url: "https://checkout.stripe.com/c/pay/cs_test_1" });
+  });
+
+  const setup = await createConnectedCheckoutSession({
+    accountId: "acct_1",
+    customerId: "cus_1",
+    successUrl: "https://ok",
+    cancelUrl: "https://cancel",
+    mode: "setup",
+  });
+  assert.equal(setup.sessionId, "cs_test_1");
+  assert.match(bodies[0]!, /mode=setup/);
+
+  const payment = await createConnectedCheckoutSession({
+    accountId: "acct_1",
+    customerId: "cus_1",
+    successUrl: "https://ok",
+    cancelUrl: "https://cancel",
+    mode: "payment",
+    amountCents: 10_000,
+    applicationFeeBps: 250,
+  });
+  assert.equal(payment.url, "https://checkout.stripe.com/c/pay/cs_test_1");
+  assert.match(bodies[1]!, /mode=payment/);
+  assert.match(bodies[1]!, /payment_intent_data.*application_fee_amount.*250/);
+});
+
+test("createConnectedCheckoutSession fails without session url", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async () => jsonResponse({ id: "cs_x" }));
+  await assert.rejects(
+    () =>
+      createConnectedCheckoutSession({
+        accountId: "acct_1",
+        customerId: "cus_1",
+        successUrl: "https://ok",
+        cancelUrl: "https://cancel",
+      }),
+    /Checkout session unavailable/,
+  );
+});
+
+test("createConnectedInvoice creates item then invoice with fee", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  const paths: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    paths.push(url);
+    if (url.includes("/v1/invoiceitems")) {
+      return jsonResponse({ id: "ii_1" });
+    }
+    if (url.includes("/v1/invoices")) {
+      assert.match(String(init?.body ?? ""), /application_fee_amount=100/);
+      return jsonResponse({
+        id: "in_1",
+        hosted_invoice_url: "https://invoice.stripe.com/i/in_1",
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+  assert.deepEqual(
+    await createConnectedInvoice({
+      accountId: "acct_1",
+      customerId: "cus_1",
+      amountCents: 4000,
+      applicationFeeBps: 250,
+      description: "Usage",
+    }),
+    { invoiceId: "in_1", hostedInvoiceUrl: "https://invoice.stripe.com/i/in_1" },
+  );
+  assert.equal(paths.length, 2);
+});
+
+test("createConnectedInvoice fails without invoice id", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+    if (String(input).includes("/v1/invoiceitems")) {
+      return jsonResponse({ id: "ii_1" });
+    }
+    return jsonResponse({});
+  });
+  await assert.rejects(
+    () =>
+      createConnectedInvoice({
+        accountId: "acct_1",
+        customerId: "cus_1",
+        amountCents: 100,
+      }),
+    /invoice create failed/,
+  );
+});
+
+test("stripeFormRequest surfaces Stripe error messages", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  t.mock.method(globalThis, "fetch", async () =>
+    jsonResponse({ error: { message: "bad request" } }, 400),
+  );
+  await assert.rejects(
+    () => refreshConnectedAccountStatus("acct_1"),
+    /failed \(400\): bad request/,
+  );
+});

--- a/src/lib/stripe/connect-accounts.ts
+++ b/src/lib/stripe/connect-accounts.ts
@@ -1,0 +1,412 @@
+/**
+ * Stripe Connected Accounts helpers for merchant billing (hybrid: OM meters, Connect charges).
+ * Uses platform STRIPE_SECRET_KEY. Direct charges on acct_… with optional application fee.
+ */
+import { getPublicOrigin } from "@/lib/oidc/issuer-urls";
+
+export type StripeOnboardingMethod = "account_link" | "oauth";
+
+export type ConnectedAccountStatus = {
+  id: string;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+};
+
+function requireStripeSecretKey(): string {
+  const key =
+    process.env.STRIPE_SECRET_KEY?.trim() || process.env.STRIPE_API_KEY?.trim();
+  if (!key || !key.startsWith("sk_")) {
+    throw new Error(
+      "STRIPE_SECRET_KEY is required for Stripe Connect (must be sk_… platform key)",
+    );
+  }
+  return key;
+}
+
+function requireConnectClientId(): string {
+  const id = process.env.STRIPE_CONNECT_CLIENT_ID?.trim();
+  if (!id) {
+    throw new Error(
+      "STRIPE_CONNECT_CLIENT_ID is required to link an existing Stripe account via OAuth",
+    );
+  }
+  return id;
+}
+
+async function stripeFormRequest<T>(input: {
+  method: string;
+  path: string;
+  body?: URLSearchParams;
+  stripeAccount?: string;
+  stripeVersion?: string;
+}): Promise<T> {
+  const apiKey = requireStripeSecretKey();
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+  if (input.stripeAccount) {
+    headers["Stripe-Account"] = input.stripeAccount;
+  }
+  if (input.stripeVersion) {
+    headers["Stripe-Version"] = input.stripeVersion;
+  }
+  const response = await fetch(`https://api.stripe.com${input.path}`, {
+    method: input.method,
+    headers,
+    body: input.body?.toString(),
+  });
+  const json = (await response.json()) as T & {
+    error?: { message?: string };
+  };
+  if (!response.ok) {
+    throw new Error(
+      `Stripe ${input.method} ${input.path} failed (${response.status}): ${
+        json.error?.message ?? JSON.stringify(json)
+      }`,
+    );
+  }
+  return json;
+}
+
+async function stripeJsonRequest<T>(input: {
+  method: string;
+  path: string;
+  body?: unknown;
+  stripeVersion: string;
+}): Promise<T> {
+  const apiKey = requireStripeSecretKey();
+  const response = await fetch(`https://api.stripe.com${input.path}`, {
+    method: input.method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "Stripe-Version": input.stripeVersion,
+    },
+    body: input.body === undefined ? undefined : JSON.stringify(input.body),
+  });
+  const json = (await response.json()) as T & {
+    error?: { message?: string };
+  };
+  if (!response.ok) {
+    throw new Error(
+      `Stripe ${input.method} ${input.path} failed (${response.status}): ${
+        json.error?.message ?? JSON.stringify(json)
+      }`,
+    );
+  }
+  return json;
+}
+
+/** Application fee in cents for a charge amount in cents. */
+export function applicationFeeAmountCents(input: {
+  amountCents: number;
+  applicationFeeBps: number;
+}): number {
+  if (input.amountCents <= 0 || input.applicationFeeBps <= 0) {
+    return 0;
+  }
+  return Math.floor((input.amountCents * input.applicationFeeBps) / 10_000);
+}
+
+/**
+ * Create a merchant Connected Account.
+ * Tries Accounts v2 merchant config; falls back to Express (v1) if v2 is unavailable.
+ */
+export async function createMerchantConnectedAccount(input: {
+  clientId: string;
+  email?: string;
+  country?: string;
+  displayName?: string;
+}): Promise<string> {
+  const country = (input.country ?? "US").toUpperCase();
+  const email = input.email?.trim();
+  const displayName = input.displayName?.trim() || `PymtHouse ${input.clientId}`;
+
+  try {
+    const created = await stripeJsonRequest<{ id?: string }>({
+      method: "POST",
+      path: "/v2/core/accounts",
+      stripeVersion: "2025-03-31.preview",
+      body: {
+        contact_email: email || undefined,
+        display_name: displayName,
+        dashboard: "full",
+        identity: {
+          country: country.toLowerCase(),
+          entity_type: "company",
+        },
+        configuration: {
+          merchant: {
+            capabilities: {
+              card_payments: { requested: true },
+              stripe_balance: {
+                payouts: { requested: true },
+              },
+            },
+          },
+        },
+        defaults: {
+          currency: "usd",
+          responsibilities: {
+            fees_collector: "application",
+            losses_collector: "application",
+          },
+        },
+        metadata: {
+          pymthouse_client_id: input.clientId,
+        },
+        include: ["configuration.merchant", "identity", "requirements"],
+      },
+    });
+    if (created.id?.startsWith("acct_")) {
+      return created.id;
+    }
+  } catch {
+    // Fall through to Express v1 — widely available on Connect platforms.
+  }
+
+  const body = new URLSearchParams();
+  body.set("type", "express");
+  body.set("country", country);
+  body.set("capabilities[card_payments][requested]", "true");
+  body.set("capabilities[transfers][requested]", "true");
+  body.set("metadata[pymthouse_client_id]", input.clientId);
+  if (email) {
+    body.set("email", email);
+  }
+  if (displayName) {
+    body.set("business_profile[name]", displayName);
+  }
+  const account = await stripeFormRequest<{ id?: string }>({
+    method: "POST",
+    path: "/v1/accounts",
+    body,
+  });
+  if (!account.id?.startsWith("acct_")) {
+    throw new Error("Stripe did not return a Connected Account id");
+  }
+  return account.id;
+}
+
+export async function createAccountOnboardingLink(input: {
+  accountId: string;
+  refreshUrl: string;
+  returnUrl: string;
+}): Promise<string> {
+  const body = new URLSearchParams();
+  body.set("account", input.accountId);
+  body.set("refresh_url", input.refreshUrl);
+  body.set("return_url", input.returnUrl);
+  body.set("type", "account_onboarding");
+  const link = await stripeFormRequest<{ url?: string }>({
+    method: "POST",
+    path: "/v1/account_links",
+    body,
+  });
+  if (!link.url) {
+    throw new Error("Stripe Account Link URL unavailable");
+  }
+  return link.url;
+}
+
+export async function refreshConnectedAccountStatus(
+  accountId: string,
+): Promise<ConnectedAccountStatus> {
+  const account = await stripeFormRequest<{
+    id: string;
+    charges_enabled?: boolean;
+    payouts_enabled?: boolean;
+    details_submitted?: boolean;
+  }>({
+    method: "GET",
+    path: `/v1/accounts/${encodeURIComponent(accountId)}`,
+  });
+  return {
+    id: account.id,
+    chargesEnabled: Boolean(account.charges_enabled),
+    payoutsEnabled: Boolean(account.payouts_enabled),
+    detailsSubmitted: Boolean(account.details_submitted),
+  };
+}
+
+export function buildConnectOAuthAuthorizeUrl(input: {
+  state: string;
+  redirectUri: string;
+}): string {
+  const clientId = requireConnectClientId();
+  const url = new URL("https://connect.stripe.com/oauth/authorize");
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("scope", "read_write");
+  url.searchParams.set("state", input.state);
+  url.searchParams.set("redirect_uri", input.redirectUri);
+  return url.toString();
+}
+
+export async function exchangeConnectOAuthCode(code: string): Promise<string> {
+  const body = new URLSearchParams();
+  body.set("client_secret", requireStripeSecretKey());
+  body.set("code", code);
+  body.set("grant_type", "authorization_code");
+  const result = await stripeFormRequest<{
+    stripe_user_id?: string;
+  }>({
+    method: "POST",
+    path: "/v1/oauth/token",
+    body,
+  });
+  const accountId = result.stripe_user_id?.trim();
+  if (!accountId?.startsWith("acct_")) {
+    throw new Error("Stripe OAuth did not return stripe_user_id");
+  }
+  return accountId;
+}
+
+export async function createConnectedCustomer(input: {
+  accountId: string;
+  name?: string;
+  email?: string;
+  metadata?: Record<string, string>;
+}): Promise<string> {
+  const body = new URLSearchParams();
+  if (input.name?.trim()) {
+    body.set("name", input.name.trim());
+  }
+  if (input.email?.trim()) {
+    body.set("email", input.email.trim());
+  }
+  for (const [key, value] of Object.entries(input.metadata ?? {})) {
+    body.set(`metadata[${key}]`, value);
+  }
+  const customer = await stripeFormRequest<{ id?: string }>({
+    method: "POST",
+    path: "/v1/customers",
+    body,
+    stripeAccount: input.accountId,
+  });
+  if (!customer.id?.startsWith("cus_")) {
+    throw new Error("Stripe did not return a customer id on Connected Account");
+  }
+  return customer.id;
+}
+
+export async function createConnectedCheckoutSession(input: {
+  accountId: string;
+  customerId: string;
+  successUrl: string;
+  cancelUrl: string;
+  applicationFeeBps?: number;
+  /** Optional one-time line for fee preview; setup mode collects PM only. */
+  mode?: "setup" | "payment";
+  amountCents?: number;
+  currency?: string;
+  productName?: string;
+}): Promise<{ url: string; sessionId: string }> {
+  const body = new URLSearchParams();
+  const mode = input.mode ?? "setup";
+  body.set("mode", mode);
+  body.set("customer", input.customerId);
+  body.set("success_url", input.successUrl);
+  body.set("cancel_url", input.cancelUrl);
+  if (mode === "setup") {
+    body.set("payment_method_types[0]", "card");
+  } else {
+    const amount = input.amountCents ?? 0;
+    body.set("line_items[0][price_data][currency]", (input.currency ?? "usd").toLowerCase());
+    body.set("line_items[0][price_data][unit_amount]", String(amount));
+    body.set(
+      "line_items[0][price_data][product_data][name]",
+      input.productName ?? "Subscription",
+    );
+    body.set("line_items[0][quantity]", "1");
+    const fee = applicationFeeAmountCents({
+      amountCents: amount,
+      applicationFeeBps: input.applicationFeeBps ?? 0,
+    });
+    if (fee > 0) {
+      body.set("payment_intent_data[application_fee_amount]", String(fee));
+    }
+  }
+  const session = await stripeFormRequest<{ id?: string; url?: string }>({
+    method: "POST",
+    path: "/v1/checkout/sessions",
+    body,
+    stripeAccount: input.accountId,
+  });
+  if (!session.url || !session.id) {
+    throw new Error("Stripe Checkout session unavailable on Connected Account");
+  }
+  return { url: session.url, sessionId: session.id };
+}
+
+export async function createConnectedInvoice(input: {
+  accountId: string;
+  customerId: string;
+  amountCents: number;
+  currency?: string;
+  description?: string;
+  applicationFeeBps?: number;
+  autoAdvance?: boolean;
+}): Promise<{ invoiceId: string; hostedInvoiceUrl: string | null }> {
+  const currency = (input.currency ?? "usd").toLowerCase();
+  const itemBody = new URLSearchParams();
+  itemBody.set("customer", input.customerId);
+  itemBody.set("amount", String(input.amountCents));
+  itemBody.set("currency", currency);
+  if (input.description?.trim()) {
+    itemBody.set("description", input.description.trim());
+  }
+  await stripeFormRequest({
+    method: "POST",
+    path: "/v1/invoiceitems",
+    body: itemBody,
+    stripeAccount: input.accountId,
+  });
+
+  const invoiceBody = new URLSearchParams();
+  invoiceBody.set("customer", input.customerId);
+  invoiceBody.set("auto_advance", String(input.autoAdvance ?? true));
+  const collection = "charge_automatically";
+  invoiceBody.set("collection_method", collection);
+  const fee = applicationFeeAmountCents({
+    amountCents: input.amountCents,
+    applicationFeeBps: input.applicationFeeBps ?? 0,
+  });
+  if (fee > 0) {
+    invoiceBody.set("application_fee_amount", String(fee));
+  }
+  const invoice = await stripeFormRequest<{
+    id?: string;
+    hosted_invoice_url?: string | null;
+  }>({
+    method: "POST",
+    path: "/v1/invoices",
+    body: invoiceBody,
+    stripeAccount: input.accountId,
+  });
+  if (!invoice.id) {
+    throw new Error("Stripe invoice create failed on Connected Account");
+  }
+  return {
+    invoiceId: invoice.id,
+    hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+  };
+}
+
+export function connectAccountLinkUrls(clientId: string): {
+  refreshUrl: string;
+  returnUrl: string;
+} {
+  const origin = getPublicOrigin();
+  const base = `${origin}/apps/${encodeURIComponent(clientId)}/settings?tab=payments`;
+  return {
+    refreshUrl: `${base}&connect=refresh`,
+    returnUrl: `${base}&connected=1`,
+  };
+}
+
+export function connectOAuthCallbackUrl(clientId: string): string {
+  return `${getPublicOrigin()}/api/v1/apps/${encodeURIComponent(clientId)}/billing/stripe/oauth/callback`;
+}

--- a/src/lib/stripe/connect-accounts.ts
+++ b/src/lib/stripe/connect-accounts.ts
@@ -40,6 +40,7 @@ async function stripeFormRequest<T>(input: {
   body?: URLSearchParams;
   stripeAccount?: string;
   stripeVersion?: string;
+  idempotencyKey?: string;
 }): Promise<T> {
   const apiKey = requireStripeSecretKey();
   const headers: Record<string, string> = {
@@ -52,14 +53,23 @@ async function stripeFormRequest<T>(input: {
   if (input.stripeVersion) {
     headers["Stripe-Version"] = input.stripeVersion;
   }
+  if (input.idempotencyKey?.trim()) {
+    headers["Idempotency-Key"] = input.idempotencyKey.trim();
+  }
   const response = await fetch(`https://api.stripe.com${input.path}`, {
     method: input.method,
     headers,
     body: input.body?.toString(),
+    signal: AbortSignal.timeout(30_000),
   });
-  const json = (await response.json()) as T & {
-    error?: { message?: string };
-  };
+  let json: T & { error?: { message?: string } };
+  try {
+    json = (await response.json()) as T & { error?: { message?: string } };
+  } catch {
+    throw new Error(
+      `Stripe ${input.method} ${input.path} failed (${response.status}): non-JSON body`,
+    );
+  }
   if (!response.ok) {
     throw new Error(
       `Stripe ${input.method} ${input.path} failed (${response.status}): ${
@@ -85,10 +95,16 @@ async function stripeJsonRequest<T>(input: {
       "Stripe-Version": input.stripeVersion,
     },
     body: input.body === undefined ? undefined : JSON.stringify(input.body),
+    signal: AbortSignal.timeout(30_000),
   });
-  const json = (await response.json()) as T & {
-    error?: { message?: string };
-  };
+  let json: T & { error?: { message?: string } };
+  try {
+    json = (await response.json()) as T & { error?: { message?: string } };
+  } catch {
+    throw new Error(
+      `Stripe ${input.method} ${input.path} failed (${response.status}): non-JSON body`,
+    );
+  }
   if (!response.ok) {
     throw new Error(
       `Stripe ${input.method} ${input.path} failed (${response.status}): ${
@@ -135,7 +151,6 @@ export async function createMerchantConnectedAccount(input: {
         dashboard: "full",
         identity: {
           country: country.toLowerCase(),
-          entity_type: "company",
         },
         configuration: {
           merchant: {
@@ -303,6 +318,7 @@ export async function createConnectedCheckoutSession(input: {
   amountCents?: number;
   currency?: string;
   productName?: string;
+  metadata?: Record<string, string>;
 }): Promise<{ url: string; sessionId: string }> {
   const body = new URLSearchParams();
   const mode = input.mode ?? "setup";
@@ -313,7 +329,10 @@ export async function createConnectedCheckoutSession(input: {
   if (mode === "setup") {
     body.set("payment_method_types[0]", "card");
   } else {
-    const amount = input.amountCents ?? 0;
+    const amount = input.amountCents;
+    if (typeof amount !== "number" || !Number.isInteger(amount) || amount <= 0) {
+      throw new Error("amountCents must be a positive integer for payment mode");
+    }
     body.set("line_items[0][price_data][currency]", (input.currency ?? "usd").toLowerCase());
     body.set("line_items[0][price_data][unit_amount]", String(amount));
     body.set(
@@ -327,6 +346,11 @@ export async function createConnectedCheckoutSession(input: {
     });
     if (fee > 0) {
       body.set("payment_intent_data[application_fee_amount]", String(fee));
+    }
+  }
+  for (const [key, value] of Object.entries(input.metadata ?? {})) {
+    if (key.trim() && value.trim()) {
+      body.set(`metadata[${key.trim()}]`, value.trim());
     }
   }
   const session = await stripeFormRequest<{ id?: string; url?: string }>({
@@ -349,8 +373,10 @@ export async function createConnectedInvoice(input: {
   description?: string;
   applicationFeeBps?: number;
   autoAdvance?: boolean;
+  idempotencyKey?: string;
 }): Promise<{ invoiceId: string; hostedInvoiceUrl: string | null }> {
   const currency = (input.currency ?? "usd").toLowerCase();
+  const idempotencyBase = input.idempotencyKey?.trim();
   const itemBody = new URLSearchParams();
   itemBody.set("customer", input.customerId);
   itemBody.set("amount", String(input.amountCents));
@@ -358,11 +384,12 @@ export async function createConnectedInvoice(input: {
   if (input.description?.trim()) {
     itemBody.set("description", input.description.trim());
   }
-  await stripeFormRequest({
+  const item = await stripeFormRequest<{ id?: string }>({
     method: "POST",
     path: "/v1/invoiceitems",
     body: itemBody,
     stripeAccount: input.accountId,
+    idempotencyKey: idempotencyBase ? `${idempotencyBase}:item` : undefined,
   });
 
   const invoiceBody = new URLSearchParams();
@@ -377,22 +404,38 @@ export async function createConnectedInvoice(input: {
   if (fee > 0) {
     invoiceBody.set("application_fee_amount", String(fee));
   }
-  const invoice = await stripeFormRequest<{
-    id?: string;
-    hosted_invoice_url?: string | null;
-  }>({
-    method: "POST",
-    path: "/v1/invoices",
-    body: invoiceBody,
-    stripeAccount: input.accountId,
-  });
-  if (!invoice.id) {
-    throw new Error("Stripe invoice create failed on Connected Account");
+  try {
+    const invoice = await stripeFormRequest<{
+      id?: string;
+      hosted_invoice_url?: string | null;
+    }>({
+      method: "POST",
+      path: "/v1/invoices",
+      body: invoiceBody,
+      stripeAccount: input.accountId,
+      idempotencyKey: idempotencyBase ? `${idempotencyBase}:invoice` : undefined,
+    });
+    if (!invoice.id) {
+      throw new Error("Stripe invoice create failed on Connected Account");
+    }
+    return {
+      invoiceId: invoice.id,
+      hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+    };
+  } catch (err) {
+    if (item.id?.trim()) {
+      try {
+        await stripeFormRequest({
+          method: "DELETE",
+          path: `/v1/invoiceitems/${item.id.trim()}`,
+          stripeAccount: input.accountId,
+        });
+      } catch {
+        // Best-effort cleanup; surface the original invoice failure.
+      }
+    }
+    throw err;
   }
-  return {
-    invoiceId: invoice.id,
-    hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
-  };
 }
 
 export function connectAccountLinkUrls(clientId: string): {

--- a/src/lib/stripe/merchant-connect.test.ts
+++ b/src/lib/stripe/merchant-connect.test.ts
@@ -5,12 +5,13 @@ import {
   isMerchantConnectPaymentsReady,
 } from "./merchant-connect";
 
-test("isMerchantConnectPaymentsReady requires connected account and charges", () => {
+test("isMerchantConnectPaymentsReady requires account, charges, and details", () => {
   assert.equal(isMerchantConnectPaymentsReady(null), false);
   assert.equal(
     isMerchantConnectPaymentsReady({
       stripeConnectedAccountId: "acct_1",
       stripeChargesEnabled: false,
+      stripeDetailsSubmitted: true,
     } as never),
     false,
   );
@@ -18,6 +19,7 @@ test("isMerchantConnectPaymentsReady requires connected account and charges", ()
     isMerchantConnectPaymentsReady({
       stripeConnectedAccountId: "  ",
       stripeChargesEnabled: true,
+      stripeDetailsSubmitted: true,
     } as never),
     false,
   );
@@ -25,6 +27,15 @@ test("isMerchantConnectPaymentsReady requires connected account and charges", ()
     isMerchantConnectPaymentsReady({
       stripeConnectedAccountId: "acct_1",
       stripeChargesEnabled: true,
+      stripeDetailsSubmitted: false,
+    } as never),
+    false,
+  );
+  assert.equal(
+    isMerchantConnectPaymentsReady({
+      stripeConnectedAccountId: "acct_1",
+      stripeChargesEnabled: true,
+      stripeDetailsSubmitted: true,
     } as never),
     true,
   );

--- a/src/lib/stripe/merchant-connect.test.ts
+++ b/src/lib/stripe/merchant-connect.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  connectPaymentsOnlyEnabled,
+  isMerchantConnectPaymentsReady,
+} from "./merchant-connect";
+
+test("isMerchantConnectPaymentsReady requires connected account and charges", () => {
+  assert.equal(isMerchantConnectPaymentsReady(null), false);
+  assert.equal(
+    isMerchantConnectPaymentsReady({
+      stripeConnectedAccountId: "acct_1",
+      stripeChargesEnabled: false,
+    } as never),
+    false,
+  );
+  assert.equal(
+    isMerchantConnectPaymentsReady({
+      stripeConnectedAccountId: "  ",
+      stripeChargesEnabled: true,
+    } as never),
+    false,
+  );
+  assert.equal(
+    isMerchantConnectPaymentsReady({
+      stripeConnectedAccountId: "acct_1",
+      stripeChargesEnabled: true,
+    } as never),
+    true,
+  );
+});
+
+test("connectPaymentsOnlyEnabled honors env override and config flag", (t) => {
+  const previous = process.env.STRIPE_CONNECT_PAYMENTS_ONLY;
+  t.after(() => {
+    if (previous === undefined) {
+      delete process.env.STRIPE_CONNECT_PAYMENTS_ONLY;
+    } else {
+      process.env.STRIPE_CONNECT_PAYMENTS_ONLY = previous;
+    }
+  });
+
+  delete process.env.STRIPE_CONNECT_PAYMENTS_ONLY;
+  assert.equal(connectPaymentsOnlyEnabled(null), false);
+  assert.equal(
+    connectPaymentsOnlyEnabled({ connectPaymentsOnly: true } as never),
+    true,
+  );
+
+  process.env.STRIPE_CONNECT_PAYMENTS_ONLY = "1";
+  assert.equal(
+    connectPaymentsOnlyEnabled({ connectPaymentsOnly: false } as never),
+    true,
+  );
+});

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -37,12 +37,13 @@ async function persistConnectedAccountFlags(input: {
 }): Promise<void> {
   const ready = input.chargesEnabled && input.detailsSubmitted;
   const existing = await getAppBillingConfig(input.clientId);
+  // Do not write stripeConnectStatus here — that column is Plane A (OM Stripe
+  // app install). Merchant readiness is stripeChargesEnabled + detailsSubmitted.
   await upsertAppBillingConfig(input.clientId, {
     stripeConnectedAccountId: input.accountId,
     stripeChargesEnabled: input.chargesEnabled,
     stripePayoutsEnabled: input.payoutsEnabled,
     stripeDetailsSubmitted: input.detailsSubmitted,
-    stripeConnectStatus: ready ? "connected" : "pending",
     connectedAt: ready
       ? (existing?.connectedAt ?? new Date().toISOString())
       : (existing?.connectedAt ?? null),
@@ -135,7 +136,6 @@ export async function startMerchantConnect({
     await upsertAppBillingConfig(clientId, {
       stripeConnectedAccountId: accountId,
       stripeOnboardingMethod: "account_link" satisfies StripeOnboardingMethod,
-      stripeConnectStatus: "pending",
       stripeChargesEnabled: false,
       stripePayoutsEnabled: false,
       stripeDetailsSubmitted: false,

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -158,7 +158,7 @@ export async function refreshMerchantAccountLink(clientId: string): Promise<{
 }> {
   const config = await getAppBillingConfig(clientId);
   const accountId = config?.stripeConnectedAccountId?.trim();
-  if (!accountId) {
+  if (!config || !accountId) {
     throw new Error("No Connected Account yet — start onboarding first");
   }
   if (config.stripeOnboardingMethod === "oauth" && config.stripeChargesEnabled) {
@@ -180,28 +180,21 @@ export async function completeMerchantConnectOAuth(input: {
   code: string;
 }): Promise<void> {
   const rows = await db
-    .select()
-    .from(appBillingOauthStates)
+    .delete(appBillingOauthStates)
     .where(
       and(
         eq(appBillingOauthStates.state, input.state),
         eq(appBillingOauthStates.clientId, input.clientId),
       ),
     )
-    .limit(1);
+    .returning();
   const row = rows[0];
   if (!row) {
     throw new Error("Invalid or expired OAuth state");
   }
   if (row.expiresAt < new Date().toISOString()) {
-    await db
-      .delete(appBillingOauthStates)
-      .where(eq(appBillingOauthStates.id, row.id));
     throw new Error("OAuth state expired");
   }
-  await db
-    .delete(appBillingOauthStates)
-    .where(eq(appBillingOauthStates.id, row.id));
 
   const accountId = await exchangeConnectOAuthCode(input.code);
   await upsertAppBillingConfig(input.clientId, {
@@ -225,7 +218,9 @@ export function isMerchantConnectPaymentsReady(
   config: typeof appBillingConfig.$inferSelect | null | undefined,
 ): boolean {
   return Boolean(
-    config?.stripeConnectedAccountId?.trim() && config.stripeChargesEnabled,
+    config?.stripeConnectedAccountId?.trim() &&
+      config.stripeChargesEnabled &&
+      config.stripeDetailsSubmitted,
   );
 }
 
@@ -370,6 +365,10 @@ export async function createMerchantConnectCheckoutForUser(input: {
     cancelUrl: input.cancelUrl,
     mode: "setup",
     applicationFeeBps: config!.applicationFeeBps ?? 0,
+    metadata: {
+      pymthouse_client_id: input.clientId,
+      external_user_id: input.externalUserId,
+    },
   });
   return { checkoutUrl: session.url, sessionId: session.sessionId };
 }

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -1,0 +1,375 @@
+/**
+ * PymtHouse merchant Connect orchestration via Stripe Account Links.
+ * OpenMeter Stripe app wiring remains a side effect for Starter until cutover.
+ */
+import { and, eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db/index";
+import {
+  appBillingConfig,
+  appBillingOauthStates,
+  appUserStripeCustomers,
+} from "@/db/schema";
+import {
+  getAppBillingConfig,
+  upsertAppBillingConfig,
+  ensureAppStripeBillingReady,
+} from "@/lib/openmeter/billing-profiles";
+import {
+  connectAccountLinkUrls,
+  createAccountOnboardingLink,
+  createConnectedCheckoutSession,
+  createConnectedCustomer,
+  createMerchantConnectedAccount,
+  exchangeConnectOAuthCode,
+  refreshConnectedAccountStatus,
+  type StripeOnboardingMethod,
+} from "@/lib/stripe/connect-accounts";
+
+export type MerchantConnectMode = "account_link";
+
+async function persistConnectedAccountFlags(input: {
+  clientId: string;
+  accountId: string;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+}): Promise<void> {
+  const ready = input.chargesEnabled && input.detailsSubmitted;
+  const existing = await getAppBillingConfig(input.clientId);
+  await upsertAppBillingConfig(input.clientId, {
+    stripeConnectedAccountId: input.accountId,
+    stripeChargesEnabled: input.chargesEnabled,
+    stripePayoutsEnabled: input.payoutsEnabled,
+    stripeDetailsSubmitted: input.detailsSubmitted,
+    stripeConnectStatus: ready ? "connected" : "pending",
+    connectedAt: ready
+      ? (existing?.connectedAt ?? new Date().toISOString())
+      : (existing?.connectedAt ?? null),
+  });
+}
+
+async function syncConnectedAccountFlags(
+  clientId: string,
+  accountId: string,
+): Promise<{
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+}> {
+  const status = await refreshConnectedAccountStatus(accountId);
+  await persistConnectedAccountFlags({
+    clientId,
+    accountId,
+    chargesEnabled: status.chargesEnabled,
+    payoutsEnabled: status.payoutsEnabled,
+    detailsSubmitted: status.detailsSubmitted,
+  });
+  return {
+    chargesEnabled: status.chargesEnabled,
+    payoutsEnabled: status.payoutsEnabled,
+    detailsSubmitted: status.detailsSubmitted,
+  };
+}
+
+/**
+ * Apply Connect capability flags from a verified `account.updated` webhook.
+ * No-ops (returns updated:false) when the acct_ is not linked to an app.
+ */
+export async function applyConnectedAccountWebhookUpdate(input: {
+  accountId: string;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+}): Promise<{ updated: boolean; clientId?: string }> {
+  const rows = await db
+    .select({ clientId: appBillingConfig.clientId })
+    .from(appBillingConfig)
+    .where(eq(appBillingConfig.stripeConnectedAccountId, input.accountId))
+    .limit(1);
+  const clientId = rows[0]?.clientId;
+  if (!clientId) {
+    return { updated: false };
+  }
+  await persistConnectedAccountFlags({
+    clientId,
+    accountId: input.accountId,
+    chargesEnabled: input.chargesEnabled,
+    payoutsEnabled: input.payoutsEnabled,
+    detailsSubmitted: input.detailsSubmitted,
+  });
+  return { updated: true, clientId };
+}
+
+/** Ensure OM Starter billing profile still exists (platform path). */
+async function ensureOmStarterSideEffect(clientId: string): Promise<void> {
+  try {
+    await ensureAppStripeBillingReady({ clientId });
+  } catch {
+    // Non-fatal: merchant Connect can proceed without OM Stripe profile.
+  }
+}
+
+export async function startMerchantConnect({
+  clientId,
+  email,
+  displayName,
+}: {
+  clientId: string;
+  /** Reserved for audit / future session binding; Account Links do not persist OAuth state. */
+  userId: string;
+  mode?: MerchantConnectMode;
+  email?: string;
+  displayName?: string;
+}): Promise<{ method: "account_link"; url: string; accountId: string }> {
+  await ensureOmStarterSideEffect(clientId);
+
+  const existing = await getAppBillingConfig(clientId);
+  let accountId = existing?.stripeConnectedAccountId?.trim() || "";
+  if (!accountId) {
+    accountId = await createMerchantConnectedAccount({
+      clientId,
+      email,
+      displayName,
+    });
+    await upsertAppBillingConfig(clientId, {
+      stripeConnectedAccountId: accountId,
+      stripeOnboardingMethod: "account_link" satisfies StripeOnboardingMethod,
+      stripeConnectStatus: "pending",
+      stripeChargesEnabled: false,
+      stripePayoutsEnabled: false,
+      stripeDetailsSubmitted: false,
+    });
+  }
+
+  const urls = connectAccountLinkUrls(clientId);
+  const linkUrl = await createAccountOnboardingLink({
+    accountId,
+    refreshUrl: urls.refreshUrl,
+    returnUrl: urls.returnUrl,
+  });
+  await syncConnectedAccountFlags(clientId, accountId);
+  return { method: "account_link", url: linkUrl, accountId };
+}
+
+export async function refreshMerchantAccountLink(clientId: string): Promise<{
+  url: string;
+  accountId: string;
+}> {
+  const config = await getAppBillingConfig(clientId);
+  const accountId = config?.stripeConnectedAccountId?.trim();
+  if (!accountId) {
+    throw new Error("No Connected Account yet — start onboarding first");
+  }
+  if (config.stripeOnboardingMethod === "oauth" && config.stripeChargesEnabled) {
+    throw new Error("OAuth-linked accounts do not use Account Links");
+  }
+  const urls = connectAccountLinkUrls(clientId);
+  const url = await createAccountOnboardingLink({
+    accountId,
+    refreshUrl: urls.refreshUrl,
+    returnUrl: urls.returnUrl,
+  });
+  await syncConnectedAccountFlags(clientId, accountId);
+  return { url, accountId };
+}
+
+export async function completeMerchantConnectOAuth(input: {
+  clientId: string;
+  state: string;
+  code: string;
+}): Promise<void> {
+  const rows = await db
+    .select()
+    .from(appBillingOauthStates)
+    .where(
+      and(
+        eq(appBillingOauthStates.state, input.state),
+        eq(appBillingOauthStates.clientId, input.clientId),
+      ),
+    )
+    .limit(1);
+  const row = rows[0];
+  if (!row) {
+    throw new Error("Invalid or expired OAuth state");
+  }
+  if (row.expiresAt < new Date().toISOString()) {
+    await db
+      .delete(appBillingOauthStates)
+      .where(eq(appBillingOauthStates.id, row.id));
+    throw new Error("OAuth state expired");
+  }
+  await db
+    .delete(appBillingOauthStates)
+    .where(eq(appBillingOauthStates.id, row.id));
+
+  const accountId = await exchangeConnectOAuthCode(input.code);
+  await upsertAppBillingConfig(input.clientId, {
+    stripeConnectedAccountId: accountId,
+    stripeOnboardingMethod: "oauth",
+  });
+  await syncConnectedAccountFlags(input.clientId, accountId);
+  await ensureOmStarterSideEffect(input.clientId);
+}
+
+export async function syncMerchantConnectStatus(clientId: string): Promise<void> {
+  const config = await getAppBillingConfig(clientId);
+  const accountId = config?.stripeConnectedAccountId?.trim();
+  if (!accountId) {
+    return;
+  }
+  await syncConnectedAccountFlags(clientId, accountId);
+}
+
+export function isMerchantConnectPaymentsReady(
+  config: typeof appBillingConfig.$inferSelect | null | undefined,
+): boolean {
+  return Boolean(
+    config?.stripeConnectedAccountId?.trim() && config.stripeChargesEnabled,
+  );
+}
+
+export function connectPaymentsOnlyEnabled(
+  config: typeof appBillingConfig.$inferSelect | null | undefined,
+): boolean {
+  if (process.env.STRIPE_CONNECT_PAYMENTS_ONLY?.trim() === "1") {
+    return true;
+  }
+  return Boolean(config?.connectPaymentsOnly);
+}
+
+export async function upsertAppUserStripeCustomer(input: {
+  clientId: string;
+  externalUserId: string;
+  stripeConnectedAccountId: string;
+  stripeCustomerId: string;
+  openmeterCustomerId?: string | null;
+  openmeterCustomerKey?: string | null;
+}): Promise<void> {
+  const existing = await db
+    .select()
+    .from(appUserStripeCustomers)
+    .where(
+      and(
+        eq(appUserStripeCustomers.clientId, input.clientId),
+        eq(appUserStripeCustomers.externalUserId, input.externalUserId),
+      ),
+    )
+    .limit(1);
+  const now = new Date().toISOString();
+  if (existing[0]) {
+    await db
+      .update(appUserStripeCustomers)
+      .set({
+        stripeConnectedAccountId: input.stripeConnectedAccountId,
+        stripeCustomerId: input.stripeCustomerId,
+        openmeterCustomerId: input.openmeterCustomerId ?? null,
+        openmeterCustomerKey: input.openmeterCustomerKey ?? null,
+        updatedAt: now,
+      })
+      .where(eq(appUserStripeCustomers.id, existing[0].id));
+    return;
+  }
+  await db.insert(appUserStripeCustomers).values({
+    id: uuidv4(),
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+    stripeConnectedAccountId: input.stripeConnectedAccountId,
+    stripeCustomerId: input.stripeCustomerId,
+    openmeterCustomerId: input.openmeterCustomerId ?? null,
+    openmeterCustomerKey: input.openmeterCustomerKey ?? null,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+export async function getAppUserStripeCustomer(input: {
+  clientId: string;
+  externalUserId: string;
+}): Promise<typeof appUserStripeCustomers.$inferSelect | null> {
+  const rows = await db
+    .select()
+    .from(appUserStripeCustomers)
+    .where(
+      and(
+        eq(appUserStripeCustomers.clientId, input.clientId),
+        eq(appUserStripeCustomers.externalUserId, input.externalUserId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function ensureMerchantOwnedStripeCustomer(input: {
+  clientId: string;
+  externalUserId: string;
+  accountId: string;
+  name?: string;
+  openmeterCustomerId?: string;
+  openmeterCustomerKey?: string;
+}): Promise<string> {
+  const existing = await getAppUserStripeCustomer({
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+  });
+  if (
+    existing?.stripeCustomerId &&
+    existing.stripeConnectedAccountId === input.accountId
+  ) {
+    return existing.stripeCustomerId;
+  }
+  const stripeCustomerId = await createConnectedCustomer({
+    accountId: input.accountId,
+    name: input.name ?? input.externalUserId,
+    metadata: {
+      pymthouse_client_id: input.clientId,
+      external_user_id: input.externalUserId,
+      ...(input.openmeterCustomerId
+        ? { openmeter_customer_id: input.openmeterCustomerId }
+        : {}),
+      ...(input.openmeterCustomerKey
+        ? { customer_key: input.openmeterCustomerKey }
+        : {}),
+    },
+  });
+  await upsertAppUserStripeCustomer({
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+    stripeConnectedAccountId: input.accountId,
+    stripeCustomerId,
+    openmeterCustomerId: input.openmeterCustomerId,
+    openmeterCustomerKey: input.openmeterCustomerKey,
+  });
+  return stripeCustomerId;
+}
+
+export async function createMerchantConnectCheckoutForUser(input: {
+  clientId: string;
+  externalUserId: string;
+  successUrl: string;
+  cancelUrl: string;
+  openmeterCustomerId?: string;
+  openmeterCustomerKey?: string;
+}): Promise<{ checkoutUrl: string; sessionId: string }> {
+  const config = await getAppBillingConfig(input.clientId);
+  if (!isMerchantConnectPaymentsReady(config)) {
+    throw new Error("Merchant Stripe Connect is not ready to accept payments");
+  }
+  const accountId = config!.stripeConnectedAccountId!;
+  const customerId = await ensureMerchantOwnedStripeCustomer({
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+    accountId,
+    openmeterCustomerId: input.openmeterCustomerId,
+    openmeterCustomerKey: input.openmeterCustomerKey,
+  });
+  const session = await createConnectedCheckoutSession({
+    accountId,
+    customerId,
+    successUrl: input.successUrl,
+    cancelUrl: input.cancelUrl,
+    mode: "setup",
+    applicationFeeBps: config!.applicationFeeBps ?? 0,
+  });
+  return { checkoutUrl: session.url, sessionId: session.sessionId };
+}

--- a/src/lib/stripe/payments-tab-errors.ts
+++ b/src/lib/stripe/payments-tab-errors.ts
@@ -1,0 +1,31 @@
+/**
+ * Client-safe Payments-tab `?error=` mapping (no Node builtins).
+ */
+
+/**
+ * Map Payments-tab `?error=` query values to fixed copy.
+ * Unknown / free-form values are ignored (prevents reflected phishing).
+ */
+export function paymentsTabErrorMessage(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const code = raw.trim().toLowerCase();
+  const messages: Record<string, string> = {
+    access_denied: "Stripe connection was cancelled.",
+    invalid_request: "Stripe rejected the connection request.",
+    invalid_client: "Stripe Connect is misconfigured on this environment.",
+    invalid_grant: "Stripe authorization code was invalid or expired.",
+    unauthorized_client: "Stripe rejected this Connect client.",
+    unsupported_response_type: "Stripe rejected the Connect response type.",
+    invalid_scope: "Stripe rejected the requested Connect scope.",
+    server_error: "Stripe reported a temporary server error. Try again.",
+    temporarily_unavailable: "Stripe is temporarily unavailable. Try again.",
+    oauth_denied: "Stripe connection was denied.",
+    invalid_oauth_state: "Stripe connection link was invalid. Try again.",
+    oauth_state_expired: "Stripe connection link expired. Try again.",
+    connect_misconfigured: "Stripe Connect is misconfigured on this environment.",
+    oauth_exchange_failed: "Could not complete Stripe connection. Try again.",
+    oauth_failed: "Stripe connection failed. Try again.",
+    missing_oauth_params: "Stripe connection was incomplete. Try again.",
+  };
+  return messages[code] ?? null;
+}

--- a/src/lib/stripe/payments-tab-errors.ts
+++ b/src/lib/stripe/payments-tab-errors.ts
@@ -2,30 +2,30 @@
  * Client-safe Payments-tab `?error=` mapping (no Node builtins).
  */
 
+const PAYMENTS_TAB_ERROR_MESSAGES = new Map<string, string>([
+  ["access_denied", "Stripe connection was cancelled."],
+  ["invalid_request", "Stripe rejected the connection request."],
+  ["invalid_client", "Stripe Connect is misconfigured on this environment."],
+  ["invalid_grant", "Stripe authorization code was invalid or expired."],
+  ["unauthorized_client", "Stripe rejected this Connect client."],
+  ["unsupported_response_type", "Stripe rejected the Connect response type."],
+  ["invalid_scope", "Stripe rejected the requested Connect scope."],
+  ["server_error", "Stripe reported a temporary server error. Try again."],
+  ["temporarily_unavailable", "Stripe is temporarily unavailable. Try again."],
+  ["oauth_denied", "Stripe connection was denied."],
+  ["invalid_oauth_state", "Stripe connection link was invalid. Try again."],
+  ["oauth_state_expired", "Stripe connection link expired. Try again."],
+  ["connect_misconfigured", "Stripe Connect is misconfigured on this environment."],
+  ["oauth_exchange_failed", "Could not complete Stripe connection. Try again."],
+  ["oauth_failed", "Stripe connection failed. Try again."],
+  ["missing_oauth_params", "Stripe connection was incomplete. Try again."],
+]);
+
 /**
  * Map Payments-tab `?error=` query values to fixed copy.
  * Unknown / free-form values are ignored (prevents reflected phishing).
  */
 export function paymentsTabErrorMessage(raw: string | null | undefined): string | null {
   if (!raw) return null;
-  const code = raw.trim().toLowerCase();
-  const messages: Record<string, string> = {
-    access_denied: "Stripe connection was cancelled.",
-    invalid_request: "Stripe rejected the connection request.",
-    invalid_client: "Stripe Connect is misconfigured on this environment.",
-    invalid_grant: "Stripe authorization code was invalid or expired.",
-    unauthorized_client: "Stripe rejected this Connect client.",
-    unsupported_response_type: "Stripe rejected the Connect response type.",
-    invalid_scope: "Stripe rejected the requested Connect scope.",
-    server_error: "Stripe reported a temporary server error. Try again.",
-    temporarily_unavailable: "Stripe is temporarily unavailable. Try again.",
-    oauth_denied: "Stripe connection was denied.",
-    invalid_oauth_state: "Stripe connection link was invalid. Try again.",
-    oauth_state_expired: "Stripe connection link expired. Try again.",
-    connect_misconfigured: "Stripe Connect is misconfigured on this environment.",
-    oauth_exchange_failed: "Could not complete Stripe connection. Try again.",
-    oauth_failed: "Stripe connection failed. Try again.",
-    missing_oauth_params: "Stripe connection was incomplete. Try again.",
-  };
-  return messages[code] ?? null;
+  return PAYMENTS_TAB_ERROR_MESSAGES.get(raw.trim().toLowerCase()) ?? null;
 }

--- a/src/lib/stripe/webhook.test.ts
+++ b/src/lib/stripe/webhook.test.ts
@@ -31,6 +31,23 @@ test("verifyStripeWebhookSignature accepts valid v1 signature", () => {
   );
 });
 
+test("verifyStripeWebhookSignature accepts any matching v1 when multiple are present", () => {
+  const secret = "whsec_test_secret";
+  const rawBody = '{"type":"account.updated"}';
+  const now = 1_700_000_000;
+  const good = signBody(secret, now, rawBody);
+  const header = `${good},v1=${"00".repeat(32)}`;
+  assert.equal(
+    verifyStripeWebhookSignature({
+      rawBody,
+      signatureHeader: header,
+      secret,
+      nowSec: now,
+    }),
+    true,
+  );
+});
+
 test("verifyStripeWebhookSignature rejects tampered body and skew", () => {
   const secret = "whsec_test_secret";
   const rawBody = '{"type":"account.updated"}';

--- a/src/lib/stripe/webhook.test.ts
+++ b/src/lib/stripe/webhook.test.ts
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { paymentsTabErrorMessage } from "./payments-tab-errors";
+import {
+  merchantConnectOAuthErrorCode,
+  parseStripeAccountUpdated,
+  sanitizeStripeOAuthProviderError,
+  verifyStripeWebhookSignature,
+} from "./webhook";
+
+function signBody(secret: string, timestamp: number, rawBody: string): string {
+  const payload = `${timestamp}.${rawBody}`;
+  const v1 = createHmac("sha256", secret).update(payload, "utf8").digest("hex");
+  return `t=${timestamp},v1=${v1}`;
+}
+
+test("verifyStripeWebhookSignature accepts valid v1 signature", () => {
+  const secret = "whsec_test_secret";
+  const rawBody = '{"type":"account.updated"}';
+  const now = 1_700_000_000;
+  const header = signBody(secret, now, rawBody);
+  assert.equal(
+    verifyStripeWebhookSignature({
+      rawBody,
+      signatureHeader: header,
+      secret,
+      nowSec: now,
+    }),
+    true,
+  );
+});
+
+test("verifyStripeWebhookSignature rejects tampered body and skew", () => {
+  const secret = "whsec_test_secret";
+  const rawBody = '{"type":"account.updated"}';
+  const now = 1_700_000_000;
+  const header = signBody(secret, now, rawBody);
+  assert.equal(
+    verifyStripeWebhookSignature({
+      rawBody: rawBody + "x",
+      signatureHeader: header,
+      secret,
+      nowSec: now,
+    }),
+    false,
+  );
+  assert.equal(
+    verifyStripeWebhookSignature({
+      rawBody,
+      signatureHeader: header,
+      secret,
+      nowSec: now + 301,
+      toleranceSec: 300,
+    }),
+    false,
+  );
+});
+
+test("parseStripeAccountUpdated extracts Connect flags", () => {
+  const body = JSON.stringify({
+    type: "account.updated",
+    data: {
+      object: {
+        id: "acct_123",
+        charges_enabled: true,
+        payouts_enabled: false,
+        details_submitted: true,
+      },
+    },
+  });
+  assert.deepEqual(parseStripeAccountUpdated(body), {
+    accountId: "acct_123",
+    chargesEnabled: true,
+    payoutsEnabled: false,
+    detailsSubmitted: true,
+  });
+  assert.equal(parseStripeAccountUpdated('{"type":"customer.created"}'), null);
+});
+
+test("merchantConnectOAuthErrorCode never returns raw messages", () => {
+  assert.equal(
+    merchantConnectOAuthErrorCode(new Error("Invalid or expired OAuth state")),
+    "invalid_oauth_state",
+  );
+  assert.equal(
+    merchantConnectOAuthErrorCode(new Error("OAuth state expired")),
+    "oauth_state_expired",
+  );
+  assert.equal(
+    merchantConnectOAuthErrorCode(
+      new Error("Stripe POST /v1/oauth/token failed (400): bad code"),
+    ),
+    "oauth_exchange_failed",
+  );
+  assert.equal(
+    merchantConnectOAuthErrorCode(new Error("secret sk_live_abc leaked")),
+    "oauth_failed",
+  );
+});
+
+test("sanitizeStripeOAuthProviderError allowlists Stripe codes", () => {
+  assert.equal(sanitizeStripeOAuthProviderError("access_denied"), "access_denied");
+  assert.equal(
+    sanitizeStripeOAuthProviderError("totally_weird<script>"),
+    "oauth_denied",
+  );
+});
+
+test("paymentsTabErrorMessage ignores free-form phishing text", () => {
+  assert.equal(paymentsTabErrorMessage("access_denied"), "Stripe connection was cancelled.");
+  assert.equal(
+    paymentsTabErrorMessage(
+      "Your Stripe account was suspended. Re-verify at https://evil.example",
+    ),
+    null,
+  );
+  assert.equal(paymentsTabErrorMessage(null), null);
+});

--- a/src/lib/stripe/webhook.ts
+++ b/src/lib/stripe/webhook.ts
@@ -1,0 +1,147 @@
+/**
+ * Stripe Connect webhook helpers (signature verify + account.updated parse).
+ * No stripe SDK — HMAC over the raw body per Stripe docs.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export { paymentsTabErrorMessage } from "@/lib/stripe/payments-tab-errors";
+
+const DEFAULT_TOLERANCE_SEC = 300;
+
+export type StripeAccountUpdatedPayload = {
+  accountId: string;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+};
+
+export function requireStripeWebhookSecret(): string {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET?.trim();
+  if (!secret || !secret.startsWith("whsec_")) {
+    throw new Error(
+      "STRIPE_WEBHOOK_SECRET is required (whsec_… from Stripe Dashboard → Webhooks)",
+    );
+  }
+  return secret;
+}
+
+/**
+ * Verify Stripe-Signature (t=…,v1=…). Returns false on any mismatch / skew.
+ */
+export function verifyStripeWebhookSignature(input: {
+  rawBody: string;
+  signatureHeader: string | null;
+  secret: string;
+  toleranceSec?: number;
+  nowSec?: number;
+}): boolean {
+  if (!input.signatureHeader?.trim()) {
+    return false;
+  }
+  const parts = Object.fromEntries(
+    input.signatureHeader.split(",").map((part) => {
+      const [k, ...rest] = part.trim().split("=");
+      return [k, rest.join("=")];
+    }),
+  ) as Record<string, string>;
+  const timestamp = parts.t;
+  const v1 = parts.v1;
+  if (!timestamp || !v1) {
+    return false;
+  }
+  const ts = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(ts)) {
+    return false;
+  }
+  const now = input.nowSec ?? Math.floor(Date.now() / 1000);
+  const tolerance = input.toleranceSec ?? DEFAULT_TOLERANCE_SEC;
+  if (Math.abs(now - ts) > tolerance) {
+    return false;
+  }
+
+  const signedPayload = `${timestamp}.${input.rawBody}`;
+  const expected = createHmac("sha256", input.secret)
+    .update(signedPayload, "utf8")
+    .digest("hex");
+
+  const expectedBuf = Buffer.from(expected, "utf8");
+  const actualBuf = Buffer.from(v1, "utf8");
+  if (expectedBuf.length !== actualBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBuf, actualBuf);
+}
+
+/** Extract Connect capability flags from an account.updated event body. */
+export function parseStripeAccountUpdated(
+  rawBody: string,
+): StripeAccountUpdatedPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody) as unknown;
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+  const event = parsed as {
+    type?: unknown;
+    data?: { object?: Record<string, unknown> };
+  };
+  if (event.type !== "account.updated") {
+    return null;
+  }
+  const obj = event.data?.object;
+  if (!obj || typeof obj !== "object") {
+    return null;
+  }
+  const accountId =
+    typeof obj.id === "string" ? obj.id.trim() : "";
+  if (!accountId.startsWith("acct_")) {
+    return null;
+  }
+  return {
+    accountId,
+    chargesEnabled: Boolean(obj.charges_enabled),
+    payoutsEnabled: Boolean(obj.payouts_enabled),
+    detailsSubmitted: Boolean(obj.details_submitted),
+  };
+}
+
+/**
+ * Map OAuth / Connect failures to stable query codes (never raw exception text).
+ */
+export function merchantConnectOAuthErrorCode(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  if (/Invalid or expired OAuth state/i.test(message)) {
+    return "invalid_oauth_state";
+  }
+  if (/OAuth state expired/i.test(message)) {
+    return "oauth_state_expired";
+  }
+  if (/STRIPE_CONNECT_CLIENT_ID|STRIPE_SECRET_KEY/i.test(message)) {
+    return "connect_misconfigured";
+  }
+  if (/oauth\/token|exchangeConnectOAuthCode|authorization_code/i.test(message)) {
+    return "oauth_exchange_failed";
+  }
+  return "oauth_failed";
+}
+
+/** Allowlist Stripe-provided OAuth `error` query values for redirects. */
+export function sanitizeStripeOAuthProviderError(error: string): string {
+  const code = error.trim().toLowerCase();
+  const allowed = new Set([
+    "access_denied",
+    "invalid_request",
+    "invalid_client",
+    "invalid_grant",
+    "unauthorized_client",
+    "unsupported_response_type",
+    "invalid_scope",
+    "server_error",
+    "temporarily_unavailable",
+  ]);
+  return allowed.has(code) ? code : "oauth_denied";
+}

--- a/src/lib/stripe/webhook.ts
+++ b/src/lib/stripe/webhook.ts
@@ -26,7 +26,8 @@ export function requireStripeWebhookSecret(): string {
 }
 
 /**
- * Verify Stripe-Signature (t=…,v1=…). Returns false on any mismatch / skew.
+ * Verify Stripe-Signature (t=…,v1=…). Accepts any matching v1 (rotation can
+ * send multiple). Returns false on any mismatch / skew.
  */
 export function verifyStripeWebhookSignature(input: {
   rawBody: string;
@@ -38,15 +39,18 @@ export function verifyStripeWebhookSignature(input: {
   if (!input.signatureHeader?.trim()) {
     return false;
   }
-  const parts = Object.fromEntries(
-    input.signatureHeader.split(",").map((part) => {
-      const [k, ...rest] = part.trim().split("=");
-      return [k, rest.join("=")];
-    }),
-  ) as Record<string, string>;
-  const timestamp = parts.t;
-  const v1 = parts.v1;
-  if (!timestamp || !v1) {
+  let timestamp: string | undefined;
+  const v1Signatures: string[] = [];
+  for (const part of input.signatureHeader.split(",")) {
+    const [k, ...rest] = part.trim().split("=");
+    const value = rest.join("=");
+    if (k === "t") {
+      timestamp = value;
+    } else if (k === "v1" && value) {
+      v1Signatures.push(value);
+    }
+  }
+  if (!timestamp || v1Signatures.length === 0) {
     return false;
   }
   const ts = Number.parseInt(timestamp, 10);
@@ -60,16 +64,25 @@ export function verifyStripeWebhookSignature(input: {
   }
 
   const signedPayload = `${timestamp}.${input.rawBody}`;
-  const expected = createHmac("sha256", input.secret)
+  const expectedBuf = createHmac("sha256", input.secret)
     .update(signedPayload, "utf8")
-    .digest("hex");
+    .digest();
 
-  const expectedBuf = Buffer.from(expected, "utf8");
-  const actualBuf = Buffer.from(v1, "utf8");
-  if (expectedBuf.length !== actualBuf.length) {
-    return false;
+  for (const v1 of v1Signatures) {
+    let actualBuf: Buffer;
+    try {
+      actualBuf = Buffer.from(v1, "hex");
+    } catch {
+      continue;
+    }
+    if (
+      expectedBuf.length === actualBuf.length &&
+      timingSafeEqual(expectedBuf, actualBuf)
+    ) {
+      return true;
+    }
   }
-  return timingSafeEqual(expectedBuf, actualBuf);
+  return false;
 }
 
 /** Extract Connect capability flags from an account.updated event body. */


### PR DESCRIPTION
## Summary
- Stripe Connect merchant onboarding via Account Links + Connected Account APIs.
- Merchant checkout path on Connected Accounts; `account.updated` webhook sync.
- Payments tab Connect UI (without activation-gate billing mode / end-user cap).
- Migration `0033_stripe_connect_merchant` (renumbered from draft #124's 0034).

**Base:** `feat/openmeter-billing-foundations` (#321). Stacked split of draft #124.

## Test plan
- [x] `npx tsc --noEmit`
- [x] Connect/merchant/webhook/stripe-connect unit tests
- [ ] Manual Account Link onboarding against Stripe test mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stripe Connect merchant onboarding, account linking, payment readiness, and webhook support.
  * Merchants can configure billing, progressive invoicing, invoice thresholds, and application fees.
  * Owners can add a Stripe payment method for automatic overage invoicing.
  * End-user checkout now supports merchant-connected accounts with optional payments-only enforcement.
  * Billing and Payments screens now show clearer connection, readiness, invoice, and payment-method statuses.

* **Documentation**
  * Documented the dual Stripe billing architecture, setup steps, webhook behavior, and configuration variables.

* **Bug Fixes**
  * Restricted on-ramp funding and settlement actions to platform administrators.
  * Improved billing data loading resilience and sanitized payment-flow error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->