### PR TITLE
fix(auth): stop /apps ↔ / redirect loop from a stale client session

### DIFF
--- a/src/app/marketplace/layout.tsx
+++ b/src/app/marketplace/layout.tsx
@@ -9,16 +9,12 @@ export default function MarketplaceLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const { data: session, status } = useSession();
+  const { data: session } = useSession();
 
-  if (status === "loading") {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-950 text-zinc-500">
-        <div className="animate-pulse">Loading...</div>
-      </div>
-    );
-  }
-
+  // No loading gate: signed-in requests get their session from the server on
+  // first paint, so only anonymous visitors ever see an unresolved session —
+  // and the public layout is already the right answer for them. Blocking on
+  // `status === "loading"` would put a spinner in front of a public page.
   if (session?.user) {
     return (
       <MarketplaceLayoutProvider insideDashboard>

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -120,9 +120,13 @@ export default function DashboardLayout({
     [userRole]
   );
 
+  // Must not target "/": the home page redirects any request carrying a session
+  // cookie to /apps, so a client/server session disagreement would ping-pong
+  // /apps → / → /apps forever. /login is where the server-side guards send
+  // unauthenticated requests, and it never redirects them back out.
   useEffect(() => {
     if (status === "unauthenticated") {
-      router.push("/");
+      router.push("/login");
     }
   }, [status, router]);
 

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -12,7 +12,14 @@ export default function Providers({
   session: Session | null;
 }>) {
   return (
-    <SessionProvider session={session} refetchOnWindowFocus={false}>
+    // `null` must never reach SessionProvider: next-auth v4 pins it as the
+    // session for the tab's whole SPA lifetime and then refuses every refetch
+    // (`_session === null` early-returns in _getSession, and update() no-ops),
+    // so a tab loaded while signed out stays "unauthenticated" on the client
+    // even after the cookie becomes valid. `undefined` means "unknown", which
+    // makes the provider fetch /api/auth/session on mount. A real session is
+    // still passed through so signed-in loads render without a loading pass.
+    <SessionProvider session={session ?? undefined} refetchOnWindowFocus={false}>
       <TurnkeyProviderWrapper>{children}</TurnkeyProviderWrapper>
     </SessionProvider>
   );


### PR DESCRIPTION
## The bug

Clicking **Get Started** on production sent the browser into an infinite redirect loop between `/apps` and `/`. Both sides returned `200` with an `_rsc=` param and alternating `Referer`s, because RSC-navigation redirects are encoded in the flight payload rather than as `3xx` responses:

```
GET /       200  Referer: https://pymthouse.com/apps   ?_rsc=uMsgUhXD70uJBGNq
GET /apps   200  Referer: https://pymthouse.com/       ?_rsc=2Md0sTUZcnjCijMr
```

Hard to reproduce, because it needs a tab that was full-loaded while signed out and whose session cookie later became valid.

## Root cause

The server and the client disagreed about whether a session existed, and the two guards pointed at each other.

**Server side** — `/` redirects any request carrying a session cookie to `/apps` (`app/page.tsx`). `/start`, which **Get Started** links to, does the same, so it drops a session-holder straight into `/apps`.

**Client side** — `/apps` renders inside `DashboardLayout`, which pushed to `/` whenever `useSession()` reported `unauthenticated`.

The disagreement came from the root layout passing `getServerSession()`'s result straight into `SessionProvider`. next-auth v4 treats a `null` session prop as a *definitive* answer, not as "unknown":

- `hasInitialSession = props.session !== undefined` is `true` for `null`, so `_session` is pinned to `null` and the initial `/api/auth/session` fetch is skipped.
- Every later refetch early-returns on `_session === null` in `_getSession`, and `update()` no-ops when `!session`. `refetchOnWindowFocus={false}` removes the last nudge — though even with it enabled the early-return still applies.

So a tab loaded while signed out reported `unauthenticated` on the client for its entire SPA lifetime. Once the cookie became valid out-of-band (sign-in in another window, a cookie set by a flow that doesn't go through `next-auth/react`'s `signIn()`, browser session restore), the next navigation into `/apps` looped forever.

## The fix

1. **`Providers.tsx`** — pass `undefined` instead of `null` so a signed-out server render means "unknown" and the provider resolves the session on mount. A real session is still passed through, so signed-in loads render without a loading pass. This removes the stale state at its source.
2. **`DashboardLayout.tsx`** — send client-unauthenticated users to `/login`, where the server-side guards already send them, instead of `/`. A client/server disagreement can then never form a cycle. The gate is **kept** rather than removed, because `/apps/new`, `/apps/[id]`, `/admin/apps`, `/admin/oidc-clients` and `/dashboard` are client components with no server-side session guard, so it is load-bearing for those routes.
3. **`app/marketplace/layout.tsx`** — drop the blocking full-screen `loading` gate. With change 1, only anonymous visitors can see an unresolved session there, and the public layout is already the right answer for them; keeping the gate would newly put a spinner in front of a public page. Signed-in users still get their session on first paint, so there is no layout shift.

Either change 1 or 2 alone breaks the loop; together they also remove the underlying stale-session class of bugs.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on the three changed files — clean
- `npm test` — 506/506 pass
- **Snyk Code** — no findings in the changed files. One pre-existing medium Open Redirect (CWE-601) in `src/components/apps/PaymentsTab.tsx` is untouched by this PR and left for a separate fix.
- **SonarQube** — `analyze_code_snippet` clean on both structurally-changed files; project gate green. All three files sit in `sonar.coverage.exclusions`, so no new-coverage impact.
- **Browser** (local dev, anonymous):
  - `GET /api/auth/session` now fires on an anonymous load of `/` — the recovery path the pinned `null` used to suppress. Single `/?_rsc=` request, no ping-pong.
  - `/marketplace` renders the public layout immediately, no blocking spinner.
  - `/apps` → `307` → `/login` → `200`, settles with no further navigation.
  - `/login` renders fully, including the Explore-and-Build CTA panel.

Not reproducible locally end-to-end: the authenticated stale-tab path needs a valid production session cookie plus an out-of-band cookie change. Verification targets the mechanism instead — the pinned-`null` state that caused it can no longer be created, and the `/` loop partner is no longer a redirect target.