### PR TITLE
refactor(auth): route Turnkey Wallet Kit config through one helper

### DIFF
--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -8,12 +8,10 @@ import OwnerBillingView from "@/components/OwnerBillingView";
 import OwnerPaymentMethodButton from "@/components/OwnerPaymentMethodButton";
 import { authOptions } from "@/lib/next-auth-options";
 import { getOwnerBillingData } from "@/lib/owner-billing-data";
+import { isTurnkeyWalletConfigured } from "@/lib/turnkey-wallet-config";
 
 function isTurnkeyFundingConfigured(): boolean {
-  return Boolean(
-    process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
-      process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim(),
-  );
+  return isTurnkeyWalletConfigured();
 }
 
 export default async function BillingPage() {

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -13,6 +13,7 @@ import { MarketingFooter } from "@/components/MarketingFooter";
 import { TurnkeyEmbeddedAuth } from "@/components/TurnkeyEmbeddedAuth";
 import { toSafeLogoUrl } from "@/lib/safe-logo-url";
 import { safeCallbackUrl } from "@/lib/turnkey-nextauth-bridge";
+import { isTurnkeyWalletConfigured } from "@/lib/turnkey-wallet-config";
 
 interface AppBranding {
   mode: "blackLabel" | "whiteLabel";
@@ -62,13 +63,10 @@ function shouldShowStartCta(input: {
   isWhiteLabel: boolean;
   resumePersona: "explorer" | "builder" | null;
 }): boolean {
-  const turnkeyConfigured =
-    !!process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
-    !!process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim();
   const loginUiReady =
     input.status === "unauthenticated" &&
     input.brandingResolved &&
-    (!turnkeyConfigured ||
+    (!isTurnkeyWalletConfigured() ||
       (input.clientState === ClientState.Ready &&
         input.authState === AuthState.Unauthenticated));
   return (

--- a/src/components/TurnkeyEmbeddedAuth.tsx
+++ b/src/components/TurnkeyEmbeddedAuth.tsx
@@ -14,6 +14,7 @@ import {
   bridgeTurnkeySessionToNextAuth,
   safeCallbackUrl,
 } from "@/lib/turnkey-nextauth-bridge";
+import { isTurnkeyWalletConfigured } from "@/lib/turnkey-wallet-config";
 
 const DEFAULT_AUTH_LOGO = "/pymthouse-mark.svg";
 const AUTH_BUTTON_CLASS =
@@ -60,11 +61,7 @@ export function TurnkeyEmbeddedAuth({
   logoUrl?: string | null;
   title?: string;
 }>) {
-  const turnkeyConfigured =
-    !!process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
-    !!process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim();
-
-  if (!turnkeyConfigured) {
+  if (!isTurnkeyWalletConfigured()) {
     return (
       <p className="text-xs text-zinc-500 leading-relaxed">
         Turnkey Wallet Kit is not configured. Set{" "}

--- a/src/components/TurnkeyProvider.tsx
+++ b/src/components/TurnkeyProvider.tsx
@@ -5,6 +5,7 @@ import {
   type TurnkeyProviderConfig,
 } from "@turnkey/react-wallet-kit";
 import { useEffect } from "react";
+import { getTurnkeyWalletConfigId } from "@/lib/turnkey-wallet-config";
 import { TurnkeyModalDismissGuard } from "./TurnkeyModalDismissGuard";
 
 // Wallet Kit auto-calls fetchUser/fetchWallets on mount whenever it thinks
@@ -140,8 +141,8 @@ export default function TurnkeyProviderWrapper({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const organizationId = process.env.NEXT_PUBLIC_ORGANIZATION_ID;
-  const authProxyConfigId = process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID;
+  const organizationId = process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim();
+  const authProxyConfigId = getTurnkeyWalletConfigId();
 
   if (!organizationId || !authProxyConfigId) {
     return <>{children}</>;

--- a/src/components/apps/FundAccountOnRampPanel.tsx
+++ b/src/components/apps/FundAccountOnRampPanel.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { formatUsdMicrosString } from "@/lib/format-usd-micros";
 import { SANDBOX_ONRAMP_USD_AMOUNT } from "@/lib/onramp/amount";
+import { isTurnkeyWalletConfigured } from "@/lib/turnkey-wallet-config";
 
 type FundAccountOnRampPanelProps = Readonly<{
   clientId: string;
@@ -235,9 +236,7 @@ export default function FundAccountOnRampPanel({
   ownerExternalUserId,
 }: FundAccountOnRampPanelProps) {
   const router = useRouter();
-  const turnkeyConfigured =
-    !!process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
-    !!process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim();
+  const turnkeyConfigured = isTurnkeyWalletConfigured();
 
   const {
     authState,

--- a/src/lib/turnkey-wallet-config.ts
+++ b/src/lib/turnkey-wallet-config.ts
@@ -1,0 +1,17 @@
+/**
+ * Auth Proxy / Wallet Kit config id for the Turnkey org region.
+ * Single place the variable name is spelled, so a region change is one edit.
+ */
+export function getTurnkeyWalletConfigId(): string | undefined {
+  return process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim() || undefined;
+}
+
+/**
+ * True when public Turnkey Wallet Kit env is set (client can show embedded wallet UI).
+ */
+export function isTurnkeyWalletConfigured(): boolean {
+  return !!(
+    process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
+    getTurnkeyWalletConfigId()
+  );
+}

--- a/src/lib/turnkey.ts
+++ b/src/lib/turnkey.ts
@@ -34,15 +34,10 @@ function parseCompactJwsPayloadObject(jwt: string): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
-/**
- * True when public Turnkey Wallet Kit env is set (client can show embedded wallet UI).
- */
-export function isTurnkeyWalletConfigured(): boolean {
-  return !!(
-    process.env.NEXT_PUBLIC_ORGANIZATION_ID?.trim() &&
-    process.env.NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID?.trim()
-  );
-}
+export {
+  getTurnkeyWalletConfigId,
+  isTurnkeyWalletConfigured,
+} from "@/lib/turnkey-wallet-config";
 
 /**
  * Verify Turnkey session JWT signature and decode claims.


### PR DESCRIPTION
## Summary

Five call sites each inlined their own `NEXT_PUBLIC_ORGANIZATION_ID` + `NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID` check. `TurnkeyProvider` was the only one that did **not** trim, so a value with stray whitespace passed every gate and was then handed raw to Wallet Kit.

- Add `getTurnkeyWalletConfigId` / `isTurnkeyWalletConfigured` in `src/lib/turnkey-wallet-config.ts`. It is a separate module rather than living in `src/lib/turnkey.ts` because that file pulls in db code and these are read from client components.
- Route `TurnkeyProvider`, `TurnkeyEmbeddedAuth`, login gating, the on-ramp panel, and billing Turnkey messaging through the helper.
- `src/lib/turnkey.ts` re-exports both, so `turnkey-github-auth.ts` and its tests are unchanged.

**Env variable names are unchanged** — this stays on `NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID`, so no `.env.example`, `validate-env`, staging script, or doc updates, and nothing to rename in staging/prod before deploy. Picking the region-correct config id is a value change in the environment, not a code change.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx tsx --test src/lib/turnkey-github-auth.test.ts` (16/16)
- [x] `next build --webpack` compiles
- [ ] With `NEXT_PUBLIC_ORGANIZATION_ID` + `NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID` set, TurnkeyProvider mounts and the login Wallet Kit UI appears
- [ ] Billing admin fund panel still appears only when Turnkey wallet config is present
