### PR TITLE
feat(billing): merchant Custom Invoicing + Connect supplier sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,9 +190,23 @@ OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS=5000000
 # ---------- Plane B: Merchant Stripe Connect (revenue rail) ----------
 # Builders collect from end users on Connected Accounts; PymtHouse takes application_fee_bps.
 # Connect webhook signing secret (Dashboard → Webhooks → connected-account events → /webhooks/stripe)
+# Prefer STRIPE_CONNECT_WEBHOOK_SECRET when the Connect endpoint has its own secret.
 # STRIPE_WEBHOOK_SECRET=whsec_…
+# STRIPE_CONNECT_WEBHOOK_SECRET=whsec_…
 # After hard cutover, force Connect-only checkout globally (optional; prefer per-app connectPaymentsOnly)
 # STRIPE_CONNECT_PAYMENTS_ONLY=0
+
+# ---------- Merchant Custom Invoicing (OpenMeter → Connect collection) ----------
+# Bootstrap: npm run openmeter:custom-invoicing:bootstrap
+# OPENMETER_CUSTOM_INVOICING_APP_ID=
+# OPENMETER_MERCHANT_BILLING_PROFILE_ID=
+# Shared secret on the Konnect notification channel (X-Webhook-Secret header)
+# OPENMETER_WEBHOOK_SECRET=
+# Optional: enable draft/issuing sync hooks after initial rollout (default off)
+# OPENMETER_CUSTOM_INVOICING_DRAFT_HOOK=0
+# OPENMETER_CUSTOM_INVOICING_ISSUING_HOOK=0
+# Railway worker id (optional)
+# INVOICING_WORKER_ID=
 
 # Required for usage totals, allowance balance, and signed-ticket metering
 # OPENMETER_URL=http://127.0.0.1:48888

--- a/deploy/invoicing-worker/Dockerfile
+++ b/deploy/invoicing-worker/Dockerfile
@@ -1,0 +1,16 @@
+# Include tsx so the worker entrypoint can run TypeScript without a build step.
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm install --no-save tsx@4.21.0
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY scripts/invoicing-worker.ts ./scripts/invoicing-worker.ts
+
+ENV NODE_ENV=production
+USER node
+
+CMD ["npx", "tsx", "scripts/invoicing-worker.ts"]

--- a/deploy/invoicing-worker/railway.json
+++ b/deploy/invoicing-worker/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/invoicing-worker/Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/docs/adr-stripe-connect-openmeter-webhooks.md
+++ b/docs/adr-stripe-connect-openmeter-webhooks.md
@@ -145,25 +145,44 @@ failover design.
 ### Plane B — PymtHouse Connect endpoint
 
 Dashboard: **Developers → Webhooks → Listen to events on Connected accounts**.  
-Env: `STRIPE_WEBHOOK_SECRET` (`whsec_…`), endpoint `POST /webhooks/stripe`.  
+Env: `STRIPE_CONNECT_WEBHOOK_SECRET` (preferred) or `STRIPE_WEBHOOK_SECRET` (`whsec_…`),
+endpoint `POST /webhooks/stripe`.  
 Verify `Stripe-Signature` over the raw body (`src/lib/stripe/webhook.ts`).
 
 | Event | Handler intent | Neon / OM effect |
 |---|---|---|
 | `account.updated` | `applyConnectedAccountWebhookUpdate` | Refresh `stripe_charges_enabled`, `stripe_details_submitted`, `stripe_payouts_enabled`; set `stripe_connect_status` |
-| `account.application.deauthorized` | Clear merchant link | `connectReady=false`; block new paid checkouts; keep metering |
-| `checkout.session.completed` | Retail payment success | Idempotent: map metadata → ensure OM customer + subscription; write `app_user_stripe_customers` |
-| `payment_intent.succeeded` | Alternate / one-shot retail | Same as above when Checkout is not used |
-| `invoice.paid` (Connect) | Recurring retail on connected account | Advance local subscription cache; do **not** also charge via OM Stripe app |
-| `customer.subscription.deleted` (optional) | Merchant cancelled retail sub | Align OM subscription cancel / phase-out |
+| `account.application.deauthorized` | Ledger insert | Audit trail; readiness cleared via subsequent `account.updated` |
+| `checkout.session.completed` | Ledger insert | Worker / future retail subscription ensure |
+| `payment_intent.succeeded` / `payment_failed` / `requires_action` | Ledger → invoicing worker | Report Custom Invoicing `payment/status` (paid / failed / action_required) |
+| `charge.dispute.created` | Ledger → worker | Report `payment_uncollectible` |
 
 **Readiness predicate** (merchant checkout / activation gate): Connected Account id
 present, `charges_enabled`, and `details_submitted`.
 `payouts_enabled` is recorded but **not** required (see activation-gate.md).
 
-**Idempotency:** store processed Stripe `event.id` (or rely on natural upserts keyed
-by `client_id` + `external_user_id` + `openmeter_subscription_id`). Retries are
-normal.
+**Idempotency:** `invoice_events` unique on `(source, external_event_id)` for both
+OpenMeter notification ids and Stripe `evt_…` ids.
+
+### Plane C — Merchant Custom Invoicing (OpenMeter invoices → Connect collection)
+
+For `billingMode: "merchant"` apps, OpenMeter generates end-user invoices on a
+**non-default** billing profile whose tax/invoicing/payment apps are the Konnect
+**Custom Invoicing** app ([docs](https://developer.konghq.com/metering-and-billing/custom-invoicing/)).
+OM pauses at `payment_processing.pending` (and optionally draft/issuing sync hooks).
+
+| Stream | Endpoint | Role |
+|---|---|---|
+| OpenMeter Invoice Notifications | `POST /webhooks/openmeter` | Thin ingress → `invoice_events` |
+| Stripe Connect (Plane B) | `POST /webhooks/stripe` | PaymentIntent outcomes → same ledger |
+| Railway `invoicing-worker` | claims via `FOR UPDATE SKIP LOCKED` | Off-session direct charge + `application_fee_amount`; reports `POST …/apps/custom-invoicing/{id}/payment/status` |
+
+Bootstrap: `npm run openmeter:custom-invoicing:bootstrap`. Env:
+`OPENMETER_CUSTOM_INVOICING_APP_ID`, `OPENMETER_MERCHANT_BILLING_PROFILE_ID`,
+`OPENMETER_WEBHOOK_SECRET`. Pin end-user customers with
+`assignMerchantCustomInvoicingProfile` (customer overrides — never org default).
+
+Plane A (owner cost rail via native OM Stripe app) is **unchanged**.
 
 ## Anti-patterns (rejected)
 
@@ -221,8 +240,12 @@ and keep the same OM metering + Connect readiness model.
   `POST /api/v1/me/billing/payment-method`
 - Merchant Account Links + Checkout: `src/lib/stripe/merchant-connect.ts`,
   `src/lib/stripe/connect-accounts.ts`
-- Connect webhook verify / `account.updated`: `src/lib/stripe/webhook.ts`,
+- Connect webhook verify / ledger ingress: `src/lib/stripe/webhook.ts`,
   `src/app/webhooks/stripe/route.ts`
+- Custom Invoicing client: `src/lib/openmeter/custom-invoicing.ts`
+- OpenMeter invoice notifications: `src/app/webhooks/openmeter/route.ts`
+- Ledger + worker: `src/lib/invoicing/*`, `scripts/invoicing-worker.ts`,
+  `deploy/invoicing-worker/`
 - Activation gate: `src/lib/activation/app-activation.ts`,
   [`docs/activation-gate.md`](./activation-gate.md)
 
@@ -238,16 +261,17 @@ and keep the same OM metering + Connect readiness model.
 - [x] Payments tab copy: “Merchant Stripe Connect” vs OpenMeter Stripe billing
 - [x] Owner Stripe payment-method attach on `/billing` (Plane A)
 - [x] MoonPay gated to platform admin only
+- [x] Plane B ledger for payment_intent.* / deauth / checkout.completed
+- [x] Merchant Custom Invoicing (Konnect) + Railway worker + Connect charges
 
 ### Remaining
 
 - [ ] Stripe Dashboard: dedicated Connect webhook endpoint (connected-account
       events) pointed at production `/webhooks/stripe`; document secret rotation.
-- [ ] Expand Plane B beyond `account.updated`: `checkout.session.completed`,
-      `account.application.deauthorized`, and idempotent event ledger.
-- [ ] Guarantee merchant end-user OM customers use a **non-charging** billing
-      profile (assert in `prepareAppCustomerStripeBilling` when
-      `billing_mode=merchant`).
+- [ ] Konnect: run `openmeter:custom-invoicing:bootstrap` in each env; set
+      `OPENMETER_*` / `STRIPE_CONNECT_WEBHOOK_SECRET` on Vercel + Railway.
+- [ ] Wire `assignMerchantCustomInvoicingProfile` into merchant end-user
+      provisioning when `billing_mode=merchant`.
 - [ ] Cutover audit (#324): flag apps where OM would auto-charge the same
       customer that Connect already bills.
 - [ ] x402 / stablecoin payment methods on Plane A and Plane B (design above).
@@ -255,9 +279,12 @@ and keep the same OM metering + Connect readiness model.
 ## Success criteria
 
 1. Owner network invoices collect only via Plane A (platform Stripe + OM app).
-2. Builder retail payments collect only via Plane B (connected account).
+2. Builder retail payments collect only via Plane B (connected account), including
+   OM-generated invoices completed via Custom Invoicing + Connect charges.
 3. No end user is charged twice for the same plan period.
 4. `canSellPaidPlans` tracks Connect readiness from Plane B webhooks, not OM app
    install status (`billingReady`).
 5. Engineers and UI never call OM app install “Stripe Connect.”
 6. MoonPay is never presented as the primary owner funding path.
+7. Invoice event processing is durable (ledger + SKIP LOCKED worker) and
+   idempotent under webhook retries.

--- a/docs/adr-stripe-connect-openmeter-webhooks.md
+++ b/docs/adr-stripe-connect-openmeter-webhooks.md
@@ -235,6 +235,13 @@ and keep the same OM metering + Connect readiness model.
 
 - OM app install / Konnect link: `src/lib/openmeter/stripe-app-install.ts`
 - Billing profiles / owners profile: `src/lib/openmeter/billing-profiles.ts`
+- Supplier sync (Connect → OM profile): `src/lib/openmeter/supplier-sync.ts`,
+  `src/lib/openmeter/billing-supplier.ts`
+- Settlement metadata keys: `src/lib/openmeter/settlement-metadata.ts`
+  (`stripe_charge_model`, `stripe_connect_account_id`) — Plane A Stripe-app
+  profiles never stamp these; merchant Custom Invoicing does. Durable settlement
+  lives in [pymthouse/settlement](https://github.com/pymthouse/settlement); the
+  Railway `invoicing-worker` is the interim collector.
 - Customer Stripe app data: `src/lib/openmeter/stripe-customer-data.ts`
 - Owner PM attach: `src/lib/openmeter/owner-payment-method.ts`,
   `POST /api/v1/me/billing/payment-method`

--- a/drizzle/0041_merchant_custom_invoicing.sql
+++ b/drizzle/0041_merchant_custom_invoicing.sql
@@ -1,0 +1,52 @@
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "openmeter_merchant_billing_profile_id" text;--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "invoice_events" (
+  "id" text PRIMARY KEY NOT NULL,
+  "source" text NOT NULL,
+  "external_event_id" text NOT NULL,
+  "event_type" text NOT NULL,
+  "payload" jsonb NOT NULL,
+  "status" text NOT NULL DEFAULT 'pending',
+  "attempts" integer NOT NULL DEFAULT 0,
+  "next_attempt_at" text NOT NULL,
+  "claimed_by" text,
+  "last_error" text,
+  "created_at" text NOT NULL,
+  "updated_at" text NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_invoice_events_source_external"
+  ON "invoice_events" ("source","external_event_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_invoice_events_claim"
+  ON "invoice_events" ("status","next_attempt_at");--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "merchant_invoices" (
+  "id" text PRIMARY KEY NOT NULL,
+  "openmeter_invoice_id" text NOT NULL,
+  "app_id" text NOT NULL,
+  "openmeter_customer_id" text,
+  "stripe_connected_account_id" text,
+  "stripe_customer_id" text,
+  "stripe_payment_intent_id" text,
+  "stripe_invoice_id" text,
+  "state" text NOT NULL DEFAULT 'created',
+  "amount_usd_micros" text,
+  "currency" text NOT NULL DEFAULT 'USD',
+  "application_fee_amount" integer NOT NULL DEFAULT 0,
+  "last_error" text,
+  "created_at" text NOT NULL,
+  "updated_at" text NOT NULL
+);--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "merchant_invoices"
+    ADD CONSTRAINT "merchant_invoices_app_id_developer_apps_id_fk"
+    FOREIGN KEY ("app_id") REFERENCES "public"."developer_apps"("id")
+    ON DELETE no action ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_merchant_invoices_om_id"
+  ON "merchant_invoices" ("openmeter_invoice_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_merchant_invoices_app"
+  ON "merchant_invoices" ("app_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_merchant_invoices_pi"
+  ON "merchant_invoices" ("stripe_payment_intent_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_merchant_invoices_state"
+  ON "merchant_invoices" ("state");

--- a/drizzle/0042_connect_supplier_sync.sql
+++ b/drizzle/0042_connect_supplier_sync.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_country" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_name" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_business_type" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_address_line1" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_address_line2" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_address_city" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_address_state" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_address_postal_code" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_tax_id" text;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_tax_id_on_file_at_stripe" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "app_billing_config" ADD COLUMN IF NOT EXISTS "supplier_synced_at" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1786400000000,
       "tag": "0041_merchant_custom_invoicing",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1786500000000,
+      "tag": "0042_connect_supplier_sync",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1786300000000,
       "tag": "0040_owner_starter_plan_name",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1786400000000,
+      "tag": "0041_merchant_custom_invoicing",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "api-keys:hard-cutover": "npx tsx scripts/api-keys-hard-cutover.ts",
     "oidc:seed": "npx tsx scripts/seed-oidc.ts",
     "openmeter:bootstrap": "npx tsx scripts/openmeter-bootstrap.ts",
+    "openmeter:custom-invoicing:bootstrap": "npx tsx scripts/openmeter-custom-invoicing-bootstrap.ts",
+    "invoicing:worker": "npx tsx scripts/invoicing-worker.ts",
     "openmeter:ensure-customer": "npx tsx scripts/openmeter-ensure-customer.ts",
     "openmeter:migrate-starter-prepaid": "npx tsx scripts/openmeter-migrate-starter-prepaid.ts",
     "openmeter:fix-starter-allowance": "npx tsx scripts/openmeter-fix-starter-allowance.ts",

--- a/scripts/invoicing-worker.ts
+++ b/scripts/invoicing-worker.ts
@@ -1,0 +1,33 @@
+/**
+ * Railway entrypoint for the merchant Custom Invoicing worker.
+ * Usage: npm run invoicing:worker
+ */
+import dotenv from "dotenv";
+
+dotenv.config({ path: ".env.local" });
+dotenv.config();
+
+import { closeDb } from "../src/db/index";
+import { runInvoicingWorker } from "../src/lib/invoicing/worker";
+
+async function main(): Promise<void> {
+  const stop = async () => {
+    console.log("[invoicing-worker] shutting down…");
+    await closeDb({ timeout: 5 });
+    process.exit(0);
+  };
+  process.on("SIGINT", () => {
+    void stop();
+  });
+  process.on("SIGTERM", () => {
+    void stop();
+  });
+
+  await runInvoicingWorker();
+}
+
+main().catch(async (err) => {
+  console.error("[invoicing-worker] fatal:", err);
+  await closeDb({ timeout: 2 }).catch(() => undefined);
+  process.exit(1);
+});

--- a/scripts/openmeter-backfill-connect-suppliers.ts
+++ b/scripts/openmeter-backfill-connect-suppliers.ts
@@ -1,0 +1,60 @@
+/**
+ * Backfill Connect supplier identity onto app_billing_config + OM profiles.
+ *
+ *   npx tsx scripts/openmeter-backfill-connect-suppliers.ts --dry-run
+ *   npx tsx scripts/openmeter-backfill-connect-suppliers.ts --apply
+ */
+import "./load-env-first";
+import { closeDb, db } from "../src/db/index";
+import { appBillingConfig } from "../src/db/schema";
+import { syncTenantSupplierFromConnect } from "../src/lib/openmeter/supplier-sync";
+import { isNotNull } from "drizzle-orm";
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const dryRun = !apply;
+
+  const rows = await db
+    .select({
+      clientId: appBillingConfig.clientId,
+      accountId: appBillingConfig.stripeConnectedAccountId,
+    })
+    .from(appBillingConfig)
+    .where(isNotNull(appBillingConfig.stripeConnectedAccountId));
+
+  console.log(
+    `${dryRun ? "DRY-RUN" : "APPLY"}: ${rows.length} app(s) with connected accounts`,
+  );
+
+  for (const row of rows) {
+    const accountId = row.accountId?.trim();
+    if (!accountId) continue;
+    if (dryRun) {
+      console.log(`would sync ${row.clientId} ← ${accountId}`);
+      continue;
+    }
+    try {
+      const result = await syncTenantSupplierFromConnect({
+        clientId: row.clientId,
+        accountId,
+      });
+      console.log(
+        `${row.clientId}: ${result.status} gaps=${result.gaps.join(",") || "none"}`,
+      );
+    } catch (err) {
+      console.error(
+        `${row.clientId}: FAILED`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/scripts/openmeter-custom-invoicing-bootstrap.ts
+++ b/scripts/openmeter-custom-invoicing-bootstrap.ts
@@ -1,0 +1,228 @@
+/**
+ * Bootstrap Konnect Custom Invoicing for the merchant plane:
+ * 1. Notification webhook channel → PUBLIC_ORIGIN/webhooks/openmeter
+ * 2. Install Custom Invoicing app (hooks disabled initially)
+ * 3. Non-default merchant billing profile referencing that app
+ * 4. Invoice created + updated notification rules
+ *
+ * Prints env vars to set: OPENMETER_CUSTOM_INVOICING_APP_ID,
+ * OPENMETER_MERCHANT_BILLING_PROFILE_ID, OPENMETER_WEBHOOK_SECRET.
+ *
+ * @see https://developer.konghq.com/metering-and-billing/custom-invoicing/
+ * @see https://developer.konghq.com/metering-and-billing/notifications/
+ */
+import { randomBytes } from "node:crypto";
+import dotenv from "dotenv";
+
+dotenv.config({ path: ".env.local" });
+dotenv.config();
+
+import { getPublicOrigin } from "../src/lib/oidc/issuer-urls";
+import {
+  createKonnectMerchantCustomInvoicingProfile,
+  listKonnectApps,
+  listKonnectBillingProfiles,
+  resolveKonnectCustomInvoicingAppId,
+  selectKonnectCustomInvoicingApp,
+} from "../src/lib/openmeter/konnect-billing-profiles";
+import { konnectAdminFetch } from "../src/lib/openmeter/konnect-admin-client";
+import {
+  getHostedOpenMeterUrl,
+  isKonnectMeteringUrl,
+  normalizeKonnectMeteringUrl,
+} from "../src/lib/openmeter/constants";
+
+const CHANNEL_NAME = "pymthouse-merchant-invoices";
+const PROFILE_NAME = "pymthouse-merchant-custom-invoicing";
+
+type KonnectPage<T> = { data?: T[] };
+
+type NotificationChannel = {
+  id?: string;
+  name?: string;
+  type?: string;
+  url?: string;
+};
+
+type MarketplaceInstallResponse = {
+  app?: { id?: string };
+  id?: string;
+};
+
+function requireKonnect(): { baseUrl: string; apiKey: string } {
+  const apiKey = process.env.OPENMETER_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("OPENMETER_API_KEY is required");
+  }
+  const raw = getHostedOpenMeterUrl();
+  if (!isKonnectMeteringUrl(raw, apiKey)) {
+    throw new Error(
+      "Custom Invoicing bootstrap targets Konnect Metering & Billing. " +
+        "Set OPENMETER_URL to https://{region}.api.konghq.com/v3/openmeter",
+    );
+  }
+  return { baseUrl: normalizeKonnectMeteringUrl(raw), apiKey };
+}
+
+async function listNotificationChannels(): Promise<NotificationChannel[]> {
+  const page = await konnectAdminFetch<KonnectPage<NotificationChannel>>(
+    "/notification/channels?page[size]=100",
+  );
+  return page.data ?? [];
+}
+
+async function ensureNotificationChannel(input: {
+  url: string;
+  webhookSecret: string;
+}): Promise<{ channelId: string; created: boolean }> {
+  const existing = (await listNotificationChannels()).find(
+    (ch) => ch.name === CHANNEL_NAME || ch.url === input.url,
+  );
+  if (existing?.id) {
+    return { channelId: existing.id, created: false };
+  }
+
+  const created = await konnectAdminFetch<NotificationChannel>(
+    "/notification/channels",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        type: "WEBHOOK",
+        name: CHANNEL_NAME,
+        url: input.url,
+        customHeaders: {
+          "X-Webhook-Secret": input.webhookSecret,
+        },
+        disabled: false,
+      }),
+    },
+    "notification",
+  );
+  if (!created.id) {
+    throw new Error("Failed to create notification channel");
+  }
+  return { channelId: created.id, created: true };
+}
+
+async function ensureInvoiceRules(channelId: string): Promise<void> {
+  for (const type of ["invoice.created", "invoice.updated"] as const) {
+    const name = `pymthouse-${type}`;
+    await konnectAdminFetch(
+      "/notification/rules",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          type,
+          name,
+          channels: [channelId],
+          disabled: false,
+        }),
+      },
+      "notification",
+    ).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      // Idempotent: rule may already exist.
+      if (!/\(409\)|\(400\).*already|duplicate/i.test(message)) {
+        console.warn(`[bootstrap] rule ${type}: ${message}`);
+      }
+    });
+  }
+}
+
+async function installCustomInvoicingApp(): Promise<string> {
+  const apps = await listKonnectApps();
+  const existing = selectKonnectCustomInvoicingApp(apps);
+  if (existing) {
+    return existing;
+  }
+
+  const installed = await konnectAdminFetch<MarketplaceInstallResponse>(
+    "/marketplace/listings/custom_invoicing/install",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        name: "PymtHouse Custom Invoicing",
+        // Hooks off initially per Kong docs; payment status sync is always mandatory.
+        enableDraftSyncHook: false,
+        enableIssuingSyncHook: false,
+      }),
+    },
+    "marketplace",
+  );
+  const appId = installed.app?.id ?? installed.id;
+  if (!appId) {
+    throw new Error("Marketplace install did not return a Custom Invoicing app id");
+  }
+  return appId;
+}
+
+async function ensureMerchantProfile(appId: string): Promise<string> {
+  const envId = process.env.OPENMETER_MERCHANT_BILLING_PROFILE_ID?.trim();
+  if (envId) {
+    return envId;
+  }
+  const profiles = await listKonnectBillingProfiles();
+  const existing = profiles.find((p) => p.name === PROFILE_NAME);
+  if (existing?.id) {
+    return existing.id;
+  }
+  return createKonnectMerchantCustomInvoicingProfile({
+    customInvoicingAppId: appId,
+    name: PROFILE_NAME,
+    progressiveBilling: true,
+    collectionMethod: "charge_automatically",
+  });
+}
+
+async function main(): Promise<void> {
+  requireKonnect();
+
+  const webhookSecret =
+    process.env.OPENMETER_WEBHOOK_SECRET?.trim() ||
+    `whsec_${randomBytes(24).toString("base64url")}`;
+  const origin = getPublicOrigin().replace(/\/$/, "");
+  const webhookUrl = `${origin}/webhooks/openmeter`;
+
+  console.log("[bootstrap] Ensuring notification channel →", webhookUrl);
+  const { channelId, created } = await ensureNotificationChannel({
+    url: webhookUrl,
+    webhookSecret,
+  });
+  console.log(
+    `[bootstrap] Channel ${channelId} (${created ? "created" : "existing"})`,
+  );
+
+  console.log("[bootstrap] Installing / resolving Custom Invoicing app…");
+  let appId: string;
+  try {
+    appId = await installCustomInvoicingApp();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[bootstrap] Marketplace install failed (${message}); resolving existing…`);
+    appId = await resolveKonnectCustomInvoicingAppId();
+  }
+  console.log("[bootstrap] Custom Invoicing app:", appId);
+
+  console.log("[bootstrap] Ensuring merchant billing profile (non-default)…");
+  const profileId = await ensureMerchantProfile(appId);
+  console.log("[bootstrap] Merchant billing profile:", profileId);
+
+  console.log("[bootstrap] Ensuring invoice.created / invoice.updated rules…");
+  await ensureInvoiceRules(channelId);
+
+  console.log("\nSet these env vars (Vercel + Railway invoicing worker):\n");
+  console.log(`OPENMETER_CUSTOM_INVOICING_APP_ID=${appId}`);
+  console.log(`OPENMETER_MERCHANT_BILLING_PROFILE_ID=${profileId}`);
+  console.log(`OPENMETER_WEBHOOK_SECRET=${webhookSecret}`);
+  console.log(
+    "\nPin merchant-mode end-user customers via assignMerchantCustomInvoicingProfile",
+  );
+  console.log(
+    "(never set the merchant profile as the org default — use customer overrides).",
+  );
+}
+
+main().catch((err) => {
+  console.error("[bootstrap] failed:", err);
+  process.exit(1);
+});

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -31,6 +31,7 @@ type BillingPatchFields = {
   applicationFeeBps?: number;
   billingMode?: "owner_rollup" | "merchant";
   endUserCap?: number;
+  supplierTaxId?: string | null;
 };
 
 type ParseResult =
@@ -120,6 +121,31 @@ async function applyBillingModeField(
         ),
       };
     }
+    const { supplierGaps, supplierIsComplete } = await import(
+      "@/lib/openmeter/billing-supplier"
+    );
+    const gaps = supplierGaps({
+      country: config?.supplierCountry,
+      name: config?.supplierName,
+      taxId: config?.supplierTaxId,
+    });
+    if (!supplierIsComplete({
+      country: config?.supplierCountry,
+      name: config?.supplierName,
+      taxId: config?.supplierTaxId,
+    })) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          {
+            error:
+              "Switching to merchant mode requires a complete invoice supplier (country, legal name, and tax id where required). Complete Connect onboarding and set supplierTaxId if needed.",
+            supplierGaps: gaps,
+          },
+          { status: 400 },
+        ),
+      };
+    }
   }
   return null;
 }
@@ -149,14 +175,15 @@ async function parseBillingPatchBody(
     body.invoiceThresholdUsdMicros === undefined &&
     body.applicationFeeBps === undefined &&
     body.billingMode === undefined &&
-    body.endUserCap === undefined
+    body.endUserCap === undefined &&
+    body.supplierTaxId === undefined
   ) {
     return {
       ok: false,
       response: NextResponse.json(
         {
           error:
-            "Provide progressiveBilling, invoiceThresholdUsdMicros, applicationFeeBps, billingMode, and/or endUserCap to update",
+            "Provide progressiveBilling, invoiceThresholdUsdMicros, applicationFeeBps, billingMode, endUserCap, and/or supplierTaxId to update",
         },
         { status: 400 },
       ),
@@ -164,6 +191,22 @@ async function parseBillingPatchBody(
   }
 
   const fields: BillingPatchFields = {};
+
+  if (body.supplierTaxId !== undefined) {
+    if (body.supplierTaxId !== null && typeof body.supplierTaxId !== "string") {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { error: "supplierTaxId must be a string or null" },
+          { status: 400 },
+        ),
+      };
+    }
+    fields.supplierTaxId =
+      typeof body.supplierTaxId === "string"
+        ? body.supplierTaxId.trim() || null
+        : null;
+  }
 
   if (body.progressiveBilling !== undefined) {
     const parsed = parseProgressiveBillingInput(body.progressiveBilling);
@@ -245,6 +288,7 @@ async function persistBillingPatch(
     applicationFeeBps,
     billingMode,
     endUserCap,
+    supplierTaxId,
   } = fields;
   // Persist OpenMeter profile settings before Neon billingMode/endUserCap so
   // a failed OM write cannot leave the app on a new revenue plane.
@@ -259,6 +303,13 @@ async function persistBillingPatch(
           applicationFeeBps,
         })
       : {};
+
+  if (supplierTaxId !== undefined) {
+    const { setAppSupplierTaxId } = await import(
+      "@/lib/openmeter/supplier-sync"
+    );
+    await setAppSupplierTaxId({ clientId: appId, taxId: supplierTaxId });
+  }
 
   if (billingMode !== undefined || endUserCap !== undefined) {
     await upsertAppBillingConfig(appId, {

--- a/src/app/webhooks/openmeter/route.ts
+++ b/src/app/webhooks/openmeter/route.ts
@@ -1,0 +1,103 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { insertInvoiceEvent } from "@/lib/invoicing/ledger";
+import { requireOpenMeterWebhookSecret } from "@/lib/openmeter/custom-invoicing";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
+
+export const runtime = "nodejs";
+
+/**
+ * OpenMeter / Konnect Invoice Notifications ingress.
+ * Configure a webhook Channel with header X-Webhook-Secret (or Authorization Bearer).
+ * @see https://developer.konghq.com/metering-and-billing/notifications/
+ */
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+function extractProvidedSecret(request: Request): string | null {
+  const headerSecret = request.headers.get("x-webhook-secret")?.trim();
+  if (headerSecret) {
+    return headerSecret;
+  }
+  const auth = request.headers.get("authorization")?.trim();
+  if (auth?.toLowerCase().startsWith("bearer ")) {
+    return auth.slice(7).trim();
+  }
+  return null;
+}
+
+function parseOpenMeterEvent(body: unknown): {
+  eventId: string;
+  eventType: string;
+} | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+  const record = body as Record<string, unknown>;
+  const eventId =
+    (typeof record.id === "string" && record.id.trim()) ||
+    (typeof record.eventId === "string" && record.eventId.trim()) ||
+    "";
+  const eventType =
+    (typeof record.type === "string" && record.type.trim()) ||
+    (typeof record.eventType === "string" && record.eventType.trim()) ||
+    "unknown";
+  if (!eventId) {
+    return null;
+  }
+  return { eventId, eventType };
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const tag = "[openmeter-webhook]";
+  let secret: string;
+  try {
+    secret = requireOpenMeterWebhookSecret();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(tag, "misconfigured:", sanitizeForLog(message));
+    return NextResponse.json({ error: "webhook_misconfigured" }, { status: 503 });
+  }
+
+  const provided = extractProvidedSecret(request);
+  if (!provided || !secretsMatch(provided, secret)) {
+    console.warn(tag, "secret rejected");
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const event = parseOpenMeterEvent(parsed);
+  if (!event) {
+    return NextResponse.json({ error: "missing_event_id" }, { status: 400 });
+  }
+
+  try {
+    const result = await insertInvoiceEvent({
+      source: "openmeter",
+      externalEventId: event.eventId,
+      eventType: event.eventType,
+      payload: parsed,
+    });
+    return NextResponse.json({
+      received: true,
+      inserted: result.inserted,
+      id: result.id,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(tag, "insert failed:", sanitizeForLog(message));
+    return NextResponse.json({ error: "handler_failed" }, { status: 500 });
+  }
+}

--- a/src/app/webhooks/stripe/route.ts
+++ b/src/app/webhooks/stripe/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { insertInvoiceEvent } from "@/lib/invoicing/ledger";
 import { applyConnectedAccountWebhookUpdate } from "@/lib/stripe/merchant-connect";
 import {
   parseStripeAccountUpdated,
@@ -10,16 +11,51 @@ import { sanitizeForLog } from "@/lib/sanitize-for-log";
 export const runtime = "nodejs";
 
 /**
- * Stripe Connect platform webhook.
- * Configure in Dashboard → Developers → Webhooks (Connect events):
+ * Stripe Connect platform webhook (events from connected accounts).
+ * Configure in Dashboard → Developers → Webhooks (Connect endpoint):
  *   POST {PUBLIC_ORIGIN}/webhooks/stripe
- * Subscribe at least to `account.updated`.
+ *
+ * Subscribe at least to:
+ *   account.updated
+ *   payment_intent.succeeded
+ *   payment_intent.payment_failed
+ *   payment_intent.requires_action
+ *   charge.dispute.created
+ *   account.application.deauthorized
+ *
+ * Prefer STRIPE_CONNECT_WEBHOOK_SECRET when the Connect endpoint has its own
+ * signing secret; falls back to STRIPE_WEBHOOK_SECRET.
  */
+const LEDGER_EVENT_TYPES = new Set([
+  "payment_intent.succeeded",
+  "payment_intent.payment_failed",
+  "payment_intent.requires_action",
+  "charge.dispute.created",
+  "account.application.deauthorized",
+  "checkout.session.completed",
+]);
+
+function resolveConnectWebhookSecret(): string {
+  const connectSecret = process.env.STRIPE_CONNECT_WEBHOOK_SECRET?.trim();
+  if (connectSecret?.startsWith("whsec_")) {
+    return connectSecret;
+  }
+  return requireStripeWebhookSecret();
+}
+
+function stripeEventId(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+  const id = (parsed as { id?: unknown }).id;
+  return typeof id === "string" && id.startsWith("evt_") ? id : null;
+}
+
 export async function POST(request: Request): Promise<Response> {
   const tag = "[stripe-webhook]";
   let secret: string;
   try {
-    secret = requireStripeWebhookSecret();
+    secret = resolveConnectWebhookSecret();
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(tag, "misconfigured:", sanitizeForLog(message));
@@ -50,25 +86,49 @@ export async function POST(request: Request): Promise<Response> {
       ? String((parsed as { type?: unknown }).type ?? "")
       : "";
 
-  if (type !== "account.updated") {
+  if (type === "account.updated") {
+    const account = parseStripeAccountUpdated(rawBody);
+    if (!account) {
+      return NextResponse.json({ received: true, ignored: "malformed_account" });
+    }
+    try {
+      const result = await applyConnectedAccountWebhookUpdate(account);
+      return NextResponse.json({
+        received: true,
+        updated: result.updated,
+        clientId: result.clientId ?? null,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(tag, "account.updated failed:", sanitizeForLog(message));
+      return NextResponse.json({ error: "handler_failed" }, { status: 500 });
+    }
+  }
+
+  if (!LEDGER_EVENT_TYPES.has(type)) {
     return NextResponse.json({ received: true, ignored: type || "unknown" });
   }
 
-  const account = parseStripeAccountUpdated(rawBody);
-  if (!account) {
-    return NextResponse.json({ received: true, ignored: "malformed_account" });
+  const eventId = stripeEventId(parsed);
+  if (!eventId) {
+    return NextResponse.json({ received: true, ignored: "missing_event_id" });
   }
 
   try {
-    const result = await applyConnectedAccountWebhookUpdate(account);
+    const result = await insertInvoiceEvent({
+      source: "stripe",
+      externalEventId: eventId,
+      eventType: type,
+      payload: parsed,
+    });
     return NextResponse.json({
       received: true,
-      updated: result.updated,
-      clientId: result.clientId ?? null,
+      inserted: result.inserted,
+      id: result.id,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(tag, "account.updated failed:", sanitizeForLog(message));
+    console.error(tag, "ledger insert failed:", sanitizeForLog(message));
     return NextResponse.json({ error: "handler_failed" }, { status: 500 });
   }
 }

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import {
   sanitizeUsdCentsInput,
   usdCentsDisplayToMicros,
   usdMicrosToCentsDisplay,
 } from "@/lib/format-usd-micros";
 import { paymentsTabErrorMessage } from "@/lib/stripe/payments-tab-errors";
-import { resolvedInvoicingBehavior } from "@/lib/billing/invoicing-behavior";
 
 type ActivationInfo = {
   clientId: string;
@@ -39,8 +38,6 @@ type StripeStatus = {
   billingMode?: "owner_rollup" | "merchant";
   endUserCap?: number;
   activation?: ActivationInfo | null;
-  /** True when the viewer may edit platform-controlled fields. */
-  isPlatformAdmin?: boolean;
 };
 
 type InvoiceRow = {
@@ -57,46 +54,6 @@ type Props = {
   appId: string;
   canManageBilling: boolean;
 };
-
-/**
- * Cost-rail values PymtHouse sets, shown read-only and attributed to the
- * platform so they do not read as app configuration the Builder forgot to fill
- * in. See docs/adr-owner-vs-app-billing.md.
- */
-function PlatformLimits({
-  endUserCap,
-  applicationFeeBps,
-}: Readonly<{ endUserCap: string; applicationFeeBps: string }>) {
-  return (
-    <div className="rounded-lg border border-white/[0.06] bg-black/20 px-3 py-3">
-      <p className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-zinc-500">
-        Platform limits
-      </p>
-      <dl className="mt-2 grid grid-cols-1 gap-x-6 gap-y-1.5 sm:grid-cols-2">
-        <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-xs text-zinc-500">End-user cap</dt>
-          <dd className="font-mono text-sm tabular-nums text-zinc-300">
-            {endUserCap}
-          </dd>
-        </div>
-        <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-xs text-zinc-500">Platform fee</dt>
-          <dd className="font-mono text-sm tabular-nums text-zinc-300">
-            {applicationFeeBps} bps
-          </dd>
-        </div>
-      </dl>
-      <p className="mt-2 text-[11px] text-zinc-600">
-        Set by PymtHouse. The cap protects against unbilled network spend; the fee
-        applies to Connect payments. Contact support to request a change.
-      </p>
-    </div>
-  );
-}
-
-/** Primary action styling for this tab's save buttons. */
-const BUTTON_CLASS =
-  "inline-flex items-center rounded-md bg-emerald-500/15 px-3 py-2 text-sm font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/30 transition-colors hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-emerald-500/15";
 
 /** Only allow redirect to Stripe-hosted Connect / Account Link URLs. */
 function redirectToStripeConnectUrl(url: string): void {
@@ -119,81 +76,229 @@ function redirectToStripeConnectUrl(url: string): void {
   );
 }
 
-function CapabilityValue({ allowed }: Readonly<{ allowed: boolean }>) {
-  return (
-    <span
-      className={`inline-flex items-center gap-1 text-sm ${
-        allowed ? "text-emerald-400" : "text-zinc-400"
-      }`}
-    >
-      <span aria-hidden>{allowed ? "✓" : "—"}</span>
-      {allowed ? "Allowed" : "Blocked"}
-    </span>
-  );
-}
-
-/**
- * Activation status as a neutral definition grid, matching the Stripe Connect
- * block above it.
- *
- * Warning styling is reserved for the blocked cases that need an action; a
- * healthy app reads as information, not as a problem. The end-user count lives
- * here only — the duplicate "End-user cap" field below was removed.
- */
-function PaymentsActivationCard({
+function PaymentsActivationBanner({
   activation,
 }: Readonly<{ activation: ActivationInfo }>) {
   const modeLabel =
-    activation.billingMode === "merchant" ? "Merchant" : "Owner roll-up";
-  const blocked = !activation.canProvisionEndUsers || !activation.canSellPaidPlans;
+    activation.billingMode === "merchant" ? "merchant" : "owner roll-up";
   const sellHint = activation.connectReady
     ? "Switch billing mode to merchant to unlock paid plan checkout."
     : "Connect Stripe and complete onboarding to sell paid plans.";
   const provisionHint =
     activation.reason === "end_user_cap_reached"
       ? "End-user cap reached — raise the cap or switch to merchant mode."
-      : "Owner wallet is empty and no payment method is on file — add a card on the billing page or top up credits.";
+      : "Owner wallet has no spendable balance — top up credits to provision more users.";
 
   return (
-    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
-      <h3 className="text-sm font-semibold text-zinc-200">Activation</h3>
-      <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2.5 sm:grid-cols-2">
-        <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-xs text-zinc-500">Billing mode</dt>
-          <dd className="text-sm text-zinc-200">{modeLabel}</dd>
-        </div>
-        <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-xs text-zinc-500">End users</dt>
-          <dd className="font-mono text-sm tabular-nums text-zinc-200">
-            {activation.appUserCount.toLocaleString("en-US")} /{" "}
-            {activation.endUserCap.toLocaleString("en-US")}
-          </dd>
-        </div>
-        <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-xs text-zinc-500">Provision end users</dt>
-          <dd>
-            <CapabilityValue allowed={activation.canProvisionEndUsers} />
-          </dd>
-        </div>
-        <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-xs text-zinc-500">Sell paid plans</dt>
-          <dd>
-            <CapabilityValue allowed={activation.canSellPaidPlans} />
-          </dd>
-        </div>
-      </dl>
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-2">
+      <h3 className="text-sm font-semibold text-amber-950">Activation</h3>
+      <p className="text-sm text-amber-900">
+        Mode: <span className="font-mono">{modeLabel}</span>
+        {" · "}
+        Provision end users: {activation.canProvisionEndUsers ? "allowed" : "blocked"}
+        {" · "}
+        Sell paid plans: {activation.canSellPaidPlans ? "allowed" : "blocked"}
+        {" · "}
+        Users {activation.appUserCount}/{activation.endUserCap}
+      </p>
+      {!activation.canSellPaidPlans && (
+        <p className="text-sm text-amber-900">{sellHint}</p>
+      )}
+      {!activation.canProvisionEndUsers && (
+        <p className="text-sm text-amber-900">{provisionHint}</p>
+      )}
+    </div>
+  );
+}
 
-      {blocked ? (
-        <div className="mt-3 space-y-1.5 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2">
-          {!activation.canProvisionEndUsers ? (
-            <p className="text-xs text-amber-300">{provisionHint}</p>
-          ) : null}
-          {!activation.canSellPaidPlans ? (
-            <p className="text-xs text-amber-300">{sellHint}</p>
-          ) : null}
-        </div>
-      ) : null}
-    </section>
+function applyStatusToForm(
+  nextStatus: StripeStatus,
+  set: {
+    progressiveBilling: (v: boolean) => void;
+    applicationFeeBps: (v: string) => void;
+    billingMode: (v: "owner_rollup" | "merchant") => void;
+    endUserCap: (v: string) => void;
+    thresholdDisplay: (v: string) => void;
+  },
+): void {
+  set.progressiveBilling(nextStatus.progressiveBilling ?? true);
+  set.applicationFeeBps(String(nextStatus.applicationFeeBps ?? 0));
+  set.billingMode(nextStatus.billingMode === "merchant" ? "merchant" : "owner_rollup");
+  set.endUserCap(String(nextStatus.endUserCap ?? 25));
+  set.thresholdDisplay(
+    nextStatus.invoiceThresholdUsdMicros
+      ? usdMicrosToCentsDisplay(nextStatus.invoiceThresholdUsdMicros)
+      : "",
+  );
+}
+
+function parseThresholdMicros(display: string): string | null {
+  const trimmed = display.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  const micros = usdCentsDisplayToMicros(trimmed);
+  if (micros == null) {
+    throw new Error("Invoice threshold must be a valid dollar amount");
+  }
+  return micros;
+}
+
+function connectUiFlags(status: StripeStatus | null) {
+  const hasAccount = Boolean(status?.stripeConnectedAccountId?.trim());
+  // Match backend isConnectReady: charges + details submitted.
+  const merchantReady =
+    hasAccount &&
+    Boolean(status?.stripeChargesEnabled) &&
+    Boolean(status?.stripeDetailsSubmitted);
+  const pendingOnboarding = hasAccount && !merchantReady;
+  const hasLegacyOmLink = Boolean(
+    status?.openmeterStripeAppId || status?.openmeterBillingProfileId,
+  );
+  return {
+    hasAccount,
+    merchantReady,
+    pendingOnboarding,
+    hasLegacyOmLink,
+    canDisconnect: hasAccount || hasLegacyOmLink,
+  };
+}
+
+function connectBadgeClass(flags: ReturnType<typeof connectUiFlags>): string {
+  if (flags.merchantReady) return "bg-green-100 text-green-800";
+  if (flags.pendingOnboarding) return "bg-amber-100 text-amber-900";
+  return "bg-gray-100 text-gray-700";
+}
+
+function connectBadgeLabel(
+  flags: ReturnType<typeof connectUiFlags>,
+  fallbackStatus: string | undefined,
+): string {
+  if (flags.hasAccount) {
+    return flags.merchantReady ? "connected" : "pending";
+  }
+  if (flags.hasLegacyOmLink) {
+    return "needs merchant connect";
+  }
+  return fallbackStatus ?? "disconnected";
+}
+
+type BusySetters = {
+  setBusy: (v: boolean) => void;
+  setError: (v: string | null) => void;
+};
+
+async function postConnectRedirect(
+  url: string,
+  init: RequestInit,
+  setters: BusySetters,
+  failLabel: string,
+): Promise<void> {
+  setters.setBusy(true);
+  setters.setError(null);
+  try {
+    const res = await fetch(url, init);
+    const body = await res.json();
+    if (!res.ok || !body.url) {
+      throw new Error(body.error || failLabel);
+    }
+    redirectToStripeConnectUrl(body.url);
+  } catch (err) {
+    setters.setError(err instanceof Error ? err.message : String(err));
+    setters.setBusy(false);
+  }
+}
+
+async function requestDisconnectStripe(
+  appId: string,
+  setters: BusySetters,
+  reload: () => Promise<void>,
+): Promise<void> {
+  if (!globalThis.confirm("Disconnect Stripe from this app?")) {
+    return;
+  }
+  setters.setBusy(true);
+  setters.setError(null);
+  try {
+    const res = await fetch(`/api/v1/apps/${appId}/billing/stripe`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      const body = await res.json();
+      throw new Error(body.error || "Disconnect failed");
+    }
+    await reload();
+  } catch (err) {
+    setters.setError(err instanceof Error ? err.message : String(err));
+  } finally {
+    setters.setBusy(false);
+  }
+}
+
+async function requestSaveBillingSettings(input: {
+  appId: string;
+  progressiveBilling: boolean;
+  thresholdDisplay: string;
+  applicationFeeBps: string;
+  billingMode: "owner_rollup" | "merchant";
+  endUserCap: string;
+  setters: BusySetters & {
+    setSettingsSaved: (v: string | null) => void;
+    setStatus: Dispatch<SetStateAction<StripeStatus | null>>;
+  };
+}): Promise<void> {
+  const { setters } = input;
+  setters.setBusy(true);
+  setters.setError(null);
+  setters.setSettingsSaved(null);
+  try {
+    const invoiceThresholdUsdMicros = parseThresholdMicros(input.thresholdDisplay);
+    const res = await fetch(`/api/v1/apps/${input.appId}/billing/stripe`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        progressiveBilling: input.progressiveBilling,
+        invoiceThresholdUsdMicros,
+        applicationFeeBps: Number.parseInt(input.applicationFeeBps, 10) || 0,
+        billingMode: input.billingMode,
+        endUserCap: Number.parseInt(input.endUserCap, 10) || 25,
+      }),
+    });
+    const body = await res.json();
+    if (!res.ok) {
+      throw new Error(body.error || "Failed to save billing settings");
+    }
+    setters.setStatus((prev) => (prev ? { ...prev, ...body } : body));
+    setters.setSettingsSaved("Saved");
+  } catch (err) {
+    setters.setError(err instanceof Error ? err.message : String(err));
+  } finally {
+    setters.setBusy(false);
+  }
+}
+
+function PaymentsInvoicesList({ invoices }: Readonly<{ invoices: InvoiceRow[] }>) {
+  if (invoices.length === 0) {
+    return <p className="text-sm text-muted-foreground">No customer invoices yet.</p>;
+  }
+  return (
+    <ul className="divide-y text-sm">
+      {invoices.map((inv) => (
+        <li key={inv.id} className="py-2 flex justify-between gap-4">
+          <div className="min-w-0">
+            <span className="font-mono">{inv.number ?? inv.id}</span>
+            {inv.customerKey ? (
+              <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                {inv.customerKey}
+              </p>
+            ) : null}
+          </div>
+          <span className="shrink-0">
+            {inv.totalAmount} {inv.currency} · {inv.status}
+          </span>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -211,26 +316,6 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
   );
   const [endUserCap, setEndUserCap] = useState("25");
   const [settingsSaved, setSettingsSaved] = useState<string | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  /** Last persisted form values; save stays disabled until these change. */
-  const [savedForm, setSavedForm] = useState({
-    progressiveBilling: true,
-    thresholdDisplay: "",
-    applicationFeeBps: "0",
-    billingMode: "owner_rollup" as "owner_rollup" | "merchant",
-    endUserCap: "25",
-  });
-
-  const isPlatformAdmin = status?.isPlatformAdmin === true;
-
-  const isDirty =
-    savedForm.progressiveBilling !== progressiveBilling ||
-    savedForm.thresholdDisplay !== thresholdDisplay ||
-    savedForm.billingMode !== billingMode ||
-    // Only admins can move these, so only they can make the form dirty with them.
-    (isPlatformAdmin &&
-      (savedForm.applicationFeeBps !== applicationFeeBps ||
-        savedForm.endUserCap !== endUserCap));
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -245,23 +330,12 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
       }
       const nextStatus = (await statusRes.json()) as StripeStatus;
       setStatus(nextStatus);
-      setProgressiveBilling(nextStatus.progressiveBilling ?? true);
-      setApplicationFeeBps(String(nextStatus.applicationFeeBps ?? 0));
-      setBillingMode(
-        nextStatus.billingMode === "merchant" ? "merchant" : "owner_rollup",
-      );
-      setEndUserCap(String(nextStatus.endUserCap ?? 25));
-      const loadedThreshold = nextStatus.invoiceThresholdUsdMicros
-        ? usdMicrosToCentsDisplay(nextStatus.invoiceThresholdUsdMicros)
-        : "";
-      setThresholdDisplay(loadedThreshold);
-      setSavedForm({
-        progressiveBilling: nextStatus.progressiveBilling ?? true,
-        thresholdDisplay: loadedThreshold,
-        applicationFeeBps: String(nextStatus.applicationFeeBps ?? 0),
-        billingMode:
-          nextStatus.billingMode === "merchant" ? "merchant" : "owner_rollup",
-        endUserCap: String(nextStatus.endUserCap ?? 25),
+      applyStatusToForm(nextStatus, {
+        progressiveBilling: setProgressiveBilling,
+        applicationFeeBps: setApplicationFeeBps,
+        billingMode: setBillingMode,
+        endUserCap: setEndUserCap,
+        thresholdDisplay: setThresholdDisplay,
       });
       if (invoicesRes.ok) {
         const body = await invoicesRes.json();
@@ -276,188 +350,399 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
 
   useEffect(() => {
     load().catch(() => undefined);
-    if (globalThis.window !== undefined) {
-      const params = new URLSearchParams(globalThis.location.search);
-      if (params.get("error")) {
-        setError(paymentsTabErrorMessage(params.get("error")));
-      }
-      if (params.get("connected") === "1" || params.get("connect") === "refresh") {
-        load().catch(() => undefined);
-      }
+    if (globalThis.window === undefined) {
+      return;
+    }
+    const params = new URLSearchParams(globalThis.location.search);
+    if (params.get("error")) {
+      setError(paymentsTabErrorMessage(params.get("error")));
+    }
+    if (params.get("connected") === "1" || params.get("connect") === "refresh") {
+      load().catch(() => undefined);
     }
   }, [load]);
 
-  async function startMerchantOnboarding() {
-    setBusy(true);
-    setError(null);
-    try {
-      const res = await fetch(`/api/v1/apps/${appId}/billing/stripe/connect`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode: "account_link" }),
-      });
-      const body = await res.json();
-      if (!res.ok) {
-        throw new Error(body.error || "Connect failed");
-      }
-      if (!body.url) {
-        throw new Error(body.error || "Connect URL missing");
-      }
-      redirectToStripeConnectUrl(body.url);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setBusy(false);
-    }
-  }
-
-  async function refreshAccountLink() {
-    setBusy(true);
-    setError(null);
-    try {
-      const res = await fetch(
-        `/api/v1/apps/${appId}/billing/stripe/account-link`,
-        { method: "POST" },
-      );
-      const body = await res.json();
-      if (!res.ok || !body.url) {
-        throw new Error(body.error || "Account Link failed");
-      }
-      redirectToStripeConnectUrl(body.url);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setBusy(false);
-    }
-  }
-
-  async function disconnectStripe() {
-    if (!globalThis.confirm("Disconnect Stripe from this app?")) {
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    try {
-      const res = await fetch(`/api/v1/apps/${appId}/billing/stripe`, {
-        method: "DELETE",
-      });
-      if (!res.ok) {
-        const body = await res.json();
-        throw new Error(body.error || "Disconnect failed");
-      }
-      await load();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function saveBillingProfileSettings() {
-    setBusy(true);
-    setError(null);
-    setSaveError(null);
-    setSettingsSaved(null);
-    try {
-      const trimmed = thresholdDisplay.trim();
-      let invoiceThresholdUsdMicros: string | null = null;
-      if (trimmed !== "") {
-        const micros = usdCentsDisplayToMicros(trimmed);
-        if (micros == null) {
-          throw new Error("Invoice threshold must be a valid dollar amount");
-        }
-        invoiceThresholdUsdMicros = micros;
-      }
-      // Platform-controlled fields are admin-only server-side; sending them as
-      // an owner would be rejected with 403, so omit them entirely.
-      const payload: Record<string, unknown> = {
-        progressiveBilling,
-        invoiceThresholdUsdMicros,
-      };
-      // Only send billingMode when it changed — re-sending "merchant" re-runs
-      // Connect readiness validation and fails unrelated saves if Connect later
-      // becomes non-ready.
-      if (billingMode !== savedForm.billingMode) {
-        payload.billingMode = billingMode;
-      }
-      if (isPlatformAdmin) {
-        const parsedCap = Number.parseInt(endUserCap, 10);
-        if (
-          !Number.isFinite(parsedCap) ||
-          parsedCap < 1 ||
-          parsedCap > 1_000_000
-        ) {
-          throw new Error("End-user cap must be an integer between 1 and 1000000");
-        }
-        payload.endUserCap = parsedCap;
-        const parsedFee = Number.parseInt(applicationFeeBps, 10);
-        if (
-          !Number.isFinite(parsedFee) ||
-          parsedFee < 0 ||
-          parsedFee > 10_000
-        ) {
-          throw new Error(
-            "Platform application fee must be an integer between 0 and 10000",
-          );
-        }
-        payload.applicationFeeBps = parsedFee;
-      }
-      const res = await fetch(`/api/v1/apps/${appId}/billing/stripe`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const body = await res.json();
-      if (!res.ok) {
-        throw new Error(body.error || "Failed to save billing settings");
-      }
-      setStatus((prev) => (prev ? { ...prev, ...body } : body));
-      setSavedForm({
-        progressiveBilling,
-        thresholdDisplay,
-        applicationFeeBps,
-        billingMode,
-        endUserCap,
-      });
-      setSettingsSaved("Saved");
-    } catch (err) {
-      setSaveError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusy(false);
-    }
-  }
-
   if (loading) {
-    return <p className="text-sm text-zinc-500">Loading payments…</p>;
+    return <p className="text-sm text-muted-foreground">Loading payments…</p>;
   }
 
-  const hasAccount = Boolean(status?.stripeConnectedAccountId?.trim());
-  /** Merchant Connect ready (acct_… + charges). Not legacy OM Stripe-app install. */
-  const merchantReady =
-    hasAccount && Boolean(status?.stripeChargesEnabled);
-  const pendingOnboarding = hasAccount && !merchantReady;
-  const hasLegacyOmLink = Boolean(
-    status?.openmeterStripeAppId || status?.openmeterBillingProfileId,
+  return (
+    <PaymentsTabLoaded
+      appId={appId}
+      canManageBilling={canManageBilling}
+      status={status}
+      invoices={invoices}
+      error={error}
+      busy={busy}
+      applicationFeeBps={applicationFeeBps}
+      progressiveBilling={progressiveBilling}
+      thresholdDisplay={thresholdDisplay}
+      billingMode={billingMode}
+      endUserCap={endUserCap}
+      settingsSaved={settingsSaved}
+      setBusy={setBusy}
+      setError={setError}
+      setStatus={setStatus}
+      setSettingsSaved={setSettingsSaved}
+      setBillingMode={setBillingMode}
+      setEndUserCap={setEndUserCap}
+      setApplicationFeeBps={setApplicationFeeBps}
+      setProgressiveBilling={setProgressiveBilling}
+      setThresholdDisplay={setThresholdDisplay}
+      reload={load}
+    />
   );
-  /** Allow clearing legacy OM link and/or merchant Connect account. */
-  const canDisconnect = hasAccount || hasLegacyOmLink;
-  // Prefer activation.connectReady when present; fall back to flat status fields
-  // so the merchant option stays selectable if activation was omitted.
-  const connectReadyForMode =
-    status?.activation?.connectReady ??
-    (hasAccount &&
-      Boolean(status?.stripeChargesEnabled) &&
-      Boolean(status?.stripeDetailsSubmitted));
+}
+
+function PaymentsConnectActions(props: Readonly<{
+  appId: string;
+  busy: boolean;
+  flags: ReturnType<typeof connectUiFlags>;
+  busySetters: BusySetters;
+  reload: () => Promise<void>;
+}>) {
+  const { appId, busy, flags, busySetters, reload } = props;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {!flags.hasAccount && (
+        <button
+          type="button"
+          className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
+          disabled={busy}
+          onClick={() =>
+            void postConnectRedirect(
+              `/api/v1/apps/${appId}/billing/stripe/connect`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ mode: "account_link" }),
+              },
+              busySetters,
+              "Connect failed",
+            )
+          }
+        >
+          Complete onboarding
+        </button>
+      )}
+      {flags.pendingOnboarding && (
+        <button
+          type="button"
+          className="rounded-md border px-3 py-2 text-sm disabled:opacity-50"
+          disabled={busy}
+          onClick={() =>
+            void postConnectRedirect(
+              `/api/v1/apps/${appId}/billing/stripe/account-link`,
+              { method: "POST" },
+              busySetters,
+              "Account Link failed",
+            )
+          }
+        >
+          Refresh Account Link
+        </button>
+      )}
+      {flags.canDisconnect && (
+        <button
+          type="button"
+          className="rounded-md border px-3 py-2 text-sm disabled:opacity-50"
+          disabled={busy}
+          onClick={() => void requestDisconnectStripe(appId, busySetters, reload)}
+        >
+          Disconnect
+        </button>
+      )}
+    </div>
+  );
+}
+
+function PaymentsBillingModeForm(props: Readonly<{
+  busy: boolean;
+  billingMode: "owner_rollup" | "merchant";
+  endUserCap: string;
+  applicationFeeBps: string;
+  connectReadyForMerchant: boolean;
+  settingsSaved: string | null;
+  setBillingMode: (v: "owner_rollup" | "merchant") => void;
+  setEndUserCap: (v: string) => void;
+  setApplicationFeeBps: (v: string) => void;
+  onSave: () => void;
+}>) {
+  const {
+    busy,
+    billingMode,
+    endUserCap,
+    applicationFeeBps,
+    connectReadyForMerchant,
+    settingsSaved,
+    setBillingMode,
+    setEndUserCap,
+    setApplicationFeeBps,
+    onSave,
+  } = props;
+  return (
+    <div className="pt-2 border-t space-y-3">
+      <label className="block text-sm">
+        <span className="text-muted-foreground">Billing mode</span>
+        <select
+          className="mt-1 w-full max-w-xs rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+          value={billingMode}
+          onChange={(e) =>
+            setBillingMode(e.target.value === "merchant" ? "merchant" : "owner_rollup")
+          }
+          disabled={busy}
+        >
+          <option value="owner_rollup">Owner roll-up (default)</option>
+          <option value="merchant" disabled={!connectReadyForMerchant}>
+            Merchant (requires Connect ready)
+          </option>
+        </select>
+      </label>
+      <label className="block text-sm">
+        <span className="text-muted-foreground">End-user cap (owner roll-up)</span>
+        <input
+          type="number"
+          min={1}
+          max={1000000}
+          className="mt-1 w-40 rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+          value={endUserCap}
+          onChange={(e) => setEndUserCap(e.target.value)}
+          disabled={busy}
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="text-muted-foreground">Platform application fee (bps)</span>
+        <input
+          type="number"
+          min={0}
+          max={10000}
+          className="mt-1 w-40 rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+          value={applicationFeeBps}
+          onChange={(e) => setApplicationFeeBps(e.target.value)}
+          disabled={busy}
+        />
+      </label>
+      <p className="text-xs text-muted-foreground">
+        100 bps = 1%. Applied on Connect payment intents / invoices.
+      </p>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
+          disabled={busy}
+          onClick={onSave}
+        >
+          Save billing settings
+        </button>
+        {settingsSaved ? (
+          <span className="text-xs text-emerald-600">{settingsSaved}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function PaymentsProgressiveBillingForm(props: Readonly<{
+  canManageBilling: boolean;
+  busy: boolean;
+  progressiveBilling: boolean;
+  thresholdDisplay: string;
+  settingsSaved: string | null;
+  setProgressiveBilling: (v: boolean) => void;
+  setThresholdDisplay: (v: string) => void;
+  setSettingsSaved: (v: string | null) => void;
+  onSave: () => void;
+}>) {
+  const {
+    canManageBilling,
+    busy,
+    progressiveBilling,
+    thresholdDisplay,
+    settingsSaved,
+    setProgressiveBilling,
+    setThresholdDisplay,
+    setSettingsSaved,
+    onSave,
+  } = props;
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <div>
+        <h3 className="text-base font-semibold">Mid-cycle invoicing</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Progressive billing allows OpenMeter to invoice unpaid usage before the
+          billing cycle ends. Set an optional dollar threshold; the clearinghouse
+          worker charges when gathering invoices reach that amount.
+        </p>
+      </div>
+      <label className="flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          className="mt-0.5"
+          checked={progressiveBilling}
+          disabled={!canManageBilling || busy}
+          onChange={(e) => {
+            setProgressiveBilling(e.target.checked);
+            setSettingsSaved(null);
+          }}
+        />
+        <span>
+          Enable progressive billing
+          <span className="block text-xs text-muted-foreground">
+            Synced to this app&apos;s OpenMeter billing profile.
+          </span>
+        </span>
+      </label>
+      <div>
+        <label htmlFor="invoice-threshold" className="block text-xs text-muted-foreground mb-1">
+          Invoice when unpaid usage reaches (USD)
+        </label>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">$</span>
+          <input
+            id="invoice-threshold"
+            type="text"
+            inputMode="decimal"
+            placeholder="e.g. 10.00 (leave blank to disable)"
+            disabled={!canManageBilling || busy || !progressiveBilling}
+            value={thresholdDisplay}
+            onChange={(e) => {
+              setThresholdDisplay(sanitizeUsdCentsInput(e.target.value));
+              setSettingsSaved(null);
+            }}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30 disabled:opacity-50"
+          />
+        </div>
+      </div>
+      {canManageBilling && (
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
+            disabled={busy}
+            onClick={onSave}
+          >
+            Save invoicing settings
+          </button>
+          {settingsSaved ? (
+            <span className="text-xs text-emerald-600">{settingsSaved}</span>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PaymentsStatusDetails({ status }: Readonly<{ status: StripeStatus | null }>) {
+  return (
+    <dl className="text-sm grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <div>
+        <dt className="text-muted-foreground">Connected account</dt>
+        <dd className="font-mono text-xs break-all">
+          {status?.stripeConnectedAccountId ?? "—"}
+        </dd>
+      </div>
+      <div>
+        <dt className="text-muted-foreground">Onboarding</dt>
+        <dd>{status?.stripeOnboardingMethod ?? "—"}</dd>
+      </div>
+      <div>
+        <dt className="text-muted-foreground">Charges</dt>
+        <dd>{status?.stripeChargesEnabled ? "Enabled" : "Paused / pending"}</dd>
+      </div>
+      <div>
+        <dt className="text-muted-foreground">Payouts</dt>
+        <dd>{status?.stripePayoutsEnabled ? "Enabled" : "Paused / pending"}</dd>
+      </div>
+      <div>
+        <dt className="text-muted-foreground">OM billing profile</dt>
+        <dd className="font-mono text-xs break-all">
+          {status?.openmeterBillingProfileId ?? "—"}
+        </dd>
+      </div>
+      <div>
+        <dt className="text-muted-foreground">Connected</dt>
+        <dd>{status?.connectedAt ?? "—"}</dd>
+      </div>
+    </dl>
+  );
+}
+
+function PaymentsTabLoaded(props: Readonly<{
+  appId: string;
+  canManageBilling: boolean;
+  status: StripeStatus | null;
+  invoices: InvoiceRow[];
+  error: string | null;
+  busy: boolean;
+  applicationFeeBps: string;
+  progressiveBilling: boolean;
+  thresholdDisplay: string;
+  billingMode: "owner_rollup" | "merchant";
+  endUserCap: string;
+  settingsSaved: string | null;
+  setBusy: (v: boolean) => void;
+  setError: (v: string | null) => void;
+  setStatus: Dispatch<SetStateAction<StripeStatus | null>>;
+  setSettingsSaved: (v: string | null) => void;
+  setBillingMode: (v: "owner_rollup" | "merchant") => void;
+  setEndUserCap: (v: string) => void;
+  setApplicationFeeBps: (v: string) => void;
+  setProgressiveBilling: (v: boolean) => void;
+  setThresholdDisplay: (v: string) => void;
+  reload: () => Promise<void>;
+}>) {
+  const {
+    appId,
+    canManageBilling,
+    status,
+    invoices,
+    error,
+    busy,
+    applicationFeeBps,
+    progressiveBilling,
+    thresholdDisplay,
+    billingMode,
+    endUserCap,
+    settingsSaved,
+    setBusy,
+    setError,
+    setStatus,
+    setSettingsSaved,
+    setBillingMode,
+    setEndUserCap,
+    setApplicationFeeBps,
+    setProgressiveBilling,
+    setThresholdDisplay,
+    reload,
+  } = props;
+
+  const flags = connectUiFlags(status);
+  const busySetters = { setBusy, setError };
+  const connectReadyForMerchant = Boolean(status?.activation?.connectReady);
+  const save = () =>
+    void requestSaveBillingSettings({
+      appId,
+      progressiveBilling,
+      thresholdDisplay,
+      applicationFeeBps,
+      billingMode,
+      endUserCap,
+      setters: { setBusy, setError, setSettingsSaved, setStatus },
+    });
+  const showDetails =
+    flags.hasAccount || flags.hasLegacyOmLink || Boolean(status?.connectedAt);
 
   return (
     <div className="space-y-6">
       {status?.activation && (
-        <PaymentsActivationCard activation={status.activation} />
+        <PaymentsActivationBanner activation={status.activation} />
       )}
 
-      <div className="rounded-lg border border-white/[0.06] p-4 space-y-3">
+      <div className="rounded-lg border p-4 space-y-3">
         <div className="flex items-center justify-between gap-4">
           <div>
             <h3 className="text-base font-semibold">Merchant Stripe Connect</h3>
-            <p className="text-sm text-zinc-500">
+            <p className="text-sm text-muted-foreground">
               Collect from your end users on a Stripe Connected Account (Plane B).
               OpenMeter Stripe billing (Plane A) meters usage and invoices you for
               network cost separately. Complete Stripe-hosted onboarding (Account Links)
@@ -465,278 +750,58 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
             </p>
           </div>
           <span
-            className={`text-xs font-medium px-2 py-1 rounded ${
-              merchantReady
-                ? "bg-green-100 text-green-800"
-                : pendingOnboarding
-                  ? "bg-amber-100 text-amber-900"
-                  : "bg-gray-100 text-gray-700"
-            }`}
+            className={`text-xs font-medium px-2 py-1 rounded ${connectBadgeClass(flags)}`}
           >
-            {hasAccount
-              ? merchantReady
-                ? "connected"
-                : "pending"
-              : hasLegacyOmLink
-                ? "needs merchant connect"
-                : (status?.status ?? "disconnected")}
+            {connectBadgeLabel(flags, status?.status)}
           </span>
         </div>
 
-        {(hasAccount || hasLegacyOmLink || status?.connectedAt) && (
-          <dl className="text-sm grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <div>
-              <dt className="text-zinc-500">Connected account</dt>
-              <dd className="font-mono text-xs break-all">
-                {status?.stripeConnectedAccountId ?? "—"}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-zinc-500">Onboarding</dt>
-              <dd>{status?.stripeOnboardingMethod ?? "—"}</dd>
-            </div>
-            <div>
-              <dt className="text-zinc-500">Charges</dt>
-              <dd>{status?.stripeChargesEnabled ? "Enabled" : "Paused / pending"}</dd>
-            </div>
-            <div>
-              <dt className="text-zinc-500">Payouts</dt>
-              <dd>{status?.stripePayoutsEnabled ? "Enabled" : "Paused / pending"}</dd>
-            </div>
-            <div>
-              <dt className="text-zinc-500">OpenMeter Stripe billing</dt>
-              <dd>
-                {status?.billingReady
-                  ? "Ready"
-                  : status?.openmeterBillingProfileId
-                    ? "Partial"
-                    : "Not provisioned"}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-zinc-500">OM billing profile</dt>
-              <dd className="font-mono text-xs break-all">
-                {status?.openmeterBillingProfileId ?? "—"}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-zinc-500">Connected</dt>
-              <dd>{status?.connectedAt ?? "—"}</dd>
-            </div>
-          </dl>
+        {showDetails && <PaymentsStatusDetails status={status} />}
+
+        {canManageBilling && (
+          <PaymentsConnectActions
+            appId={appId}
+            busy={busy}
+            flags={flags}
+            busySetters={busySetters}
+            reload={reload}
+          />
         )}
 
         {canManageBilling && (
-          <div className="flex flex-wrap gap-2">
-            {!hasAccount && (
-              <button
-                type="button"
-                className="rounded-md bg-emerald-500/15 px-3 py-2 text-sm text-emerald-300 disabled:opacity-50"
-                disabled={busy}
-                onClick={() => void startMerchantOnboarding()}
-              >
-                Complete onboarding
-              </button>
-            )}
-            {pendingOnboarding && (
-              <button
-                type="button"
-                className="rounded-md border border-white/10 px-3 py-2 text-sm text-zinc-200 transition-colors hover:border-emerald-500/40 hover:text-emerald-300 disabled:opacity-50"
-                disabled={busy}
-                onClick={() => void refreshAccountLink()}
-              >
-                Refresh Account Link
-              </button>
-            )}
-            {canDisconnect && (
-              <button
-                type="button"
-                className="rounded-md border border-white/10 px-3 py-2 text-sm text-zinc-400 transition-colors hover:border-red-500/40 hover:text-red-300 disabled:opacity-50"
-                disabled={busy}
-                onClick={() => void disconnectStripe()}
-              >
-                Disconnect
-              </button>
-            )}
-          </div>
-        )}
-
-        {canManageBilling && (
-          <div className="pt-2 border-t space-y-3">
-            <label className="block text-sm">
-              <span className="text-zinc-500">Billing mode</span>
-              <select
-                className="mt-1 w-full max-w-xs rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
-                value={billingMode}
-                onChange={(e) =>
-                  setBillingMode(
-                    e.target.value === "merchant" ? "merchant" : "owner_rollup",
-                  )
-                }
-                disabled={busy}
-              >
-                <option value="owner_rollup">Owner roll-up (default)</option>
-                <option
-                  value="merchant"
-                  disabled={!connectReadyForMode}
-                >
-                  Merchant (requires Connect ready)
-                </option>
-              </select>
-            </label>
-            {isPlatformAdmin ? (
-              <>
-                <label className="block text-sm">
-                  <span className="text-zinc-400">End-user cap</span>
-                  <input
-                    type="number"
-                    min={1}
-                    max={1000000}
-                    className="mt-1 w-40 rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
-                    value={endUserCap}
-                    onChange={(e) => setEndUserCap(e.target.value)}
-                    disabled={busy}
-                  />
-                </label>
-                <label className="block text-sm">
-                  <span className="text-zinc-500">Platform application fee (bps)</span>
-                  <input
-                    type="number"
-                    min={0}
-                    max={10000}
-                    className="mt-1 w-40 rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
-                    value={applicationFeeBps}
-                    onChange={(e) => setApplicationFeeBps(e.target.value)}
-                    disabled={busy}
-                  />
-                </label>
-                <p className="text-xs text-zinc-500">
-                  100 bps = 1%. Applied on Connect payment intents / invoices.
-                  Platform-controlled — visible here because you are an admin.
-                </p>
-              </>
-            ) : (
-              <PlatformLimits
-                endUserCap={endUserCap}
-                applicationFeeBps={applicationFeeBps}
-              />
-            )}
-            <div className="flex flex-wrap items-center gap-3">
-              <button
-                type="button"
-                className={BUTTON_CLASS}
-                disabled={busy || !isDirty}
-                onClick={() => void saveBillingProfileSettings()}
-              >
-                {busy ? "Saving…" : "Save billing settings"}
-              </button>
-              {!isDirty && settingsSaved ? (
-                <output className="text-xs text-emerald-400">
-                  {settingsSaved}
-                </output>
-              ) : null}
-              {isDirty && !busy ? (
-                <span className="text-xs text-zinc-500">Unsaved changes</span>
-              ) : null}
-              {saveError ? (
-                <span className="text-xs text-rose-400" role="alert">
-                  {saveError}
-                </span>
-              ) : null}
-            </div>
-          </div>
+          <PaymentsBillingModeForm
+            busy={busy}
+            billingMode={billingMode}
+            endUserCap={endUserCap}
+            applicationFeeBps={applicationFeeBps}
+            connectReadyForMerchant={connectReadyForMerchant}
+            settingsSaved={settingsSaved}
+            setBillingMode={setBillingMode}
+            setEndUserCap={setEndUserCap}
+            setApplicationFeeBps={setApplicationFeeBps}
+            onSave={save}
+          />
         )}
       </div>
 
-      {merchantReady && (
-        <div className="rounded-lg border border-white/[0.06] p-4 space-y-3">
-          <div>
-            <h3 className="text-base font-semibold">Mid-cycle invoicing</h3>
-            <p className="mt-1 text-xs text-zinc-500">
-              Progressive billing allows OpenMeter to invoice unpaid usage before the
-              billing cycle ends. Set an optional dollar threshold; the clearinghouse
-              worker charges when gathering invoices reach that amount.
-            </p>
-          </div>
-          <label className="flex items-start gap-2 text-sm">
-            <input
-              type="checkbox"
-              className="mt-0.5"
-              checked={progressiveBilling}
-              disabled={!canManageBilling || busy}
-              onChange={(e) => {
-                setProgressiveBilling(e.target.checked);
-                setSettingsSaved(null);
-              }}
-            />
-            <span className="block">
-              <span className="block">Enable progressive billing</span>
-              <span className="block text-xs text-zinc-500">
-                Synced to this app&apos;s OpenMeter billing profile.
-              </span>
-            </span>
-          </label>
-          {/*
-            Checked with a blank threshold is a valid but ambiguous state, so
-            state the behaviour it actually resolves to rather than leaving the
-            reader to infer it from an empty field.
-          */}
-          <p className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-xs text-zinc-400">
-            {resolvedInvoicingBehavior(progressiveBilling, thresholdDisplay)}
-          </p>
-          <div>
-            <label htmlFor="invoice-threshold" className="block text-xs text-zinc-500 mb-1">
-              Invoice when unpaid usage reaches (USD)
-            </label>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-zinc-500">$</span>
-              <input
-                id="invoice-threshold"
-                type="text"
-                inputMode="decimal"
-                placeholder="e.g. 10.00 (leave blank to disable)"
-                disabled={!canManageBilling || busy || !progressiveBilling}
-                value={thresholdDisplay}
-                onChange={(e) => {
-                  setThresholdDisplay(sanitizeUsdCentsInput(e.target.value));
-                  setSettingsSaved(null);
-                }}
-                className="w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30 disabled:opacity-50"
-              />
-            </div>
-          </div>
-          {canManageBilling && (
-            <div className="flex flex-wrap items-center gap-3">
-              <button
-                type="button"
-                className={BUTTON_CLASS}
-                disabled={busy || !isDirty}
-                onClick={() => void saveBillingProfileSettings()}
-              >
-                {busy ? "Saving…" : "Save invoicing settings"}
-              </button>
-              {!isDirty && settingsSaved ? (
-                <output className="text-xs text-emerald-400">
-                  {settingsSaved}
-                </output>
-              ) : null}
-              {isDirty && !busy ? (
-                <span className="text-xs text-zinc-500">Unsaved changes</span>
-              ) : null}
-              {saveError ? (
-                <span className="text-xs text-rose-400" role="alert">
-                  {saveError}
-                </span>
-              ) : null}
-            </div>
-          )}
-        </div>
+      {flags.merchantReady && (
+        <PaymentsProgressiveBillingForm
+          canManageBilling={canManageBilling}
+          busy={busy}
+          progressiveBilling={progressiveBilling}
+          thresholdDisplay={thresholdDisplay}
+          settingsSaved={settingsSaved}
+          setProgressiveBilling={setProgressiveBilling}
+          setThresholdDisplay={setThresholdDisplay}
+          setSettingsSaved={setSettingsSaved}
+          onSave={save}
+        />
       )}
 
-      <div className="rounded-lg border border-white/[0.06] p-4 space-y-3">
+      <div className="rounded-lg border p-4 space-y-3">
         <div>
           <h3 className="text-base font-semibold">Customer invoices</h3>
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 text-xs text-muted-foreground">
             End users billed through this app&apos;s Stripe Connect account. Platform invoices
             for your developer prepaid wallet are on{" "}
             <a href="/billing" className="text-emerald-500 hover:text-emerald-400">
@@ -745,30 +810,10 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
             .
           </p>
         </div>
-        {invoices.length === 0 ? (
-          <p className="text-sm text-zinc-500">No customer invoices yet.</p>
-        ) : (
-          <ul className="divide-y text-sm">
-            {invoices.map((inv) => (
-              <li key={inv.id} className="py-2 flex justify-between gap-4">
-                <div className="min-w-0">
-                  <span className="font-mono">{inv.number ?? inv.id}</span>
-                  {inv.customerKey ? (
-                    <p className="mt-0.5 truncate font-mono text-xs text-zinc-500">
-                      {inv.customerKey}
-                    </p>
-                  ) : null}
-                </div>
-                <span className="shrink-0">
-                  {inv.totalAmount} {inv.currency} · {inv.status}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
+        <PaymentsInvoicesList invoices={invoices} />
       </div>
 
-      {error && <p className="text-sm text-rose-400">{error}</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
     </div>
   );
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -596,6 +596,29 @@ export const appBillingConfig = pgTable(
     endUserCap: integer("end_user_cap").notNull().default(25),
     /** ISO timestamp of first cost-rail denial notification. */
     activationNotifiedAt: text("activation_notified_at"),
+    /**
+     * Merchant supplier identity — who is legally selling on this app's invoices.
+     * Synced from the Stripe connected account; tax id is developer-supplied.
+     */
+    /** ISO 3166-1 alpha-2, from the connected account. Immutable at Stripe. */
+    supplierCountry: text("supplier_country"),
+    /** Registered entity name, or the individual's name for sole traders. */
+    supplierName: text("supplier_name"),
+    /** individual | company | non_profit | government_entity */
+    supplierBusinessType: text("supplier_business_type"),
+    supplierAddressLine1: text("supplier_address_line1"),
+    supplierAddressLine2: text("supplier_address_line2"),
+    supplierAddressCity: text("supplier_address_city"),
+    supplierAddressState: text("supplier_address_state"),
+    supplierAddressPostalCode: text("supplier_address_postal_code"),
+    /** Developer-supplied VAT/tax number — Stripe exposes only a boolean. */
+    supplierTaxId: text("supplier_tax_id"),
+    /** Stripe reported company.tax_id_provided / vat_id_provided. */
+    supplierTaxIdOnFileAtStripe: boolean("supplier_tax_id_on_file_at_stripe")
+      .notNull()
+      .default(false),
+    /** ISO timestamp of the last successful sync from the connected account. */
+    supplierSyncedAt: text("supplier_synced_at"),
     connectedAt: text("connected_at"),
     createdAt: text("created_at")
       .notNull()

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -561,6 +561,8 @@ export const appBillingConfig = pgTable(
     stripeConnectStatus: text("stripe_connect_status").notNull().default("disconnected"),
     openmeterStripeAppId: text("openmeter_stripe_app_id"),
     openmeterBillingProfileId: text("openmeter_billing_profile_id"),
+    /** Merchant-plane Custom Invoicing billing profile (never org default). */
+    openmeterMerchantBillingProfileId: text("openmeter_merchant_billing_profile_id"),
     defaultCurrency: text("default_currency").notNull().default("USD"),
     checkoutSuccessUrl: text("checkout_success_url"),
     checkoutCancelUrl: text("checkout_cancel_url"),
@@ -853,6 +855,79 @@ export const turnkeyFundingEvents = pgTable(
   ],
 );
 
+/**
+ * Durable outbox for OpenMeter Invoice Notifications + Stripe Connect payment
+ * events. Claimed by the Railway invoicing worker via FOR UPDATE SKIP LOCKED.
+ */
+export const invoiceEvents = pgTable(
+  "invoice_events",
+  {
+    id: text("id").primaryKey(),
+    /** openmeter | stripe */
+    source: text("source").notNull(),
+    /** Provider event id (OM notification id or Stripe evt_…). */
+    externalEventId: text("external_event_id").notNull(),
+    eventType: text("event_type").notNull(),
+    payload: jsonb("payload").notNull(),
+    /** pending | processing | done | failed | dead */
+    status: text("status").notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    nextAttemptAt: text("next_attempt_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    claimedBy: text("claimed_by"),
+    lastError: text("last_error"),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    updatedAt: text("updated_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (t) => [
+    uniqueIndex("idx_invoice_events_source_external").on(t.source, t.externalEventId),
+    index("idx_invoice_events_claim").on(t.status, t.nextAttemptAt),
+  ],
+);
+
+/**
+ * Maps OpenMeter invoices to Stripe Connect PaymentIntents / hosted invoices
+ * for merchant-plane Custom Invoicing collection.
+ */
+export const merchantInvoices = pgTable(
+  "merchant_invoices",
+  {
+    id: text("id").primaryKey(),
+    openmeterInvoiceId: text("openmeter_invoice_id").notNull(),
+    appId: text("app_id")
+      .notNull()
+      .references(() => developerApps.id),
+    openmeterCustomerId: text("openmeter_customer_id"),
+    stripeConnectedAccountId: text("stripe_connected_account_id"),
+    stripeCustomerId: text("stripe_customer_id"),
+    stripePaymentIntentId: text("stripe_payment_intent_id"),
+    stripeInvoiceId: text("stripe_invoice_id"),
+    /** Mirrors OM lifecycle + charge substates (e.g. payment_processing.pending). */
+    state: text("state").notNull().default("created"),
+    amountUsdMicros: text("amount_usd_micros"),
+    currency: text("currency").notNull().default("USD"),
+    applicationFeeAmount: integer("application_fee_amount").notNull().default(0),
+    lastError: text("last_error"),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    updatedAt: text("updated_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (t) => [
+    uniqueIndex("idx_merchant_invoices_om_id").on(t.openmeterInvoiceId),
+    index("idx_merchant_invoices_app").on(t.appId),
+    index("idx_merchant_invoices_pi").on(t.stripePaymentIntentId),
+    index("idx_merchant_invoices_state").on(t.state),
+  ],
+);
+
 /** Fiat on-ramp session ledger for MoonPay / Turnkey attribution and settlement. */
 export const onrampSessions = pgTable(
   "onramp_sessions",
@@ -1020,3 +1095,7 @@ export type PriceOracleSnapshot = typeof priceOracleSnapshots.$inferSelect;
 export type NewPriceOracleSnapshot = typeof priceOracleSnapshots.$inferInsert;
 export type AppOpenMeterConfig = typeof appOpenMeterConfig.$inferSelect;
 export type UsageIngestReceipt = typeof usageIngestReceipts.$inferSelect;
+export type InvoiceEvent = typeof invoiceEvents.$inferSelect;
+export type NewInvoiceEvent = typeof invoiceEvents.$inferInsert;
+export type MerchantInvoice = typeof merchantInvoices.$inferSelect;
+export type NewMerchantInvoice = typeof merchantInvoices.$inferInsert;

--- a/src/lib/invoicing/ledger.ts
+++ b/src/lib/invoicing/ledger.ts
@@ -1,0 +1,267 @@
+/**
+ * Durable invoice event ledger (outbox) + merchant invoice mapping helpers.
+ */
+import { and, asc, eq, lte, or, sql } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db/index";
+import { invoiceEvents, merchantInvoices } from "@/db/schema";
+
+export type InvoiceEventSource = "openmeter" | "stripe";
+export type InvoiceEventStatus =
+  | "pending"
+  | "processing"
+  | "done"
+  | "failed"
+  | "dead";
+
+export const MAX_INVOICE_EVENT_ATTEMPTS = 12;
+
+/** Insert event; returns true if newly inserted, false on duplicate. */
+export async function insertInvoiceEvent(input: {
+  source: InvoiceEventSource;
+  externalEventId: string;
+  eventType: string;
+  payload: unknown;
+}): Promise<{ inserted: boolean; id: string }> {
+  const id = uuidv4();
+  const now = new Date().toISOString();
+  try {
+    await db.insert(invoiceEvents).values({
+      id,
+      source: input.source,
+      externalEventId: input.externalEventId,
+      eventType: input.eventType,
+      payload: input.payload as Record<string, unknown>,
+      status: "pending",
+      attempts: 0,
+      nextAttemptAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { inserted: true, id };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/unique|duplicate/i.test(message)) {
+      return { inserted: false, id };
+    }
+    throw err;
+  }
+}
+
+function backoffSeconds(attempts: number): number {
+  // 5s, 15s, 45s, … capped at 1h
+  return Math.min(3600, 5 * 3 ** Math.max(0, attempts - 1));
+}
+
+/**
+ * Claim a batch of pending (or retryable failed) events with SKIP LOCKED.
+ * Safe for multiple Railway worker replicas.
+ */
+export async function claimInvoiceEvents(input: {
+  workerId: string;
+  limit?: number;
+}): Promise<Array<typeof invoiceEvents.$inferSelect>> {
+  const limit = input.limit ?? 10;
+  const now = new Date().toISOString();
+  const rows = await db.execute(sql`
+    UPDATE invoice_events
+    SET
+      status = 'processing',
+      claimed_by = ${input.workerId},
+      attempts = attempts + 1,
+      updated_at = ${now}
+    WHERE id IN (
+      SELECT id FROM invoice_events
+      WHERE status IN ('pending', 'failed')
+        AND next_attempt_at <= ${now}
+        AND attempts < ${MAX_INVOICE_EVENT_ATTEMPTS}
+      ORDER BY next_attempt_at ASC
+      FOR UPDATE SKIP LOCKED
+      LIMIT ${limit}
+    )
+    RETURNING *
+  `);
+
+  // postgres.js / drizzle execute returns RowList; normalize to array of records.
+  const list = Array.isArray(rows) ? rows : (rows as { rows?: unknown[] }).rows ?? [];
+  return list.map((row) => normalizeClaimedRow(row as Record<string, unknown>));
+}
+
+function normalizeClaimedRow(
+  row: Record<string, unknown>,
+): typeof invoiceEvents.$inferSelect {
+  return {
+    id: String(row.id),
+    source: String(row.source),
+    externalEventId: String(row.external_event_id ?? row.externalEventId),
+    eventType: String(row.event_type ?? row.eventType),
+    payload: (row.payload ?? {}) as Record<string, unknown>,
+    status: String(row.status),
+    attempts: Number(row.attempts ?? 0),
+    nextAttemptAt: String(row.next_attempt_at ?? row.nextAttemptAt ?? ""),
+    claimedBy: row.claimed_by != null ? String(row.claimed_by) : (row.claimedBy as string | null),
+    lastError: row.last_error != null ? String(row.last_error) : (row.lastError as string | null),
+    createdAt: String(row.created_at ?? row.createdAt ?? ""),
+    updatedAt: String(row.updated_at ?? row.updatedAt ?? ""),
+  };
+}
+
+export async function markInvoiceEventDone(id: string): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .update(invoiceEvents)
+    .set({
+      status: "done",
+      claimedBy: null,
+      lastError: null,
+      updatedAt: now,
+    })
+    .where(eq(invoiceEvents.id, id));
+}
+
+export async function markInvoiceEventFailed(input: {
+  id: string;
+  error: string;
+  attempts: number;
+}): Promise<void> {
+  const now = new Date();
+  const dead = input.attempts >= MAX_INVOICE_EVENT_ATTEMPTS;
+  const next = new Date(
+    now.getTime() + backoffSeconds(input.attempts) * 1000,
+  ).toISOString();
+  await db
+    .update(invoiceEvents)
+    .set({
+      status: dead ? "dead" : "failed",
+      claimedBy: null,
+      lastError: input.error.slice(0, 2000),
+      nextAttemptAt: next,
+      updatedAt: now.toISOString(),
+    })
+    .where(eq(invoiceEvents.id, input.id));
+}
+
+export async function upsertMerchantInvoice(input: {
+  openmeterInvoiceId: string;
+  appId: string;
+  openmeterCustomerId?: string | null;
+  stripeConnectedAccountId?: string | null;
+  stripeCustomerId?: string | null;
+  stripePaymentIntentId?: string | null;
+  stripeInvoiceId?: string | null;
+  state?: string;
+  amountUsdMicros?: string | null;
+  currency?: string;
+  applicationFeeAmount?: number;
+  lastError?: string | null;
+}): Promise<typeof merchantInvoices.$inferSelect> {
+  const now = new Date().toISOString();
+  const existing = await db
+    .select()
+    .from(merchantInvoices)
+    .where(eq(merchantInvoices.openmeterInvoiceId, input.openmeterInvoiceId))
+    .limit(1);
+
+  if (existing[0]) {
+    const [updated] = await db
+      .update(merchantInvoices)
+      .set({
+        openmeterCustomerId:
+          input.openmeterCustomerId ?? existing[0].openmeterCustomerId,
+        stripeConnectedAccountId:
+          input.stripeConnectedAccountId ?? existing[0].stripeConnectedAccountId,
+        stripeCustomerId: input.stripeCustomerId ?? existing[0].stripeCustomerId,
+        stripePaymentIntentId:
+          input.stripePaymentIntentId ?? existing[0].stripePaymentIntentId,
+        stripeInvoiceId: input.stripeInvoiceId ?? existing[0].stripeInvoiceId,
+        state: input.state ?? existing[0].state,
+        amountUsdMicros: input.amountUsdMicros ?? existing[0].amountUsdMicros,
+        currency: input.currency ?? existing[0].currency,
+        applicationFeeAmount:
+          input.applicationFeeAmount ?? existing[0].applicationFeeAmount,
+        lastError: input.lastError === undefined ? existing[0].lastError : input.lastError,
+        updatedAt: now,
+      })
+      .where(eq(merchantInvoices.id, existing[0].id))
+      .returning();
+    return updated;
+  }
+
+  const [created] = await db
+    .insert(merchantInvoices)
+    .values({
+      id: uuidv4(),
+      openmeterInvoiceId: input.openmeterInvoiceId,
+      appId: input.appId,
+      openmeterCustomerId: input.openmeterCustomerId ?? null,
+      stripeConnectedAccountId: input.stripeConnectedAccountId ?? null,
+      stripeCustomerId: input.stripeCustomerId ?? null,
+      stripePaymentIntentId: input.stripePaymentIntentId ?? null,
+      stripeInvoiceId: input.stripeInvoiceId ?? null,
+      state: input.state ?? "created",
+      amountUsdMicros: input.amountUsdMicros ?? null,
+      currency: input.currency ?? "USD",
+      applicationFeeAmount: input.applicationFeeAmount ?? 0,
+      lastError: input.lastError ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return created;
+}
+
+export async function getMerchantInvoiceByOmId(
+  openmeterInvoiceId: string,
+): Promise<typeof merchantInvoices.$inferSelect | null> {
+  const rows = await db
+    .select()
+    .from(merchantInvoices)
+    .where(eq(merchantInvoices.openmeterInvoiceId, openmeterInvoiceId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getMerchantInvoiceByPaymentIntent(
+  paymentIntentId: string,
+): Promise<typeof merchantInvoices.$inferSelect | null> {
+  const rows = await db
+    .select()
+    .from(merchantInvoices)
+    .where(eq(merchantInvoices.stripePaymentIntentId, paymentIntentId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listMerchantInvoicesForApp(input: {
+  appId: string;
+  limit?: number;
+}): Promise<Array<typeof merchantInvoices.$inferSelect>> {
+  return db
+    .select()
+    .from(merchantInvoices)
+    .where(eq(merchantInvoices.appId, input.appId))
+    .orderBy(asc(merchantInvoices.createdAt))
+    .limit(input.limit ?? 100);
+}
+
+/** Stuck invoices for sweeper: payment pending / syncing older than threshold. */
+export async function listStuckMerchantInvoices(input: {
+  olderThanIso: string;
+  limit?: number;
+}): Promise<Array<typeof merchantInvoices.$inferSelect>> {
+  return db
+    .select()
+    .from(merchantInvoices)
+    .where(
+      and(
+        or(
+          eq(merchantInvoices.state, "payment_processing.pending"),
+          eq(merchantInvoices.state, "draft.syncing"),
+          eq(merchantInvoices.state, "issuing.syncing"),
+          eq(merchantInvoices.state, "charge_initiated"),
+        ),
+        lte(merchantInvoices.updatedAt, input.olderThanIso),
+      ),
+    )
+    .limit(input.limit ?? 50);
+}

--- a/src/lib/invoicing/payment-triggers.test.ts
+++ b/src/lib/invoicing/payment-triggers.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { paymentTriggerFromStripeEvent } from "./state-machine";
+
+test("maps Stripe payment events to Custom Invoicing triggers", () => {
+  assert.equal(paymentTriggerFromStripeEvent("payment_intent.succeeded"), "paid");
+  assert.equal(
+    paymentTriggerFromStripeEvent("payment_intent.payment_failed"),
+    "payment_failed",
+  );
+  assert.equal(
+    paymentTriggerFromStripeEvent("payment_intent.requires_action"),
+    "action_required",
+  );
+  assert.equal(
+    paymentTriggerFromStripeEvent("charge.dispute.created"),
+    "payment_uncollectible",
+  );
+  assert.equal(paymentTriggerFromStripeEvent("invoice.paid"), null);
+});

--- a/src/lib/invoicing/state-machine.ts
+++ b/src/lib/invoicing/state-machine.ts
@@ -1,0 +1,463 @@
+/**
+ * Merchant Custom Invoicing state machine.
+ *
+ * OpenMeter notifications drive when to act; Stripe Connect webhooks are the
+ * source of truth for payment outcomes reported back via payment/status.
+ */
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/index";
+import {
+  appBillingConfig,
+  appUserStripeCustomers,
+  developerApps,
+  oidcClients,
+} from "@/db/schema";
+import {
+  getMerchantInvoiceByOmId,
+  getMerchantInvoiceByPaymentIntent,
+  upsertMerchantInvoice,
+} from "@/lib/invoicing/ledger";
+import {
+  submitDraftSynchronized,
+  submitIssuingSynchronized,
+  updateCustomInvoicingPaymentStatus,
+  type CustomInvoicingPaymentTrigger,
+} from "@/lib/openmeter/custom-invoicing";
+import { parseOpenMeterCustomerKey } from "@/lib/openmeter/customer-key";
+import { ceilUsdMicrosToCents } from "@/lib/format-usd-micros";
+import {
+  createOffSessionConnectedPaymentIntent,
+  retrieveConnectedPaymentIntent,
+} from "@/lib/stripe/connect-charges";
+
+const ENABLE_DRAFT_HOOK =
+  process.env.OPENMETER_CUSTOM_INVOICING_DRAFT_HOOK === "1";
+const ENABLE_ISSUING_HOOK =
+  process.env.OPENMETER_CUSTOM_INVOICING_ISSUING_HOOK === "1";
+
+type OmInvoicePayload = {
+  id?: string;
+  status?: string;
+  statusDetails?: { extendedStatus?: string };
+  currency?: string;
+  totals?: { total?: string | number };
+  customer?: { id?: string; key?: string };
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function extractOmInvoice(payload: unknown): OmInvoicePayload | null {
+  const root = asRecord(payload);
+  if (!root) {
+    return null;
+  }
+  // Notification may nest the invoice under data / invoice / subject.
+  const candidates = [
+    root,
+    asRecord(root.data),
+    asRecord(asRecord(root.data)?.object),
+    asRecord(root.invoice),
+    asRecord(root.subject),
+  ];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const id =
+      (typeof candidate.id === "string" && candidate.id) ||
+      (typeof candidate.invoiceId === "string" && candidate.invoiceId) ||
+      "";
+    if (id && /^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$/i.test(id)) {
+      return candidate as OmInvoicePayload;
+    }
+    const nested = asRecord(candidate.invoice);
+    if (nested && typeof nested.id === "string") {
+      return nested as OmInvoicePayload;
+    }
+  }
+  return null;
+}
+
+function extendedStatus(invoice: OmInvoicePayload): string {
+  return (
+    invoice.statusDetails?.extendedStatus ||
+    String(invoice.status ?? "")
+  ).toLowerCase();
+}
+
+function totalUsdMicros(invoice: OmInvoicePayload): string | null {
+  const total = invoice.totals?.total;
+  if (total == null) return null;
+  // OM totals are typically decimal currency strings (e.g. "12.34").
+  const asNumber = Number(total);
+  if (!Number.isFinite(asNumber)) return null;
+  return String(Math.round(asNumber * 1_000_000));
+}
+
+async function resolveAppIdFromCustomerKey(
+  customerKey: string | undefined,
+): Promise<string | null> {
+  if (!customerKey) return null;
+  const parsed = parseOpenMeterCustomerKey(customerKey);
+  if (!parsed) return null;
+  // customer key uses public OIDC client id (app_…)
+  const rows = await db
+    .select({ appId: developerApps.id })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, parsed.clientId))
+    .limit(1);
+  return rows[0]?.appId ?? null;
+}
+
+async function resolveMerchantBilling(appId: string) {
+  const rows = await db
+    .select()
+    .from(appBillingConfig)
+    .where(eq(appBillingConfig.clientId, appId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function resolveStripeCustomer(input: {
+  appId: string;
+  openmeterCustomerId?: string | null;
+  customerKey?: string | null;
+}): Promise<{
+  stripeCustomerId: string;
+  stripeConnectedAccountId: string;
+} | null> {
+  if (input.openmeterCustomerId) {
+    const byOm = await db
+      .select()
+      .from(appUserStripeCustomers)
+      .where(
+        and(
+          eq(appUserStripeCustomers.clientId, input.appId),
+          eq(appUserStripeCustomers.openmeterCustomerId, input.openmeterCustomerId),
+        ),
+      )
+      .limit(1);
+    if (byOm[0]) {
+      return {
+        stripeCustomerId: byOm[0].stripeCustomerId,
+        stripeConnectedAccountId: byOm[0].stripeConnectedAccountId,
+      };
+    }
+  }
+  const parsed = input.customerKey
+    ? parseOpenMeterCustomerKey(input.customerKey)
+    : null;
+  if (parsed) {
+    const byExt = await db
+      .select()
+      .from(appUserStripeCustomers)
+      .where(
+        and(
+          eq(appUserStripeCustomers.clientId, input.appId),
+          eq(appUserStripeCustomers.externalUserId, parsed.externalUserId),
+        ),
+      )
+      .limit(1);
+    if (byExt[0]) {
+      return {
+        stripeCustomerId: byExt[0].stripeCustomerId,
+        stripeConnectedAccountId: byExt[0].stripeConnectedAccountId,
+      };
+    }
+  }
+  return null;
+}
+
+async function handleDraftSync(invoice: OmInvoicePayload): Promise<void> {
+  if (!ENABLE_DRAFT_HOOK || !invoice.id) return;
+  await submitDraftSynchronized(invoice.id, {});
+}
+
+async function handleIssuingSync(
+  invoice: OmInvoicePayload,
+  paymentExternalId?: string,
+): Promise<void> {
+  if (!ENABLE_ISSUING_HOOK || !invoice.id) return;
+  await submitIssuingSynchronized(invoice.id, {
+    payment: paymentExternalId ? { externalId: paymentExternalId } : undefined,
+  });
+}
+
+async function initiateCharge(invoice: OmInvoicePayload): Promise<void> {
+  if (!invoice.id) {
+    throw new Error("OpenMeter invoice missing id");
+  }
+  const customerKey = invoice.customer?.key;
+  const appId = await resolveAppIdFromCustomerKey(customerKey);
+  if (!appId) {
+    throw new Error(
+      `Cannot resolve merchant app from customer key=${customerKey ?? "missing"}`,
+    );
+  }
+
+  const billing = await resolveMerchantBilling(appId);
+  if (!billing?.stripeConnectedAccountId || !billing.stripeChargesEnabled) {
+    throw new Error(`Merchant Connect not ready for app ${appId}`);
+  }
+  if (billing.billingMode !== "merchant") {
+    // Plane A invoices must not enter this worker path.
+    throw new Error(`App ${appId} billingMode=${billing.billingMode}, expected merchant`);
+  }
+
+  const stripeCustomer = await resolveStripeCustomer({
+    appId,
+    openmeterCustomerId: invoice.customer?.id,
+    customerKey,
+  });
+  if (!stripeCustomer) {
+    throw new Error(
+      `No Stripe customer mapping for OM customer ${invoice.customer?.id ?? customerKey}`,
+    );
+  }
+
+  const micros = totalUsdMicros(invoice);
+  const amountCents = micros
+    ? Number.parseInt(ceilUsdMicrosToCents(micros), 10)
+    : 0;
+  if (!Number.isFinite(amountCents) || amountCents < 0) {
+    throw new Error(`Invalid amount from invoice totals: ${micros}`);
+  }
+  if (amountCents <= 0) {
+    await updateCustomInvoicingPaymentStatus(invoice.id, { trigger: "paid" });
+    await upsertMerchantInvoice({
+      openmeterInvoiceId: invoice.id,
+      appId,
+      openmeterCustomerId: invoice.customer?.id,
+      stripeConnectedAccountId: stripeCustomer.stripeConnectedAccountId,
+      stripeCustomerId: stripeCustomer.stripeCustomerId,
+      state: "paid",
+      amountUsdMicros: micros,
+      currency: String(invoice.currency ?? "USD"),
+    });
+    return;
+  }
+
+  const existing = await getMerchantInvoiceByOmId(invoice.id);
+  if (existing?.stripePaymentIntentId) {
+    // Already initiated — wait for Stripe webhook.
+    return;
+  }
+
+  const charge = await createOffSessionConnectedPaymentIntent({
+    accountId: stripeCustomer.stripeConnectedAccountId,
+    customerId: stripeCustomer.stripeCustomerId,
+    amountCents,
+    currency: String(invoice.currency ?? "usd"),
+    applicationFeeBps: billing.applicationFeeBps,
+    description: `OpenMeter invoice ${invoice.id}`,
+    idempotencyKey: invoice.id,
+    metadata: {
+      openmeter_invoice_id: invoice.id,
+      pymthouse_app_id: appId,
+    },
+  });
+
+  if (charge.kind === "payment_intent") {
+    await upsertMerchantInvoice({
+      openmeterInvoiceId: invoice.id,
+      appId,
+      openmeterCustomerId: invoice.customer?.id,
+      stripeConnectedAccountId: stripeCustomer.stripeConnectedAccountId,
+      stripeCustomerId: stripeCustomer.stripeCustomerId,
+      stripePaymentIntentId: charge.paymentIntentId,
+      state: "charge_initiated",
+      amountUsdMicros: micros,
+      currency: String(invoice.currency ?? "USD"),
+      applicationFeeAmount: charge.applicationFeeAmount,
+    });
+    await handleIssuingSync(invoice, charge.paymentIntentId);
+    // If Stripe returned succeeded synchronously (rare for off_session), still
+    // wait for webhook as source of truth — except requires_action needs report.
+    if (charge.status === "requires_action") {
+      await updateCustomInvoicingPaymentStatus(invoice.id, {
+        trigger: "action_required",
+      });
+    }
+    return;
+  }
+
+  await upsertMerchantInvoice({
+    openmeterInvoiceId: invoice.id,
+    appId,
+    openmeterCustomerId: invoice.customer?.id,
+    stripeConnectedAccountId: stripeCustomer.stripeConnectedAccountId,
+    stripeCustomerId: stripeCustomer.stripeCustomerId,
+    stripeInvoiceId: charge.invoiceId,
+    state: "hosted_invoice_sent",
+    amountUsdMicros: micros,
+    currency: String(invoice.currency ?? "USD"),
+    applicationFeeAmount: charge.applicationFeeAmount,
+  });
+  await handleIssuingSync(invoice, charge.invoiceId);
+  await updateCustomInvoicingPaymentStatus(invoice.id, {
+    trigger: "action_required",
+  });
+}
+
+export function paymentTriggerFromStripeEvent(
+  eventType: string,
+): CustomInvoicingPaymentTrigger | null {
+  switch (eventType) {
+    case "payment_intent.succeeded":
+      return "paid";
+    case "payment_intent.payment_failed":
+      return "payment_failed";
+    case "payment_intent.requires_action":
+      return "action_required";
+    case "charge.dispute.created":
+      return "payment_uncollectible";
+    default:
+      return null;
+  }
+}
+
+function stripeObjectId(payload: unknown): string | null {
+  const root = asRecord(payload);
+  const data = asRecord(root?.data);
+  const obj = asRecord(data?.object);
+  const id = obj?.id;
+  return typeof id === "string" ? id : null;
+}
+
+function stripeMetadataOmInvoiceId(payload: unknown): string | null {
+  const root = asRecord(payload);
+  const data = asRecord(root?.data);
+  const obj = asRecord(data?.object);
+  const metadata = asRecord(obj?.metadata);
+  const id = metadata?.openmeter_invoice_id;
+  return typeof id === "string" && id.trim() ? id.trim() : null;
+}
+
+async function handleStripePaymentEvent(input: {
+  eventType: string;
+  payload: unknown;
+}): Promise<void> {
+  const trigger = paymentTriggerFromStripeEvent(input.eventType);
+  if (!trigger) {
+    return;
+  }
+
+  const piId = stripeObjectId(input.payload);
+  const fromMeta = stripeMetadataOmInvoiceId(input.payload);
+  let mapping = piId ? await getMerchantInvoiceByPaymentIntent(piId) : null;
+  if (!mapping && fromMeta) {
+    mapping = await getMerchantInvoiceByOmId(fromMeta);
+  }
+  if (!mapping) {
+    // Not a merchant Custom Invoicing charge — ignore.
+    return;
+  }
+
+  await updateCustomInvoicingPaymentStatus(mapping.openmeterInvoiceId, {
+    trigger,
+  });
+  await upsertMerchantInvoice({
+    openmeterInvoiceId: mapping.openmeterInvoiceId,
+    appId: mapping.appId,
+    state: trigger === "paid" ? "paid" : trigger,
+    stripePaymentIntentId: piId ?? mapping.stripePaymentIntentId,
+  });
+}
+
+async function handleOpenMeterEvent(input: {
+  eventType: string;
+  payload: unknown;
+}): Promise<void> {
+  const invoice = extractOmInvoice(input.payload);
+  if (!invoice?.id) {
+    // Non-invoice notification (e.g. entitlement) — ignore for this worker.
+    return;
+  }
+
+  const status = extendedStatus(invoice);
+  const customerKey = invoice.customer?.key;
+  const appId = await resolveAppIdFromCustomerKey(customerKey);
+
+  if (appId) {
+    await upsertMerchantInvoice({
+      openmeterInvoiceId: invoice.id,
+      appId,
+      openmeterCustomerId: invoice.customer?.id,
+      state: status || input.eventType,
+      amountUsdMicros: totalUsdMicros(invoice),
+      currency: String(invoice.currency ?? "USD"),
+    });
+  }
+
+  if (status.includes("draft") && status.includes("sync")) {
+    await handleDraftSync(invoice);
+    return;
+  }
+  if (status.includes("issuing") && status.includes("sync")) {
+    const existing = await getMerchantInvoiceByOmId(invoice.id);
+    await handleIssuingSync(
+      invoice,
+      existing?.stripePaymentIntentId ?? existing?.stripeInvoiceId ?? undefined,
+    );
+    return;
+  }
+  if (
+    status === "payment_processing.pending" ||
+    status === "payment_processing" ||
+    (status.includes("payment") && status.includes("pending"))
+  ) {
+    await initiateCharge(invoice);
+  }
+}
+
+export async function processInvoiceEvent(input: {
+  source: string;
+  eventType: string;
+  payload: unknown;
+}): Promise<void> {
+  if (input.source === "openmeter") {
+    await handleOpenMeterEvent(input);
+    return;
+  }
+  if (input.source === "stripe") {
+    if (input.eventType === "account.application.deauthorized") {
+      // Ledger-only audit for now; readiness cleared via account.updated elsewhere.
+      return;
+    }
+    await handleStripePaymentEvent(input);
+    return;
+  }
+  throw new Error(`Unknown invoice event source: ${input.source}`);
+}
+
+/** Re-poll Stripe for a stuck charge and report status to OpenMeter. */
+export async function reconcileMerchantInvoice(
+  openmeterInvoiceId: string,
+): Promise<void> {
+  const mapping = await getMerchantInvoiceByOmId(openmeterInvoiceId);
+  if (!mapping?.stripePaymentIntentId || !mapping.stripeConnectedAccountId) {
+    return;
+  }
+  const pi = await retrieveConnectedPaymentIntent({
+    accountId: mapping.stripeConnectedAccountId,
+    paymentIntentId: mapping.stripePaymentIntentId,
+  });
+  let trigger: CustomInvoicingPaymentTrigger | null = null;
+  if (pi.status === "succeeded") trigger = "paid";
+  else if (pi.status === "requires_action") trigger = "action_required";
+  else if (pi.status === "canceled") trigger = "payment_failed";
+  else if (pi.status === "requires_payment_method") trigger = "payment_failed";
+  if (!trigger) return;
+
+  await updateCustomInvoicingPaymentStatus(mapping.openmeterInvoiceId, {
+    trigger,
+  });
+  await upsertMerchantInvoice({
+    openmeterInvoiceId: mapping.openmeterInvoiceId,
+    appId: mapping.appId,
+    state: trigger === "paid" ? "paid" : trigger,
+  });
+}

--- a/src/lib/invoicing/worker.ts
+++ b/src/lib/invoicing/worker.ts
@@ -1,0 +1,116 @@
+/**
+ * Railway invoicing worker: claim ledger events, run state machine, sweep stuck invoices.
+ */
+import {
+  claimInvoiceEvents,
+  listStuckMerchantInvoices,
+  markInvoiceEventDone,
+  markInvoiceEventFailed,
+} from "@/lib/invoicing/ledger";
+import {
+  processInvoiceEvent,
+  reconcileMerchantInvoice,
+} from "@/lib/invoicing/state-machine";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
+
+const DEFAULT_POLL_MS = 2_000;
+const DEFAULT_SWEEP_MS = 60_000;
+const STUCK_AGE_MS = 15 * 60 * 1000;
+
+export type InvoicingWorkerOptions = {
+  workerId?: string;
+  pollIntervalMs?: number;
+  sweepIntervalMs?: number;
+  batchSize?: number;
+  /** When true, run a single claim+sweep cycle then return (tests). */
+  once?: boolean;
+};
+
+export async function runInvoicingWorker(
+  options: InvoicingWorkerOptions = {},
+): Promise<void> {
+  const workerId =
+    options.workerId ||
+    process.env.INVOICING_WORKER_ID?.trim() ||
+    `invoicing-${process.pid}`;
+  const pollMs = options.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const sweepMs = options.sweepIntervalMs ?? DEFAULT_SWEEP_MS;
+  const batchSize = options.batchSize ?? 10;
+  const tag = `[invoicing-worker:${workerId}]`;
+
+  let lastSweep = 0;
+
+  const cycle = async (): Promise<void> => {
+    const claimed = await claimInvoiceEvents({
+      workerId,
+      limit: batchSize,
+    });
+    for (const event of claimed) {
+      try {
+        await processInvoiceEvent({
+          source: event.source,
+          eventType: event.eventType,
+          payload: event.payload,
+        });
+        await markInvoiceEventDone(event.id);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(
+          tag,
+          `event ${event.id} (${event.eventType}) failed:`,
+          sanitizeForLog(message),
+        );
+        await markInvoiceEventFailed({
+          id: event.id,
+          error: message,
+          attempts: event.attempts,
+        });
+      }
+    }
+
+    const now = Date.now();
+    if (now - lastSweep >= sweepMs) {
+      lastSweep = now;
+      await runSweeper(tag);
+    }
+  };
+
+  if (options.once) {
+    await cycle();
+    return;
+  }
+
+  console.log(tag, "started");
+  for (;;) {
+    try {
+      await cycle();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(tag, "cycle error:", sanitizeForLog(message));
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+async function runSweeper(tag: string): Promise<void> {
+  const olderThanIso = new Date(Date.now() - STUCK_AGE_MS).toISOString();
+  const stuck = await listStuckMerchantInvoices({
+    olderThanIso,
+    limit: 25,
+  });
+  for (const row of stuck) {
+    try {
+      await reconcileMerchantInvoice(row.openmeterInvoiceId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        tag,
+        `sweep ${row.openmeterInvoiceId} failed:`,
+        sanitizeForLog(message),
+      );
+    }
+  }
+  if (stuck.length > 0) {
+    console.log(tag, `swept ${stuck.length} stuck merchant invoice(s)`);
+  }
+}

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -17,21 +17,26 @@ import {
 import { getHostedOpenMeterUrl } from "./constants";
 import { shouldUseKonnectRoutes } from "./route-mode";
 import {
+  type BillingProfileSupplierInput,
+  buildOpenMeterSupplierAddress,
+} from "./billing-supplier";
+import {
   ensureKonnectCustomerStripeBilling,
   ensureStripeCustomerAppData,
   setKonnectCustomerBillingProfile,
 } from "./stripe-customer-data";
 
-/** ISO 3166-1 alpha-2; required on billing profile supplier for OpenMeter invoicing. */
-function billingSupplierCountryCode(): string {
-  const raw = process.env.OPENMETER_BILLING_SUPPLIER_COUNTRY?.trim() || "US";
-  return raw.toUpperCase();
-}
+export type { BillingProfileSupplierInput } from "./billing-supplier";
 
-export function buildBillingProfileSupplier(displayName: string) {
+export function buildBillingProfileSupplier(
+  displayName: string,
+  supplier?: BillingProfileSupplierInput,
+) {
+  const taxId = supplier?.taxId?.trim();
   return {
     name: displayName,
-    addresses: [{ country: billingSupplierCountryCode() }],
+    addresses: [buildOpenMeterSupplierAddress(supplier)],
+    ...(taxId ? { taxId: { code: taxId } } : {}),
   };
 }
 
@@ -370,6 +375,29 @@ export async function prepareAppCustomerStripeBilling(input: {
       customerId: input.customerId,
       billingProfileId: merchantProfileId,
     });
+    const accountId = config.stripeConnectedAccountId?.trim();
+    if (accountId) {
+      const { resolveMerchantChargeModel } = await import("./supplier-sync");
+      const { merchantSettlementMetadata } = await import(
+        "./settlement-metadata"
+      );
+      const { ensureCustomerMetadata } = await import("./customers");
+      const chargeModel = resolveMerchantChargeModel(config);
+      if (chargeModel !== "direct") {
+        console.warn(
+          "merchant customer settlement metadata: supplier incomplete; using destination",
+          input.clientId,
+        );
+      }
+      await ensureCustomerMetadata(
+        input.client,
+        input.customerId,
+        merchantSettlementMetadata({
+          connectedAccountId: accountId,
+          chargeModel,
+        }),
+      );
+    }
     return;
   }
 

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -357,6 +357,22 @@ export async function prepareAppCustomerStripeBilling(input: {
   customerKey?: string;
   name?: string;
 }): Promise<void> {
+  const config = await getAppBillingConfig(input.clientId);
+  const merchantProfileId =
+    config?.openmeterMerchantBillingProfileId?.trim() ||
+    process.env.OPENMETER_MERCHANT_BILLING_PROFILE_ID?.trim() ||
+    null;
+
+  // Merchant plane: pin to Custom Invoicing profile (no platform Stripe charge).
+  if (config?.billingMode === "merchant" && merchantProfileId) {
+    await assignMerchantCustomInvoicingProfile({
+      client: input.client,
+      customerId: input.customerId,
+      billingProfileId: merchantProfileId,
+    });
+    return;
+  }
+
   const ready = await ensureAppStripeBillingReady({ clientId: input.clientId });
   const useKonnect = shouldUseKonnectRoutes(
     getHostedOpenMeterUrl(),
@@ -657,4 +673,29 @@ export async function upsertAppBillingConfig(
     updatedAt: now,
     ...values,
   });
+}
+
+/**
+ * Pin an end-user OM customer to the shared merchant Custom Invoicing billing
+ * profile (never the org default). Requires OPENMETER_MERCHANT_BILLING_PROFILE_ID.
+ */
+export async function assignMerchantCustomInvoicingProfile(input: {
+  client: OpenMeter;
+  customerId: string;
+  billingProfileId?: string;
+}): Promise<string> {
+  const profileId =
+    input.billingProfileId?.trim() ||
+    process.env.OPENMETER_MERCHANT_BILLING_PROFILE_ID?.trim();
+  if (!profileId) {
+    throw new Error(
+      "OPENMETER_MERCHANT_BILLING_PROFILE_ID is required to assign merchant Custom Invoicing overrides",
+    );
+  }
+  await assignCustomerBillingProfileOverride({
+    client: input.client,
+    customerId: input.customerId,
+    billingProfileId: profileId,
+  });
+  return profileId;
 }

--- a/src/lib/openmeter/billing-supplier.ts
+++ b/src/lib/openmeter/billing-supplier.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared supplier identity for OpenMeter / Konnect billing profiles.
+ *
+ * The supplier is who is legally selling on an invoice. Platform profiles use
+ * {@link platformSupplierCountryCode}; Connect merchant profiles sync from the
+ * connected Stripe account (see supplier-sync.ts).
+ */
+
+export function platformSupplierCountryCode(): string {
+  const raw = process.env.OPENMETER_BILLING_SUPPLIER_COUNTRY?.trim() || "US";
+  return raw.toUpperCase();
+}
+
+export type BillingProfileSupplierInput = {
+  country?: string | null;
+  addressLine1?: string | null;
+  addressLine2?: string | null;
+  addressCity?: string | null;
+  addressState?: string | null;
+  addressPostalCode?: string | null;
+  taxId?: string | null;
+};
+
+function present(v: unknown): v is string {
+  return typeof v === "string" && v.trim().length > 0;
+}
+
+/** Drop absent keys so OpenMeter never receives `{"city": null}`. */
+function compact(input: Record<string, unknown>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(input)
+      .filter(([, v]) => present(v))
+      .map(([k, v]) => [k, (v as string).trim()]),
+  );
+}
+
+function resolvedCountry(s?: BillingProfileSupplierInput): string {
+  const c = s?.country?.trim();
+  return c ? c.toUpperCase() : platformSupplierCountryCode();
+}
+
+/** OSS OpenMeter `Address`. */
+export function buildOpenMeterSupplierAddress(s?: BillingProfileSupplierInput) {
+  return compact({
+    country: resolvedCountry(s),
+    line1: s?.addressLine1,
+    line2: s?.addressLine2,
+    city: s?.addressCity,
+    state: s?.addressState,
+    postalCode: s?.addressPostalCode,
+  });
+}
+
+/** Konnect nests the same values under billing_address with snake_case keys. */
+export function buildKonnectSupplierAddress(s?: BillingProfileSupplierInput) {
+  return compact({
+    country: resolvedCountry(s),
+    line1: s?.addressLine1,
+    line2: s?.addressLine2,
+    city: s?.addressCity,
+    state: s?.addressState,
+    postal_code: s?.addressPostalCode,
+  });
+}
+
+/**
+ * Jurisdictions requiring the seller's tax number on a B2B invoice.
+ * Stripe will not share the verified value, so the developer must supply it.
+ *
+ * First-pass list — have tax counsel review before gating production onboarding.
+ */
+const TAX_ID_REQUIRED_COUNTRIES = new Set([
+  "AT",
+  "BE",
+  "BG",
+  "HR",
+  "CY",
+  "CZ",
+  "DK",
+  "EE",
+  "FI",
+  "FR",
+  "DE",
+  "GR",
+  "HU",
+  "IE",
+  "IT",
+  "LV",
+  "LT",
+  "LU",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SK",
+  "SI",
+  "ES",
+  "SE",
+  "GB",
+  "NO",
+  "CH",
+  "AU",
+  "NZ",
+  "SG",
+  "ZA",
+  "AE",
+  "SA",
+  "IN",
+]);
+
+export function requiresSupplierTaxId(country?: string | null): boolean {
+  const code = country?.trim().toUpperCase();
+  return code ? TAX_ID_REQUIRED_COUNTRIES.has(code) : false;
+}
+
+export type SupplierGap = "country" | "name" | "tax_id";
+
+export function supplierGaps(input: {
+  country?: string | null;
+  name?: string | null;
+  taxId?: string | null;
+}): SupplierGap[] {
+  const gaps: SupplierGap[] = [];
+  if (!present(input.country)) gaps.push("country");
+  if (!present(input.name)) gaps.push("name");
+  if (requiresSupplierTaxId(input.country) && !present(input.taxId)) {
+    gaps.push("tax_id");
+  }
+  return gaps;
+}
+
+export function supplierIsComplete(
+  input: Parameters<typeof supplierGaps>[0],
+): boolean {
+  return supplierGaps(input).length === 0;
+}

--- a/src/lib/openmeter/custom-invoicing.test.ts
+++ b/src/lib/openmeter/custom-invoicing.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  customInvoicingRequestUrl,
+  requireOpenMeterWebhookSecret,
+} from "./custom-invoicing";
+
+test("customInvoicingRequestUrl strips /api/v1 for Konnect bases", () => {
+  const savedUrl = process.env.OPENMETER_URL;
+  const savedKey = process.env.OPENMETER_API_KEY;
+  process.env.OPENMETER_URL = "https://us.api.konghq.com/v3/openmeter";
+  process.env.OPENMETER_API_KEY = "kpat_test";
+  try {
+    const url = customInvoicingRequestUrl(
+      "01G65Z755AFWAKHE12NY0CQ9FH",
+      "payment/status",
+    );
+    assert.equal(
+      url,
+      "https://us.api.konghq.com/v3/openmeter/apps/custom-invoicing/01G65Z755AFWAKHE12NY0CQ9FH/payment/status",
+    );
+  } finally {
+    process.env.OPENMETER_URL = savedUrl;
+    process.env.OPENMETER_API_KEY = savedKey;
+  }
+});
+
+test("customInvoicingRequestUrl keeps /api/v1 for self-hosted", () => {
+  const savedUrl = process.env.OPENMETER_URL;
+  const savedKey = process.env.OPENMETER_API_KEY;
+  process.env.OPENMETER_URL = "http://127.0.0.1:48888";
+  delete process.env.OPENMETER_API_KEY;
+  try {
+    const url = customInvoicingRequestUrl(
+      "01G65Z755AFWAKHE12NY0CQ9FH",
+      "draft/synchronized",
+    );
+    assert.equal(
+      url,
+      "http://127.0.0.1:48888/api/v1/apps/custom-invoicing/01G65Z755AFWAKHE12NY0CQ9FH/draft/synchronized",
+    );
+  } finally {
+    process.env.OPENMETER_URL = savedUrl;
+    if (savedKey === undefined) {
+      delete process.env.OPENMETER_API_KEY;
+    } else {
+      process.env.OPENMETER_API_KEY = savedKey;
+    }
+  }
+});
+
+test("requireOpenMeterWebhookSecret throws when unset", () => {
+  const saved = process.env.OPENMETER_WEBHOOK_SECRET;
+  delete process.env.OPENMETER_WEBHOOK_SECRET;
+  try {
+    assert.throws(() => requireOpenMeterWebhookSecret(), /OPENMETER_WEBHOOK_SECRET/);
+  } finally {
+    if (saved === undefined) {
+      delete process.env.OPENMETER_WEBHOOK_SECRET;
+    } else {
+      process.env.OPENMETER_WEBHOOK_SECRET = saved;
+    }
+  }
+});

--- a/src/lib/openmeter/custom-invoicing.ts
+++ b/src/lib/openmeter/custom-invoicing.ts
@@ -1,0 +1,147 @@
+/**
+ * OpenMeter / Konnect Custom Invoicing App client.
+ *
+ * Completes invoice lifecycle pauses at draft.syncing, issuing.syncing, and
+ * payment_processing.pending. Paths match OpenMeter OpenAPI and rewrite to
+ * Konnect `/apps/custom-invoicing/...` via {@link rewriteKonnectPathname}.
+ *
+ * @see https://developer.konghq.com/metering-and-billing/custom-invoicing/
+ * @see https://openmeter.io/docs/integrations/external-invoicing/overview
+ */
+import {
+  getHostedOpenMeterUrl,
+  isKonnectMeteringUrl,
+  normalizeKonnectMeteringUrl,
+} from "./constants";
+import { rewriteKonnectPathname } from "./konnect-routes";
+
+export type CustomInvoicingPaymentTrigger =
+  | "paid"
+  | "payment_failed"
+  | "payment_uncollectible"
+  | "payment_overdue"
+  | "action_required"
+  | "void";
+
+export type CustomInvoicingLineExternalIdMapping = {
+  lineId: string;
+  externalId: string;
+};
+
+export type CustomInvoicingLineDiscountExternalIdMapping = {
+  lineDiscountId: string;
+  externalId: string;
+};
+
+export type CustomInvoicingSyncResult = {
+  invoiceNumber?: string;
+  externalId?: string;
+  lineExternalIds?: CustomInvoicingLineExternalIdMapping[];
+  lineDiscountExternalIds?: CustomInvoicingLineDiscountExternalIdMapping[];
+};
+
+export type CustomInvoicingDraftSynchronizedRequest = {
+  invoicing?: CustomInvoicingSyncResult;
+};
+
+export type CustomInvoicingFinalizedRequest = {
+  invoicing?: {
+    invoiceNumber?: string;
+    sentToCustomerAt?: string;
+  };
+  payment?: {
+    externalId?: string;
+  };
+};
+
+export type CustomInvoicingUpdatePaymentStatusRequest = {
+  trigger: CustomInvoicingPaymentTrigger;
+};
+
+function requireOpenMeterApiKey(): string {
+  const apiKey = process.env.OPENMETER_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("OPENMETER_API_KEY is required for Custom Invoicing API calls");
+  }
+  return apiKey;
+}
+
+/** Resolve request URL for self-hosted (`/api/v1/...`) or Konnect (`/apps/...`). */
+export function customInvoicingRequestUrl(invoiceId: string, suffix: string): string {
+  const rawBase = getHostedOpenMeterUrl();
+  const apiKey = process.env.OPENMETER_API_KEY?.trim();
+  const useKonnect = isKonnectMeteringUrl(rawBase, apiKey);
+  const sdkPath = `/api/v1/apps/custom-invoicing/${encodeURIComponent(invoiceId)}/${suffix}`;
+  if (useKonnect) {
+    const base = normalizeKonnectMeteringUrl(rawBase);
+    const path = rewriteKonnectPathname(sdkPath, "POST");
+    return `${base}${path}`;
+  }
+  return `${rawBase.replace(/\/$/, "")}${sdkPath}`;
+}
+
+async function customInvoicingPost(
+  invoiceId: string,
+  suffix: string,
+  body: unknown,
+): Promise<void> {
+  const apiKey = requireOpenMeterApiKey();
+  const url = customInvoicingRequestUrl(invoiceId, suffix);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body ?? {}),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `Custom Invoicing POST ${suffix} for ${invoiceId} failed (${response.status}): ${text}`,
+    );
+  }
+}
+
+/** Submit draft sync results (resume after draft.syncing). */
+export async function submitDraftSynchronized(
+  invoiceId: string,
+  body: CustomInvoicingDraftSynchronizedRequest = {},
+): Promise<void> {
+  await customInvoicingPost(invoiceId, "draft/synchronized", body);
+}
+
+/** Submit issuing sync results (resume after issuing.syncing). */
+export async function submitIssuingSynchronized(
+  invoiceId: string,
+  body: CustomInvoicingFinalizedRequest = {},
+): Promise<void> {
+  await customInvoicingPost(invoiceId, "issuing/synchronized", body);
+}
+
+/** Report payment outcome (mandatory at payment_processing.pending). */
+export async function updateCustomInvoicingPaymentStatus(
+  invoiceId: string,
+  body: CustomInvoicingUpdatePaymentStatusRequest,
+): Promise<void> {
+  await customInvoicingPost(invoiceId, "payment/status", body);
+}
+
+export function resolveCustomInvoicingAppId(): string | null {
+  return process.env.OPENMETER_CUSTOM_INVOICING_APP_ID?.trim() || null;
+}
+
+export function resolveMerchantBillingProfileId(): string | null {
+  return process.env.OPENMETER_MERCHANT_BILLING_PROFILE_ID?.trim() || null;
+}
+
+export function requireOpenMeterWebhookSecret(): string {
+  const secret = process.env.OPENMETER_WEBHOOK_SECRET?.trim();
+  if (!secret) {
+    throw new Error(
+      "OPENMETER_WEBHOOK_SECRET is required (shared secret configured on the Konnect notification channel)",
+    );
+  }
+  return secret;
+}

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -420,6 +420,27 @@ export async function ensureOpenMeterCustomerForAppUser(input: {
   );
 }
 
+/**
+ * Merge metadata onto an existing OpenMeter customer without changing subjects.
+ * Used to stamp settlement charge-model keys for merchant Custom Invoicing.
+ */
+export async function ensureCustomerMetadata(
+  client: OpenMeter,
+  customerId: string,
+  metadata: Record<string, string>,
+): Promise<void> {
+  const customer = (await client.customers.get(customerId)) as OpenMeterCustomerRecord;
+  if (!customer?.id) {
+    throw new Error(`OpenMeter customer not found: ${customerId}`);
+  }
+  await ensureCustomerUsageAttribution(
+    client,
+    customer,
+    customer.usageAttribution?.subjectKeys ?? [],
+    metadata,
+  );
+}
+
 export async function assignCustomerBillingProfileOverride(input: {
   client: OpenMeter;
   customerId: string;

--- a/src/lib/openmeter/invoices.ts
+++ b/src/lib/openmeter/invoices.ts
@@ -1,8 +1,8 @@
 import type { OpenMeter } from "@openmeter/sdk";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db/index";
-import { developerApps, oidcClients } from "@/db/schema";
+import { developerApps, merchantInvoices, oidcClients } from "@/db/schema";
 import {
   classifyInvoiceLineKind,
   type InvoiceLineSummary,
@@ -44,6 +44,10 @@ export type TenantInvoiceDto = {
   invoiceType?: string;
   /** Expanded charge lines when `expand=lines` is available. */
   lines?: InvoiceLineSummary[];
+  /** Merchant Custom Invoicing collection state from local ledger (when present). */
+  collectionState?: string;
+  stripePaymentIntentId?: string;
+  stripeInvoiceId?: string;
 };
 
 type OmInvoiceLineLike = {
@@ -265,6 +269,25 @@ async function listInvoicesForCustomerIds(input: {
   const totalCount = allItems.length;
   const offset = (page - 1) * pageSize;
   const items = allItems.slice(offset, offset + pageSize);
+
+  const omIds = items.map((item) => item.id);
+  if (omIds.length > 0) {
+    const mappings = await db
+      .select()
+      .from(merchantInvoices)
+      .where(inArray(merchantInvoices.openmeterInvoiceId, omIds));
+    const byOmId = new Map(
+      mappings.map((row) => [row.openmeterInvoiceId, row] as const),
+    );
+    for (const item of items) {
+      const mapping = byOmId.get(item.id);
+      if (mapping) {
+        item.collectionState = mapping.state;
+        item.stripePaymentIntentId = mapping.stripePaymentIntentId ?? undefined;
+        item.stripeInvoiceId = mapping.stripeInvoiceId ?? undefined;
+      }
+    }
+  }
 
   return { items, page, pageSize, totalCount };
 }

--- a/src/lib/openmeter/konnect-billing-profiles-custom-invoicing.test.ts
+++ b/src/lib/openmeter/konnect-billing-profiles-custom-invoicing.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildKonnectMerchantCustomInvoicingProfileBody,
+  isKonnectCustomInvoicingApp,
+  selectKonnectCustomInvoicingApp,
+} from "./konnect-billing-profiles";
+
+test("isKonnectCustomInvoicingApp matches custom_invoicing type", () => {
+  assert.equal(
+    isKonnectCustomInvoicingApp({ id: "1", type: "custom_invoicing" }),
+    true,
+  );
+  assert.equal(
+    isKonnectCustomInvoicingApp({
+      id: "1",
+      definition: { type: "custom_invoicing" },
+    }),
+    true,
+  );
+  assert.equal(isKonnectCustomInvoicingApp({ id: "1", type: "stripe" }), false);
+});
+
+test("selectKonnectCustomInvoicingApp returns first custom invoicing app", () => {
+  assert.equal(
+    selectKonnectCustomInvoicingApp([
+      { id: "stripe1", type: "stripe", status: "ready" },
+      { id: "ci1", type: "custom_invoicing", status: "ready" },
+    ]),
+    "ci1",
+  );
+  assert.equal(selectKonnectCustomInvoicingApp([{ id: "s", type: "stripe" }]), null);
+});
+
+test("buildKonnectMerchantCustomInvoicingProfileBody pins all slots to CI app", () => {
+  const body = buildKonnectMerchantCustomInvoicingProfileBody({
+    customInvoicingAppId: "ci_app_1",
+    name: "pymthouse-merchant-custom-invoicing",
+  });
+  assert.equal(body.default, false);
+  assert.equal(body.apps.tax.id, "ci_app_1");
+  assert.equal(body.apps.invoicing.id, "ci_app_1");
+  assert.equal(body.apps.payment.id, "ci_app_1");
+  assert.equal(body.workflow.payment.collection_method, "charge_automatically");
+});

--- a/src/lib/openmeter/konnect-billing-profiles.ts
+++ b/src/lib/openmeter/konnect-billing-profiles.ts
@@ -1,4 +1,8 @@
 import { konnectAdminConfig, konnectAdminFetch } from "./konnect-admin-client";
+import {
+  type BillingProfileSupplierInput,
+  buildKonnectSupplierAddress,
+} from "./billing-supplier";
 
 type KonnectPage<T> = {
   data?: T[];
@@ -39,8 +43,9 @@ export type KonnectCreateBillingProfileBody = {
   supplier: {
     name: string;
     addresses: {
-      billing_address: { country: string };
+      billing_address: Record<string, string>;
     };
+    tax_id?: { code: string };
   };
   workflow: {
     invoicing: {
@@ -60,9 +65,16 @@ export type KonnectCreateBillingProfileBody = {
 const KONNECT_STRIPE_INSTALL_DOCS =
   "https://developer.konghq.com/metering-and-billing/stripe-integration/";
 
-function billingSupplierCountryCode(): string {
-  const raw = process.env.OPENMETER_BILLING_SUPPLIER_COUNTRY?.trim() || "US";
-  return raw.toUpperCase();
+function buildKonnectSupplier(
+  name: string,
+  supplier?: BillingProfileSupplierInput,
+): KonnectCreateBillingProfileBody["supplier"] {
+  const taxId = supplier?.taxId?.trim();
+  return {
+    name,
+    addresses: { billing_address: buildKonnectSupplierAddress(supplier) },
+    ...(taxId ? { tax_id: { code: taxId } } : {}),
+  };
 }
 
 function billingFetch<T>(path: string, init?: RequestInit): Promise<T> {
@@ -210,17 +222,13 @@ export function buildKonnectCreateBillingProfileBody(input: {
   stripeAppId: string;
   name?: string;
   progressiveBilling?: boolean;
+  supplier?: BillingProfileSupplierInput;
 }): KonnectCreateBillingProfileBody {
   const supplierName = input.name || `Tenant ${input.clientId}`;
   return {
     name: input.name || `pymthouse-${input.clientId}`,
     default: false,
-    supplier: {
-      name: supplierName,
-      addresses: {
-        billing_address: { country: billingSupplierCountryCode() },
-      },
-    },
+    supplier: buildKonnectSupplier(supplierName, input.supplier),
     workflow: {
       invoicing: {
         auto_advance: true,
@@ -246,17 +254,14 @@ export function buildKonnectMerchantCustomInvoicingProfileBody(input: {
   name?: string;
   progressiveBilling?: boolean;
   collectionMethod?: "charge_automatically" | "send_invoice";
+  supplier?: BillingProfileSupplierInput;
 }): KonnectCreateBillingProfileBody {
   const appId = input.customInvoicingAppId;
+  const supplierName = input.name || "PymtHouse Merchant";
   return {
     name: input.name || "pymthouse-merchant-custom-invoicing",
     default: false,
-    supplier: {
-      name: input.name || "PymtHouse Merchant",
-      addresses: {
-        billing_address: { country: billingSupplierCountryCode() },
-      },
-    },
+    supplier: buildKonnectSupplier(supplierName, input.supplier),
     workflow: {
       invoicing: {
         auto_advance: true,
@@ -311,6 +316,7 @@ export async function createKonnectMerchantCustomInvoicingProfile(input: {
   name?: string;
   progressiveBilling?: boolean;
   collectionMethod?: "charge_automatically" | "send_invoice";
+  supplier?: BillingProfileSupplierInput;
 }): Promise<string> {
   const body = buildKonnectMerchantCustomInvoicingProfileBody(input);
   const profile = await billingFetch<KonnectBillingProfile>("/profiles", {
@@ -379,12 +385,14 @@ export async function createKonnectBillingProfile(input: {
   openmeterStripeAppId: string;
   name?: string;
   progressiveBilling?: boolean;
+  supplier?: BillingProfileSupplierInput;
 }): Promise<string> {
   const body = buildKonnectCreateBillingProfileBody({
     clientId: input.clientId,
     stripeAppId: input.openmeterStripeAppId,
     name: input.name,
     progressiveBilling: input.progressiveBilling,
+    supplier: input.supplier,
   });
   const profile = await billingFetch<KonnectBillingProfile>("/profiles", {
     method: "POST",
@@ -433,6 +441,37 @@ export async function updateKonnectBillingProfileProgressiveBilling(input: {
     body: JSON.stringify({
       ...replaceable,
       workflow,
+    }),
+  });
+}
+
+/** Replace the supplier on an existing Konnect billing profile (read-modify-write). */
+export async function updateKonnectBillingProfileSupplier(input: {
+  profileId: string;
+  name: string;
+  supplier?: BillingProfileSupplierInput;
+}): Promise<void> {
+  const existing = await billingFetch<Record<string, unknown>>(
+    `/profiles/${encodeURIComponent(input.profileId)}`,
+  );
+  if (!existing || typeof existing !== "object") {
+    throw new Error("Konnect billing profile not found");
+  }
+
+  const {
+    id: _id,
+    created_at: _createdAt,
+    updated_at: _updatedAt,
+    deleted_at: _deletedAt,
+    apps: _apps,
+    ...replaceable
+  } = existing;
+
+  await billingFetch(`/profiles/${encodeURIComponent(input.profileId)}`, {
+    method: "PUT",
+    body: JSON.stringify({
+      ...replaceable,
+      supplier: buildKonnectSupplier(input.name, input.supplier),
     }),
   });
 }

--- a/src/lib/openmeter/konnect-billing-profiles.ts
+++ b/src/lib/openmeter/konnect-billing-profiles.ts
@@ -48,7 +48,7 @@ export type KonnectCreateBillingProfileBody = {
       draft_period: string;
       progressive_billing?: boolean;
     };
-    payment: { collection_method: "charge_automatically" };
+    payment: { collection_method: "charge_automatically" | "send_invoice" };
   };
   apps: {
     tax: { id: string };
@@ -81,9 +81,20 @@ export function isKonnectStripeAppUnauthorized(app: KonnectBillingApp): boolean 
   return konnectAppType(app) === "stripe" && app.status === "unauthorized";
 }
 
+export function isKonnectCustomInvoicingApp(app: KonnectBillingApp): boolean {
+  return konnectAppType(app) === "custom_invoicing";
+}
+
 export function selectReadyKonnectStripeApp(apps: KonnectBillingApp[]): string | null {
   const stripe = apps.find((app) => isKonnectStripeAppReady(app));
   return stripe?.id ?? null;
+}
+
+export function selectKonnectCustomInvoicingApp(
+  apps: KonnectBillingApp[],
+): string | null {
+  const custom = apps.find((app) => isKonnectCustomInvoicingApp(app));
+  return custom?.id ?? null;
 }
 
 function uniqueAppIdsFromProfiles(profiles: KonnectBillingProfileListItem[]): string[] {
@@ -224,6 +235,92 @@ export function buildKonnectCreateBillingProfileBody(input: {
       payment: { id: input.stripeAppId },
     },
   };
+}
+
+/**
+ * Merchant-plane profile: tax / invoicing / payment all point at the Custom
+ * Invoicing app so OM pauses for pymthouse Connect collection.
+ */
+export function buildKonnectMerchantCustomInvoicingProfileBody(input: {
+  customInvoicingAppId: string;
+  name?: string;
+  progressiveBilling?: boolean;
+  collectionMethod?: "charge_automatically" | "send_invoice";
+}): KonnectCreateBillingProfileBody {
+  const appId = input.customInvoicingAppId;
+  return {
+    name: input.name || "pymthouse-merchant-custom-invoicing",
+    default: false,
+    supplier: {
+      name: input.name || "PymtHouse Merchant",
+      addresses: {
+        billing_address: { country: billingSupplierCountryCode() },
+      },
+    },
+    workflow: {
+      invoicing: {
+        auto_advance: true,
+        draft_period: "P0D",
+        progressive_billing: input.progressiveBilling ?? true,
+      },
+      payment: {
+        collection_method: input.collectionMethod ?? "charge_automatically",
+      },
+    },
+    apps: {
+      tax: { id: appId },
+      invoicing: { id: appId },
+      payment: { id: appId },
+    },
+  };
+}
+
+export async function resolveKonnectCustomInvoicingAppId(): Promise<string> {
+  const override = process.env.OPENMETER_CUSTOM_INVOICING_APP_ID?.trim();
+  if (override) {
+    const app = await getKonnectApp(override);
+    if (!app) {
+      throw new Error(
+        `OPENMETER_CUSTOM_INVOICING_APP_ID=${override} was not found. ` +
+          "Install Custom Invoicing in Konnect → Metering & Billing → Settings → Apps.",
+      );
+    }
+    if (!isKonnectCustomInvoicingApp(app)) {
+      throw new Error(
+        `OPENMETER_CUSTOM_INVOICING_APP_ID=${override} is type=${konnectAppType(app)}, expected custom_invoicing.`,
+      );
+    }
+    return override;
+  }
+
+  const apps = await listKonnectApps();
+  const fromApps = selectKonnectCustomInvoicingApp(apps);
+  if (fromApps) {
+    return fromApps;
+  }
+
+  throw new Error(
+    "No Custom Invoicing app found in Konnect. Install it via Marketplace " +
+      "(type=custom_invoicing) or set OPENMETER_CUSTOM_INVOICING_APP_ID. " +
+      `Listed apps: ${formatKonnectAppSummary(apps)}.`,
+  );
+}
+
+export async function createKonnectMerchantCustomInvoicingProfile(input: {
+  customInvoicingAppId: string;
+  name?: string;
+  progressiveBilling?: boolean;
+  collectionMethod?: "charge_automatically" | "send_invoice";
+}): Promise<string> {
+  const body = buildKonnectMerchantCustomInvoicingProfileBody(input);
+  const profile = await billingFetch<KonnectBillingProfile>("/profiles", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!profile?.id) {
+    throw new Error("Failed to create Konnect merchant Custom Invoicing billing profile");
+  }
+  return profile.id;
 }
 
 export async function resolveKonnectStripeAppId(): Promise<string> {

--- a/src/lib/openmeter/konnect-custom-invoicing-routes.test.ts
+++ b/src/lib/openmeter/konnect-custom-invoicing-routes.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { rewriteKonnectPathname } from "./konnect-routes";
+
+test("rewriteKonnectPathname maps custom-invoicing completion paths", () => {
+  assert.equal(
+    rewriteKonnectPathname(
+      "/api/v1/apps/custom-invoicing/01G65Z755AFWAKHE12NY0CQ9FH/draft/synchronized",
+      "POST",
+    ),
+    "/apps/custom-invoicing/01G65Z755AFWAKHE12NY0CQ9FH/draft/synchronized",
+  );
+  assert.equal(
+    rewriteKonnectPathname(
+      "/v3/openmeter/api/v1/apps/custom-invoicing/01G65Z755AFWAKHE12NY0CQ9FH/payment/status",
+      "POST",
+    ),
+    "/v3/openmeter/apps/custom-invoicing/01G65Z755AFWAKHE12NY0CQ9FH/payment/status",
+  );
+});

--- a/src/lib/openmeter/konnect-routes.ts
+++ b/src/lib/openmeter/konnect-routes.ts
@@ -57,6 +57,10 @@ export function rewriteKonnectPathname(pathname: string, method: string): string
 
   path = path.replace(/\/billing\/customers\/([^/]+)(?=\/|$)/, "/customers/$1/billing");
 
+  // Custom Invoicing completion endpoints keep `/apps/custom-invoicing/...`
+  // after the version strip (no further rewrite needed). Notification channels
+  // similarly land at `/notification/...`.
+
   const customerSubscriptions = CUSTOMER_SUBSCRIPTIONS_PATH_RE.exec(path);
   if (customerSubscriptions && method.toUpperCase() === "GET") {
     return path.replace(/\/customers\/[^/]+\/subscriptions$/, "/subscriptions");

--- a/src/lib/openmeter/settlement-metadata.ts
+++ b/src/lib/openmeter/settlement-metadata.ts
@@ -1,0 +1,34 @@
+/**
+ * Metadata keys consumed by pymthouse/settlement (and the #335 Railway worker)
+ * when resolving Stripe Connect charge routing for Custom Invoicing invoices.
+ *
+ * Invoice metadata wins over customer metadata over env default — OpenMeter
+ * freezes the invoice at creation, so stamp these before the first merchant
+ * invoice is raised.
+ *
+ * @see https://github.com/pymthouse/settlement
+ */
+
+export const SETTLEMENT_CHARGE_MODEL_KEY = "stripe_charge_model";
+export const SETTLEMENT_CONNECT_ACCOUNT_KEY = "stripe_connect_account_id";
+
+export type SettlementChargeModel = "platform" | "direct" | "destination";
+
+/**
+ * Merchant Custom Invoicing collects on the connected account (Plane B).
+ * Platform Stripe-app profiles never need these keys — OM handles payment.
+ */
+export function merchantSettlementMetadata(input: {
+  connectedAccountId: string;
+  /** Prefer direct when supplier is complete; otherwise destination. */
+  chargeModel: SettlementChargeModel;
+}): Record<string, string> {
+  const account = input.connectedAccountId.trim();
+  if (!account) {
+    throw new Error("connectedAccountId is required for merchant settlement metadata");
+  }
+  return {
+    [SETTLEMENT_CHARGE_MODEL_KEY]: input.chargeModel,
+    [SETTLEMENT_CONNECT_ACCOUNT_KEY]: account,
+  };
+}

--- a/src/lib/openmeter/stripe-app-install.ts
+++ b/src/lib/openmeter/stripe-app-install.ts
@@ -438,6 +438,10 @@ export async function getStripeConnectStatus(clientId: string) {
     activation = null;
   }
 
+  const { supplierStatusPayload } = await import(
+    "@/lib/openmeter/supplier-sync"
+  );
+
   return {
     status,
     billingReady,
@@ -457,5 +461,6 @@ export async function getStripeConnectStatus(clientId: string) {
     billingMode: config?.billingMode === "merchant" ? "merchant" : "owner_rollup",
     endUserCap: config?.endUserCap ?? DEFAULT_END_USER_CAP,
     activation,
+    ...supplierStatusPayload(config ?? {}),
   };
 }

--- a/src/lib/openmeter/supplier-sync.test.ts
+++ b/src/lib/openmeter/supplier-sync.test.ts
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildKonnectSupplierAddress,
+  buildOpenMeterSupplierAddress,
+  requiresSupplierTaxId,
+  supplierGaps,
+  supplierIsComplete,
+} from "./billing-supplier";
+import {
+  merchantSettlementMetadata,
+  SETTLEMENT_CHARGE_MODEL_KEY,
+  SETTLEMENT_CONNECT_ACCOUNT_KEY,
+} from "./settlement-metadata";
+import { resolveMerchantChargeModel } from "./supplier-sync";
+import { __testMapAccountIdentity } from "@/lib/stripe/connect-accounts";
+
+test("supplierGaps: US company needs no tax id", () => {
+  assert.deepEqual(
+    supplierGaps({ country: "US", name: "Acme LLC", taxId: null }),
+    [],
+  );
+  assert.equal(
+    supplierIsComplete({ country: "US", name: "Acme LLC", taxId: null }),
+    true,
+  );
+});
+
+test("supplierGaps: DE company needs tax id", () => {
+  assert.deepEqual(
+    supplierGaps({ country: "DE", name: "GmbH", taxId: null }),
+    ["tax_id"],
+  );
+  assert.deepEqual(
+    supplierGaps({ country: "DE", name: "GmbH", taxId: "DE123" }),
+    [],
+  );
+});
+
+test("supplierGaps: missing country and name", () => {
+  assert.deepEqual(supplierGaps({}), ["country", "name"]);
+});
+
+test("requiresSupplierTaxId covers EU and commons", () => {
+  assert.equal(requiresSupplierTaxId("de"), true);
+  assert.equal(requiresSupplierTaxId("US"), false);
+  assert.equal(requiresSupplierTaxId(null), false);
+});
+
+test("address builders omit null keys", () => {
+  const om = buildOpenMeterSupplierAddress({
+    country: "us",
+    addressCity: "  ",
+    addressLine1: "1 Main",
+  });
+  assert.deepEqual(om, { country: "US", line1: "1 Main" });
+
+  const kn = buildKonnectSupplierAddress({
+    country: "DE",
+    addressPostalCode: "10115",
+  });
+  assert.deepEqual(kn, { country: "DE", postal_code: "10115" });
+});
+
+test("mapAccountIdentity prefers company name and address", () => {
+  const id = __testMapAccountIdentity({
+    country: "de",
+    business_type: "company",
+    details_submitted: true,
+    company: {
+      name: "Acme GmbH",
+      address: {
+        line1: "Friedrichstr. 1",
+        city: "Berlin",
+        postal_code: "10117",
+      },
+      vat_id_provided: true,
+    },
+    individual: {
+      first_name: "A",
+      last_name: "B",
+      address: { line1: "Home" },
+    },
+  });
+  assert.equal(id.country, "DE");
+  assert.equal(id.legalName, "Acme GmbH");
+  assert.equal(id.addressLine1, "Friedrichstr. 1");
+  assert.equal(id.taxIdProvided, true);
+});
+
+test("mapAccountIdentity falls back to individual name", () => {
+  const id = __testMapAccountIdentity({
+    country: "US",
+    business_type: "individual",
+    details_submitted: true,
+    individual: { first_name: "Jane", last_name: "Doe" },
+  });
+  assert.equal(id.legalName, "Jane Doe");
+});
+
+test("resolveMerchantChargeModel gates direct on supplier completeness", () => {
+  assert.equal(
+    resolveMerchantChargeModel({
+      supplierCountry: "US",
+      supplierName: "Acme",
+      supplierTaxId: null,
+    }),
+    "direct",
+  );
+  assert.equal(
+    resolveMerchantChargeModel({
+      supplierCountry: "DE",
+      supplierName: "GmbH",
+      supplierTaxId: null,
+    }),
+    "destination",
+  );
+});
+
+test("merchantSettlementMetadata stamps settlement keys", () => {
+  const meta = merchantSettlementMetadata({
+    connectedAccountId: "acct_123",
+    chargeModel: "direct",
+  });
+  assert.equal(meta[SETTLEMENT_CHARGE_MODEL_KEY], "direct");
+  assert.equal(meta[SETTLEMENT_CONNECT_ACCOUNT_KEY], "acct_123");
+});

--- a/src/lib/openmeter/supplier-sync.ts
+++ b/src/lib/openmeter/supplier-sync.ts
@@ -1,0 +1,292 @@
+/**
+ * Sync Stripe Connect merchant identity onto app_billing_config and the
+ * OpenMeter / Konnect billing profile supplier.
+ *
+ * Invoices clone the profile at creation and are immutable — keep the supplier
+ * correct before the first merchant invoice, and re-sync on account.updated.
+ */
+import { getHostedAdminClient } from "./admin-client";
+import {
+  getAppBillingConfig,
+  upsertAppBillingConfig,
+} from "./billing-profiles";
+import {
+  type BillingProfileSupplierInput,
+  type SupplierGap,
+  buildOpenMeterSupplierAddress,
+  requiresSupplierTaxId,
+  supplierGaps,
+  supplierIsComplete,
+} from "./billing-supplier";
+import { getHostedOpenMeterUrl } from "./constants";
+import {
+  updateKonnectBillingProfileSupplier,
+} from "./konnect-billing-profiles";
+import { shouldUseKonnectRoutes } from "./route-mode";
+import {
+  type ConnectedAccountIdentity,
+  fetchConnectedAccountIdentity,
+} from "@/lib/stripe/connect-accounts";
+
+export function supplierFromBillingConfig(config: {
+  supplierCountry?: string | null;
+  supplierAddressLine1?: string | null;
+  supplierAddressLine2?: string | null;
+  supplierAddressCity?: string | null;
+  supplierAddressState?: string | null;
+  supplierAddressPostalCode?: string | null;
+  supplierTaxId?: string | null;
+}): BillingProfileSupplierInput {
+  return {
+    country: config.supplierCountry,
+    addressLine1: config.supplierAddressLine1,
+    addressLine2: config.supplierAddressLine2,
+    addressCity: config.supplierAddressCity,
+    addressState: config.supplierAddressState,
+    addressPostalCode: config.supplierAddressPostalCode,
+    taxId: config.supplierTaxId,
+  };
+}
+
+export function supplierDisplayName(config: {
+  clientId: string;
+  supplierName?: string | null;
+}): string {
+  const name = config.supplierName?.trim();
+  return name || `Tenant ${config.clientId}`;
+}
+
+export async function appSupplierGaps(
+  clientId: string,
+): Promise<SupplierGap[]> {
+  const config = await getAppBillingConfig(clientId);
+  if (!config) {
+    return ["country", "name"];
+  }
+  return supplierGaps({
+    country: config.supplierCountry,
+    name: config.supplierName,
+    taxId: config.supplierTaxId,
+  });
+}
+
+export async function syncSupplierToOpenMeterProfile(input: {
+  profileId: string;
+  name: string;
+  supplier?: BillingProfileSupplierInput;
+}): Promise<void> {
+  const useKonnect = shouldUseKonnectRoutes(
+    getHostedOpenMeterUrl(),
+    process.env.OPENMETER_API_KEY,
+  );
+  if (useKonnect) {
+    await updateKonnectBillingProfileSupplier({
+      profileId: input.profileId,
+      name: input.name,
+      supplier: input.supplier,
+    });
+    return;
+  }
+
+  const client = getHostedAdminClient();
+  const profile = await client.billing.profiles.get(input.profileId);
+  if (!profile?.id) {
+    throw new Error("OpenMeter billing profile not found");
+  }
+
+  const taxId = input.supplier?.taxId?.trim();
+  await client.billing.profiles.update(input.profileId, {
+    name: profile.name,
+    default: profile.default ?? false,
+    supplier: {
+      name: input.name,
+      addresses: [buildOpenMeterSupplierAddress(input.supplier)],
+      ...(taxId ? { taxId: { code: taxId } } : {}),
+    },
+    workflow: profile.workflow,
+    apps: profile.apps,
+  } as Parameters<typeof client.billing.profiles.update>[1]);
+}
+
+function preferredMerchantProfileId(config: {
+  openmeterMerchantBillingProfileId?: string | null;
+  openmeterBillingProfileId?: string | null;
+}): string | null {
+  return (
+    config.openmeterMerchantBillingProfileId?.trim() ||
+    config.openmeterBillingProfileId?.trim() ||
+    null
+  );
+}
+
+export type SyncTenantSupplierResult = {
+  status:
+    | "synced"
+    | "onboarding_incomplete"
+    | "no_account"
+    | "pushed_partial";
+  gaps: SupplierGap[];
+};
+
+/**
+ * Fetch Connect identity, persist columns, push to the billing profile.
+ * Never overwrites developer-supplied supplierTaxId.
+ */
+export async function syncTenantSupplierFromConnect(input: {
+  clientId: string;
+  accountId?: string;
+  identity?: ConnectedAccountIdentity;
+}): Promise<SyncTenantSupplierResult> {
+  const config = await getAppBillingConfig(input.clientId);
+  if (!config) {
+    return { status: "no_account", gaps: ["country", "name"] };
+  }
+
+  const accountId =
+    input.accountId?.trim() ||
+    config.stripeConnectedAccountId?.trim() ||
+    "";
+  if (!accountId) {
+    return { status: "no_account", gaps: ["country", "name"] };
+  }
+
+  const identity =
+    input.identity ?? (await fetchConnectedAccountIdentity(accountId));
+
+  // Bail when onboarding has not produced a country yet — avoid blanking a
+  // good supplier during re-onboarding.
+  if (!identity.detailsSubmitted && !identity.country) {
+    return {
+      status: "onboarding_incomplete",
+      gaps: supplierGaps({
+        country: config.supplierCountry,
+        name: config.supplierName,
+        taxId: config.supplierTaxId,
+      }),
+    };
+  }
+
+  const country = identity.country || config.supplierCountry || null;
+  const supplierName = identity.legalName || config.supplierName || null;
+
+  await upsertAppBillingConfig(input.clientId, {
+    supplierCountry: country,
+    supplierName,
+    supplierBusinessType: identity.businessType,
+    supplierAddressLine1: identity.addressLine1,
+    supplierAddressLine2: identity.addressLine2,
+    supplierAddressCity: identity.addressCity,
+    supplierAddressState: identity.addressState,
+    supplierAddressPostalCode: identity.addressPostalCode,
+    supplierTaxIdOnFileAtStripe: identity.taxIdProvided,
+    // Never overwrite developer-supplied tax id.
+    supplierSyncedAt: new Date().toISOString(),
+  });
+
+  const refreshed = await getAppBillingConfig(input.clientId);
+  const supplier = supplierFromBillingConfig(refreshed ?? config);
+  const name = supplierDisplayName({
+    clientId: input.clientId,
+    supplierName: refreshed?.supplierName ?? supplierName,
+  });
+  const gaps = supplierGaps({
+    country: refreshed?.supplierCountry ?? country,
+    name: refreshed?.supplierName ?? supplierName,
+    taxId: refreshed?.supplierTaxId,
+  });
+
+  const profileId = preferredMerchantProfileId(refreshed ?? config);
+  if (profileId) {
+    await syncSupplierToOpenMeterProfile({
+      profileId,
+      name,
+      supplier,
+    });
+  }
+
+  return {
+    status: gaps.length === 0 ? "synced" : "pushed_partial",
+    gaps,
+  };
+}
+
+export async function setAppSupplierTaxId(input: {
+  clientId: string;
+  taxId: string | null;
+}): Promise<SyncTenantSupplierResult> {
+  const trimmed = input.taxId?.trim() || null;
+  await upsertAppBillingConfig(input.clientId, {
+    supplierTaxId: trimmed,
+  });
+
+  const config = await getAppBillingConfig(input.clientId);
+  if (!config) {
+    return { status: "no_account", gaps: ["country", "name"] };
+  }
+
+  const supplier = supplierFromBillingConfig(config);
+  const name = supplierDisplayName(config);
+  const gaps = supplierGaps({
+    country: config.supplierCountry,
+    name: config.supplierName,
+    taxId: config.supplierTaxId,
+  });
+
+  const profileId = preferredMerchantProfileId(config);
+  if (profileId) {
+    await syncSupplierToOpenMeterProfile({
+      profileId,
+      name,
+      supplier,
+    });
+  }
+
+  return {
+    status: gaps.length === 0 ? "synced" : "pushed_partial",
+    gaps,
+  };
+}
+
+/** Prefer direct when supplier is complete; otherwise destination (platform MoR). */
+export function resolveMerchantChargeModel(config: {
+  supplierCountry?: string | null;
+  supplierName?: string | null;
+  supplierTaxId?: string | null;
+}): "direct" | "destination" {
+  if (
+    supplierIsComplete({
+      country: config.supplierCountry,
+      name: config.supplierName,
+      taxId: config.supplierTaxId,
+    })
+  ) {
+    return "direct";
+  }
+  return "destination";
+}
+
+export function supplierStatusPayload(config: {
+  supplierCountry?: string | null;
+  supplierName?: string | null;
+  supplierTaxId?: string | null;
+  supplierTaxIdOnFileAtStripe?: boolean | null;
+  supplierSyncedAt?: string | null;
+  supplierBusinessType?: string | null;
+}) {
+  const gaps = supplierGaps({
+    country: config.supplierCountry,
+    name: config.supplierName,
+    taxId: config.supplierTaxId,
+  });
+  return {
+    supplierCountry: config.supplierCountry ?? null,
+    supplierName: config.supplierName ?? null,
+    supplierBusinessType: config.supplierBusinessType ?? null,
+    supplierTaxId: config.supplierTaxId ?? null,
+    supplierTaxIdOnFileAtStripe: Boolean(config.supplierTaxIdOnFileAtStripe),
+    supplierTaxIdRequired: requiresSupplierTaxId(config.supplierCountry),
+    supplierSyncedAt: config.supplierSyncedAt ?? null,
+    supplierGaps: gaps,
+    supplierComplete: gaps.length === 0,
+  };
+}

--- a/src/lib/stripe/connect-accounts.ts
+++ b/src/lib/stripe/connect-accounts.ts
@@ -13,6 +13,106 @@ export type ConnectedAccountStatus = {
   detailsSubmitted: boolean;
 };
 
+/**
+ * KYC-verified merchant identity from the connected account — the supplier on
+ * merchant OpenMeter invoices. Stripe never shares the tax id value itself.
+ */
+export type ConnectedAccountIdentity = {
+  country: string | null;
+  legalName: string | null;
+  businessType: string | null;
+  addressLine1: string | null;
+  addressLine2: string | null;
+  addressCity: string | null;
+  addressState: string | null;
+  addressPostalCode: string | null;
+  taxIdProvided: boolean;
+  detailsSubmitted: boolean;
+};
+
+type StripeAddress = {
+  line1?: string | null;
+  line2?: string | null;
+  city?: string | null;
+  state?: string | null;
+  postal_code?: string | null;
+  country?: string | null;
+};
+
+type StripeAccountIdentityShape = {
+  id?: string;
+  country?: string | null;
+  business_type?: string | null;
+  details_submitted?: boolean;
+  business_profile?: { name?: string | null } | null;
+  company?: {
+    name?: string | null;
+    address?: StripeAddress | null;
+    tax_id_provided?: boolean;
+    vat_id_provided?: boolean;
+  } | null;
+  individual?: {
+    first_name?: string | null;
+    last_name?: string | null;
+    address?: StripeAddress | null;
+  } | null;
+  settings?: { dashboard?: { display_name?: string | null } | null } | null;
+};
+
+function trimmedOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function resolveLegalName(account: StripeAccountIdentityShape): string | null {
+  const individualName = [
+    trimmedOrNull(account.individual?.first_name),
+    trimmedOrNull(account.individual?.last_name),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return (
+    trimmedOrNull(account.company?.name) ??
+    (individualName || null) ??
+    trimmedOrNull(account.business_profile?.name) ??
+    trimmedOrNull(account.settings?.dashboard?.display_name)
+  );
+}
+
+function mapAccountIdentity(
+  account: StripeAccountIdentityShape,
+): ConnectedAccountIdentity {
+  const address = account.company?.address ?? account.individual?.address ?? null;
+  return {
+    country: trimmedOrNull(account.country)?.toUpperCase() ?? null,
+    legalName: resolveLegalName(account),
+    businessType: trimmedOrNull(account.business_type),
+    addressLine1: trimmedOrNull(address?.line1),
+    addressLine2: trimmedOrNull(address?.line2),
+    addressCity: trimmedOrNull(address?.city),
+    addressState: trimmedOrNull(address?.state),
+    addressPostalCode: trimmedOrNull(address?.postal_code),
+    taxIdProvided: Boolean(
+      account.company?.tax_id_provided || account.company?.vat_id_provided,
+    ),
+    detailsSubmitted: Boolean(account.details_submitted),
+  };
+}
+
+export async function fetchConnectedAccountIdentity(
+  accountId: string,
+): Promise<ConnectedAccountIdentity> {
+  const account = await stripeFormRequest<StripeAccountIdentityShape>({
+    method: "GET",
+    path: `/v1/accounts/${encodeURIComponent(accountId)}`,
+  });
+  return mapAccountIdentity(account);
+}
+
+/** Exported for tests. */
+export const __testMapAccountIdentity = mapAccountIdentity;
+
 function requireStripeSecretKey(): string {
   const key =
     process.env.STRIPE_SECRET_KEY?.trim() || process.env.STRIPE_API_KEY?.trim();

--- a/src/lib/stripe/connect-charges.test.ts
+++ b/src/lib/stripe/connect-charges.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createOffSessionConnectedPaymentIntent } from "./connect-charges";
+
+test("createOffSessionConnectedPaymentIntent posts PI with Stripe-Account and Idempotency-Key", async (t) => {
+  const savedKey = process.env.STRIPE_SECRET_KEY;
+  process.env.STRIPE_SECRET_KEY = "sk_test_connect_charges";
+
+  const calls: Array<{
+    url: string;
+    headers: Record<string, string>;
+    body: string;
+  }> = [];
+
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const headers: Record<string, string> = {};
+    const h = init?.headers;
+    if (h && typeof h === "object" && !(h instanceof Headers)) {
+      Object.assign(headers, h as Record<string, string>);
+    }
+    calls.push({
+      url,
+      headers,
+      body: String(init?.body ?? ""),
+    });
+    return new Response(
+      JSON.stringify({ id: "pi_test_123", status: "processing" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  t.after(() => {
+    process.env.STRIPE_SECRET_KEY = savedKey;
+  });
+
+  const result = await createOffSessionConnectedPaymentIntent({
+    accountId: "acct_merchant",
+    customerId: "cus_enduser",
+    amountCents: 1234,
+    applicationFeeBps: 250,
+    idempotencyKey: "01G65Z755AFWAKHE12NY0CQ9FH",
+    metadata: { openmeter_invoice_id: "01G65Z755AFWAKHE12NY0CQ9FH" },
+  });
+
+  assert.equal(result.kind, "payment_intent");
+  if (result.kind === "payment_intent") {
+    assert.equal(result.paymentIntentId, "pi_test_123");
+    assert.equal(result.applicationFeeAmount, 30); // floor(1234 * 250 / 10000)
+  }
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].url, /\/v1\/payment_intents$/);
+  assert.equal(calls[0].headers["Stripe-Account"], "acct_merchant");
+  assert.equal(
+    calls[0].headers["Idempotency-Key"],
+    "01G65Z755AFWAKHE12NY0CQ9FH",
+  );
+  assert.match(calls[0].body, /off_session=true/);
+  assert.match(calls[0].body, /confirm=true/);
+  assert.match(calls[0].body, /application_fee_amount=30/);
+});

--- a/src/lib/stripe/connect-charges.ts
+++ b/src/lib/stripe/connect-charges.ts
@@ -1,0 +1,217 @@
+/**
+ * Off-session PaymentIntent charges on Stripe Connected Accounts (direct charges
+ * + application_fee_amount). Falls back to hosted invoice when no default PM.
+ */
+import {
+  applicationFeeAmountCents,
+  createConnectedInvoice,
+} from "@/lib/stripe/connect-accounts";
+
+function requireStripeSecretKey(): string {
+  const key =
+    process.env.STRIPE_SECRET_KEY?.trim() || process.env.STRIPE_API_KEY?.trim();
+  if (!key?.startsWith("sk_")) {
+    throw new Error(
+      "STRIPE_SECRET_KEY is required for Connect charges (must be sk_… platform key)",
+    );
+  }
+  return key;
+}
+
+function buildOffSessionPaymentIntentBody(input: {
+  amountCents: number;
+  currency: string;
+  customerId: string;
+  fee: number;
+  description?: string;
+  metadata?: Record<string, string>;
+}): URLSearchParams {
+  const body = new URLSearchParams();
+  body.set("amount", String(input.amountCents));
+  body.set("currency", input.currency);
+  body.set("customer", input.customerId);
+  body.set("confirm", "true");
+  body.set("off_session", "true");
+  body.set("automatic_payment_methods[enabled]", "true");
+  body.set("automatic_payment_methods[allow_redirects]", "never");
+  if (input.fee > 0) {
+    body.set("application_fee_amount", String(input.fee));
+  }
+  if (input.description?.trim()) {
+    body.set("description", input.description.trim());
+  }
+  for (const [key, value] of Object.entries(input.metadata ?? {})) {
+    if (key.trim() && value.trim()) {
+      body.set(`metadata[${key.trim()}]`, value.trim());
+    }
+  }
+  return body;
+}
+
+function isMissingPaymentMethodError(err: unknown): boolean {
+  const stripeCode =
+    err && typeof err === "object" && "stripeCode" in err
+      ? String((err as { stripeCode?: string }).stripeCode ?? "")
+      : "";
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    stripeCode === "invoice_no_payment_method_types" ||
+    /no.*payment.?method|off_session.*payment_method/i.test(message)
+  );
+}
+
+async function stripeFormRequest<T>(input: {
+  method: string;
+  path: string;
+  body?: URLSearchParams;
+  stripeAccount?: string;
+  idempotencyKey?: string;
+}): Promise<T> {
+  const apiKey = requireStripeSecretKey();
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+  if (input.stripeAccount) {
+    headers["Stripe-Account"] = input.stripeAccount;
+  }
+  if (input.idempotencyKey?.trim()) {
+    headers["Idempotency-Key"] = input.idempotencyKey.trim();
+  }
+  const response = await fetch(`https://api.stripe.com${input.path}`, {
+    method: input.method,
+    headers,
+    body: input.body?.toString(),
+    signal: AbortSignal.timeout(30_000),
+  });
+  let json: T & { error?: { message?: string; code?: string } };
+  try {
+    json = (await response.json()) as T & {
+      error?: { message?: string; code?: string };
+    };
+  } catch {
+    throw new Error(
+      `Stripe ${input.method} ${input.path} failed (${response.status}): non-JSON body`,
+    );
+  }
+  if (!response.ok) {
+    const err = new Error(
+      `Stripe ${input.method} ${input.path} failed (${response.status}): ${
+        json.error?.message ?? JSON.stringify(json)
+      }`,
+    ) as Error & { stripeCode?: string };
+    err.stripeCode = json.error?.code;
+    throw err;
+  }
+  return json;
+}
+
+export type OffSessionChargeResult =
+  | {
+      kind: "payment_intent";
+      paymentIntentId: string;
+      status: string;
+      applicationFeeAmount: number;
+    }
+  | {
+      kind: "hosted_invoice";
+      invoiceId: string;
+      hostedInvoiceUrl: string | null;
+      applicationFeeAmount: number;
+    };
+
+/**
+ * Create + confirm an off-session PaymentIntent on the connected account.
+ * Idempotency-Key should be the OpenMeter invoice id.
+ *
+ * Do NOT treat a successful create as final payment — wait for Stripe webhooks
+ * (payment_intent.succeeded / payment_failed / requires_action).
+ */
+export async function createOffSessionConnectedPaymentIntent(input: {
+  accountId: string;
+  customerId: string;
+  amountCents: number;
+  currency?: string;
+  applicationFeeBps?: number;
+  description?: string;
+  idempotencyKey: string;
+  metadata?: Record<string, string>;
+}): Promise<OffSessionChargeResult> {
+  if (input.amountCents <= 0) {
+    throw new Error("amountCents must be a positive integer");
+  }
+  const currency = (input.currency ?? "usd").toLowerCase();
+  const fee = applicationFeeAmountCents({
+    amountCents: input.amountCents,
+    applicationFeeBps: input.applicationFeeBps ?? 0,
+  });
+
+  const body = buildOffSessionPaymentIntentBody({
+    amountCents: input.amountCents,
+    currency,
+    customerId: input.customerId,
+    fee,
+    description: input.description,
+    metadata: input.metadata,
+  });
+
+  try {
+    const pi = await stripeFormRequest<{
+      id?: string;
+      status?: string;
+    }>({
+      method: "POST",
+      path: "/v1/payment_intents",
+      body,
+      stripeAccount: input.accountId,
+      idempotencyKey: input.idempotencyKey,
+    });
+    if (!pi.id?.startsWith("pi_")) {
+      throw new Error("Stripe did not return a PaymentIntent id");
+    }
+    return {
+      kind: "payment_intent",
+      paymentIntentId: pi.id,
+      status: String(pi.status ?? "unknown"),
+      applicationFeeAmount: fee,
+    };
+  } catch (err) {
+    if (!isMissingPaymentMethodError(err)) {
+      throw err;
+    }
+    const invoice = await createConnectedInvoice({
+      accountId: input.accountId,
+      customerId: input.customerId,
+      amountCents: input.amountCents,
+      currency,
+      description: input.description,
+      applicationFeeBps: input.applicationFeeBps,
+      autoAdvance: true,
+      idempotencyKey: `${input.idempotencyKey}:invoice`,
+    });
+    return {
+      kind: "hosted_invoice",
+      invoiceId: invoice.invoiceId,
+      hostedInvoiceUrl: invoice.hostedInvoiceUrl,
+      applicationFeeAmount: fee,
+    };
+  }
+}
+
+/** Retrieve a PaymentIntent on a connected account (sweeper / reconcile). */
+export async function retrieveConnectedPaymentIntent(input: {
+  accountId: string;
+  paymentIntentId: string;
+}): Promise<{ id: string; status: string }> {
+  const pi = await stripeFormRequest<{ id?: string; status?: string }>({
+    method: "GET",
+    path: `/v1/payment_intents/${encodeURIComponent(input.paymentIntentId)}`,
+    stripeAccount: input.accountId,
+  });
+  if (!pi.id) {
+    throw new Error("PaymentIntent not found");
+  }
+  return { id: pi.id, status: String(pi.status ?? "unknown") };
+}
+
+export { applicationFeeAmountCents };

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -99,6 +99,22 @@ export async function applyConnectedAccountWebhookUpdate(input: {
     payoutsEnabled: input.payoutsEnabled,
     detailsSubmitted: input.detailsSubmitted,
   });
+  // Best-effort supplier sync — must not block Connect onboarding.
+  try {
+    const { syncTenantSupplierFromConnect } = await import(
+      "@/lib/openmeter/supplier-sync"
+    );
+    await syncTenantSupplierFromConnect({
+      clientId,
+      accountId: input.accountId,
+    });
+  } catch (err) {
+    console.warn(
+      "supplier sync after account.updated failed",
+      clientId,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
   return { updated: true, clientId };
 }
 


### PR DESCRIPTION
## Summary
- Rebased onto `main` (migration renumbered `0036` → `0041_merchant_custom_invoicing`).
- Merchant Custom Invoicing via OpenMeter + Stripe Connect (Neon ledger + Railway worker interim).
- **Supplier sync:** Connect KYC → `app_billing_config` + OM/Konnect billing profile supplier; tax id developer-supplied; gate merchant mode until complete.
- **Settlement wiring:** stamp `stripe_charge_model` / `stripe_connect_account_id` on merchant OM customers (`direct` when supplier complete, else `destination`). Plane A Stripe-app profiles remain OM-native (no settlement).

## Test plan
- [ ] `npx tsx --test src/lib/openmeter/supplier-sync.test.ts` (+ Custom Invoicing tests)
- [ ] `npx tsc --noEmit`
- [ ] Apply migrations `0041` + `0042`
- [ ] Connect onboarding → `account.updated` fills supplier country/name on billing status GET
- [ ] PATCH `supplierTaxId` for DE merchant; then switch `billingMode=merchant`
- [ ] Merchant customer provision stamps settlement metadata keys
- [ ] Optional: `npx tsx scripts/openmeter-backfill-connect-suppliers.ts --dry-run`

## Notes
- Durable Kafka settlement: https://github.com/pymthouse/settlement. Railway `invoicing-worker` remains the interim collector from this PR.
- Orphan Stripe webhook endpoints for deleted OM Stripe apps should be cleaned up separately (ops).