### PR TITLE
feat(billing): dual-plane Stripe tidy + faster /billing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,27 +142,33 @@ OPENMETER_URL=http://127.0.0.1:48888
 # - self_hosted: use OpenMeter SDK /api/v1 routes
 # - hosted: use hosted Konnect-style routes (no /api/v1 prefix)
 OPENMETER_ROUTE_MODE=auto
-# ISO 3166-1 alpha-2 country on per-app billing profile supplier (default US)
-# OPENMETER_BILLING_SUPPLIER_COUNTRY=US
-# Konnect only: pin a specific org Stripe app when multiple are installed
-# OPENMETER_STRIPE_APP_ID=01G65Z755AFWAKHE12NY0CQ9FH
 # Optional for local docker; required for OpenMeter Cloud / auth-enabled installs.
 OPENMETER_API_KEY=
 # Optional collector-only ingest key. Falls back to OPENMETER_API_KEY when unset.
 OPENMETER_INGEST_API_KEY=
-# Platform Stripe secret key for the SAME account installed in Konnect/OpenMeter.
-# STRIPE_SECRET_KEY=sk_live_…
-# After hard cutover, force Connect-only checkout globally (optional; prefer per-app connectPaymentsOnly)
-# STRIPE_CONNECT_PAYMENTS_ONLY=0
-# Connect webhook signing secret (Dashboard → Webhooks → endpoint for /webhooks/stripe, include account.updated)
-# STRIPE_WEBHOOK_SECRET=whsec_…
-# Optional override for the shared owners Stripe billing profile id
-# OPENMETER_OWNERS_BILLING_PROFILE_ID=
-# Deprecated: sandbox free profile — Starter now uses Stripe profiles + included usage.
-# OPENMETER_FREE_BILLING_PROFILE_ID=
 OPENMETER_TRIAL_FEATURE_KEY=network_spend
 # Default included usage (USD micros) when seeding per-app Starter plan (5000000 = $5)
 OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS=5000000
+
+# ---------- Plane A: OpenMeter Stripe app (platform cost rail) ----------
+# Developers pay PymtHouse for network usage via Kong/OM billing profiles.
+# ISO 3166-1 alpha-2 country on per-app billing profile supplier (default US)
+# OPENMETER_BILLING_SUPPLIER_COUNTRY=US
+# Konnect only: pin a specific org Stripe app when multiple are installed
+# OPENMETER_STRIPE_APP_ID=01G65Z755AFWAKHE12NY0CQ9FH
+# Platform Stripe secret key for the SAME account installed in Konnect/OpenMeter
+# (used to mint cus_… for OM customer app_data).
+# STRIPE_SECRET_KEY=sk_live_…
+# Optional override for the shared owners Stripe billing profile id
+# OPENMETER_OWNERS_BILLING_PROFILE_ID=
+
+# ---------- Plane B: Merchant Stripe Connect (revenue rail) ----------
+# Builders collect from end users on Connected Accounts; PymtHouse takes application_fee_bps.
+# Connect webhook signing secret (Dashboard → Webhooks → connected-account events → /webhooks/stripe)
+# STRIPE_WEBHOOK_SECRET=whsec_…
+# After hard cutover, force Connect-only checkout globally (optional; prefer per-app connectPaymentsOnly)
+# STRIPE_CONNECT_PAYMENTS_ONLY=0
+
 # Required for usage totals, allowance balance, and signed-ticket metering
 # OPENMETER_URL=http://127.0.0.1:48888
 

--- a/docs/adr-stripe-connect-openmeter-webhooks.md
+++ b/docs/adr-stripe-connect-openmeter-webhooks.md
@@ -1,0 +1,262 @@
+# ADR: Stripe Connect + OpenMeter via two webhook planes
+
+Status: **accepted** (design binding for stacked billing PRs).  
+Supersedes the ambiguous “Stripe Connect” naming in the OpenMeter Stripe **app
+install** path. Companion to [`activation-gate.md`](./activation-gate.md).
+
+| Stack | PR | Role |
+|---|---|---|
+| OpenMeter Stripe billing foundations | [#321](https://github.com/pymthouse/pymthouse/pull/321) | Platform OM Stripe app, billing profiles, customer Stripe app data |
+| Merchant Connect onboarding | [#322](https://github.com/pymthouse/pymthouse/pull/322) | Account Links, Connect webhook, connected Checkout |
+| Plans / phase-out | [#323](https://github.com/pymthouse/pymthouse/pull/323) | Progressive billing, subscription change |
+| Cutover scripts | [#324](https://github.com/pymthouse/pymthouse/pull/324) | Sandbox → Stripe / Connect cutover tooling |
+| Activation gate | [#325](https://github.com/pymthouse/pymthouse/pull/325) | Cost vs revenue rails; readiness predicate |
+
+## Context
+
+OpenMeter’s Stripe **app** (marketplace install / API key / Konnect org Stripe
+app) integrates with a **normal Stripe account**: Tax, Invoicing, Payments, and
+Checkout. On install it registers Stripe webhooks (notably
+`setup_intent.succeeded`) so Checkout can attach a default payment method to an
+OpenMeter customer.
+
+That product is **not** Stripe Connect. It does not onboard Express/Standard
+connected accounts, does not emit Account Links, and does not document
+destination charges or `application_fee_amount` on connected-account payments.
+
+PymtHouse needs both:
+
+1. **Cost rail** — app owners pay PymtHouse for network usage (always on).
+2. **Revenue rail** — Builders optionally collect from their own end users, with
+   PymtHouse taking `application_fee_bps`.
+
+Conflating “connect Stripe to OpenMeter” with “Stripe Connect for merchants”
+produced oversized PR #124 and incorrect product assumptions. This ADR fixes the
+architecture and the vocabulary.
+
+## Decision
+
+**Use two independent Stripe webhook planes and never ask the OpenMeter Stripe
+app to charge on connected accounts.**
+
+| Plane | Stripe account scope | Owner | Purpose |
+|---|---|---|---|
+| **A — OpenMeter Stripe app** | Platform (or Konnect org) Stripe account | OpenMeter / Konnect (auto-installed) | Cost-rail Checkout, invoice sync, PM attach for **owners** |
+| **B — PymtHouse Connect** | Connected accounts (`events from Connect`) | `POST /webhooks/stripe` | Merchant readiness, end-user Checkout completion, deauth |
+
+OpenMeter remains the **metering and entitlement brain** for both rails. For
+merchant end users it must **meter without auto-collecting** on the platform
+Stripe app (Sandbox / non-charging profile, or subscription created only after
+Connect payment with no chargeable PM in OM).
+
+### Vocabulary (use in UI and docs)
+
+| Say | Mean |
+|---|---|
+| **Connect Stripe billing** / OpenMeter Stripe app | Install OM’s Stripe app on the platform account |
+| **Merchant Stripe Connect** / connected account | Builder Express/Standard account via Account Links |
+| Do **not** say “Stripe Connect” for OM app install | Causes the confusion this ADR kills |
+
+## Architecture
+
+```
+ Network usage ──► OpenMeter (plans, entitlements, invoices)
+                         │
+                         │ Plane A: OM Stripe app webhooks
+                         │ (platform account only)
+                         ▼
+                   Platform Stripe
+                   • Owner Checkout / invoices
+                   • setup_intent.succeeded → OM attaches PM
+
+ Builder onboarding ──► Account Links (acct_…)
+ End-user retail pay ──► Checkout / PaymentIntent
+                         (destination or stripeAccount
+                          + application_fee_amount)
+                         │
+                         │ Plane B: /webhooks/stripe
+                         │ (Connect events; event.account)
+                         ▼
+                   PymtHouse
+                   • account.updated → readiness flags
+                   • checkout.session.completed → ensure OM
+                     customer + subscription (meter only)
+                   • deauthorized → clear connectReady
+```
+
+### Sequence — merchant sells a paid plan
+
+```mermaid
+sequenceDiagram
+  participant B as Builder
+  participant PH as PymtHouse
+  participant S as Stripe (Connect)
+  participant OM as OpenMeter
+
+  B->>PH: Start Account Link onboarding
+  PH->>S: accounts.create + accountLinks.create
+  S-->>B: Hosted onboarding
+  S->>PH: webhook account.updated (Plane B)
+  PH->>PH: Persist charges_enabled, details_submitted
+
+  Note over PH: canSellPaidPlans when connectReady
+
+  B->>PH: Activate priced plan / create checkout
+  PH->>S: Checkout Session on connected account<br/>metadata: clientId, externalUserId, planId
+  S-->>B: Hosted Checkout
+  S->>PH: webhook checkout.session.completed (Plane B)
+  PH->>OM: Ensure customer + create/change subscription<br/>(non-charging billing profile)
+  OM-->>PH: subscription id
+  PH->>PH: Cache subscription / audit payment
+
+  Note over OM: Usage events still settle cost rail<br/>to owner wallet via platform Stripe (Plane A)
+```
+
+### Sequence — owner cost rail (unchanged OM path)
+
+```mermaid
+sequenceDiagram
+  participant O as App owner
+  participant PH as PymtHouse
+  participant OM as OpenMeter
+  participant S as Platform Stripe
+
+  O->>PH: Top-up / attach payment method
+  PH->>OM: apps.stripe.createCheckoutSession (setup)
+  OM->>S: Checkout (platform account)
+  S->>OM: setup_intent.succeeded (Plane A — OM webhook)
+  OM->>OM: Attach cus_ + default PM
+  Note over OM,S: Later invoices charge_automatically<br/>on platform account for network usage
+```
+
+## Event catalogue
+
+### Plane A — OpenMeter-owned (do not duplicate)
+
+Registered when the OM Stripe app is installed. PymtHouse must **not** steal these
+handlers for the same objects unless OM is unreachable and we have an explicit
+failover design.
+
+| Event | Consumer | Effect |
+|---|---|---|
+| `setup_intent.succeeded` | OpenMeter Stripe app | Bind Stripe customer + default PM to OM customer |
+| Invoice / payment sync events | OpenMeter Stripe app | Collect platform invoices for owners |
+
+### Plane B — PymtHouse Connect endpoint
+
+Dashboard: **Developers → Webhooks → Listen to events on Connected accounts**.  
+Env: `STRIPE_WEBHOOK_SECRET` (`whsec_…`), endpoint `POST /webhooks/stripe`.  
+Verify `Stripe-Signature` over the raw body (`src/lib/stripe/webhook.ts`).
+
+| Event | Handler intent | Neon / OM effect |
+|---|---|---|
+| `account.updated` | `applyConnectedAccountWebhookUpdate` | Refresh `stripe_charges_enabled`, `stripe_details_submitted`, `stripe_payouts_enabled`; set `stripe_connect_status` |
+| `account.application.deauthorized` | Clear merchant link | `connectReady=false`; block new paid checkouts; keep metering |
+| `checkout.session.completed` | Retail payment success | Idempotent: map metadata → ensure OM customer + subscription; write `app_user_stripe_customers` |
+| `payment_intent.succeeded` | Alternate / one-shot retail | Same as above when Checkout is not used |
+| `invoice.paid` (Connect) | Recurring retail on connected account | Advance local subscription cache; do **not** also charge via OM Stripe app |
+| `customer.subscription.deleted` (optional) | Merchant cancelled retail sub | Align OM subscription cancel / phase-out |
+
+**Readiness predicate** (activation gate): `charges_enabled && details_submitted`.
+`payouts_enabled` is recorded but **not** required (see activation-gate.md).
+
+**Idempotency:** store processed Stripe `event.id` (or rely on natural upserts keyed
+by `client_id` + `external_user_id` + `openmeter_subscription_id`). Retries are
+normal.
+
+## Anti-patterns (rejected)
+
+1. **OM Checkout for merchant end users on the platform Stripe app** — money lands
+   in the wrong merchant-of-record; Connect fees and branding are wrong.
+2. **Installing one OM Stripe app per Builder** — works for a few partners, not a
+   marketplace; not Connect.
+3. **Charging on Connect and also `charge_automatically` in OM for the same
+   customer** — double charge. Merchant end users must sit on a non-collecting OM
+   billing profile (or have no chargeable PM in OM).
+4. **Gating end-user provisioning on Connect readiness** — cost rail is owner
+   solvency; Connect only gates priced-plan activation and retail Checkout
+   ([activation-gate.md](./activation-gate.md)).
+5. **Treating `application_fee_bps` as cost recovery** — retail can be $0; network
+   cost must always meter to the owner wallet.
+
+## Design decisions and trade-offs
+
+| Decision | Trade-off |
+|---|---|
+| Two webhook planes | Operational clarity; two secrets / two destinations to monitor |
+| OM meters, Connect collects (revenue) | PymtHouse owns Checkout UX and tax edge cases for merchants; OM invoice UI for end users is secondary |
+| Platform OM Stripe app only | Simpler Konnect ops; cannot use OM’s multi-Stripe-app routing for Builders |
+| Account Links only (no OAuth Connect) | Aligns with current `merchant-connect.ts`; OAuth remains legacy path for OM self-hosted API-key install only |
+| Keep OM install API named carefully in UI | Module renamed to `stripe-app-install.ts`; HTTP routes under `/billing/stripe/connect` remain for merchant Connect |
+
+## MoonPay (admin-only; not a user funding rail)
+
+MoonPay / Turnkey on-ramp (`FundAccountOnRampPanel`, `POST …/onramp/sessions`) is
+**platform-admin tooling** for signer refill experiments. It is **not** the developer
+funding UX. Owners attach a payment method on `/billing` via Plane A
+(`POST /api/v1/me/billing/payment-method` → OM `apps.stripe.createCheckoutSession`
+setup). Non-admins receive 403 on on-ramp APIs.
+
+## Future: x402 / stablecoin payments via Stripe
+
+eth/usdc (and other crypto/stablecoin) settlement via Stripe is a **future payment-method
+type** on the existing planes — not a third webhook plane:
+
+| Rail | Where it lands |
+|---|---|
+| Owner cost top-up / PM | Plane A (platform Stripe account + OM Stripe app) |
+| Merchant retail | Plane B (Connected Account Checkout / PaymentIntents) |
+
+No implementation in the current stack. When Stripe exposes the product surface we need
+for x402-style flows, wire it as an additional `payment_method_types` / Checkout option
+and keep the same OM metering + Connect readiness model.
+
+## Related code
+
+- OM app install / Konnect link: `src/lib/openmeter/stripe-app-install.ts`
+- Billing profiles / owners profile: `src/lib/openmeter/billing-profiles.ts`
+- Customer Stripe app data: `src/lib/openmeter/stripe-customer-data.ts`
+- Owner PM attach: `src/lib/openmeter/owner-payment-method.ts`,
+  `POST /api/v1/me/billing/payment-method`
+- Merchant Account Links + Checkout: `src/lib/stripe/merchant-connect.ts`,
+  `src/lib/stripe/connect-accounts.ts`
+- Connect webhook verify / `account.updated`: `src/lib/stripe/webhook.ts`,
+  `src/app/webhooks/stripe/route.ts`
+- Activation gate: `src/lib/activation/app-activation.ts`,
+  [`docs/activation-gate.md`](./activation-gate.md)
+
+## Implementation tasks
+
+### Done or in-flight (stacked PRs)
+
+- [x] Platform OM Stripe app + billing profile foundations (#321)
+- [x] Account Links onboarding + `account.updated` webhook (#322)
+- [x] Connected Checkout helpers (#322)
+- [x] Activation gate separating cost / revenue (#325)
+- [x] Rename OM install module → `stripe-app-install.ts`; expose `billingReady`
+- [x] Payments tab copy: “Merchant Stripe Connect” vs OpenMeter Stripe billing
+- [x] Owner Stripe payment-method attach on `/billing` (Plane A)
+- [x] MoonPay gated to platform admin only
+
+### Remaining
+
+- [ ] Stripe Dashboard: dedicated Connect webhook endpoint (connected-account
+      events) pointed at production `/webhooks/stripe`; document secret rotation.
+- [ ] Expand Plane B beyond `account.updated`: `checkout.session.completed`,
+      `account.application.deauthorized`, and idempotent event ledger.
+- [ ] Guarantee merchant end-user OM customers use a **non-charging** billing
+      profile (assert in `prepareAppCustomerStripeBilling` when
+      `billing_mode=merchant`).
+- [ ] Cutover audit (#324): flag apps where OM would auto-charge the same
+      customer that Connect already bills.
+- [ ] x402 / stablecoin payment methods on Plane A and Plane B (design above).
+
+## Success criteria
+
+1. Owner network invoices collect only via Plane A (platform Stripe + OM app).
+2. Builder retail payments collect only via Plane B (connected account).
+3. No end user is charged twice for the same plan period.
+4. `canSellPaidPlans` tracks Connect readiness from Plane B webhooks, not OM app
+   install status (`billingReady`).
+5. Engineers and UI never call OM app install “Stripe Connect.”
+6. MoonPay is never presented as the primary owner funding path.

--- a/docs/openmeter-railway.md
+++ b/docs/openmeter-railway.md
@@ -162,31 +162,47 @@ Redeploy Vercel. Usage, balance, and allowances return **503** without `OPENMETE
 
 Dashboard / builder-sdk apps use PymtHouse BFF routes; they do not call OpenMeter directly.
 
-### Stripe billing (per developer app)
+### Stripe billing (dual plane)
 
-Starter is a **real synced OpenMeter plan** on a **Stripe billing profile**. Included usage/credits let users start without a payment method. PymtHouse provisions a Stripe Customer (`cus_…`) via `STRIPE_SECRET_KEY` (same Stripe account as Konnect) and upserts Konnect customer billing app-data — no card required for Starter.
+See [`adr-stripe-connect-openmeter-webhooks.md`](./adr-stripe-connect-openmeter-webhooks.md).
 
-Sandbox billing profiles are **not** used at runtime; migrate legacy Sandbox-linked customers with the cutover scripts (separate PR).
+**Plane A — OpenMeter Stripe app (platform cost rail):** Starter is a real synced
+OpenMeter plan on a Stripe billing profile. Included usage/credits let users start
+without a payment method. PymtHouse provisions a Stripe Customer (`cus_…`) via
+`STRIPE_SECRET_KEY` (same Stripe account as Konnect) and upserts Konnect customer
+billing app-data. Owners attach a card from **`/billing` → Add payment method**
+(`POST /api/v1/me/billing/payment-method` → OM Checkout setup) so overage invoices
+can `charge_automatically`.
 
-PymtHouse **Payments** tab → **Connect Stripe** (optional; Starter auto-ensures the app Stripe profile) stores a per-app billing profile in `app_billing_config`.
+**Plane B — Merchant Stripe Connect:** app **Settings → Payments → Merchant Stripe
+Connect** uses Account Links + `/webhooks/stripe` for end-user retail collection.
+Never charges through the OM Stripe app.
+
+**MoonPay:** admin-only signer-refill tooling (`POST …/onramp/sessions` requires
+platform admin). Not shown on owner `/billing` for non-admins.
+
+Sandbox billing profiles are **not** used at runtime; migrate legacy Sandbox-linked
+customers with the cutover scripts (separate PR).
 
 **Konnect (production):**
 
 1. Install Stripe once in [Konnect → Metering & Billing → Settings → Stripe](https://developer.konghq.com/metering-and-billing/stripe-integration/) (API key + billing profile wizard).
 2. Set `OPENMETER_URL`, `OPENMETER_API_KEY`, and `STRIPE_SECRET_KEY` (same Stripe account) on Vercel.
 3. Bootstrap should log `Konnect Stripe app is ready` (not a missing-app warning).
-4. Starter provision auto-creates the per-app Stripe billing profile when missing. Optional: **Settings → Payments → Connect Stripe** or mid-cycle invoicing settings.
+4. Starter provision auto-creates the per-app Stripe billing profile when missing.
 5. Optional: `OPENMETER_STRIPE_APP_ID` when multiple Stripe apps exist in the org.
+6. Configure a Connect webhook (connected-account events) → `/webhooks/stripe` with `STRIPE_WEBHOOK_SECRET`.
 
 **Self-hosted (Railway/OSS):**
 
 1. Ensure `OPENMETER_APPS_BASE_URL` is set on Railway OpenMeter (see §3) and redeploy **openmeter**.
 2. Bootstrap should log `Stripe marketplace OAuth is available` (not a 501 warning).
-3. Set `STRIPE_SECRET_KEY` for customer provisioning. Install Stripe via Connect (OAuth or `{ "stripeSecretKey": "sk_…" }`) so a Stripe app exists in OpenMeter.
-4. After the Stripe app exists, Starter provision auto-ensures the per-app billing profile; invoices/checkout use that profile.
-5. Publish paid plans (OpenMeter plan sync) and use checkout via `POST …/billing/checkout` for end users (collects payment method).
+3. Set `STRIPE_SECRET_KEY` for customer provisioning. Install the OM Stripe app via marketplace API key or OAuth so a Stripe app exists in OpenMeter.
+4. After the Stripe app exists, Starter provision auto-ensures the per-app billing profile; owner PM attach and invoices use that profile.
+5. Publish paid plans (OpenMeter plan sync). Merchant end-user checkout uses Connect (Plane B), not OM Checkout on the platform account.
 
-Stripe redirect URI for each app: `{NEXTAUTH_URL}/api/v1/apps/{clientId}/billing/stripe/callback`.
+Legacy OM Stripe app OAuth callback (self-hosted install): `{NEXTAUTH_URL}/api/v1/apps/{clientId}/billing/stripe/callback`.
+Merchant Connect Account Links use `{NEXTAUTH_URL}/api/v1/apps/{clientId}/billing/stripe/…` Account Link routes.
 
 ## 8. Signer (`pymthouse` Railway service)
 

--- a/src/app/api/v1/apps/[id]/billing/stripe/callback/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthorizedProviderApp } from "@/lib/provider-apps";
-import { completeStripeOAuthCallback } from "@/lib/openmeter/stripe-connect";
+import { completeStripeOAuthCallback } from "@/lib/openmeter/stripe-app-install";
 import { getPublicOrigin } from "@/lib/oidc/issuer-urls";
 
 export async function GET(

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -14,7 +14,7 @@ import {
 import {
   disconnectStripeConnect,
   getStripeConnectStatus,
-} from "@/lib/openmeter/stripe-connect";
+} from "@/lib/openmeter/stripe-app-install";
 import { getAppOpenMeterConfigRow } from "@/lib/openmeter/client-factory";
 
 async function requireHostedBillingApp(clientId: string) {

--- a/src/app/api/v1/apps/[id]/onramp/sessions/[sessionId]/settle/route.ts
+++ b/src/app/api/v1/apps/[id]/onramp/sessions/[sessionId]/settle/route.ts
@@ -1,24 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  canManageMerchantBilling,
-  getAuthorizedProviderApp,
-} from "@/lib/provider-apps";
+import { getAdminUser } from "@/lib/admin-auth";
+import { getAuthorizedProviderApp } from "@/lib/provider-apps";
 import { settleOnRampSession } from "@/lib/onramp/sessions";
 
+/**
+ * MoonPay settle — platform-admin only (signer refill tooling).
+ */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; sessionId: string }> },
 ) {
+  const admin = await getAdminUser(request);
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Only a platform admin can settle MoonPay on-ramp sessions." },
+      { status: 403 },
+    );
+  }
+
   const { id: clientId, sessionId } = await params;
   const access = await getAuthorizedProviderApp(clientId, request);
   if (!access) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-  if (!(await canManageMerchantBilling(access))) {
-    return NextResponse.json(
-      { error: "Only the app owner or platform admin can settle prepaid credits." },
-      { status: 403 },
-    );
   }
 
   try {

--- a/src/app/api/v1/apps/[id]/onramp/sessions/route.ts
+++ b/src/app/api/v1/apps/[id]/onramp/sessions/route.ts
@@ -1,25 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  canManageMerchantBilling,
-  getAuthorizedProviderApp,
-} from "@/lib/provider-apps";
+import { getAdminUser } from "@/lib/admin-auth";
+import { getAuthorizedProviderApp } from "@/lib/provider-apps";
 import { createOnRampSession } from "@/lib/onramp/sessions";
 import { SANDBOX_ONRAMP_USD_AMOUNT } from "@/lib/onramp/amount";
 
+/**
+ * MoonPay / Turnkey prepaid on-ramp — platform-admin only (signer refill tooling).
+ * Owner funding uses Stripe payment-method attach on /billing instead.
+ */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const admin = await getAdminUser(request);
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Only a platform admin can create MoonPay on-ramp sessions." },
+      { status: 403 },
+    );
+  }
+
   const { id: clientId } = await params;
   const access = await getAuthorizedProviderApp(clientId, request);
   if (!access) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-  if (!(await canManageMerchantBilling(access))) {
-    return NextResponse.json(
-      { error: "Only the app owner or platform admin can fund prepaid credits." },
-      { status: 403 },
-    );
   }
 
   const body = await request.json().catch(() => ({}));
@@ -32,9 +36,8 @@ export async function POST(
       ? body.turnkeyOrganizationId.trim()
       : undefined;
 
-  // Owner-funding only: credit the signed-in owner, never a client-chosen subject.
+  // Admin refill credits the signed-in admin's owner wallet for this app context.
   const externalUserId = access.userId;
-  // Amount is fixed server-side for the sandbox demo (Turnkey status API has no amount).
   const fiatCurrencyCode = "USD";
   const fiatAmount = SANDBOX_ONRAMP_USD_AMOUNT;
 

--- a/src/app/api/v1/me/billing/payment-method/route.ts
+++ b/src/app/api/v1/me/billing/payment-method/route.ts
@@ -33,15 +33,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const status =
+    let status = 502;
+    if (
       message.includes("STRIPE_") ||
       message.includes("OPENMETER_") ||
       message.includes("No ready Stripe") ||
       message.includes("No Stripe app")
-        ? 400
-        : message.includes("Cannot reach OpenMeter")
-          ? 503
-          : 502;
+    ) {
+      status = 400;
+    } else if (message.includes("Cannot reach OpenMeter")) {
+      status = 503;
+    }
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/v1/me/billing/payment-method/route.ts
+++ b/src/app/api/v1/me/billing/payment-method/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/next-auth-options";
+import { createOwnerPaymentMethodCheckout } from "@/lib/openmeter/owner-payment-method";
+
+/**
+ * Start Stripe Checkout (setup) so the signed-in owner can attach a payment
+ * method for platform cost-rail invoices (OpenMeter Stripe app / Plane A).
+ */
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const sessionUser = session?.user as Record<string, unknown> | undefined;
+  const userId = typeof sessionUser?.id === "string" ? sessionUser.id : undefined;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    body = {};
+  }
+
+  try {
+    const result = await createOwnerPaymentMethodCheckout({
+      ownerUserId: userId,
+      successUrl:
+        typeof body.successUrl === "string" ? body.successUrl : undefined,
+      cancelUrl: typeof body.cancelUrl === "string" ? body.cancelUrl : undefined,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const status =
+      message.includes("STRIPE_") ||
+      message.includes("OPENMETER_") ||
+      message.includes("No ready Stripe") ||
+      message.includes("No Stripe app")
+        ? 400
+        : message.includes("Cannot reach OpenMeter")
+          ? 503
+          : 502;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,9 +1,12 @@
 export const dynamic = "force-dynamic";
 
 import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
 
 import FundAccountOnRampPanel from "@/components/apps/FundAccountOnRampPanel";
 import OwnerBillingView from "@/components/OwnerBillingView";
+import OwnerPaymentMethodButton from "@/components/OwnerPaymentMethodButton";
+import { authOptions } from "@/lib/next-auth-options";
 import { getOwnerBillingData } from "@/lib/owner-billing-data";
 
 function isTurnkeyFundingConfigured(): boolean {
@@ -35,12 +38,15 @@ export default async function BillingPage() {
   }
 
   const { data } = result;
+  const session = await getServerSession(authOptions);
+  const sessionUser = session?.user as Record<string, unknown> | undefined;
+  const isAdmin = sessionUser?.role === "admin";
   const fundingClientId = data.fundingClientId?.trim() || null;
-  const fundingAvailable = Boolean(
-    isTurnkeyFundingConfigured() && fundingClientId && data.userId,
+  const adminFundAvailable = Boolean(
+    isAdmin && isTurnkeyFundingConfigured() && fundingClientId && data.userId,
   );
-  const fundPanel =
-    fundingAvailable && fundingClientId ? (
+  const adminFundPanel =
+    adminFundAvailable && fundingClientId ? (
       <FundAccountOnRampPanel
         clientId={fundingClientId}
         ownerExternalUserId={data.userId}
@@ -50,8 +56,10 @@ export default async function BillingPage() {
   return (
     <OwnerBillingView
       data={data}
-      fundPanel={fundPanel}
-      fundingAvailable={fundingAvailable}
+      paymentMethodPanel={
+        data.openMeterConfigured ? <OwnerPaymentMethodButton /> : null
+      }
+      adminFundPanel={adminFundPanel}
     />
   );
 }

--- a/src/components/OwnerBillingView.tsx
+++ b/src/components/OwnerBillingView.tsx
@@ -77,7 +77,7 @@ function SubscriptionCard({
       ) : (
         <p className="mt-3 text-xs text-zinc-600">
           No included usage allowance on this plan — cycle usage settles against prepaid
-          credits.
+          credits or your Stripe payment method.
         </p>
       )}
 
@@ -87,7 +87,7 @@ function SubscriptionCard({
           <span className="font-mono tabular-nums">
             {formatUsdMicrosDisplay(overage.toString())}
           </span>{" "}
-          overage burns prepaid credits
+          overage burns prepaid credits, then invoices your Stripe payment method
         </p>
       ) : null}
 
@@ -102,23 +102,30 @@ function SubscriptionCard({
 
 export default function OwnerBillingView({
   data,
-  fundPanel,
-  fundingAvailable = false,
+  paymentMethodPanel,
+  adminFundPanel,
 }: Readonly<{
   data: OwnerBillingPayload;
-  /** MoonPay on-ramp (credits prepaid balance for your account). */
-  fundPanel?: ReactNode;
-  /** True when Turnkey is configured and an owned app can host on-ramp APIs. */
-  fundingAvailable?: boolean;
+  /** Stripe Checkout (setup) to attach a card for platform overage invoices. */
+  paymentMethodPanel?: ReactNode;
+  /** Admin-only MoonPay signer refill tooling (hidden from normal owners). */
+  adminFundPanel?: ReactNode;
 }>) {
+  const billingActions =
+    paymentMethodPanel || adminFundPanel ? (
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {paymentMethodPanel}
+        {adminFundPanel}
+      </div>
+    ) : null;
+
   return (
     <DashboardLayout>
       <div className="mb-6 sm:mb-8">
         <h1 className="text-xl sm:text-2xl font-bold text-zinc-100">Billing</h1>
         <p className="mt-1 text-xs sm:text-sm text-zinc-500">
           Prepaid credits, active subscriptions, and platform invoices for your account.
-          Plan allowances are tracked per billing cycle; prepaid credits burn only after the
-          allowance is exhausted.
+          Attach a Stripe payment method so overage invoices can charge automatically.
         </p>
         {data.openMeterConfigured ? (
           <p className="mt-2 text-xs text-zinc-600">
@@ -142,12 +149,15 @@ export default function OwnerBillingView({
       {!data.openMeterConfigured ? null : (
         <>
           <section className="mb-8">
-            <div className="mb-3 flex flex-wrap items-center gap-2">
-              <h2 className="text-sm font-semibold text-zinc-200">Prepaid credits</h2>
-              <InfoTooltip
-                label="Credits for your account — usable across all apps you own. Separate from per-cycle plan allowances."
-                wide
-              />
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-sm font-semibold text-zinc-200">Payment &amp; credits</h2>
+                <InfoTooltip
+                  label="Add a Stripe card for automatic overage invoices. Prepaid credits (when present) burn first under credit_then_invoice settlement."
+                  wide
+                />
+              </div>
+              {billingActions}
             </div>
             {hasDisplayablePrepaidCredit(data.creditAllowance) && data.creditAllowance ? (
               <AllowanceStrip
@@ -158,35 +168,14 @@ export default function OwnerBillingView({
                   (sum, row) => sum + row.requestCount,
                   0,
                 )}
-                actions={fundPanel}
               />
             ) : (
-              <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-5">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="min-w-0 flex-1 text-sm text-zinc-500">
-                    <p>
-                      No prepaid credit balance yet. Starter included usage comes from your
-                      plan allowance; this balance stays empty until you top up.
-                    </p>
-                    <p className="mt-2">
-                      {fundingAvailable ? (
-                        <>
-                          Use <span className="text-zinc-300">Fund with MoonPay</span> to add
-                          sandbox prepaid credits — they cover pay-per-use plans with no
-                          allowance, and burn after any plan allowance is exhausted.
-                        </>
-                      ) : (
-                        <>
-                          Prepaid credits appear here after a top-up. MoonPay funding requires
-                          Turnkey Wallet Kit configuration and at least one owned app.
-                        </>
-                      )}
-                    </p>
-                  </div>
-                  {fundPanel ? (
-                    <div className="shrink-0 sm:pt-0.5">{fundPanel}</div>
-                  ) : null}
-                </div>
+              <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-5 text-sm text-zinc-500">
+                <p>
+                  No prepaid credit balance yet. Starter included usage comes from your plan
+                  allowance. Attach a payment method so usage beyond the allowance can be
+                  invoiced on Stripe.
+                </p>
               </div>
             )}
           </section>
@@ -195,7 +184,8 @@ export default function OwnerBillingView({
             <h2 className="mb-3 text-sm font-semibold text-zinc-200">Active subscriptions</h2>
             <p className="mb-4 text-xs text-zinc-600">
               Usage toward each plan&apos;s included allowance for the current cycle. Overage
-              after the allowance burns prepaid credits.
+              after the allowance burns prepaid credits, then charges your Stripe payment
+              method.
             </p>
             {data.subscriptions.length === 0 ? (
               <div className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-6 text-center">
@@ -218,7 +208,7 @@ export default function OwnerBillingView({
             <div className="mb-3 flex flex-wrap items-center gap-2">
               <h2 className="text-sm font-semibold text-zinc-200">Platform invoices</h2>
               <InfoTooltip
-                label="Invoices from PymtHouse to your developer account (prepaid top-ups and overage). End-user invoices billed through your Stripe Connect account appear on each app’s Payments tab."
+                label="Invoices from PymtHouse to your developer account (overage and top-ups). End-user invoices billed through your Merchant Stripe Connect account appear on each app’s Payments tab."
                 wide
               />
             </div>

--- a/src/components/OwnerPaymentMethodButton.tsx
+++ b/src/components/OwnerPaymentMethodButton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Owner billing: start OpenMeter Stripe Checkout (setup) to attach a card for
+ * platform overage invoices.
+ */
+export default function OwnerPaymentMethodButton() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function startCheckout() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/me/billing/payment-method", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        checkoutUrl?: string;
+        error?: string;
+      };
+      if (!res.ok) {
+        throw new Error(body.error || "Could not start Stripe Checkout");
+      }
+      if (!body.checkoutUrl) {
+        throw new Error("Checkout URL missing");
+      }
+      window.location.assign(body.checkoutUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
+        disabled={busy}
+        onClick={() => void startCheckout()}
+      >
+        {busy ? "Opening Stripe…" : "Add payment method"}
+      </button>
+      {error ? (
+        <p className="max-w-xs text-right text-xs text-red-400">{error}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -10,6 +10,7 @@ import { paymentsTabErrorMessage } from "@/lib/stripe/payments-tab-errors";
 
 type StripeStatus = {
   status: string;
+  billingReady?: boolean;
   openmeterStripeAppId: string | null;
   openmeterBillingProfileId: string | null;
   defaultCurrency: string;
@@ -236,11 +237,12 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
       <div className="rounded-lg border p-4 space-y-3">
         <div className="flex items-center justify-between gap-4">
           <div>
-            <h3 className="text-base font-semibold">Stripe Connect</h3>
+            <h3 className="text-base font-semibold">Merchant Stripe Connect</h3>
             <p className="text-sm text-muted-foreground">
-              OpenMeter meters usage and subscriptions. End-user payments go through your
-              merchant Connected Account (direct charges). Complete Stripe-hosted onboarding
-              (Account Links) to create and verify your Connected Account.
+              Collect from your end users on a Stripe Connected Account (Plane B).
+              OpenMeter Stripe billing (Plane A) meters usage and invoices you for
+              network cost separately. Complete Stripe-hosted onboarding (Account Links)
+              to create and verify your Connected Account.
             </p>
           </div>
           <span
@@ -281,6 +283,16 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
             <div>
               <dt className="text-muted-foreground">Payouts</dt>
               <dd>{status?.stripePayoutsEnabled ? "Enabled" : "Paused / pending"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">OpenMeter Stripe billing</dt>
+              <dd>
+                {status?.billingReady
+                  ? "Ready"
+                  : status?.openmeterBillingProfileId
+                    ? "Partial"
+                    : "Not provisioned"}
+              </dd>
             </div>
             <div>
               <dt className="text-muted-foreground">OM billing profile</dt>

--- a/src/lib/openmeter/billing-profiles.test.ts
+++ b/src/lib/openmeter/billing-profiles.test.ts
@@ -3,9 +3,28 @@ import test from "node:test";
 import type { OpenMeter } from "@openmeter/sdk";
 import {
   ensureOwnersBillingProfile,
+  isAppBillingReady,
   resetOwnersBillingProfileCacheForTests,
 } from "./billing-profiles";
 import { __testSetHostedOpenMeterClient, resetHostedOpenMeterClientForTests } from "./client";
+
+test("isAppBillingReady requires Stripe app id and billing profile id", () => {
+  assert.equal(isAppBillingReady(null), false);
+  assert.equal(
+    isAppBillingReady({
+      openmeterStripeAppId: "app",
+      openmeterBillingProfileId: null,
+    }),
+    false,
+  );
+  assert.equal(
+    isAppBillingReady({
+      openmeterStripeAppId: "app",
+      openmeterBillingProfileId: "profile",
+    }),
+    true,
+  );
+});
 
 test("ensureOwnersBillingProfile returns OPENMETER_OWNERS_BILLING_PROFILE_ID when set", async (t) => {
   resetOwnersBillingProfileCacheForTests();

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -88,14 +88,26 @@ export async function getAppBillingConfig(clientId: string) {
   return rows[0] ?? null;
 }
 
-/** Stripe Connect completed and wired into OpenMeter billing profiles. */
+/**
+ * Platform OpenMeter Stripe billing is ready (Plane A): org Stripe app +
+ * tenant billing profile. Distinct from merchant Stripe Connect readiness.
+ */
+export function isAppBillingReady(
+  config: {
+    openmeterStripeAppId?: string | null;
+    openmeterBillingProfileId?: string | null;
+  } | null | undefined,
+): boolean {
+  return (
+    Boolean(config?.openmeterStripeAppId?.trim()) &&
+    Boolean(config?.openmeterBillingProfileId?.trim())
+  );
+}
+
+/** @deprecated Prefer {@link isAppBillingReady}; name kept for existing call sites. */
 export async function isStripeBillingEnabledForApp(clientId: string): Promise<boolean> {
   const config = await getAppBillingConfig(clientId);
-  return (
-    config?.stripeConnectStatus === "connected" &&
-    Boolean(config.openmeterStripeAppId?.trim()) &&
-    Boolean(config.openmeterBillingProfileId?.trim())
-  );
+  return isAppBillingReady(config);
 }
 
 export async function ensureTenantBillingProfile(input: {
@@ -176,14 +188,12 @@ export async function ensureAppStripeBillingReady(input: {
   openmeterBillingProfileId: string;
 }> {
   const existing = await getAppBillingConfig(input.clientId);
-  if (
-    existing?.stripeConnectStatus === "connected" &&
-    existing.openmeterStripeAppId?.trim() &&
-    existing.openmeterBillingProfileId?.trim()
-  ) {
+  const existingStripeAppId = existing?.openmeterStripeAppId?.trim();
+  const existingProfileId = existing?.openmeterBillingProfileId?.trim();
+  if (existingStripeAppId && existingProfileId) {
     return {
-      openmeterStripeAppId: existing.openmeterStripeAppId,
-      openmeterBillingProfileId: existing.openmeterBillingProfileId,
+      openmeterStripeAppId: existingStripeAppId,
+      openmeterBillingProfileId: existingProfileId,
     };
   }
 

--- a/src/lib/openmeter/invoices.ts
+++ b/src/lib/openmeter/invoices.ts
@@ -68,12 +68,10 @@ async function resolveOwnerCustomerIdsByUserId(
     buildOwnerCustomerKey(ownerId),
     buildOwnerWireSubject(ownerId),
   ];
-  const ids: string[] = [];
-  for (const key of keys) {
-    const id = await findCustomerIdByExactKey(client, key);
-    if (id) ids.push(id);
-  }
-  return [...new Set(ids)];
+  const ids = await Promise.all(
+    keys.map((key) => findCustomerIdByExactKey(client, key)),
+  );
+  return [...new Set(ids.filter((id): id is string => Boolean(id)))];
 }
 
 async function resolveOwnerCustomerIdsForApp(

--- a/src/lib/openmeter/konnect-billing-profiles.test.ts
+++ b/src/lib/openmeter/konnect-billing-profiles.test.ts
@@ -17,7 +17,7 @@ import {
 import {
   createStripeOAuthState,
   StripeOAuthUnavailableError,
-} from "./stripe-connect";
+} from "./stripe-app-install";
 
 test("buildKonnectCreateBillingProfileBody uses Konnect snake_case supplier address", () => {
   const body = buildKonnectCreateBillingProfileBody({

--- a/src/lib/openmeter/owner-payment-method.ts
+++ b/src/lib/openmeter/owner-payment-method.ts
@@ -1,0 +1,68 @@
+import { getPublicOrigin } from "@/lib/oidc/issuer-urls";
+import { getHostedAdminClient } from "./admin-client";
+import { prepareOwnerCustomerStripeBilling } from "./billing-profiles";
+import {
+  ensureOwnerCustomer,
+  listOwnedPublicClientIds,
+} from "./customers";
+import { getKonnectDefaultPaymentMethodId } from "./stripe-customer-data";
+
+export type OwnerPaymentMethodCheckoutResult = {
+  checkoutUrl: string;
+  sessionId: string | null;
+  customerId: string;
+  /** True when Konnect already has a default payment method on file. */
+  hasDefaultPaymentMethod: boolean;
+};
+
+/**
+ * Start an OpenMeter Stripe Checkout session (always setup mode) so the owner
+ * can attach a card for Plane A overage invoices (charge_automatically).
+ */
+export async function createOwnerPaymentMethodCheckout(input: {
+  ownerUserId: string;
+  successUrl?: string;
+  cancelUrl?: string;
+}): Promise<OwnerPaymentMethodCheckoutResult> {
+  const ownerUserId = input.ownerUserId.trim();
+  if (!ownerUserId) {
+    throw new Error("ownerUserId is required");
+  }
+
+  const client = getHostedAdminClient();
+  const publicClientIds = await listOwnedPublicClientIds(ownerUserId);
+  const customer = await ensureOwnerCustomer(
+    client,
+    ownerUserId,
+    publicClientIds,
+  );
+  await prepareOwnerCustomerStripeBilling({
+    client,
+    customerId: customer.id,
+    customerKey: customer.key,
+  });
+
+  const defaultPm = await getKonnectDefaultPaymentMethodId(customer.id);
+  const origin = getPublicOrigin();
+  const success =
+    input.successUrl?.trim() || `${origin}/billing?pm=attached`;
+  const cancel = input.cancelUrl?.trim() || `${origin}/billing`;
+
+  const checkout = await client.apps.stripe.createCheckoutSession({
+    customer: { id: customer.id },
+    options: {
+      successURL: success,
+      cancelURL: cancel,
+    },
+  });
+  if (!checkout?.url) {
+    throw new Error("Stripe checkout session URL unavailable");
+  }
+
+  return {
+    checkoutUrl: checkout.url,
+    sessionId: checkout.sessionId ?? null,
+    customerId: customer.id,
+    hasDefaultPaymentMethod: Boolean(defaultPm),
+  };
+}

--- a/src/lib/openmeter/stripe-app-install.test.ts
+++ b/src/lib/openmeter/stripe-app-install.test.ts
@@ -17,7 +17,7 @@ import {
   getStripeConnectStatus,
   parseStripeAccountIdFromConflict,
   purgeExpiredOAuthStates,
-} from "./stripe-connect";
+} from "./stripe-app-install";
 import { test } from "@/test-utils/db-guard";
 import {
   cleanupTestApp,
@@ -249,6 +249,7 @@ test("getStripeConnectStatus defaults to disconnected when no config row", async
   t.after(() => cleanupTestApp(seeded));
   const status = await getStripeConnectStatus(seeded.clientId);
   assert.equal(status.status, "disconnected");
+  assert.equal(status.billingReady, false);
   assert.equal(status.defaultCurrency, "USD");
 });
 
@@ -271,6 +272,7 @@ test("getStripeConnectStatus uses merchant account flags, not legacy OM status",
 
   let status = await getStripeConnectStatus(seeded.clientId);
   assert.equal(status.status, "disconnected");
+  assert.equal(status.billingReady, true);
   assert.equal(status.stripeConnectedAccountId, null);
   assert.equal(status.openmeterStripeAppId, "om_legacy");
 

--- a/src/lib/openmeter/stripe-app-install.ts
+++ b/src/lib/openmeter/stripe-app-install.ts
@@ -15,6 +15,14 @@ import { isOpenMeterConflictError } from "./plan-errors";
 import { shouldUseKonnectRoutes } from "./route-mode";
 import type { OpenMeter } from "@openmeter/sdk";
 
+/**
+ * OpenMeter / Konnect Stripe **app** install helpers (Plane A — platform cost rail).
+ *
+ * Renamed from `stripe-connect.ts` to avoid conflating this with merchant Stripe
+ * Connect Account Links (Plane B — `src/lib/stripe/merchant-connect.ts`).
+ * HTTP routes under `/billing/stripe/connect` remain for Connect onboarding.
+ */
+
 const OAUTH_STATE_TTL_MS = 15 * 60 * 1000;
 
 function stripeConnectCallbackUrl(clientId: string): string {
@@ -383,10 +391,18 @@ export async function getStripeConnectStatus(clientId: string) {
       : "pending"
     : "disconnected";
 
+  const openmeterStripeAppId = config?.openmeterStripeAppId ?? null;
+  const openmeterBillingProfileId = config?.openmeterBillingProfileId ?? null;
+  // Plane A readiness — independent of merchant Connect (Plane B).
+  const billingReady = Boolean(
+    openmeterStripeAppId?.trim() && openmeterBillingProfileId?.trim(),
+  );
+
   return {
     status,
-    openmeterStripeAppId: config?.openmeterStripeAppId ?? null,
-    openmeterBillingProfileId: config?.openmeterBillingProfileId ?? null,
+    billingReady,
+    openmeterStripeAppId,
+    openmeterBillingProfileId,
     defaultCurrency: config?.defaultCurrency ?? "USD",
     connectedAt: config?.connectedAt ?? null,
     progressiveBilling: config?.progressiveBilling ?? true,

--- a/src/lib/openmeter/subscriptions-billing.test.ts
+++ b/src/lib/openmeter/subscriptions-billing.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   defaultSubscriptionChangeTiming,
+  neonSubscriptionStatusAfterPlanChange,
   planRequiresPaymentMethod,
 } from "./subscriptions-billing";
 
@@ -72,5 +73,19 @@ test("defaultSubscriptionChangeTiming upgrades immediate, else next cycle", () =
       targetPriceAmount: "1",
     }),
     "immediate",
+  );
+});
+
+test("neonSubscriptionStatusAfterPlanChange is pending when checkout is required", () => {
+  assert.equal(
+    neonSubscriptionStatusAfterPlanChange({
+      checkoutUrl: "https://checkout.stripe.com/c/pay_test",
+    }),
+    "pending",
+  );
+  assert.equal(neonSubscriptionStatusAfterPlanChange({}), "active");
+  assert.equal(
+    neonSubscriptionStatusAfterPlanChange({ checkoutUrl: undefined }),
+    "active",
   );
 });

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -9,6 +9,7 @@ import {
   getAppBillingConfig,
   prepareAppCustomerStripeBilling,
 } from "./billing-profiles";
+import { getHostedOpenMeterUrl } from "./constants";
 import { buildOpenMeterCustomerKey } from "./customer-key";
 import { ensureOpenMeterCustomerForAppUser } from "./customers";
 import {
@@ -16,6 +17,7 @@ import {
   type SubscriptionChangeTiming,
 } from "./konnect-subscriptions";
 import { buildOpenMeterPlanKey } from "./plans-sync";
+import { shouldUseKonnectRoutes } from "./route-mode";
 import {
   getPrimaryOpenMeterSubscriptionForAppUser,
   resolveLocalPlanIdFromOpenMeterSubscription,
@@ -52,6 +54,17 @@ export function defaultSubscriptionChangeTiming(input: {
   const current = parsePlanPriceAmount(input.currentPriceAmount);
   const target = parsePlanPriceAmount(input.targetPriceAmount);
   return target > current ? "immediate" : "next_billing_cycle";
+}
+
+/**
+ * Neon subscription cache status after a plan change.
+ * When Checkout is required to collect a payment method, keep the row pending
+ * until Stripe completes (mirrors createEndUserCheckout).
+ */
+export function neonSubscriptionStatusAfterPlanChange(input: {
+  checkoutUrl?: string;
+}): "pending" | "active" {
+  return input.checkoutUrl ? "pending" : "active";
 }
 
 async function upsertNeonSubscriptionCache(input: {
@@ -292,6 +305,18 @@ export async function changeAppUserSubscriptionPlan(input: {
     throw new Error("User is already on this plan");
   }
 
+  if (
+    !shouldUseKonnectRoutes(
+      getHostedOpenMeterUrl(),
+      process.env.OPENMETER_API_KEY,
+    )
+  ) {
+    throw new Error(
+      "Plan change requires Konnect routes (set OPENMETER_ROUTE_MODE=hosted " +
+        "or point OPENMETER_URL at a Konnect metering endpoint).",
+    );
+  }
+
   const timing =
     input.timing ??
     defaultSubscriptionChangeTiming({
@@ -380,7 +405,7 @@ export async function changeAppUserSubscriptionPlan(input: {
     externalUserId: input.externalUserId,
     planId: targetPlan.id,
     openmeterSubscriptionId: nextSubscriptionId,
-    status: "active",
+    status: neonSubscriptionStatusAfterPlanChange({ checkoutUrl }),
     stripeCheckoutSessionId,
   });
 

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -339,6 +339,48 @@ async function resolvePlanName(input: {
   };
 }
 
+async function loadPlanKeyToLocalId(): Promise<Map<string, string>> {
+  const allPlans = await db
+    .select({
+      id: plans.id,
+      clientId: plans.clientId,
+    })
+    .from(plans);
+  const index = new Map<string, string>();
+  for (const plan of allPlans) {
+    index.set(buildOpenMeterPlanKey(plan.clientId, plan.id), plan.id);
+  }
+  return index;
+}
+
+function withSoftTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T,
+  label: string,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      console.warn(`owner-billing: ${label} timed out after ${ms}ms`);
+      resolve(fallback);
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        console.warn(
+          `owner-billing: ${label} failed`,
+          err instanceof Error ? err.message : String(err),
+        );
+        resolve(fallback);
+      },
+    );
+  });
+}
+
 async function mapSubscriptionRow(input: {
   client: OpenMeter;
   subscription: OpenMeterSubscriptionView;
@@ -346,6 +388,7 @@ async function mapSubscriptionRow(input: {
   cycle: { start: string; end: string };
   ownerUserId: string;
   ownedApps: OwnedApp[];
+  planKeyToLocalId: Map<string, string>;
 }): Promise<OwnerBillingSubscriptionRow> {
   const localPlanId = input.candidate.appPublicClientId
     ? await resolveLocalPlanIdFromOpenMeterSubscription(
@@ -357,18 +400,8 @@ async function mapSubscriptionRow(input: {
   // Owner-wallet subscriptions may still map via plan key across owned apps.
   let resolvedLocalPlanId = localPlanId;
   if (!resolvedLocalPlanId && input.subscription.planKey) {
-    const allPlans = await db
-      .select({
-        id: plans.id,
-        clientId: plans.clientId,
-      })
-      .from(plans);
-    for (const plan of allPlans) {
-      if (buildOpenMeterPlanKey(plan.clientId, plan.id) === input.subscription.planKey) {
-        resolvedLocalPlanId = plan.id;
-        break;
-      }
-    }
+    resolvedLocalPlanId =
+      input.planKeyToLocalId.get(input.subscription.planKey) ?? null;
   }
 
   const { planName, isStarterDefault } = await resolvePlanName({
@@ -488,37 +521,56 @@ export async function listOwnerActiveSubscriptions(
   const client = getHostedAdminClient();
   const cycleBounds = calendarMonthBoundsUtc(new Date());
   const cycle = { start: cycleBounds.start, end: cycleBounds.end };
-  const ownedApps = await listOwnedApps(trimmed);
+  const [ownedApps, planKeyToLocalId] = await Promise.all([
+    listOwnedApps(trimmed),
+    loadPlanKeyToLocalId(),
+  ]);
   const candidates = buildCustomerCandidates(trimmed, ownedApps);
 
+  const perCandidate = await Promise.all(
+    candidates.map(async (candidate) => {
+      const customerId = await resolveCustomerIdForCandidate({ client, candidate });
+      if (!customerId) {
+        return [] as Array<{
+          candidate: CustomerCandidate;
+          subscription: OpenMeterSubscriptionView;
+        }>;
+      }
+      const active = await listActiveSubscriptionsForCustomer({
+        client,
+        customerId,
+        customerKey: candidate.customerKey,
+      });
+      return active.map((subscription) => ({ candidate, subscription }));
+    }),
+  );
+
   const seenSubscriptionIds = new Set<string>();
-  const subscriptions: OwnerBillingSubscriptionRow[] = [];
-
-  for (const candidate of candidates) {
-    const customerId = await resolveCustomerIdForCandidate({ client, candidate });
-    if (!customerId) continue;
-
-    const active = await listActiveSubscriptionsForCustomer({
-      client,
-      customerId,
-      customerKey: candidate.customerKey,
-    });
-
-    for (const subscription of active) {
-      if (seenSubscriptionIds.has(subscription.id)) continue;
-      seenSubscriptionIds.add(subscription.id);
-      subscriptions.push(
-        await mapSubscriptionRow({
-          client,
-          subscription,
-          candidate,
-          cycle,
-          ownerUserId: trimmed,
-          ownedApps,
-        }),
-      );
+  const unique: Array<{
+    candidate: CustomerCandidate;
+    subscription: OpenMeterSubscriptionView;
+  }> = [];
+  for (const group of perCandidate) {
+    for (const entry of group) {
+      if (seenSubscriptionIds.has(entry.subscription.id)) continue;
+      seenSubscriptionIds.add(entry.subscription.id);
+      unique.push(entry);
     }
   }
+
+  const subscriptions = await Promise.all(
+    unique.map(({ candidate, subscription }) =>
+      mapSubscriptionRow({
+        client,
+        subscription,
+        candidate,
+        cycle,
+        ownerUserId: trimmed,
+        ownedApps,
+        planKeyToLocalId,
+      }),
+    ),
+  );
 
   subscriptions.sort((a, b) => {
     const usedA = BigInt(a.usedUsdMicros);
@@ -550,6 +602,9 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
   }
 
   const adminClient = getHostedAdminClient();
+  // Invoices hit Konnect /billing/invoices (often multi-second). Soft-timeout so
+  // first paint is not blocked when the invoice index is large or slow.
+  const emptyInvoices = { items: [] as TenantInvoiceDto[] };
   const [creditAllowance, subscriptions, ownedApps, invoicesResult] =
     await Promise.all([
       getOwnerPrepaidCreditBalance(userId).catch((err) => {
@@ -559,20 +614,24 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
         );
         return null;
       }),
-      listOwnerActiveSubscriptions(userId),
+      withSoftTimeout(
+        listOwnerActiveSubscriptions(userId),
+        8_000,
+        [] as OwnerBillingSubscriptionRow[],
+        "subscription lookup",
+      ),
       listOwnedApps(userId),
-      listOwnerWalletInvoices({
-        client: adminClient,
-        ownerUserId: userId,
-        page: 1,
-        pageSize: 10,
-      }).catch((err) => {
-        console.warn(
-          "owner-billing: invoice lookup failed",
-          err instanceof Error ? err.message : String(err),
-        );
-        return { items: [] as TenantInvoiceDto[] };
-      }),
+      withSoftTimeout(
+        listOwnerWalletInvoices({
+          client: adminClient,
+          ownerUserId: userId,
+          page: 1,
+          pageSize: 10,
+        }),
+        2_500,
+        emptyInvoices,
+        "invoice lookup",
+      ),
     ]);
 
   return {


### PR DESCRIPTION
## Summary
- Clarify Plane A (OpenMeter Stripe app / platform cost rail) vs Plane B (merchant Stripe Connect): rename `stripe-connect.ts` → `stripe-app-install.ts`, expose `billingReady`, update Payments tab copy.
- Owner `/billing`: Stripe payment-method attach (`POST /api/v1/me/billing/payment-method`), MoonPay admin-only, parallelize subscription lookups + soft-timeout slow Konnect invoice list.
- Scope-1 foundations fixes: Neon cache stays `pending` when Checkout URL is returned; Konnect subscription-change guard via `shouldUseKonnectRoutes`.
- Docs/config: Plane A/B `.env.example`, ADR + Railway notes.

## Stack
- Base: `feat/stripe-connect-merchant` (#322)
- Depends on: #321 → #322

## Test plan
- [ ] `npx tsc --noEmit`
- [ ] Unit: `subscriptions-billing`, `stripe-app-install`, `billing-profiles`
- [ ] App Payments tab: Merchant Connect Account Link still works; status uses `acct_…` + charges (not legacy OM install)
- [ ] `/billing` loads without 11s hang; invoices may be empty if Konnect `/billing/invoices` exceeds soft timeout
- [ ] Owner payment-method button starts Stripe Checkout setup
- [ ] Non-admin does not see MoonPay onramp panel; admin still can