### PR TITLE
fix(security): remove user-controlled branch from Stripe OAuth callback

### DIFF
--- a/src/app/api/v1/apps/[id]/billing/stripe/oauth/callback/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/oauth/callback/route.ts
@@ -22,10 +22,10 @@ export async function GET(
   // Authorization is the server-side OAuth state + Stripe code exchange inside
   // completeMerchantConnectOAuth — not the absence of a provider `error` param.
   // Only use `error` for UX when code/state are missing (OAuth denial / cancel).
+  // The sanitizer maps the provider error (including empty) to a fixed constant,
+  // so no user-controlled value branches here or reaches the redirect.
   if (!code || !state) {
-    const errorCode = oauthError
-      ? sanitizeStripeOAuthProviderError(oauthError)
-      : "missing_oauth_params";
+    const errorCode = sanitizeStripeOAuthProviderError(oauthError);
     return NextResponse.redirect(
       `${paymentsUrl}&error=${encodeURIComponent(errorCode)}`,
     );

--- a/src/lib/stripe/webhook.test.ts
+++ b/src/lib/stripe/webhook.test.ts
@@ -122,6 +122,8 @@ test("sanitizeStripeOAuthProviderError allowlists Stripe codes", () => {
     sanitizeStripeOAuthProviderError("totally_weird<script>"),
     "oauth_denied",
   );
+  assert.equal(sanitizeStripeOAuthProviderError(""), "missing_oauth_params");
+  assert.equal(sanitizeStripeOAuthProviderError("   "), "missing_oauth_params");
 });
 
 test("paymentsTabErrorMessage ignores free-form phishing text", () => {

--- a/src/lib/stripe/webhook.ts
+++ b/src/lib/stripe/webhook.ts
@@ -142,19 +142,28 @@ export function merchantConnectOAuthErrorCode(err: unknown): string {
   return "oauth_failed";
 }
 
-/** Allowlist Stripe-provided OAuth `error` query values for redirects. */
+/**
+ * Allowlist Stripe-provided OAuth `error` query values for redirects.
+ *
+ * Always returns a constant from this fixed map — never the caller-provided
+ * string — so user input cannot flow into redirects or control branching
+ * (CodeQL js/user-controlled-bypass). A missing/empty provider error maps to
+ * "missing_oauth_params".
+ */
+const STRIPE_OAUTH_PROVIDER_ERROR_CODES: Readonly<Record<string, string>> = {
+  "": "missing_oauth_params",
+  access_denied: "access_denied",
+  invalid_request: "invalid_request",
+  invalid_client: "invalid_client",
+  invalid_grant: "invalid_grant",
+  unauthorized_client: "unauthorized_client",
+  unsupported_response_type: "unsupported_response_type",
+  invalid_scope: "invalid_scope",
+  server_error: "server_error",
+  temporarily_unavailable: "temporarily_unavailable",
+};
+
 export function sanitizeStripeOAuthProviderError(error: string): string {
   const code = error.trim().toLowerCase();
-  const allowed = new Set([
-    "access_denied",
-    "invalid_request",
-    "invalid_client",
-    "invalid_grant",
-    "unauthorized_client",
-    "unsupported_response_type",
-    "invalid_scope",
-    "server_error",
-    "temporarily_unavailable",
-  ]);
-  return allowed.has(code) ? code : "oauth_denied";
+  return STRIPE_OAUTH_PROVIDER_ERROR_CODES[code] ?? "oauth_denied";
 }


### PR DESCRIPTION
## Summary
- Resolves CodeQL alert [#118](https://github.com/pymthouse/pymthouse/security/code-scanning/118) (`js/user-controlled-bypass`, high) in `src/app/api/v1/apps/[id]/billing/stripe/oauth/callback/route.ts`
- `sanitizeStripeOAuthProviderError` now maps the provider `error` param through a fixed constant table and never returns the input string; the empty case folds into the map (`missing_oauth_params`), so the route has no user-controlled conditional and no tainted value reaches the redirect

## Verification
- [x] Local CodeQL scan (`Security/CWE-807/ConditionalBypass.ql`): baseline `main` reproduces the finding at the flagged line; this branch reports 0 findings
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` clean on changed files
- [x] `src/lib/stripe/webhook.test.ts` passes (7/7), with new cases for empty/whitespace provider error
- [ ] CI green on the PR