### PR TITLE
fix(billing): personal keys bill to owner wallet

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -14,7 +14,7 @@ Dashboard wizard (post-auth) also lives at `/onboarding`. This document covers t
 
 | Persona | Who | App model |
 | --- | --- | --- |
-| **Explorer** | Individual / try the network | Joins the platform **default app** as an `app_users` row. Usage: `app_<defaultClientId>:<users.id>` on that app’s Starter plan. No OIDC/M2M settings UI. |
+| **Explorer** | Individual / try the network | Joins the platform **default app** as an `app_users` row. Usage bills to the user’s own owner wallet (`users.id`) on the platform **Owner Starter** plan — not as an end-user of the admin-owned default app. No OIDC/M2M settings UI. |
 | **Builder** | Product / merchant | Creates an owned `developer_apps` row. Full Builder API, plans, users, Stripe. |
 
 The platform default app is flagged `is_platform_default = 1` (or pinned via `PYMTHOUSE_DEFAULT_APP_CLIENT_ID`). Only platform **admins** may edit its config. Its `m2m_…` credentials are **not** for third-party Builder integrations — use your own app.

--- a/src/lib/openmeter/billing-identity.test.ts
+++ b/src/lib/openmeter/billing-identity.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import {
+  resetBillingIdentityCacheForTests,
+  resolveOpenMeterBillingIdentity,
+} from "@/lib/openmeter/billing-identity";
+import {
+  buildOpenMeterCustomerKey,
+  buildOwnerCustomerKey,
+} from "@/lib/openmeter/customer-key";
+import { test } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  createTestUserWithCleanup,
+  seedDeveloperAppWithClient,
+} from "@/test-utils/fixtures";
+import { withTemporaryPlatformDefault } from "@/test-utils/platform-default-lock";
+
+test("platform-default member bills their own owner wallet", async (t) => {
+  const seeded = await seedDeveloperAppWithClient();
+  t.after(async () => cleanupTestApp(seeded));
+  const memberId = await createTestUserWithCleanup(t);
+
+  resetBillingIdentityCacheForTests();
+  await withTemporaryPlatformDefault(seeded.clientId, async () => {
+    resetBillingIdentityCacheForTests();
+    const identity = await resolveOpenMeterBillingIdentity({
+      clientId: seeded.clientId,
+      externalUserId: memberId,
+    });
+    assert.equal(identity.isOwner, true);
+    assert.equal(identity.ownerUserId, memberId);
+    assert.equal(identity.customerKey, buildOwnerCustomerKey(memberId));
+    assert.notEqual(identity.customerKey, buildOwnerCustomerKey(seeded.userId));
+    assert.equal(identity.publicClientId, seeded.clientId);
+  });
+});
+
+test("platform-default admin owner still bills own wallet", async (t) => {
+  const seeded = await seedDeveloperAppWithClient();
+  t.after(async () => cleanupTestApp(seeded));
+
+  resetBillingIdentityCacheForTests();
+  await withTemporaryPlatformDefault(seeded.clientId, async () => {
+    resetBillingIdentityCacheForTests();
+    const identity = await resolveOpenMeterBillingIdentity({
+      clientId: seeded.clientId,
+      externalUserId: seeded.userId,
+    });
+    assert.equal(identity.isOwner, true);
+    assert.equal(identity.ownerUserId, seeded.userId);
+    assert.equal(identity.customerKey, buildOwnerCustomerKey(seeded.userId));
+  });
+});
+
+test("normal app end-user stays on compound customer", async (t) => {
+  const seeded = await seedDeveloperAppWithClient();
+  t.after(async () => cleanupTestApp(seeded));
+  const endUserId = `ext-${randomUUID()}`;
+
+  resetBillingIdentityCacheForTests();
+  const identity = await resolveOpenMeterBillingIdentity({
+    clientId: seeded.clientId,
+    externalUserId: endUserId,
+  });
+  assert.equal(identity.isOwner, false);
+  assert.equal(identity.ownerUserId, undefined);
+  assert.equal(
+    identity.customerKey,
+    buildOpenMeterCustomerKey(seeded.clientId, endUserId),
+  );
+});
+
+test("normal app owner bills shared owner wallet", async (t) => {
+  const seeded = await seedDeveloperAppWithClient();
+  t.after(async () => cleanupTestApp(seeded));
+
+  resetBillingIdentityCacheForTests();
+  const identity = await resolveOpenMeterBillingIdentity({
+    clientId: seeded.clientId,
+    externalUserId: seeded.userId,
+  });
+  assert.equal(identity.isOwner, true);
+  assert.equal(identity.ownerUserId, seeded.userId);
+  assert.equal(identity.customerKey, buildOwnerCustomerKey(seeded.userId));
+});

--- a/src/lib/openmeter/billing-identity.ts
+++ b/src/lib/openmeter/billing-identity.ts
@@ -31,6 +31,7 @@ type AppIdentityRow = {
   developerAppId: string;
   publicClientId: string;
   ownerId: string;
+  isPlatformDefault: boolean;
 };
 
 async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow | null> {
@@ -44,6 +45,7 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
       developerAppId: developerApps.id,
       publicClientId: oidcClients.clientId,
       ownerId: developerApps.ownerId,
+      isPlatformDefault: developerApps.isPlatformDefault,
     })
     .from(developerApps)
     .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
@@ -51,7 +53,12 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
     .limit(1);
 
   if (byPublic[0]?.publicClientId) {
-    return byPublic[0];
+    return {
+      developerAppId: byPublic[0].developerAppId,
+      publicClientId: byPublic[0].publicClientId,
+      ownerId: byPublic[0].ownerId,
+      isPlatformDefault: byPublic[0].isPlatformDefault === 1,
+    };
   }
 
   const byAppId = await db
@@ -59,6 +66,7 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
       developerAppId: developerApps.id,
       publicClientId: oidcClients.clientId,
       ownerId: developerApps.ownerId,
+      isPlatformDefault: developerApps.isPlatformDefault,
     })
     .from(developerApps)
     .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
@@ -73,6 +81,7 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
     developerAppId: row.developerAppId,
     publicClientId: row.publicClientId?.trim() || row.developerAppId,
     ownerId: row.ownerId,
+    isPlatformDefault: row.isPlatformDefault === 1,
   };
 }
 
@@ -100,7 +109,8 @@ export function resetBillingIdentityCacheForTests(): void {
 /**
  * Resolve the OpenMeter billing customer for an (app, external user) pair.
  * App owners map to a single bare `{users.id}` customer across all apps;
- * M2M end-users stay on `app_…:externalUserId`.
+ * platform-default (Livepeer Direct) members bill their own owner wallet;
+ * M2M end-users on normal apps stay on `app_…:externalUserId`.
  */
 export async function resolveOpenMeterBillingIdentity(input: {
   clientId: string;
@@ -160,6 +170,18 @@ async function resolveOpenMeterBillingIdentityUncached(input: {
       customerKey: buildOwnerCustomerKey(app.ownerId),
       isOwner: true,
       ownerUserId: app.ownerId,
+      publicClientId: app.publicClientId,
+      developerAppId: app.developerAppId,
+    };
+  }
+
+  // Explorer / personal network keys on Livepeer Direct: each platform user
+  // bills their own owner wallet (Owner Starter), not the admin app owner.
+  if (app.isPlatformDefault) {
+    return {
+      customerKey: buildOwnerCustomerKey(normalized),
+      isOwner: true,
+      ownerUserId: normalized,
       publicClientId: app.publicClientId,
       developerAppId: app.developerAppId,
     };


### PR DESCRIPTION
## Summary
- Platform-default (Livepeer Direct) personal/Explorer users now resolve to their own owner wallet + Owner Starter instead of a compound end-user customer on the admin-owned app.
- Fixes Usage showing billable personal key traffic while the banner says “No active subscription on your billing wallet yet.”
- Aligns `docs/onboarding.md` with the activation-gate cost rail; adds billing-identity coverage for platform-default vs normal apps.

## Test plan
- [ ] Mint a personal network key as a non-admin Explorer and confirm Owner Starter appears on `/usage` and `/billing`
- [ ] Confirm personal Livepeer Direct usage still meters/attributes to the viewer
- [ ] Confirm a normal app’s M2M end-user still uses compound `app_…:externalUserId`
- [ ] Confirm a normal app owner still shares the bare `users.id` owner wallet
- [ ] CI: typecheck / SonarQube / Snyk green on the PR