### PR TITLE
fix(security): harden Stripe OAuth callback parameter handling

### DIFF
--- a/src/app/api/v1/apps/[id]/billing/stripe/callback/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/callback/route.ts
@@ -14,6 +14,10 @@ export async function GET(
   }
 
   const state = request.nextUrl.searchParams.get("state")?.trim();
+  const code = request.nextUrl.searchParams.get("code")?.trim() || "";
+  const oauthError = request.nextUrl.searchParams.get("error")?.trim() || "";
+  const oauthErrorDescription =
+    request.nextUrl.searchParams.get("error_description")?.trim() || "";
   if (!state) {
     return NextResponse.json({ error: "Missing state" }, { status: 400 });
   }
@@ -23,7 +27,12 @@ export async function GET(
       clientId: auth.app.id,
       state,
       userId: auth.userId,
-      oauthQuery: request.nextUrl.searchParams.toString(),
+      oauthParams: {
+        code,
+        state,
+        error: oauthError,
+        errorDescription: oauthErrorDescription,
+      },
     });
     const redirect = `${getPublicOrigin()}/apps/${encodeURIComponent(clientId)}/settings?tab=payments&connected=1`;
     return NextResponse.redirect(redirect);

--- a/src/lib/openmeter/stripe-app-install.test.ts
+++ b/src/lib/openmeter/stripe-app-install.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/openmeter/client";
 import {
   buildStripeConnectInstallUrl,
+  completeStripeOAuthCallback,
   connectStripeOnKonnect,
   connectStripeWithApiKey,
   createStripeOAuthState,
@@ -372,6 +373,80 @@ test("createStripeOAuthState returns install URL on self-hosted OpenMeter", asyn
     parsed.searchParams.get("redirect_uri") ?? "",
     new RegExp(`/api/v1/apps/${seeded.clientId}/billing/stripe/callback`),
   );
+});
+
+test("completeStripeOAuthCallback rejects provider error without authorizing", async (t) => {
+  const seeded = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(seeded));
+
+  const state = `oauth-error-${seeded.clientId}`;
+  await db.insert(appBillingOauthStates).values({
+    id: crypto.randomUUID(),
+    state,
+    clientId: seeded.clientId,
+    userId: seeded.userId,
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    createdAt: new Date().toISOString(),
+  });
+
+  let fetchCalls = 0;
+  t.mock.method(globalThis, "fetch", async () => {
+    fetchCalls += 1;
+    return new Response("", { status: 200 });
+  });
+
+  await assert.rejects(
+    () =>
+      completeStripeOAuthCallback({
+        clientId: seeded.clientId,
+        state,
+        userId: seeded.userId,
+        oauthParams: {
+          code: "",
+          state,
+          error: "access_denied",
+          errorDescription: "User denied",
+        },
+      }),
+    /Stripe OAuth provider error: access_denied/,
+  );
+  assert.equal(fetchCalls, 0);
+});
+
+test("completeStripeOAuthCallback rejects missing code before authorize call", async (t) => {
+  const seeded = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(seeded));
+
+  const state = `oauth-missing-code-${seeded.clientId}`;
+  await db.insert(appBillingOauthStates).values({
+    id: crypto.randomUUID(),
+    state,
+    clientId: seeded.clientId,
+    userId: seeded.userId,
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    createdAt: new Date().toISOString(),
+  });
+
+  let fetchCalls = 0;
+  t.mock.method(globalThis, "fetch", async () => {
+    fetchCalls += 1;
+    return new Response("", { status: 200 });
+  });
+
+  await assert.rejects(
+    () =>
+      completeStripeOAuthCallback({
+        clientId: seeded.clientId,
+        state,
+        userId: seeded.userId,
+        oauthParams: {
+          code: "",
+          state,
+        },
+      }),
+    /Missing Stripe OAuth code/,
+  );
+  assert.equal(fetchCalls, 0);
 });
 
 test("connectStripeOnKonnect finalizes via org Stripe app id", async (t) => {

--- a/src/lib/openmeter/stripe-app-install.ts
+++ b/src/lib/openmeter/stripe-app-install.ts
@@ -136,6 +136,15 @@ export function parseStripeAccountIdFromConflict(err: unknown): string | null {
   return match?.[0] ?? null;
 }
 
+function normalizeOAuthErrorCode(rawCode: string): string {
+  const normalized = rawCode.trim().toLowerCase();
+  if (!normalized) {
+    return "oauth_error";
+  }
+  const safeCode = normalized.replace(/[^a-z0-9_]/g, "");
+  return safeCode || "oauth_error";
+}
+
 async function findExistingStripeAppForTenant(
   client: OpenMeter,
   clientId: string,
@@ -282,7 +291,12 @@ export async function completeStripeOAuthCallback(input: {
   clientId: string;
   state: string;
   userId: string;
-  oauthQuery: string;
+  oauthParams: {
+    code: string;
+    state: string;
+    error?: string;
+    errorDescription?: string;
+  };
 }): Promise<void> {
   const now = new Date().toISOString();
   const stateRows = await db
@@ -301,11 +315,27 @@ export async function completeStripeOAuthCallback(input: {
   if (!stateRow || stateRow.expiresAt < now) {
     throw new Error("Invalid or expired OAuth state");
   }
+  const callbackState = input.oauthParams.state.trim();
+  if (callbackState !== stateRow.state) {
+    throw new Error("Invalid or expired OAuth state");
+  }
+  const oauthError = input.oauthParams.error?.trim() || "";
+  if (oauthError) {
+    const safeErrorCode = normalizeOAuthErrorCode(oauthError);
+    throw new Error(`Stripe OAuth provider error: ${safeErrorCode}`);
+  }
+  const code = input.oauthParams.code.trim();
+  if (!code) {
+    throw new Error("Missing Stripe OAuth code");
+  }
 
   const client = getHostedAdminClient();
   const baseUrl = process.env.OPENMETER_URL?.replace(/\/$/, "") || "http://127.0.0.1:48888";
   const apiKey = process.env.OPENMETER_API_KEY?.trim();
-  const authorizeUrl = `${baseUrl}/api/v1/marketplace/listings/stripe/install/oauth2/authorize?${input.oauthQuery}`;
+  const authorizeQuery = new URLSearchParams();
+  authorizeQuery.set("code", code);
+  authorizeQuery.set("state", stateRow.state);
+  const authorizeUrl = `${baseUrl}/api/v1/marketplace/listings/stripe/install/oauth2/authorize?${authorizeQuery.toString()}`;
   const authorizeResp = await fetch(authorizeUrl, {
     method: "GET",
     redirect: "manual",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop forwarding raw callback query strings into the OpenMeter Stripe authorize endpoint
- whitelist and reconstruct only `code` and server-validated `state` for authorize requests
- fail fast on provider `error` and missing `code` before any downstream authorization call
- add regression tests that assert no authorize call is made when callback contains provider error or omits code

## Why
Code scanning flagged a user-controlled bypass vector in the Stripe OAuth callback flow. This change moves trust boundaries to server-validated parameters and removes direct propagation of user-controlled query input.

## Validation
- ✅ Typecheck: `npx tsc --noEmit -p tsconfig.json`
- ⚠️ SonarQube local scanner: reachable with `-Dsonar.host.url=https://sonarcloud.io`, but blocked by missing `SONAR_TOKEN` in this runner
- ⚠️ Snyk Code + OSS scans: blocked by missing Snyk auth (`SNYK-0005`, 401)
- ⚠️ Targeted test invocation executes but all tests are skipped by DB guard in this environment (no test database)

## Notes
A previous invocation order for test imports (`--import ./src/test-env.ts --import tsx`) fails under this runtime; running `--import tsx` first allows the test runner to load TS modules correctly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eaadb11-ed7f-4e67-aa69-1791b0a6a7f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eaadb11-ed7f-4e67-aa69-1791b0a6a7f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

