### PR TITLE
fix(security): resolve CodeQL user-controlled bypass in Stripe OAuth callback (#117)

### DIFF
--- a/src/app/api/v1/apps/[id]/billing/stripe/oauth/callback/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/oauth/callback/route.ts
@@ -17,18 +17,17 @@ export async function GET(
 
   const code = request.nextUrl.searchParams.get("code")?.trim() || "";
   const state = request.nextUrl.searchParams.get("state")?.trim() || "";
-  const oauthError = request.nextUrl.searchParams.get("error")?.trim();
+  const oauthError = request.nextUrl.searchParams.get("error")?.trim() || "";
 
-  if (oauthError) {
-    return NextResponse.redirect(
-      `${paymentsUrl}&error=${encodeURIComponent(
-        sanitizeStripeOAuthProviderError(oauthError),
-      )}`,
-    );
-  }
+  // Authorization is the server-side OAuth state + Stripe code exchange inside
+  // completeMerchantConnectOAuth — not the absence of a provider `error` param.
+  // Only use `error` for UX when code/state are missing (OAuth denial / cancel).
   if (!code || !state) {
+    const errorCode = oauthError
+      ? sanitizeStripeOAuthProviderError(oauthError)
+      : "missing_oauth_params";
     return NextResponse.redirect(
-      `${paymentsUrl}&error=${encodeURIComponent("missing_oauth_params")}`,
+      `${paymentsUrl}&error=${encodeURIComponent(errorCode)}`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Fixes [CodeQL alert #117](https://github.com/pymthouse/pymthouse/security/code-scanning/117) (`js/user-controlled-bypass`, high): the Stripe Connect OAuth callback used the user-supplied `error` query param as an early gate before `completeMerchantConnectOAuth`.
- Restructures the handler so OAuth completion is driven by presence of `code` + `state`. The provider `error` value is only used to choose an allowlisted UX error code when those params are missing (denial/cancel), not to decide whether server-side state + code exchange may run.

## Alert
- **Rule:** `js/user-controlled-bypass` (CWE-807 / CWE-290)
- **File:** `src/app/api/v1/apps/[id]/billing/stripe/oauth/callback/route.ts`
- **Issue:** User-controlled `error` query param guarded a sensitive path

## Test plan
- [x] `npx tsc --noEmit` (no new errors; pre-existing stale `.next/dev/types` noise only)
- [x] Stripe unit tests (`webhook.test.ts`, `connect-accounts.test.ts`) — 26 pass
- [x] Snyk Code scan on changed path — 0 issues
- [x] SonarQube snippet analysis — 0 issues
- [ ] Confirm CodeQL on this PR clears alert #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe OAuth callback handling when authorization parameters are incomplete.
  * OAuth completion can now proceed when valid authorization code and state values are present, even if an error parameter is also included.
  * Added clearer fallback handling for missing or provider-reported OAuth errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->