### PR TITLE
chore(railway): upgrade pymthouse-signer-test to prod go-livepeer image

### DIFF
--- a/config/railway/stack.json
+++ b/config/railway/stack.json
@@ -24,8 +24,8 @@
       "kind": "repo",
       "manifest": "deploy/pymthouse-signer-test/railway.json",
       "environments": ["preview", "production"],
-      "description": "A/B 'latest' remote signer DMZ, deployed in both preview and production. Same webhook/OIDC/Kafka and signing identity as pymthouse (the 'stable' signer); LIVEPEER_IMAGE pins a newer go-livepeer build. Entrypoint defaults BYOC_PER_CAP_PRICING=on for this service name. Apps opt in via LATEST_SIGNER_APPS on the Next app.",
-      "livepeerImage": "livepeer/go-livepeer:sha-4214202f4458cda90bd030a0bbdddf7b3a1f52a5",
+      "description": "A/B 'latest' remote signer DMZ, deployed in both preview and production. Same webhook/OIDC/Kafka and signing identity as pymthouse (the 'stable' signer); LIVEPEER_IMAGE matches the prod Dockerfile default. Entrypoint defaults BYOC_PER_CAP_PRICING=on for this service name. Apps opt in via LATEST_SIGNER_APPS on the Next app.",
+      "livepeerImage": "livepeer/go-livepeer:sha-9d92ee43300fead9cbcece0867ba04814e3ed218",
       "byocPerCapPricing": true
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Align Railway A/B signer `pymthouse-signer-test` with production by bumping `livepeerImage` in `config/railway/stack.json` from `sha-4214202…` to `sha-9d92ee4…`
- Matches the prod Dockerfile default set in #312 (`livepeer/go-livepeer:sha-9d92ee43300fead9cbcece0867ba04814e3ed218`)

## Deploy notes
After merge, redeploy the Railway stack (or `bash scripts/railway-deploy-signer.sh pymthouse-signer-test production`) so `LIVEPEER_IMAGE` is applied and the DMZ rebuilds with the new binary.

## Test plan
- [x] Confirm image exists on Docker Hub: `sha-9d92ee43300fead9cbcece0867ba04814e3ed218`
- [x] Confirm pin matches `docker/signer-dmz/Dockerfile` default `LIVEPEER_IMAGE`
- [ ] After merge/deploy: `curl -sf https://<signer-test-url>/healthz`
- [ ] Smoke signing path still works for an app opted into `LATEST_SIGNER_APPS`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bb267b8-5755-4611-b531-51fd7e5219f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bb267b8-5755-4611-b531-51fd7e5219f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

