### PR TITLE
feat(usage/billing): usage page + Payments tab (Phases 3–4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,6 +158,13 @@ OPENMETER_INGEST_API_KEY=
 # off | log | enforce_revenue | enforce
 # ACTIVATION_GATE_MODE=off
 OPENMETER_TRIAL_FEATURE_KEY=network_spend
+
+# Cost-rail defaults a new app inherits. These protect PymtHouse rather than
+# configure the Builder, so they are admin-only on the API and read-only in the
+# app's Payments tab. Setting them here changes platform policy without a
+# migration. Unset = 25 end users, 0 bps fee (the column defaults).
+# PYMTHOUSE_DEFAULT_END_USER_CAP=25
+# PYMTHOUSE_DEFAULT_APPLICATION_FEE_BPS=0
 # Default included usage (USD micros) when seeding per-app Starter plan (5000000 = $5)
 OPENMETER_DEFAULT_STARTER_INCLUDED_USD_MICROS=5000000
 

--- a/docs/adr-owner-vs-app-billing.md
+++ b/docs/adr-owner-vs-app-billing.md
@@ -1,6 +1,9 @@
 # ADR: Owner subscriptions vs. app subscriptions
 
-Status: **proposed**.
+Status: **accepted** — partially implemented. See
+[Implementation status](#implementation-status) for what has shipped and what
+is outstanding; this ADR stays until the deferred items land, because it also
+records why rules now enforced in code exist.
 Companion to [`activation-gate.md`](./activation-gate.md) and
 [`adr-stripe-connect-openmeter-webhooks.md`](./adr-stripe-connect-openmeter-webhooks.md),
 which established the cost/revenue rail split. This ADR applies that split to
@@ -198,6 +201,39 @@ irreversible:
 
 Step 5 is severable and should not wait for the model change — it closes a live
 revenue and exposure hole.
+
+## Implementation status
+
+Shipped (PR #348):
+
+- Symptom 3 — `applicationFeeBps` and `endUserCap` are rejected with `403` on
+  the owner path; the Payments tab renders them read-only and attributed to the
+  platform, and omits them from the PATCH body for non-admins.
+  `scripts/audit-platform-billing-fields.ts` reports current values.
+- Rule 1 — already satisfied before this ADR:
+  `resolveOpenMeterBillingIdentity` routes an owner on their own app to the
+  shared owner wallet, and the customer and starter-subscription paths honour
+  it. One live gap was closed: `programmatic-tokens` hardcoded
+  `user_type: "app_user"`, so owner traffic through that path was metered to
+  `app_…:{ownerId}` and never invoiced.
+- Rule 2 / UI — `/billing` leads with the account-level plan and lists every
+  owned app with where its usage settles.
+- Usage reads follow customer id — `resolveCustomerSubjectKeys` backs the owner
+  read path, and `classifyUsageAttributionConsistency` reports unattributed
+  usage.
+
+Outstanding:
+
+- **Symptom 1 (schema)** — `end_user_cap` and `application_fee_bps` still live
+  on `app_billing_config`. Authorization is correct, so their location is now
+  cosmetic; the move is deferred, not abandoned.
+- **Symptom 4** — `subscriptions.client_id` is still `NOT NULL`, so the platform
+  subscription still has no local row and exists only in OpenMeter. This is why
+  the plan name on the billing card cannot come from PymtHouse's own database.
+- **Migration steps 1–4** — backfill, enforce, dual-read, cutover. The
+  transitional union in `buildOwnerMeterSubjects` and the three
+  `openmeter-*-owner-*` scripts remain until
+  `usage_on_unattributed_subject` reports zero across all owners.
 
 ### Risks
 

--- a/docs/adr-owner-vs-app-billing.md
+++ b/docs/adr-owner-vs-app-billing.md
@@ -1,0 +1,169 @@
+# ADR: Owner subscriptions vs. app subscriptions
+
+Status: **proposed**.
+Companion to [`activation-gate.md`](./activation-gate.md) and
+[`adr-stripe-connect-openmeter-webhooks.md`](./adr-stripe-connect-openmeter-webhooks.md),
+which established the cost/revenue rail split. This ADR applies that split to
+**subscriptions and billing configuration**, which still conflate the two.
+
+## Context
+
+`activation-gate.md` already defines two independent rails:
+
+| Rail | Who pays whom | Always on? |
+|---|---|---|
+| **Cost** | App owner pays PymtHouse for all network usage their apps generate | Yes |
+| **Revenue** | Builder's end users pay the Builder | Opt-in (Connect) |
+
+The rails are correct. What is not correct is that **the objects representing
+them do not follow them**, so an owner with several apps cannot tell what they
+are subscribed to, where their usage went, or who is billing whom.
+
+### Symptom 1 — per-app config for an account-level relationship
+
+`app_billing_config` has one row per app and mixes both rails in the same table
+and the same UI tab:
+
+| Field | Rail | Correct scope today? |
+|---|---|---|
+| `billing_mode` | Revenue | ✅ per app |
+| `stripe_connected_account_id`, `stripe_*_enabled`, `stripe_onboarding_method` | Revenue | ⚠️ per app — but a Builder has one Stripe account, not one per app |
+| `checkout_success_url`, `checkout_cancel_url`, `default_currency` | Revenue | ✅ per app |
+| `progressive_billing`, `invoice_threshold_usd_micros` | Revenue (Builder → end users) | ✅ per app |
+| `end_user_cap` | **Cost** | ❌ owner-editable; see Symptom 3 |
+| `application_fee_bps` | **Platform revenue** | ❌ owner-editable; see Symptom 3 |
+
+A developer who owns four apps configures four of these, and none of them is the
+thing they actually bought — their PymtHouse plan.
+
+### Symptom 2 — the owner as a customer of their own app
+
+Owner usage historically metered to compound subjects
+`app_…:{ownerId}` and `app_…:owner:{ownerId}` — the owner as an end user of
+their own application. Migration away from this is already underway and
+incomplete:
+
+- `scripts/openmeter-migrate-owner-customers.ts` — moves owners onto a shared
+  customer keyed by bare `{users.id}`, transfers prepaid balances, cancels
+  subscriptions on legacy customers.
+- `scripts/openmeter-dedupe-owner-subscriptions.ts` — its header states the
+  problem directly: owners can hold an active subscription on both the shared
+  wallet *and* legacy per-app wallets, "which shows as multiple tiles on Billing
+  / Usage."
+- `scripts/openmeter-release-legacy-subjects.ts` — releases the legacy subjects.
+- `buildOwnerMeterSubjects()` still dual-reads all four forms, because the
+  legacy state persists in live data.
+
+This is remediation without a rule, so the state keeps being reachable.
+
+### Symptom 3 — platform controls are editable by the party they constrain
+
+`canManageMerchantBilling()` returns true when `app.ownerId === userId`, and
+`PATCH /api/v1/apps/{id}/billing/stripe` accepts every field behind that one
+check. Two of those fields are not the Builder's to set:
+
+- **`application_fee_bps`** is PymtHouse's share of Connect payments. An app
+  owner can set it to `0`. `activation-gate.md` anticipates a Builder pricing
+  retail at `$0` so the fee "collects a percentage of nothing"; they do not need
+  to bother — they can zero the fee directly.
+- **`end_user_cap`** is the cost-rail guard against unbounded network spend by
+  an owner who may not be able to pay. It is settable up to `1_000_000` by that
+  owner. The activation copy even names the remedy: "End-user cap reached —
+  raise the cap."
+
+### Symptom 4 — the schema cannot express a platform subscription
+
+`subscriptions.client_id` is `NOT NULL` and references `developer_apps`. A
+subscription therefore *must* belong to an app. The owner's platform plan has no
+app, so it exists only in OpenMeter and has no first-class local representation.
+This is why the usage page renders a card titled "Subscription" with no plan
+name and no statement of what it covers.
+
+## Decision
+
+**Three objects, each owned by exactly one rail. An owner is never a customer of
+their own app.**
+
+| # | Object | Relationship | Scope | Rail |
+|---|---|---|---|---|
+| 1 | **Platform subscription** | Owner → PymtHouse | **One per developer account** | Cost |
+| 2 | **App retail plans** | End users → Builder | Per app | Revenue |
+| 3 | **App billing config** | — | Per app, **revenue fields only** | Revenue |
+
+Cost-rail and platform-revenue controls (`end_user_cap`, `application_fee_bps`)
+move out of owner-editable configuration entirely.
+
+### Rules
+
+1. **An owner is never subscribed to a plan on an app they own.** Owner usage
+   meters to `buildOwnerCustomerKey(users.id)` and nothing else. Enforced at the
+   provisioning choke point, not just cleaned up by scripts.
+2. **All cost-rail usage across all of an owner's apps rolls up to the single
+   platform subscription.** This is already true mechanically; it becomes
+   stated, visible, and enforced.
+3. **`billing_mode` decides who bills the end user, never who pays PymtHouse.**
+   In `merchant` mode the Builder collects from their end users *and* the owner
+   still pays PymtHouse for the underlying network usage. Both are shown.
+4. **Platform-protection fields are admin-only.** `end_user_cap` and
+   `application_fee_bps` are rejected with `403` on the owner path.
+5. **One Stripe connected account per owner**, opted into per app. A Builder
+   onboards Connect once.
+
+### Why not the alternative
+
+Letting an owner subscribe to their own app's retail plan was considered and
+rejected. In `merchant` mode it means the owner sells to themselves, routing
+their own money through their own connected account minus a platform fee they
+pay to themselves. It also double-counts: the same usage appears once on the
+owner wallet and once as an app end user — precisely the duplicate tiles
+`openmeter-dedupe-owner-subscriptions.ts` exists to clean up.
+
+## Consequences
+
+### UI
+
+- `/billing` leads with the platform subscription, named, and states that it
+  covers every app the owner owns.
+- The usage page's subscription card names the plan and links to `/billing`.
+- The app Payments tab shows only revenue-rail settings. Cost-rail values render
+  read-only, attributed to the platform, with a link to `/billing`.
+- Per-app usage remains per-app; the roll-up destination is stated on each.
+
+### Schema
+
+- Split `app_billing_config`: revenue fields stay; `end_user_cap` and
+  `application_fee_bps` move to a platform-controlled location (an
+  `owner_billing_config` row, or platform defaults with admin-only per-app
+  override).
+- Consider relaxing `subscriptions.client_id` to nullable, or adding an explicit
+  `owner_subscriptions` table, so the platform plan has a local representation.
+  Required for Symptom 4; deferrable if OpenMeter stays the source of truth.
+
+### Migration
+
+The path is the one the existing scripts already take, finished and made
+irreversible:
+
+1. **Backfill** — run `openmeter-migrate-owner-customers.ts` and
+   `openmeter-dedupe-owner-subscriptions.ts` to completion across all owners.
+2. **Enforce** — reject owner-as-own-app-customer at the provisioning choke
+   point, so the legacy state is no longer reachable.
+3. **Dual-read window** — `buildOwnerMeterSubjects()` keeps reading legacy
+   compound subjects until backfill is verified clean.
+4. **Cutover** — `openmeter-release-legacy-subjects.ts`, then drop the
+   transitional forms from `buildOwnerMeterSubjects()`.
+5. **Lock the platform fields** — admin-only `403` on `end_user_cap` and
+   `application_fee_bps` (independent of the rest; ship first).
+
+Step 5 is severable and should not wait for the model change — it closes a live
+revenue and exposure hole.
+
+### Risks
+
+- Owners mid-migration may briefly see both a platform subscription and a legacy
+  per-app tile. The dual-read window covers reads; the dedupe script covers
+  writes. Do not drop transitional subjects before backfill is verified.
+- Moving `application_fee_bps` out of owner control is a behaviour change for
+  any Builder who has already lowered it. Audit current values before enforcing;
+  a Builder who zeroed it is currently paying PymtHouse nothing on Connect
+  volume.

--- a/docs/adr-owner-vs-app-billing.md
+++ b/docs/adr-owner-vs-app-billing.md
@@ -109,6 +109,47 @@ move out of owner-editable configuration entirely.
 5. **One Stripe connected account per owner**, opted into per app. A Builder
    onboards Connect once.
 
+### Usage reads follow customer id
+
+**OpenMeter must be able to charge without consulting PymtHouse.** Its billing
+automation runs per **customer**, over exactly that customer's
+`usageAttribution.subjectKeys`. Any usage query that reads a different subject
+set produces a number that cannot be reconciled with the invoice it purports to
+explain.
+
+The read path diverged from this. `buildOwnerMeterSubjects()` returns a
+hand-built union of four forms — bare `{users.id}`, `owner:{id}`,
+`app_…:{id}`, `app_…:owner:{id}` — while `ensureOwnerCustomer()` attributes only
+`[bareId]` for existing customers, attaching the transitional forms
+best-effort at create time. Its own comment records the split: *"Meter dual-read
+for usage does not require those keys on the customer record."*
+
+That divergence fails in the dangerous direction. Usage landing on an
+unattributed subject is metered, shown in the PymtHouse UI, and **never
+invoiced** — a revenue leak that looks like normal operation, because the UI
+over-reports exactly the amount the billing engine ignores.
+
+**Invariant: the subjects PymtHouse reads for a customer are the subjects
+OpenMeter attributes to that customer.**
+
+- Reads resolve subjects from the customer record
+  (`resolveCustomerSubjectKeys`), not from a hand-built union. The displayed
+  figure is therefore the billable figure by construction, and the transitional
+  union narrows automatically as migration completes rather than needing a
+  coordinated cut-over.
+- The union survives only as a fallback for a failed customer lookup, so an
+  outage degrades to the old behaviour instead of reporting zero.
+- `classifyUsageAttributionConsistency` reports any subject carrying usage that
+  no customer is attributed, as an `error`. This must reach zero before the
+  transitional forms are dropped.
+- Ingest should emit the canonical customer subject directly, so
+  `subjectKeys = [customerKey]` is sufficient and the union disappears.
+
+Consequence to expect: for an owner mid-migration, displayed usage may **fall**
+to the attributed subset. That is a correction, not a regression — the
+difference was never going to be billed. The audit surfaces the gap explicitly
+rather than letting the UI absorb it.
+
 ### Why not the alternative
 
 Letting an owner subscribe to their own app's retail plan was considered and

--- a/docs/adr-owner-vs-app-billing.md
+++ b/docs/adr-owner-vs-app-billing.md
@@ -224,16 +224,30 @@ Shipped (PR #348):
 
 Outstanding:
 
-- **Symptom 1 (schema)** — `end_user_cap` and `application_fee_bps` still live
-  on `app_billing_config`. Authorization is correct, so their location is now
-  cosmetic; the move is deferred, not abandoned.
-- **Symptom 4** — `subscriptions.client_id` is still `NOT NULL`, so the platform
-  subscription still has no local row and exists only in OpenMeter. This is why
-  the plan name on the billing card cannot come from PymtHouse's own database.
-- **Migration steps 1–4** — backfill, enforce, dual-read, cutover. The
-  transitional union in `buildOwnerMeterSubjects` and the three
-  `openmeter-*-owner-*` scripts remain until
-  `usage_on_unattributed_subject` reports zero across all owners.
+- **Symptom 1 (schema)** — resolved as *platform defaults with admin-only
+  per-app override*, the second form this ADR allows.
+  `platform-billing-defaults` supplies the values a new app inherits
+  (`PYMTHOUSE_DEFAULT_END_USER_CAP`, `PYMTHOUSE_DEFAULT_APPLICATION_FEE_BPS`),
+  so platform policy changes without a migration, and the per-app columns are
+  admin-set overrides. The columns stay on `app_billing_config`; moving them to
+  a separate table would be churn without behavioural gain now that
+  authorization is correct.
+- **Migration steps 1 and 3–4** — backfill, dual-read, cutover. Step 2
+  (enforce) is done: an owner can no longer become a customer of their own app.
+  Step 1 now has a completion signal — `npm run openmeter:audit-billing` runs
+  `classifyUsageAttributionConsistency` per owner and exits non-zero while any
+  usage sits on an unattributed subject. The transitional union in
+  `buildOwnerMeterSubjects` and the three `openmeter-*-owner-*` scripts remain
+  until that audit is clean; running it needs a live database and OpenMeter
+  tenant.
+
+- **Symptom 4** — unchanged, and larger than one nullable column.
+  `plans.client_id` is `NOT NULL` as well as `subscriptions.client_id`, which is
+  why `ensureStarterSubscriptionForAppUser` borrows "the requesting app's local
+  Starter id" for an owner subscription. Giving the platform plan a real local
+  row means making both nullable (or adding platform-scoped tables), rewiring
+  owner subscription persistence, and backfilling existing rows — a multi-table
+  change to core billing that should be verified against a real database.
 
 ### Risks
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "openmeter:dedupe-owner-subscriptions": "npx tsx scripts/openmeter-dedupe-owner-subscriptions.ts",
     "openmeter:release-legacy-subjects": "npx tsx scripts/openmeter-release-legacy-subjects.ts",
     "openmeter:audit-billing": "npx tsx scripts/openmeter-audit-billing-consistency.ts",
+    "openmeter:fix-owner-attribution": "npx tsx scripts/openmeter-fix-owner-attribution.ts",
     "openmeter:migrate-sandbox-to-stripe": "npx tsx scripts/openmeter-migrate-sandbox-to-stripe.ts",
     "openmeter:migrate-plan-subscribers": "npx tsx scripts/openmeter-migrate-plan-subscribers.ts",
     "stripe:connect-cutover": "npx tsx scripts/stripe-connect-cutover.ts",

--- a/scripts/audit-platform-billing-fields.ts
+++ b/scripts/audit-platform-billing-fields.ts
@@ -1,0 +1,120 @@
+/**
+ * Audit platform-controlled billing fields before locking them to admins.
+ *
+ * `application_fee_bps` (PymtHouse's share of Connect payments) and
+ * `end_user_cap` (the cost-rail spend guard) are currently editable by the app
+ * owner — the party each one constrains. See docs/adr-owner-vs-app-billing.md.
+ *
+ * Locking them is a behaviour change for any Builder who already moved them, so
+ * this reports the current state first. Read-only: it never writes.
+ *
+ * Usage:
+ *   npx tsx scripts/audit-platform-billing-fields.ts
+ *   npx tsx scripts/audit-platform-billing-fields.ts --json
+ */
+import "./load-env-first";
+import { eq } from "drizzle-orm";
+
+import { closeDb, db } from "../src/db/index";
+import { appBillingConfig, developerApps, users } from "../src/db/schema";
+
+/** Defaults from the schema; anything else was changed deliberately. */
+const DEFAULT_APPLICATION_FEE_BPS = 0;
+const DEFAULT_END_USER_CAP = 25;
+
+type AuditRow = {
+  appId: string;
+  appName: string;
+  ownerId: string;
+  ownerEmail: string | null;
+  billingMode: string;
+  applicationFeeBps: number;
+  endUserCap: number;
+  connectedAccountId: string | null;
+  /** Connect volume earns PymtHouse nothing at 0 bps. */
+  zeroFeeWithConnect: boolean;
+  raisedCap: boolean;
+};
+
+async function main(): Promise<void> {
+  const asJson = process.argv.includes("--json");
+
+  const rows = await db
+    .select({
+      appId: developerApps.id,
+      appName: developerApps.name,
+      ownerId: developerApps.ownerId,
+      ownerEmail: users.email,
+      billingMode: appBillingConfig.billingMode,
+      applicationFeeBps: appBillingConfig.applicationFeeBps,
+      endUserCap: appBillingConfig.endUserCap,
+      connectedAccountId: appBillingConfig.stripeConnectedAccountId,
+      chargesEnabled: appBillingConfig.stripeChargesEnabled,
+    })
+    .from(appBillingConfig)
+    .innerJoin(developerApps, eq(appBillingConfig.clientId, developerApps.id))
+    .leftJoin(users, eq(developerApps.ownerId, users.id));
+
+  const audited: AuditRow[] = rows.map((row) => ({
+    appId: row.appId,
+    appName: row.appName,
+    ownerId: row.ownerId,
+    ownerEmail: row.ownerEmail,
+    billingMode: row.billingMode,
+    applicationFeeBps: row.applicationFeeBps,
+    endUserCap: row.endUserCap,
+    connectedAccountId: row.connectedAccountId,
+    zeroFeeWithConnect:
+      row.applicationFeeBps === 0 && Boolean(row.chargesEnabled),
+    raisedCap: row.endUserCap > DEFAULT_END_USER_CAP,
+  }));
+
+  if (asJson) {
+    console.log(JSON.stringify(audited, null, 2));
+    return;
+  }
+
+  const nonDefaultFee = audited.filter(
+    (row) => row.applicationFeeBps !== DEFAULT_APPLICATION_FEE_BPS,
+  );
+  const raisedCaps = audited.filter((row) => row.raisedCap);
+  const revenueLeak = audited.filter((row) => row.zeroFeeWithConnect);
+
+  console.log(`Apps with billing config: ${audited.length}`);
+  console.log(
+    `  application_fee_bps != ${DEFAULT_APPLICATION_FEE_BPS}: ${nonDefaultFee.length}`,
+  );
+  console.log(`  end_user_cap > ${DEFAULT_END_USER_CAP}: ${raisedCaps.length}`);
+  console.log(
+    `  0 bps WITH Connect charges enabled (earning nothing): ${revenueLeak.length}`,
+  );
+
+  if (revenueLeak.length > 0) {
+    console.log("\nConnect-enabled apps taking a 0 bps platform fee:");
+    for (const row of revenueLeak) {
+      console.log(
+        `  ${row.appId}  ${row.appName}  owner=${row.ownerEmail ?? row.ownerId}  acct=${row.connectedAccountId ?? "-"}`,
+      );
+    }
+  }
+
+  if (raisedCaps.length > 0) {
+    console.log("\nApps whose owner raised their own end-user cap:");
+    for (const row of raisedCaps) {
+      console.log(
+        `  ${row.appId}  ${row.appName}  cap=${row.endUserCap}  owner=${row.ownerEmail ?? row.ownerId}`,
+      );
+    }
+  }
+
+  if (nonDefaultFee.length === 0 && raisedCaps.length === 0) {
+    console.log("\nNo app has moved either field — locking them changes nothing.");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => closeDb());

--- a/scripts/audit-platform-billing-fields.ts
+++ b/scripts/audit-platform-billing-fields.ts
@@ -65,7 +65,9 @@ async function main(): Promise<void> {
     endUserCap: row.endUserCap,
     connectedAccountId: row.connectedAccountId,
     zeroFeeWithConnect:
-      row.applicationFeeBps === 0 && Boolean(row.chargesEnabled),
+      row.applicationFeeBps === 0 &&
+      Boolean(row.chargesEnabled) &&
+      row.billingMode === "merchant",
     raisedCap: row.endUserCap > DEFAULT_END_USER_CAP,
   }));
 

--- a/scripts/openmeter-fix-owner-attribution.ts
+++ b/scripts/openmeter-fix-owner-attribution.ts
@@ -102,7 +102,9 @@ async function main(): Promise<void> {
   const locking = await readLocking();
   console.log(`owner=${ownerId} customer=${customerId}`);
   console.log(`  attribution: ${attribution.length > 0 ? attribution.join(", ") : "(none)"}`);
-  console.log(`  locking subscriptions: ${locking.map((s) => `${s.id}(${s.status})`).join(", ") || "(none)"}`);
+  const lockingSummary =
+    locking.map((s) => s.id + "(" + s.status + ")").join(", ") || "(none)";
+  console.log(`  locking subscriptions: ${lockingSummary}`);
 
   if (attribution.length > 0) {
     console.log("Nothing to do — customer already has attributed subjects.");

--- a/scripts/openmeter-fix-owner-attribution.ts
+++ b/scripts/openmeter-fix-owner-attribution.ts
@@ -1,0 +1,178 @@
+/**
+ * Repair an owner customer that has no `usageAttribution.subjectKeys`.
+ *
+ * Konnect refuses subject-key changes while a subscription is active, and
+ * `ensureCustomerUsageAttribution` deliberately returns early in that case
+ * rather than eating a 400. So a customer that reaches this state cannot be
+ * fixed in place: the subscription must be cancelled, the keys attached, and
+ * the subscription re-created.
+ *
+ * Surfaced by `customer_has_no_usage_attribution` in
+ * `openmeter-audit-billing-consistency`. Until it is fixed, that owner's usage
+ * is metered but can never be invoiced.
+ *
+ * DESTRUCTIVE: `--apply` cancels a live subscription. There is a window between
+ * cancel and re-provision in which the owner's spendable gate reads 0 and the
+ * signer returns 483. Run it deliberately, not casually.
+ *
+ * Every step is verified before the next begins. If attribution does not take,
+ * the script aborts *before* re-provisioning rather than continuing blind —
+ * leaving the subscription cancelled is recoverable by re-running; leaving the
+ * customer unattributed with a fresh lock is not.
+ *
+ * Usage:
+ *   npx tsx scripts/openmeter-fix-owner-attribution.ts --owner-id <users.id>
+ *   npx tsx scripts/openmeter-fix-owner-attribution.ts --owner-id <users.id> --apply
+ */
+import "./load-env-first";
+
+import { eq } from "drizzle-orm";
+
+import { closeDb, db } from "../src/db/index";
+import { developerApps, oidcClients } from "../src/db/schema";
+import {
+  getHostedAdminClient,
+  isHostedAdminClientAvailable,
+} from "../src/lib/openmeter/admin-client";
+import {
+  ensureOwnerCustomer,
+  findOpenMeterCustomerByKey,
+} from "../src/lib/openmeter/customers";
+import { cancelKonnectSubscription } from "../src/lib/openmeter/konnect-subscriptions";
+import { ensureOwnerStarterSubscription } from "../src/lib/openmeter/owner-starter-plan";
+import { buildOwnerCustomerKey } from "../src/lib/openmeter/customer-key";
+
+/** Subscription statuses that block subject-key changes in Konnect. */
+const LOCKING_STATUSES = new Set(["active", "scheduled", "pending"]);
+const SETTLE_POLL_ATTEMPTS = 10;
+const SETTLE_POLL_MS = 2_000;
+
+function takeArg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  return process.argv[index + 1];
+}
+
+async function main(): Promise<void> {
+  const ownerId = takeArg("--owner-id")?.trim();
+  const apply = process.argv.includes("--apply");
+  if (!ownerId) {
+    console.error("usage: --owner-id <users.id> [--apply]");
+    process.exitCode = 1;
+    return;
+  }
+  if (!isHostedAdminClientAvailable()) {
+    console.error("OpenMeter admin client unavailable (check OPENMETER_URL / OPENMETER_API_KEY)");
+    process.exitCode = 1;
+    return;
+  }
+
+  const client = getHostedAdminClient();
+  const customerKey = buildOwnerCustomerKey(ownerId);
+
+  const customer = (await findOpenMeterCustomerByKey(client, customerKey)) as
+    | { id?: string; usageAttribution?: { subjectKeys?: string[] } }
+    | null;
+  if (!customer?.id) {
+    console.error(`No OpenMeter customer for key ${customerKey}`);
+    process.exitCode = 1;
+    return;
+  }
+  const customerId = customer.id;
+
+  const readAttribution = async (): Promise<string[]> => {
+    const fresh = (await findOpenMeterCustomerByKey(client, customerKey)) as
+      | { usageAttribution?: { subjectKeys?: string[] } }
+      | null;
+    return fresh?.usageAttribution?.subjectKeys ?? [];
+  };
+  const readLocking = async (): Promise<Array<{ id: string; status: string }>> => {
+    const listed = await client.customers.listSubscriptions(customerId, {
+      pageSize: 100,
+    });
+    return (listed?.items ?? [])
+      .map((item) => ({
+        id: (item as { id?: string }).id ?? "",
+        status: (item as { status?: string }).status ?? "",
+      }))
+      .filter((item) => LOCKING_STATUSES.has(item.status));
+  };
+
+  const attribution = await readAttribution();
+  const locking = await readLocking();
+  console.log(`owner=${ownerId} customer=${customerId}`);
+  console.log(`  attribution: ${attribution.length > 0 ? attribution.join(", ") : "(none)"}`);
+  console.log(`  locking subscriptions: ${locking.map((s) => `${s.id}(${s.status})`).join(", ") || "(none)"}`);
+
+  if (attribution.length > 0) {
+    console.log("Nothing to do — customer already has attributed subjects.");
+    return;
+  }
+
+  const appRows = await db
+    .select({ publicClientId: oidcClients.clientId })
+    .from(developerApps)
+    .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(developerApps.ownerId, ownerId));
+  const publicClientIds = appRows
+    .map((row) => row.publicClientId?.trim())
+    .filter((id): id is string => Boolean(id));
+
+  if (!apply) {
+    console.log("\n[dry-run] would:");
+    for (const sub of locking) {
+      console.log(`  1. cancel subscription ${sub.id} (${sub.status}) — immediate`);
+    }
+    console.log(`  2. attach settlement subject ${customerKey} (${publicClientIds.length} apps known)`);
+    console.log("  3. re-provision Owner Starter");
+    console.log("\nRe-run with --apply to perform this. It cancels a live subscription.");
+    return;
+  }
+
+  for (const sub of locking) {
+    console.log(`cancelling ${sub.id} (immediate)…`);
+    await cancelKonnectSubscription({ subscriptionId: sub.id, timing: "immediate" });
+  }
+
+  // Konnect is not reliably read-your-writes here; poll rather than assume.
+  let remaining = await readLocking();
+  for (let i = 0; i < SETTLE_POLL_ATTEMPTS && remaining.length > 0; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, SETTLE_POLL_MS));
+    remaining = await readLocking();
+  }
+  if (remaining.length > 0) {
+    throw new Error(
+      `Subscriptions still locking after cancel (${remaining
+        .map((s) => `${s.id}(${s.status})`)
+        .join(", ")}). Not attaching keys; re-run once they settle.`,
+    );
+  }
+
+  console.log(`attaching settlement subject for ${publicClientIds.length} apps…`);
+  await ensureOwnerCustomer(client, ownerId, publicClientIds);
+
+  const attached = await readAttribution();
+  if (attached.length === 0) {
+    throw new Error(
+      "Attribution still empty after attach. Re-provision skipped deliberately: " +
+        "a new subscription would re-lock the keys and block a retry.",
+    );
+  }
+  console.log(`  attribution now: ${attached.join(", ")}`);
+
+  console.log("re-provisioning Owner Starter…");
+  const ensured = await ensureOwnerStarterSubscription({
+    ownerUserId: ownerId,
+    publicClientIds,
+  });
+  console.log(`  subscription=${ensured.openmeterSubscriptionId} created=${ensured.created}`);
+
+  console.log("\ndone — re-run openmeter:audit-billing to confirm.");
+}
+
+main()
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  })
+  .finally(() => closeDb());

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.test.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import type { Session } from "next-auth";
+
+import { platformControlledFieldsError } from "@/lib/billing/platform-controlled-fields";
+import { setProviderAppSessionResolverForTests } from "@/lib/provider-apps";
+import { test } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  seedDeveloperAppWithClient,
+  type SeededDeveloperApp,
+} from "@/test-utils/fixtures";
+
+function installSession(app: SeededDeveloperApp, role: "developer" | "admin") {
+  setProviderAppSessionResolverForTests(async () => {
+    return {
+      user: {
+        id: app.userId,
+        role,
+      },
+      expires: new Date(Date.now() + 3_600_000).toISOString(),
+    } as Session;
+  });
+}
+
+test.after(() => {
+  setProviderAppSessionResolverForTests(null);
+});
+
+test("PATCH /billing/stripe rejects platform-controlled fields for non-admins", async (t) => {
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  installSession(app, "developer");
+  t.after(async () => {
+    setProviderAppSessionResolverForTests(null);
+    await cleanupTestApp(app);
+  });
+
+  const { PATCH } = await import("./route");
+
+  for (const field of ["applicationFeeBps", "endUserCap"] as const) {
+    const body =
+      field === "applicationFeeBps"
+        ? { applicationFeeBps: 0 }
+        : { endUserCap: 1_000_000 };
+    const res = await PATCH(
+      new Request(`http://localhost/api/v1/apps/${app.clientId}/billing/stripe`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }) as never,
+      { params: Promise.resolve({ id: app.clientId }) },
+    );
+    assert.equal(res.status, 403, `${field} must 403 for non-admin`);
+    const json = (await res.json()) as { error?: string };
+    assert.equal(json.error, platformControlledFieldsError([field]));
+  }
+});
+
+test("PATCH /billing/stripe allows platform-controlled fields for admins", async (t) => {
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  installSession(app, "admin");
+  t.after(async () => {
+    setProviderAppSessionResolverForTests(null);
+    await cleanupTestApp(app);
+  });
+
+  const { PATCH } = await import("./route");
+  const res = await PATCH(
+    new Request(`http://localhost/api/v1/apps/${app.clientId}/billing/stripe`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        endUserCap: 50,
+        applicationFeeBps: 250,
+      }),
+    }) as never,
+    { params: Promise.resolve({ id: app.clientId }) },
+  );
+  // Admin clears the 403 guard. Downstream OpenMeter/Stripe may still fail
+  // without live credentials — those are not authorization failures.
+  assert.notEqual(res.status, 403);
+});

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -221,6 +221,54 @@ function openMeterPatchHttpStatus(message: string): number {
   return 502;
 }
 
+/** 403 when a non-admin PATCH tries to set platform-controlled fields. */
+function rejectPlatformControlledForNonAdmin(
+  role: string | undefined,
+  body: Record<string, unknown>,
+): NextResponse | null {
+  if (role === "admin") return null;
+  const attempted = platformControlledFieldsInBody(body);
+  if (attempted.length === 0) return null;
+  return NextResponse.json(
+    { error: platformControlledFieldsError(attempted) },
+    { status: 403 },
+  );
+}
+
+async function persistBillingPatch(
+  appId: string,
+  fields: BillingPatchFields,
+): Promise<Record<string, unknown>> {
+  const {
+    progressiveBilling,
+    invoiceThresholdUsdMicros,
+    applicationFeeBps,
+    billingMode,
+    endUserCap,
+  } = fields;
+  // Persist OpenMeter profile settings before Neon billingMode/endUserCap so
+  // a failed OM write cannot leave the app on a new revenue plane.
+  const updated =
+    progressiveBilling !== undefined ||
+    invoiceThresholdUsdMicros !== undefined ||
+    applicationFeeBps !== undefined
+      ? await updateAppBillingProfileSettings({
+          clientId: appId,
+          progressiveBilling,
+          invoiceThresholdUsdMicros,
+          applicationFeeBps,
+        })
+      : {};
+
+  if (billingMode !== undefined || endUserCap !== undefined) {
+    await upsertAppBillingConfig(appId, {
+      ...(billingMode !== undefined ? { billingMode } : {}),
+      ...(endUserCap !== undefined ? { endUserCap } : {}),
+    });
+  }
+  return updated;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -269,50 +317,24 @@ export async function PATCH(
 
   // canManageMerchantBilling admits the app owner, which is correct for
   // revenue-rail settings but not for the platform's own controls.
-  if (access.auth.role !== "admin") {
-    const attempted = platformControlledFieldsInBody(body);
-    if (attempted.length > 0) {
-      return NextResponse.json(
-        { error: platformControlledFieldsError(attempted) },
-        { status: 403 },
-      );
-    }
+  const platformReject = rejectPlatformControlledForNonAdmin(
+    access.auth.role,
+    body,
+  );
+  if (platformReject) {
+    return platformReject;
   }
 
   const parsed = await parseBillingPatchBody(body, access.auth.app.id);
   if (!parsed.ok) {
     return parsed.response;
   }
-  const {
-    progressiveBilling,
-    invoiceThresholdUsdMicros,
-    applicationFeeBps,
-    billingMode,
-    endUserCap,
-  } = parsed.fields;
 
   try {
-    // Persist OpenMeter profile settings before Neon billingMode/endUserCap so
-    // a failed OM write cannot leave the app on a new revenue plane.
-    const updated =
-      progressiveBilling !== undefined ||
-      invoiceThresholdUsdMicros !== undefined ||
-      applicationFeeBps !== undefined
-        ? await updateAppBillingProfileSettings({
-            clientId: access.auth.app.id,
-            progressiveBilling,
-            invoiceThresholdUsdMicros,
-            applicationFeeBps,
-          })
-        : {};
-
-    if (billingMode !== undefined || endUserCap !== undefined) {
-      await upsertAppBillingConfig(access.auth.app.id, {
-        ...(billingMode !== undefined ? { billingMode } : {}),
-        ...(endUserCap !== undefined ? { endUserCap } : {}),
-      });
-    }
-
+    const updated = await persistBillingPatch(
+      access.auth.app.id,
+      parsed.fields,
+    );
     const status = await getStripeConnectStatus(access.auth.app.id);
     return NextResponse.json({
       clientId: access.auth.app.id,

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -1,4 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+
+import {
+  platformControlledFieldsError,
+  platformControlledFieldsInBody,
+} from "@/lib/billing/platform-controlled-fields";
 import {
   canManageMerchantBilling,
   getAuthorizedProviderApp,
@@ -230,7 +235,13 @@ export async function GET(
   }
 
   const status = await getStripeConnectStatus(access.auth.app.id);
-  return NextResponse.json({ clientId: access.auth.app.id, ...status });
+  return NextResponse.json({
+    clientId: access.auth.app.id,
+    ...status,
+    // Drives whether the Payments tab offers the platform-controlled fields as
+    // editable inputs or as read-only, platform-attributed values.
+    isPlatformAdmin: access.auth.role === "admin",
+  });
 }
 
 export async function PATCH(
@@ -254,6 +265,18 @@ export async function PATCH(
     body = (await request.json()) as Record<string, unknown>;
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // canManageMerchantBilling admits the app owner, which is correct for
+  // revenue-rail settings but not for the platform's own controls.
+  if (access.auth.role !== "admin") {
+    const attempted = platformControlledFieldsInBody(body);
+    if (attempted.length > 0) {
+      return NextResponse.json(
+        { error: platformControlledFieldsError(attempted) },
+        { status: 403 },
+      );
+    }
   }
 
   const parsed = await parseBillingPatchBody(body, access.auth.app.id);

--- a/src/app/api/v1/me/usage/requests/route.ts
+++ b/src/app/api/v1/me/usage/requests/route.ts
@@ -9,6 +9,10 @@ import {
   listViewerSignedTicketSessions,
 } from "@/lib/openmeter/signed-ticket-events";
 import { resolveViewerUsageClientIds } from "@/lib/viewer-usage-clients";
+import {
+  isValidBoundedDateRange,
+  MAX_DATE_RANGE_DAYS,
+} from "@/lib/billing-utils";
 
 type MeUsageGroupBy = "request" | "session";
 type MeUsageScope = "own" | "all";
@@ -103,10 +107,29 @@ export async function GET(request: NextRequest) {
   const limitRaw = params.get("limit");
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
 
+  // Optional date range for the requests table's range picker. Both bounds are
+  // required together and are span-limited before hitting OpenMeter.
+  const from = params.get("from")?.trim() || undefined;
+  const to = params.get("to")?.trim() || undefined;
+  if ((from && !to) || (to && !from)) {
+    return NextResponse.json(
+      { error: "from and to must be supplied together" },
+      { status: 400 },
+    );
+  }
+  if (from && to && !isValidBoundedDateRange(from, to)) {
+    return NextResponse.json(
+      { error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days` },
+      { status: 400 },
+    );
+  }
+
   const listInput = {
     clientIds: resolvedClientIds.length > 0 ? resolvedClientIds : undefined,
     cursor,
     limit: Number.isFinite(limit) ? limit : undefined,
+    from,
+    to,
   };
 
   if (groupBy === "session") {

--- a/src/app/api/v1/me/usage/requests/route.ts
+++ b/src/app/api/v1/me/usage/requests/route.ts
@@ -77,6 +77,34 @@ function validateMeUsageRequestsParams(
   return { scope, groupBy };
 }
 
+function parseOptionalDateRange(
+  params: URLSearchParams,
+): { error: NextResponse } | { from?: string; to?: string } {
+  // Optional date range for the requests table's range picker. Both bounds are
+  // required together and are span-limited before hitting OpenMeter.
+  const from = params.get("from")?.trim() || undefined;
+  const to = params.get("to")?.trim() || undefined;
+  if ((from && !to) || (to && !from)) {
+    return {
+      error: NextResponse.json(
+        { error: "from and to must be supplied together" },
+        { status: 400 },
+      ),
+    };
+  }
+  if (from && to && !isValidBoundedDateRange(from, to)) {
+    return {
+      error: NextResponse.json(
+        {
+          error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
+        },
+        { status: 400 },
+      ),
+    };
+  }
+  return { from, to };
+}
+
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
   const sessionUser = session?.user as Record<string, unknown> | undefined;
@@ -107,29 +135,17 @@ export async function GET(request: NextRequest) {
   const limitRaw = params.get("limit");
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
 
-  // Optional date range for the requests table's range picker. Both bounds are
-  // required together and are span-limited before hitting OpenMeter.
-  const from = params.get("from")?.trim() || undefined;
-  const to = params.get("to")?.trim() || undefined;
-  if ((from && !to) || (to && !from)) {
-    return NextResponse.json(
-      { error: "from and to must be supplied together" },
-      { status: 400 },
-    );
-  }
-  if (from && to && !isValidBoundedDateRange(from, to)) {
-    return NextResponse.json(
-      { error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days` },
-      { status: 400 },
-    );
+  const dateRange = parseOptionalDateRange(params);
+  if ("error" in dateRange) {
+    return dateRange.error;
   }
 
   const listInput = {
     clientIds: resolvedClientIds.length > 0 ? resolvedClientIds : undefined,
     cursor,
     limit: Number.isFinite(limit) ? limit : undefined,
-    from,
-    to,
+    from: dateRange.from,
+    to: dateRange.to,
   };
 
   if (groupBy === "session") {

--- a/src/app/apps/[id]/identities/[externalUserId]/page.tsx
+++ b/src/app/apps/[id]/identities/[externalUserId]/page.tsx
@@ -201,7 +201,7 @@ export default async function AppIdentityDetailPage({
       <section className="mb-6 rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 sm:mb-8">
         <h2 className="text-sm font-semibold text-zinc-200">Usage over billing period</h2>
         <p className="mb-4 mt-1 text-xs text-zinc-500">
-          Requests per day, split by pipeline / model.
+          Split by pipeline / model. Toggle between requests and cost.
         </p>
         {series.length === 0 ? (
           <p className="py-6 text-center text-sm text-zinc-500">
@@ -210,7 +210,7 @@ export default async function AppIdentityDetailPage({
         ) : (
           <UsageBreakdownChart
             series={series}
-            valueLabel="Requests / day"
+            valueLabel="Usage"
             height={220}
             maxSeries={8}
           />

--- a/src/app/apps/[id]/identities/[externalUserId]/page.tsx
+++ b/src/app/apps/[id]/identities/[externalUserId]/page.tsx
@@ -201,7 +201,7 @@ export default async function AppIdentityDetailPage({
       <section className="mb-6 rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 sm:mb-8">
         <h2 className="text-sm font-semibold text-zinc-200">Usage over billing period</h2>
         <p className="mb-4 mt-1 text-xs text-zinc-500">
-          Split by pipeline / model. Toggle between requests and cost.
+          Split by pipeline / model.
         </p>
         {series.length === 0 ? (
           <p className="py-6 text-center text-sm text-zinc-500">
@@ -213,6 +213,7 @@ export default async function AppIdentityDetailPage({
             valueLabel="Usage"
             height={220}
             maxSeries={8}
+            showMetricToggle={false}
           />
         )}
       </section>

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -30,6 +30,7 @@ export default async function BillingPage() {
           creditAllowance: null,
           paymentMethods: [],
           subscriptions: [],
+          ownedApps: [],
           invoices: [],
           ledger: [],
           openMeterConfigured: false,

--- a/src/components/AllowanceProgressBar.tsx
+++ b/src/components/AllowanceProgressBar.tsx
@@ -1,4 +1,4 @@
-import { formatUsdMicrosDisplay } from "@/lib/format-usd-micros";
+import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
 
 /** Progress toward a plan's included usage allowance for the billing cycle. */
 export default function AllowanceProgressBar({
@@ -40,10 +40,10 @@ export default function AllowanceProgressBar({
       <div className="mt-2 flex flex-wrap items-baseline justify-between gap-2 text-[12px] text-zinc-500">
         <span className="font-mono">
           <b className="font-medium text-zinc-300">
-            {formatUsdMicrosDisplay(used.toString())}
+            {formatUsdMicrosSummary(used.toString())}
           </b>
           {" / "}
-          {formatUsdMicrosDisplay(allowance.toString())} included this cycle
+          {formatUsdMicrosSummary(allowance.toString())} included this cycle
         </span>
         <span className="font-mono text-[11.5px] text-zinc-600">
           {pct >= 10 ? pct.toFixed(0) : pct.toFixed(1)}% of allowance used

--- a/src/components/AllowanceStrip.tsx
+++ b/src/components/AllowanceStrip.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import InfoTooltip from "@/components/InfoTooltip";
 import {
-  formatUsdMicrosDisplay,
+  formatUsdMicrosSummary,
   hasPositiveUsdMicrosBalance,
 } from "@/lib/format-usd-micros";
 
@@ -83,11 +83,11 @@ export default function AllowanceStrip({
       <div className="flex flex-wrap items-baseline gap-3">
         <span className="font-mono text-[15px] tabular-nums leading-none text-zinc-400">
           <b className="mr-0.5 text-[22px] font-medium tracking-[-0.01em] text-zinc-100">
-            {formatUsdMicrosDisplay(remaining.toString())}
+            {formatUsdMicrosSummary(remaining.toString())}
           </b>
           <span className="text-zinc-500">
             {" "}
-            / {formatUsdMicrosDisplay(grantedDisplay.toString())} remaining
+            / {formatUsdMicrosSummary(grantedDisplay.toString())} remaining
           </span>
         </span>
       </div>
@@ -113,7 +113,7 @@ export default function AllowanceStrip({
           requests this period
           {" · "}
           <b className="font-medium text-zinc-300">
-            {formatUsdMicrosDisplay(consumed.toString())}
+            {formatUsdMicrosSummary(consumed.toString())}
           </b>{" "}
           credits consumed
         </span>

--- a/src/components/BillingUsageDashboard.helpers.tsx
+++ b/src/components/BillingUsageDashboard.helpers.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { formatBillingPeriod, formatBillingWei } from "@/lib/billing-format";
+import { formatBillingWei } from "@/lib/billing-format";
+import CycleRange from "@/components/billing/CycleRange";
 import type {
   BillingAppUsageSummary,
   BillingUsageDashboardPayload,
@@ -58,13 +59,15 @@ export function BillingDashboardHeader({
   /** App id for the Identities cross-link (single-app scope only). */
   appId?: string | null;
 }>) {
+  // The metering vendor is an implementation detail; surface whether usage is
+  // live-metered, not which product does it.
   const sourceClass = isOpenMeter ? "text-emerald-500/90" : "text-zinc-500";
-  const sourceLabel = isOpenMeter ? "OpenMeter" : "Postgres";
+  const sourceLabel = isOpenMeter ? "Live metering" : "Cached usage";
   const cycleLine = (
     <p className="text-xs text-zinc-600 mt-2 break-words">
-      Cycle: {formatBillingPeriod(cycle.start)} — {formatBillingPeriod(cycle.end)}
+      Cycle: <CycleRange start={cycle.start} end={cycle.end} />
       <span className="mx-2 text-zinc-700">·</span>
-      <span className={sourceClass}>Source: {sourceLabel}</span>
+      <span className={sourceClass}>{sourceLabel}</span>
     </p>
   );
 

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -20,7 +20,7 @@ import type {
   BillingChartSeries,
 } from "@/lib/billing-usage-dashboard-data";
 import { resolveOwnerBillingPressure } from "@/lib/billing/owner-billing-pressure";
-import { formatUsdMicrosString } from "@/lib/format-usd-micros";
+import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
 import type { OwnerBillingSubscriptionRow } from "@/lib/owner-billing-data";
 
 /** Client-safe dashboard payload (bigints as strings). */
@@ -215,13 +215,18 @@ function ActiveSubscriptionSummary({
 
   const primary = subscriptions[0];
   const extras = subscriptions.length - 1;
-  const usedLabel = formatUsdMicrosString(primary.usedUsdMicros, 4) ?? "$0";
   const allowanceMicros = primary.discountUsdMicros;
   const hasAllowance =
     allowanceMicros != null && BigInt(allowanceMicros) > 0n;
-  const usageLine = hasAllowance
-    ? `${primary.requestCount.toLocaleString()} requests this cycle`
-    : `${usedLabel} this cycle · ${primary.requestCount.toLocaleString()} requests`;
+  // Requests and dollars are separate quantities — render both explicitly
+  // rather than letting one percentage stand in for the other.
+  const requestsLabel = `${primary.requestCount.toLocaleString("en-US")} request${
+    primary.requestCount === 1 ? "" : "s"
+  }`;
+  const usageLine =
+    hasAllowance && allowanceMicros
+      ? `${requestsLabel} · ${formatUsdMicrosSummary(primary.usedUsdMicros)} of ${formatUsdMicrosSummary(allowanceMicros)} allowance used`
+      : `${requestsLabel} · ${formatUsdMicrosSummary(primary.usedUsdMicros)} this cycle`;
   const pressure = resolveOwnerBillingPressure({
     hasPaymentMethod: Boolean(defaultPaymentMethod),
     creditBalanceUsdMicros,
@@ -529,8 +534,8 @@ function BillingPeriodPanel({
         </div>
         <p className="text-xs text-zinc-500 mb-4">
           {chartDimension === "identity"
-            ? "Each series is one app × identity (requests per day)."
-            : "Each series is one app × pipeline/model (requests per day)."}
+            ? "Each bar segment is one app × identity."
+            : "Each bar segment is one app × pipeline/model."}
         </p>
         {filteredSeries.length === 0 ? (
           <p className="text-sm text-zinc-500">
@@ -539,7 +544,7 @@ function BillingPeriodPanel({
         ) : (
           <UsageBreakdownChart
             series={filteredSeries}
-            valueLabel="Requests / day"
+            valueLabel="Usage"
             height={220}
             maxSeries={12}
           />

--- a/src/components/OwnerBillingView.tsx
+++ b/src/components/OwnerBillingView.tsx
@@ -9,7 +9,7 @@ import TransactionsLedger from "@/components/billing/TransactionsLedger";
 import DashboardLayout from "@/components/DashboardLayout";
 import InfoTooltip from "@/components/InfoTooltip";
 import OwnerPaymentMethodsCard from "@/components/OwnerPaymentMethodsCard";
-import { formatBillingPeriod } from "@/lib/billing-format";
+import CycleRange from "@/components/billing/CycleRange";
 import { allocateCreditBalancesForSubscriptions } from "@/lib/billing/cost-waterfall";
 import { resolveOwnerBillingPressure } from "@/lib/billing/owner-billing-pressure";
 import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
@@ -363,8 +363,7 @@ export default function OwnerBillingView({
         </p>
         {data.openMeterConfigured ? (
           <p className="mt-2 text-xs text-zinc-600">
-            Cycle: {formatBillingPeriod(data.cycle.start)} —{" "}
-            {formatBillingPeriod(data.cycle.end)}
+            Cycle: <CycleRange start={data.cycle.start} end={data.cycle.end} />
             <span className="mx-2 text-zinc-700">·</span>
             <Link
               href="/usage"
@@ -375,7 +374,7 @@ export default function OwnerBillingView({
           </p>
         ) : (
           <p className="mt-2 text-sm text-amber-400/90">
-            OpenMeter is not configured — billing balances are unavailable.
+            Usage metering is not configured — billing balances are unavailable.
           </p>
         )}
       </div>

--- a/src/components/OwnerBillingView.tsx
+++ b/src/components/OwnerBillingView.tsx
@@ -216,41 +216,68 @@ function PlanCoverage({
   const merchant = ownedApps.filter((app) => app.billingMode === "merchant");
   const rollup = ownedApps.filter((app) => app.billingMode !== "merchant");
 
+  const summary =
+    merchant.length > 0
+      ? `${rollup.length} roll up · ${merchant.length} also bill their own users`
+      : "all usage rolls up here";
+
+  // Native <details> so the list collapses without making this server-rendered
+  // page a client component.
   return (
-    <div className="mb-4 rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
-      <p className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-zinc-500">
-        Covers {ownedApps.length} app{ownedApps.length === 1 ? "" : "s"}
-      </p>
-      <ul className="mt-2 space-y-1.5">
-        {ownedApps.map((app) => (
-          <li
-            key={app.id}
-            className="flex flex-wrap items-baseline justify-between gap-2 text-xs"
-          >
-            <Link
-              href={`/apps/${app.id}/usage`}
-              className="text-zinc-300 transition-colors hover:text-emerald-400"
+    <details className="group mt-4 rounded-xl border border-white/[0.06] bg-white/[0.02]">
+      <summary className="flex cursor-pointer list-none flex-wrap items-center gap-2 px-4 py-3 text-xs text-zinc-400 transition-colors hover:text-zinc-200">
+        <svg
+          className="h-3.5 w-3.5 shrink-0 text-zinc-500 transition-transform group-open:rotate-180"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+        <span className="font-medium text-zinc-300">
+          Covers {ownedApps.length} app{ownedApps.length === 1 ? "" : "s"}
+        </span>
+        <span className="text-zinc-600">{summary}</span>
+      </summary>
+
+      <div className="border-t border-white/[0.06] px-4 py-3">
+        <ul className="space-y-1.5">
+          {ownedApps.map((app) => (
+            <li
+              key={app.id}
+              className="flex flex-wrap items-baseline justify-between gap-2 text-xs"
             >
-              {app.name}
-            </Link>
-            <span className="text-zinc-600">
-              {app.billingMode === "merchant"
-                ? "bills its own end users · network cost rolls up here"
-                : "usage rolls up here"}
-            </span>
-          </li>
-        ))}
-      </ul>
-      {merchant.length > 0 ? (
-        <p className="mt-2 text-[11px] text-zinc-600">
-          {merchant.length} app{merchant.length === 1 ? "" : "s"} charge their end
-          users directly; you still pay PymtHouse for the network usage
-          {rollup.length > 0
-            ? `, as you do for the other ${rollup.length}.`
-            : "."}
-        </p>
-      ) : null}
-    </div>
+              <Link
+                href={`/apps/${app.id}/usage`}
+                className="text-zinc-300 transition-colors hover:text-emerald-400"
+              >
+                {app.name}
+              </Link>
+              <span className="text-zinc-600">
+                {app.billingMode === "merchant"
+                  ? "bills its own end users · network cost rolls up here"
+                  : "usage rolls up here"}
+              </span>
+            </li>
+          ))}
+        </ul>
+        {merchant.length > 0 ? (
+          <p className="mt-2 text-[11px] text-zinc-600">
+            {merchant.length} app{merchant.length === 1 ? "" : "s"} charge their end
+            users directly; you still pay PymtHouse for the network usage
+            {rollup.length > 0
+              ? `, as you do for the other ${rollup.length}.`
+              : "."}
+          </p>
+        ) : null}
+      </div>
+    </details>
   );
 }
 
@@ -277,7 +304,6 @@ function OwnerSubscriptionsSection({
         One plan for your whole account. Every app you own bills its network usage
         here — each card shows where this cycle&apos;s usage settled.
       </p>
-      <PlanCoverage ownedApps={data.ownedApps} />
       {data.subscriptions.length === 0 ? (
         <div className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-6 text-center">
           <p className="font-medium text-zinc-300">No active subscriptions</p>
@@ -301,6 +327,7 @@ function OwnerSubscriptionsSection({
           ))}
         </div>
       )}
+      <PlanCoverage ownedApps={data.ownedApps} />
     </section>
   );
 }

--- a/src/components/OwnerBillingView.tsx
+++ b/src/components/OwnerBillingView.tsx
@@ -200,6 +200,60 @@ function OwnerPaymentCreditsSection({
   );
 }
 
+/**
+ * What the platform plan covers.
+ *
+ * Both modes cost the owner: `merchant` only changes whether the Builder also
+ * bills their own end users on top. Stating that here answers "where does my
+ * usage go?" without opening each app. See docs/adr-owner-vs-app-billing.md.
+ */
+function PlanCoverage({
+  ownedApps,
+}: Readonly<{ ownedApps: OwnerBillingPayload["ownedApps"] }>) {
+  if (ownedApps.length === 0) {
+    return null;
+  }
+  const merchant = ownedApps.filter((app) => app.billingMode === "merchant");
+  const rollup = ownedApps.filter((app) => app.billingMode !== "merchant");
+
+  return (
+    <div className="mb-4 rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+      <p className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-zinc-500">
+        Covers {ownedApps.length} app{ownedApps.length === 1 ? "" : "s"}
+      </p>
+      <ul className="mt-2 space-y-1.5">
+        {ownedApps.map((app) => (
+          <li
+            key={app.id}
+            className="flex flex-wrap items-baseline justify-between gap-2 text-xs"
+          >
+            <Link
+              href={`/apps/${app.id}/usage`}
+              className="text-zinc-300 transition-colors hover:text-emerald-400"
+            >
+              {app.name}
+            </Link>
+            <span className="text-zinc-600">
+              {app.billingMode === "merchant"
+                ? "bills its own end users · network cost rolls up here"
+                : "usage rolls up here"}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {merchant.length > 0 ? (
+        <p className="mt-2 text-[11px] text-zinc-600">
+          {merchant.length} app{merchant.length === 1 ? "" : "s"} charge their end
+          users directly; you still pay PymtHouse for the network usage
+          {rollup.length > 0
+            ? `, as you do for the other ${rollup.length}.`
+            : "."}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 function OwnerSubscriptionsSection({
   data,
   defaultPaymentMethod,
@@ -216,10 +270,14 @@ function OwnerSubscriptionsSection({
 
   return (
     <section>
-      <h2 className="mb-3 text-sm font-semibold text-zinc-200">Active subscriptions</h2>
+      <h2 className="mb-3 text-sm font-semibold text-zinc-200">
+        Your PymtHouse plan
+      </h2>
       <p className="mb-4 text-xs text-zinc-600">
-        Each card shows where this cycle&apos;s usage settled.
+        One plan for your whole account. Every app you own bills its network usage
+        here — each card shows where this cycle&apos;s usage settled.
       </p>
+      <PlanCoverage ownedApps={data.ownedApps} />
       {data.subscriptions.length === 0 ? (
         <div className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-6 text-center">
           <p className="font-medium text-zinc-300">No active subscriptions</p>

--- a/src/components/SidebarCreditPreview.tsx
+++ b/src/components/SidebarCreditPreview.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import { formatUsdMicrosDisplay } from "@/lib/format-usd-micros";
+import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
 
 type CreditPayload = {
   creditAllowance: {
@@ -60,7 +60,7 @@ export default function SidebarCreditPreview() {
         if (!hasDisplayableCredit(body.creditAllowance)) return;
         setBlocked(false);
         setBalanceLabel(
-          formatUsdMicrosDisplay(body.creditAllowance!.balanceUsdMicros),
+          formatUsdMicrosSummary(body.creditAllowance!.balanceUsdMicros),
         );
       } catch {
         // Non-blocking preview — ignore abort/network/OpenMeter failures.

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 
 import {
   formatExactUsdMicrosString,
@@ -522,6 +529,44 @@ function SessionTable({
   );
 }
 
+type HistoryPageResult = {
+  openMeterConfigured: boolean;
+  nextCursor: string | null;
+  items: SignedTicketSessionRow[] | SignedTicketRequestRow[];
+  mode: ViewMode;
+};
+
+function applyHistoryPage(
+  page: HistoryPageResult,
+  append: boolean,
+  setOpenMeterConfigured: (value: boolean) => void,
+  setNextCursor: (value: string | null) => void,
+  setSessions: Dispatch<SetStateAction<SignedTicketSessionRow[]>>,
+  setRequests: Dispatch<SetStateAction<SignedTicketRequestRow[]>>,
+): void {
+  setOpenMeterConfigured(page.openMeterConfigured);
+  setNextCursor(page.nextCursor);
+  if (page.mode === "session") {
+    const rows = page.items as SignedTicketSessionRow[];
+    setSessions((prev) => (append ? [...prev, ...rows] : rows));
+    return;
+  }
+  const rows = page.items as SignedTicketRequestRow[];
+  setRequests((prev) => (append ? [...prev, ...rows] : rows));
+}
+
+function downloadRequestsCsv(requests: SignedTicketRequestRow[]): void {
+  const csv = buildRequestsCsv(requests);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = buildRequestsCsvFilename();
+  anchor.click();
+  // Revoke after the click task so the browser can start the download first.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
 export default function SignedTicketRequestHistory({
   clientId,
   clientIds,
@@ -559,18 +604,11 @@ export default function SignedTicketRequestHistory({
   const clientIdsKey = resolvedClientIds.join(",");
 
   const downloadCsv = useCallback(() => {
-    const csv = buildRequestsCsv(requests);
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = buildRequestsCsvFilename();
-    anchor.click();
-    URL.revokeObjectURL(url);
+    downloadRequestsCsv(requests);
   }, [requests]);
 
   const fetchPage = useCallback(
-    async (cursor: string | null, mode: ViewMode) => {
+    async (cursor: string | null, mode: ViewMode): Promise<HistoryPageResult> => {
       const params = new URLSearchParams();
       params.set("limit", "25");
       params.set("scope", historyScope);
@@ -621,13 +659,14 @@ export default function SignedTicketRequestHistory({
     fetchPage(null, viewMode)
       .then((page) => {
         if (cancelled) return;
-        setOpenMeterConfigured(page.openMeterConfigured);
-        setNextCursor(page.nextCursor);
-        if (page.mode === "session") {
-          setSessions(page.items as SignedTicketSessionRow[]);
-        } else {
-          setRequests(page.items as SignedTicketRequestRow[]);
-        }
+        applyHistoryPage(
+          page,
+          false,
+          setOpenMeterConfigured,
+          setNextCursor,
+          setSessions,
+          setRequests,
+        );
       })
       .catch((err: unknown) => {
         if (!cancelled) {
@@ -653,19 +692,14 @@ export default function SignedTicketRequestHistory({
     setError(null);
     try {
       const page = await fetchPage(nextCursor, viewMode);
-      setOpenMeterConfigured(page.openMeterConfigured);
-      setNextCursor(page.nextCursor);
-      if (page.mode === "session") {
-        setSessions((prev) => [
-          ...prev,
-          ...(page.items as SignedTicketSessionRow[]),
-        ]);
-      } else {
-        setRequests((prev) => [
-          ...prev,
-          ...(page.items as SignedTicketRequestRow[]),
-        ]);
-      }
+      applyHistoryPage(
+        page,
+        true,
+        setOpenMeterConfigured,
+        setNextCursor,
+        setSessions,
+        setRequests,
+      );
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to load more");
     } finally {

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -7,7 +7,13 @@ import {
   formatExactUsdMicrosString,
   formatUsdFromWei,
   formatUsdMicrosString,
+  formatUsdMicrosSummary,
 } from "@/lib/format-usd-micros";
+import {
+  buildRequestsCsv,
+  buildRequestsCsvFilename,
+  sumRequestFeeUsdMicros,
+} from "@/lib/usage/requests-csv";
 import type {
   SignedTicketRequestRow,
   SignedTicketSessionRow,
@@ -68,28 +74,24 @@ function normalizeClientIds(
 
 function historyCopy(scope: HistoryScope): {
   title: string;
-  subtitle: string;
+  /** Scope shown as a chip beside the title, not as prose. */
+  scopeChip: string;
   emptySessions: string;
   emptyRequests: string;
 } {
   if (scope === "all") {
     return {
-      title: "Signed ticket requests",
-      subtitle:
-        "Platform-wide signed ticket sessions (and requests), newest first. Filtered by the application selector when a subset is selected.",
-      emptySessions:
-        "No signed ticket sessions for the selected apps in this billing cycle.",
-      emptyRequests:
-        "No signed ticket requests for the selected apps in this billing cycle.",
+      title: "Requests",
+      scopeChip: "All identities",
+      emptySessions: "No sessions for the selected apps in this billing cycle.",
+      emptyRequests: "No requests for the selected apps in this billing cycle.",
     };
   }
   return {
-    title: "Your signed ticket requests",
-    subtitle: "Only sessions and requests billed to your usage identity.",
-    emptySessions:
-      "No signed ticket sessions for your usage identity in this billing cycle.",
-    emptyRequests:
-      "No signed ticket requests for your usage identity in this billing cycle.",
+    title: "Requests",
+    scopeChip: "Your usage identity",
+    emptySessions: "No sessions for your usage identity in this billing cycle.",
+    emptyRequests: "No requests for your usage identity in this billing cycle.",
   };
 }
 
@@ -170,6 +172,12 @@ function RequestRow({
   );
 }
 
+/** Columns before Request ID, so the footer can span them correctly. */
+function leadingColumnCount(compact?: boolean, showIdentity?: boolean): number {
+  // Time is always present; App and Identity are conditional.
+  return 1 + (compact ? 0 : 1) + (showIdentity ? 1 : 0);
+}
+
 export function RequestTable({
   items,
   nextCursor,
@@ -212,6 +220,28 @@ export function RequestTable({
               />
             ))}
           </tbody>
+          <tfoot>
+            <tr className="border-t border-zinc-700 text-xs">
+              <th
+                scope="row"
+                className="px-2 py-2.5 text-left font-medium text-zinc-400"
+                colSpan={leadingColumnCount(compact, showIdentity) + 2}
+              >
+                {items.length.toLocaleString("en-US")} request
+                {items.length === 1 ? "" : "s"}
+                {nextCursor ? (
+                  <span className="ml-1.5 text-zinc-600">
+                    loaded — load more to include the rest of the cycle
+                  </span>
+                ) : (
+                  <span className="ml-1.5 text-zinc-600">· complete for this range</span>
+                )}
+              </th>
+              <td className="px-2 py-2.5 text-right font-mono tabular-nums text-zinc-200">
+                {formatUsdMicrosSummary(sumRequestFeeUsdMicros(items))}
+              </td>
+            </tr>
+          </tfoot>
         </table>
       </div>
 
@@ -515,14 +545,29 @@ export default function SignedTicketRequestHistory({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
 
   const copy = historyCopy(historyScope);
+  // Both bounds are required together; the API rejects a half-open range.
+  const rangeActive = Boolean(fromDate && toDate);
 
   const resolvedClientIds = useMemo(
     () => normalizeClientIds(clientId, clientIds),
     [clientId, clientIds],
   );
   const clientIdsKey = resolvedClientIds.join(",");
+
+  const downloadCsv = useCallback(() => {
+    const csv = buildRequestsCsv(requests);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = buildRequestsCsvFilename();
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }, [requests]);
 
   const fetchPage = useCallback(
     async (cursor: string | null, mode: ViewMode) => {
@@ -532,6 +577,10 @@ export default function SignedTicketRequestHistory({
       params.set("groupBy", mode);
       if (cursor) {
         params.set("cursor", cursor);
+      }
+      if (fromDate && toDate) {
+        params.set("from", fromDate);
+        params.set("to", toDate);
       }
       for (const id of resolvedClientIds) {
         params.append("clientId", id);
@@ -558,7 +607,7 @@ export default function SignedTicketRequestHistory({
         mode,
       };
     },
-    [resolvedClientIds, historyScope],
+    [resolvedClientIds, historyScope, fromDate, toDate],
   );
 
   useEffect(() => {
@@ -594,7 +643,7 @@ export default function SignedTicketRequestHistory({
     return () => {
       cancelled = true;
     };
-  }, [fetchPage, clientIdsKey, historyScope, viewMode]);
+  }, [fetchPage, clientIdsKey, historyScope, viewMode, fromDate, toDate]);
 
   async function onLoadMore() {
     if (!nextCursor || loadingMore) {
@@ -632,9 +681,61 @@ export default function SignedTicketRequestHistory({
   return (
     <section className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-4 sm:p-5">
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="text-sm font-semibold text-zinc-200">{copy.title}</h2>
-          <p className="text-xs text-zinc-500 mt-1">{copy.subtitle}</p>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold text-zinc-200">{copy.title}</h2>
+            <span
+              className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-black/20 px-2 py-0.5 text-[11px] text-zinc-400"
+              title="Rows are limited to this identity scope. Change it with the identity filter above."
+            >
+              <span className="text-zinc-600">Scope</span>
+              {copy.scopeChip}
+            </span>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <label className="flex items-center gap-1 text-[11px] text-zinc-500">
+              <span className="sr-only">From date</span>
+              <input
+                type="date"
+                value={fromDate}
+                max={toDate || undefined}
+                onChange={(e) => setFromDate(e.target.value)}
+                className="rounded-md border border-zinc-700 bg-black/20 px-2 py-1 text-[11px] text-zinc-300"
+              />
+            </label>
+            <span className="text-[11px] text-zinc-600">→</span>
+            <label className="flex items-center gap-1 text-[11px] text-zinc-500">
+              <span className="sr-only">To date</span>
+              <input
+                type="date"
+                value={toDate}
+                min={fromDate || undefined}
+                onChange={(e) => setToDate(e.target.value)}
+                className="rounded-md border border-zinc-700 bg-black/20 px-2 py-1 text-[11px] text-zinc-300"
+              />
+            </label>
+            {rangeActive ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setFromDate("");
+                  setToDate("");
+                }}
+                className="text-[11px] text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline"
+              >
+                Clear range
+              </button>
+            ) : null}
+            {viewMode === "request" && requests.length > 0 ? (
+              <button
+                type="button"
+                onClick={downloadCsv}
+                className="rounded-md border border-zinc-700 px-2 py-1 text-[11px] text-zinc-300 transition-colors hover:border-emerald-500/40 hover:text-emerald-300"
+              >
+                Export CSV
+              </button>
+            ) : null}
+          </div>
         </div>
         <div className="inline-flex rounded-lg border border-zinc-700 p-0.5 self-start">
           <button

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -765,7 +765,7 @@ export default function SignedTicketRequestHistory({
 
       {!openMeterConfigured ? (
         <p className="text-sm text-zinc-500 py-6 text-center">
-          OpenMeter is not configured, so per-request history is unavailable.
+          Usage metering is not configured, so per-request history is unavailable.
         </p>
       ) : null}
       {openMeterConfigured && loading ? (

--- a/src/components/UsageBreakdownChart.tsx
+++ b/src/components/UsageBreakdownChart.tsx
@@ -106,11 +106,8 @@ function ToggleGroup<T extends string>({
   label: string;
 }>) {
   return (
-    <div
-      className="inline-flex rounded-lg border border-zinc-700 p-0.5"
-      role="group"
-      aria-label={label}
-    >
+    <fieldset className="m-0 inline-flex min-w-0 rounded-lg border border-solid border-zinc-700 p-0.5">
+      <legend className="sr-only">{label}</legend>
       {options.map((option) => (
         <button
           key={option.key}
@@ -126,7 +123,7 @@ function ToggleGroup<T extends string>({
           {option.label}
         </button>
       ))}
-    </div>
+    </fieldset>
   );
 }
 
@@ -168,20 +165,33 @@ export default function UsageBreakdownChart({
     () => visible.map((s) => bucketPoints(s.points, bucket)),
     [visible, bucket],
   );
-  const buckets = bucketedSeries[0] ?? [];
+  // Axis = union of all series dates so a sparse series cannot shift values.
+  const buckets = useMemo(() => {
+    const byDate = new Map<string, BucketedPoint>();
+    for (const points of bucketedSeries) {
+      for (const point of points) {
+        if (!byDate.has(point.date)) byDate.set(point.date, point);
+      }
+    }
+    return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+  }, [bucketedSeries]);
+  const seriesByDate = useMemo(
+    () => bucketedSeries.map((points) => new Map(points.map((p) => [p.date, p]))),
+    [bucketedSeries],
+  );
   const n = buckets.length;
   const todayKey = utcTodayKey();
 
   // Stacked: the axis must cover each column's summed height.
   const columnTotals = useMemo(
     () =>
-      Array.from({ length: n }, (_, i) =>
-        bucketedSeries.reduce(
-          (sum, points) => sum + (points[i] ? pointMagnitude(points[i], metric) : 0),
-          0,
-        ),
+      buckets.map((bucketPoint) =>
+        seriesByDate.reduce((sum, byDate) => {
+          const point = byDate.get(bucketPoint.date);
+          return sum + (point ? pointMagnitude(point, metric) : 0);
+        }, 0),
       ),
-    [bucketedSeries, n, metric],
+    [buckets, seriesByDate, metric],
   );
 
   const yTicks = useMemo(
@@ -236,7 +246,13 @@ export default function UsageBreakdownChart({
     return out;
   }, [n]);
 
-  const hasAnyValue = columnTotals.some((total) => total > 0);
+  // Empty state is based on request counts, not the selected metric — a zero
+  // cost view must not hide the metric toggle with no way back.
+  const hasAnyValue = useMemo(
+    () =>
+      bucketedSeries.some((points) => points.some((point) => point.value > 0)),
+    [bucketedSeries],
+  );
 
   if (visible.length === 0 || n === 0 || !hasAnyValue) {
     return (
@@ -313,10 +329,11 @@ export default function UsageBreakdownChart({
 
           {Array.from({ length: n }, (_, i) => {
             let cursor = 0;
+            const bucketDate = buckets[i].date;
             return (
-              <g key={buckets[i].date} opacity={hoverIndex === null || hoverIndex === i ? 1 : 0.45}>
-                {bucketedSeries.map((points, sIdx) => {
-                  const point = points[i];
+              <g key={bucketDate} opacity={hoverIndex === null || hoverIndex === i ? 1 : 0.45}>
+                {seriesByDate.map((byDate, sIdx) => {
+                  const point = byDate.get(bucketDate);
                   if (!point) return null;
                   const magnitude = pointMagnitude(point, metric);
                   if (magnitude <= 0) return null;
@@ -408,8 +425,8 @@ export default function UsageBreakdownChart({
                 {formatBucketTitle(buckets[hoverIndex], todayKey, bucket)}
               </p>
               <ul className="mt-1 space-y-0.5">
-                {bucketedSeries.map((points, sIdx) => {
-                  const point = points[hoverIndex];
+                {seriesByDate.map((byDate, sIdx) => {
+                  const point = byDate.get(buckets[hoverIndex].date);
                   if (!point || pointMagnitude(point, metric) <= 0) return null;
                   const s = visible[sIdx];
                   const color =
@@ -439,12 +456,11 @@ export default function UsageBreakdownChart({
                   {metric === "requests"
                     ? columnTotals[hoverIndex].toLocaleString("en-US")
                     : formatUsdMicrosSummary(
-                        bucketedSeries
-                          .reduce(
-                            (sum, points) =>
-                              sum + BigInt(points[hoverIndex]?.feeUsdMicros ?? "0"),
-                            0n,
-                          )
+                        seriesByDate
+                          .reduce((sum, byDate) => {
+                            const point = byDate.get(buckets[hoverIndex].date);
+                            return sum + BigInt(point?.feeUsdMicros ?? "0");
+                          }, 0n)
                           .toString(),
                       )}
                 </span>

--- a/src/components/UsageBreakdownChart.tsx
+++ b/src/components/UsageBreakdownChart.tsx
@@ -1,207 +1,303 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
-import type { DashboardUsageChartSeries } from "@/lib/dashboard-usage-summary";
 
+import type { DashboardUsageChartSeries } from "@/lib/dashboard-usage-summary";
+import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
+import {
+  bucketPoints,
+  buildNiceTicks,
+  buildSeriesColorMap,
+  pointMagnitude,
+  type BucketedPoint,
+  type UsageChartBucket,
+  type UsageChartMetric,
+} from "@/lib/usage/chart-scale";
+
+/**
+ * Categorical slots, in fixed order, stepped for a dark chart surface.
+ * Validated for colour-vision deficiency against zinc-950: worst adjacent
+ * pair ΔE 8.4 (protan). Do not reorder or extend without re-validating —
+ * the previous ad-hoc Tailwind ramp had a teal/pink pair at ΔE 5.0, which
+ * deuteranopic readers could not tell apart.
+ */
 const SERIES_COLORS = [
-  "rgb(52 211 153)", // emerald
-  "rgb(96 165 250)", // blue
-  "rgb(251 191 36)", // amber
-  "rgb(167 139 250)", // purple
-  "rgb(244 114 182)", // pink
-  "rgb(45 212 191)", // teal
-  "rgb(251 146 60)", // orange
-  "rgb(129 140 248)", // indigo
+  "#3987e5", // blue
+  "#d95926", // orange
+  "#199e70", // aqua
+  "#c98500", // yellow
+  "#d55181", // magenta
+  "#008300", // green
+  "#9085e9", // violet
+  "#e66767", // red
 ];
 
 type UsageBreakdownChartProps = Readonly<{
   series: DashboardUsageChartSeries[];
-  /** Cap how many series are drawn; remaining are dropped (already sorted by volume). */
+  /** Cap how many series are drawn; the rest fold into "Other". */
   maxSeries?: number;
   valueLabel?: string;
   className?: string;
   height?: number;
+  /** Hide the metric toggle when the caller has no cost data. */
+  showMetricToggle?: boolean;
 }>;
 
 function utcTodayKey(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-function formatDayTooltipTitle(dayKey: string, todayKey: string): string {
-  if (dayKey === todayKey) return "Today";
-  const d = new Date(`${dayKey}T12:00:00.000Z`);
-  return d.toLocaleDateString(undefined, {
-    weekday: "short",
+function formatBucketTitle(
+  point: BucketedPoint,
+  todayKey: string,
+  bucket: UsageChartBucket,
+): string {
+  const opts: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "numeric",
     timeZone: "UTC",
+  };
+  if (bucket === "week") {
+    const start = new Date(`${point.date}T12:00:00.000Z`).toLocaleDateString(
+      "en-US",
+      opts,
+    );
+    const end = new Date(`${point.endDate}T12:00:00.000Z`).toLocaleDateString(
+      "en-US",
+      opts,
+    );
+    return start === end ? start : `${start} – ${end}`;
+  }
+  if (point.date === todayKey) return "Today";
+  return new Date(`${point.date}T12:00:00.000Z`).toLocaleDateString("en-US", {
+    weekday: "short",
+    ...opts,
   });
 }
 
-function formatXTick(dayKey: string, todayKey: string): string {
-  if (dayKey === todayKey) return "Today";
-  return dayKey.slice(5);
+function formatXTick(point: BucketedPoint, todayKey: string): string {
+  if (point.date === todayKey) return "Today";
+  return point.date.slice(5);
 }
 
-/** Y-axis top ≈ 20% above the peak so lines fill ~80% of the plot height. */
-function buildYTicks(maxValue: number, tickCount = 4): number[] {
-  if (!Number.isFinite(maxValue) || maxValue <= 0) {
-    return Array.from({ length: tickCount + 1 }, (_, i) => i);
-  }
-  const padded = Math.ceil(maxValue * 1.2);
-  const step = Math.max(1, Math.ceil(padded / tickCount));
-  const top = Math.ceil(padded / step) * step;
-  const ticks: number[] = [];
-  for (let v = 0; v <= top; v += step) ticks.push(v);
-  return ticks;
+function formatMetricValue(
+  metric: UsageChartMetric,
+  point: { value: number; feeUsdMicros: string },
+): string {
+  return metric === "requests"
+    ? point.value.toLocaleString("en-US")
+    : formatUsdMicrosSummary(point.feeUsdMicros);
 }
 
-function seriesLabel(s: DashboardUsageChartSeries): string {
-  return `${s.appName} · ${s.jobType}`;
+function formatAxisTick(metric: UsageChartMetric, tick: number): string {
+  if (metric === "requests") return tick.toLocaleString("en-US");
+  return `$${tick.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+}
+
+function ToggleGroup<T extends string>({
+  options,
+  value,
+  onChange,
+  label,
+}: Readonly<{
+  options: ReadonlyArray<{ key: T; label: string }>;
+  value: T;
+  onChange: (next: T) => void;
+  label: string;
+}>) {
+  return (
+    <div
+      className="inline-flex rounded-lg border border-zinc-700 p-0.5"
+      role="group"
+      aria-label={label}
+    >
+      {options.map((option) => (
+        <button
+          key={option.key}
+          type="button"
+          onClick={() => onChange(option.key)}
+          aria-pressed={value === option.key}
+          className={`rounded-md px-2.5 py-1 text-xs font-semibold transition-colors ${
+            value === option.key
+              ? "bg-zinc-700 text-zinc-100"
+              : "text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 /**
- * Multi-series daily usage chart. Each series is one app × pipeline/model
- * constraint (OpenMeter `pipeline` + `model_id` from signer events).
- * pair — the two primary visual separators for admin usage.
+ * Stacked-bar usage chart. Each series is one app × pipeline/model (or
+ * app × identity). Bars stack so the column height reads as the day's total —
+ * the previous overlapping translucent areas made totals impossible to read.
+ *
+ * Requests and cost are separate views selected by a toggle, never a second
+ * y-axis.
  */
 export default function UsageBreakdownChart({
   series,
   maxSeries = 8,
-  valueLabel = "Requests / day",
+  valueLabel = "Requests",
   className = "",
-  height = 160,
+  height = 200,
+  showMetricToggle = true,
 }: UsageBreakdownChartProps) {
+  const [metric, setMetric] = useState<UsageChartMetric>("requests");
+  const [bucket, setBucket] = useState<UsageChartBucket>("day");
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  const plotRef = useRef<HTMLDivElement>(null);
+
+  // Colour slots come from the full series list so filtering never repaints.
+  const colorMap = useMemo(
+    () =>
+      buildSeriesColorMap(
+        series.map((s) => `${s.appId}|${s.jobType}`),
+        SERIES_COLORS.length,
+      ),
+    [series],
+  );
+
   const visible = useMemo(() => series.slice(0, maxSeries), [series, maxSeries]);
-  const dates = useMemo(() => visible[0]?.points.map((p) => p.date) ?? [], [visible]);
-  const n = dates.length;
+  const hiddenCount = Math.max(0, series.length - visible.length);
+
+  const bucketedSeries = useMemo(
+    () => visible.map((s) => bucketPoints(s.points, bucket)),
+    [visible, bucket],
+  );
+  const buckets = bucketedSeries[0] ?? [];
+  const n = buckets.length;
   const todayKey = utcTodayKey();
 
+  // Stacked: the axis must cover each column's summed height.
+  const columnTotals = useMemo(
+    () =>
+      Array.from({ length: n }, (_, i) =>
+        bucketedSeries.reduce(
+          (sum, points) => sum + (points[i] ? pointMagnitude(points[i], metric) : 0),
+          0,
+        ),
+      ),
+    [bucketedSeries, n, metric],
+  );
+
+  const yTicks = useMemo(
+    () =>
+      buildNiceTicks(Math.max(0, ...columnTotals), {
+        tickCount: 4,
+        integerOnly: metric === "requests",
+      }),
+    [columnTotals, metric],
+  );
+  const yMax = Math.max(yTicks.at(-1) ?? 1, 1);
+
   const width = 720;
-  const padLeft = 44;
+  const padLeft = 52;
   const padRight = 12;
   const padTop = 12;
   const padBottom = 26;
   const plotW = width - padLeft - padRight;
   const plotH = height - padTop - padBottom;
 
-  // Scale to the tallest individual series point (not the stacked daily sum),
-  // so multi-line charts fill ~80% of the Y-axis rather than sitting halfway up.
-  const maxValue = useMemo(
-    () => Math.max(0, ...visible.flatMap((s) => s.points.map((p) => p.value))),
-    [visible],
-  );
-  const yTicks = useMemo(() => buildYTicks(maxValue), [maxValue]);
-  const yMax = Math.max(1, yTicks.at(-1) ?? 1);
-
-  const xAt = useCallback(
-    (i: number) => (n <= 1 ? padLeft + plotW / 2 : padLeft + (i / (n - 1)) * plotW),
-    [n, plotW],
-  );
   const yAt = useCallback(
     (v: number) => padTop + plotH - (v / yMax) * plotH,
     [yMax, plotH],
   );
 
-  const linePaths = useMemo(
-    () =>
-      visible.map((s) =>
-        s.points
-          .map((p, i) => `${i === 0 ? "M" : "L"}${xAt(i)},${yAt(p.value)}`)
-          .join(" "),
-      ),
-    [visible, xAt, yAt],
+  const slotW = n > 0 ? plotW / n : plotW;
+  // Thin marks with breathing room; never wider than a comfortable bar.
+  const barW = Math.max(2, Math.min(28, slotW * 0.62));
+  const barX = useCallback(
+    (i: number) => padLeft + slotW * i + (slotW - barW) / 2,
+    [slotW, barW],
   );
-
-  const areaPaths = useMemo(() => {
-    if (n === 0) return [];
-    const baseY = yAt(0);
-    return visible.map((s) => {
-      const top = s.points
-        .map((p, i) => `${i === 0 ? "M" : "L"}${xAt(i)},${yAt(p.value)}`)
-        .join(" ");
-      return `${top} L${xAt(n - 1)},${baseY} L${xAt(0)},${baseY} Z`;
-    });
-  }, [visible, n, xAt, yAt]);
-
-  const xLabelTicks = useMemo(
-    () =>
-      [0, Math.floor(n / 4), Math.floor(n / 2), Math.floor((n * 3) / 4), n - 1].filter(
-        (i, idx, arr) => i >= 0 && (idx === 0 || i !== arr[idx - 1]),
-      ),
-    [n],
-  );
-
-  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
-  const plotRef = useRef<HTMLDivElement>(null);
 
   const resolveIndexFromClientX = useCallback(
     (clientX: number) => {
       const el = plotRef.current;
       if (!el || n <= 0) return null;
       const rect = el.getBoundingClientRect();
-      const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
-      return n === 1 ? 0 : Math.round(ratio * (n - 1));
+      const ratio = Math.max(0, Math.min(0.999, (clientX - rect.left) / rect.width));
+      return Math.min(n - 1, Math.floor(ratio * n));
     },
     [n],
   );
 
-  const appsInLegend = useMemo(() => {
-    const order: string[] = [];
-    const byApp = new Map<string, DashboardUsageChartSeries[]>();
-    for (const s of visible) {
-      if (!byApp.has(s.appId)) {
-        order.push(s.appId);
-        byApp.set(s.appId, []);
-      }
-      byApp.get(s.appId)!.push(s);
-    }
-    return order.map((appId) => ({
-      appId,
-      appName: byApp.get(appId)![0].appName,
-      series: byApp.get(appId)!,
-    }));
-  }, [visible]);
+  const xLabelIndices = useMemo(() => {
+    if (n === 0) return [];
+    const target = Math.min(n, 6);
+    const stride = Math.max(1, Math.round(n / target));
+    const out: number[] = [];
+    for (let i = 0; i < n; i += stride) out.push(i);
+    if (out.at(-1) !== n - 1) out.push(n - 1);
+    return out;
+  }, [n]);
 
-  if (visible.length === 0 || n === 0) {
+  const hasAnyValue = columnTotals.some((total) => total > 0);
+
+  if (visible.length === 0 || n === 0 || !hasAnyValue) {
     return (
       <div
-        className={`rounded-lg border border-zinc-800 bg-zinc-950/40 px-4 py-8 text-center text-sm text-zinc-500 ${className}`}
+        className={`rounded-lg border border-zinc-800 bg-zinc-950/40 px-4 py-8 text-center ${className}`}
       >
-        No data for this period.
+        <p className="text-sm text-zinc-400">No usage in this period yet</p>
+        <p className="mt-1 text-xs text-zinc-600">
+          Requests appear here within a few minutes of your first metered call.
+        </p>
       </div>
     );
   }
 
-  let tooltipLeftPct = 50;
-  if (hoverIndex !== null && n > 1) {
-    tooltipLeftPct = ((xAt(hoverIndex) - padLeft) / plotW) * 100;
-  } else if (hoverIndex === 0) {
-    tooltipLeftPct = 0;
-  }
+  const tooltipLeftPct = hoverIndex === null ? 50 : ((hoverIndex + 0.5) / n) * 100;
 
   return (
     <div className={`min-w-0 ${className}`}>
+      <div className="mb-3 flex flex-wrap items-center justify-end gap-2">
+        {showMetricToggle ? (
+          <ToggleGroup
+            label="Chart metric"
+            value={metric}
+            onChange={setMetric}
+            options={[
+              { key: "requests", label: "Requests" },
+              { key: "cost", label: "$" },
+            ]}
+          />
+        ) : null}
+        <ToggleGroup
+          label="Time bucket"
+          value={bucket}
+          onChange={setBucket}
+          options={[
+            { key: "day", label: "Daily" },
+            { key: "week", label: "Weekly" },
+          ]}
+        />
+      </div>
+
       <div className="relative w-full select-none" style={{ height }}>
         <div
           className="pointer-events-none absolute inset-y-0 left-0 flex flex-col justify-between font-mono text-[9px] tabular-nums text-zinc-500"
-          style={{ width: padLeft - 4, paddingTop: padTop, paddingBottom: padBottom }}
+          style={{ width: padLeft - 6, paddingTop: padTop, paddingBottom: padBottom }}
           aria-hidden="true"
         >
           {[...yTicks].reverse().map((tick) => (
             <span key={tick} className="text-right leading-none">
-              {tick.toLocaleString("en-US")}
+              {formatAxisTick(metric, tick)}
             </span>
           ))}
         </div>
 
         <svg
           viewBox={`0 0 ${width} ${height}`}
-          className="block h-full w-full text-zinc-400"
+          className="block h-full w-full"
           preserveAspectRatio="none"
-          aria-label={`${valueLabel} by app and job type`}
+          aria-label={`${valueLabel} by series`}
         >
-          <title>{`${valueLabel} by app and job type`}</title>
+          <title>{`${valueLabel} by series`}</title>
           {yTicks.map((tick) => (
             <line
               key={tick}
@@ -214,37 +310,39 @@ export default function UsageBreakdownChart({
               strokeOpacity={tick === 0 ? 1 : 0.75}
             />
           ))}
-          {areaPaths.map((d, i) => (
-            <path
-              key={`area-${visible[i].appId}-${visible[i].jobType}`}
-              d={d}
-              fill={SERIES_COLORS[i % SERIES_COLORS.length]}
-              fillOpacity={0.12}
-            />
-          ))}
-          {linePaths.map((d, i) => (
-            <path
-              key={visible[i].appId + visible[i].jobType}
-              d={d}
-              fill="none"
-              stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          ))}
-          {hoverIndex !== null && (
-            <line
-              x1={xAt(hoverIndex)}
-              x2={xAt(hoverIndex)}
-              y1={padTop}
-              y2={height - padBottom}
-              stroke="rgb(161 161 170)"
-              strokeWidth={1}
-              strokeDasharray="4 3"
-              opacity={0.85}
-            />
-          )}
+
+          {Array.from({ length: n }, (_, i) => {
+            let cursor = 0;
+            return (
+              <g key={buckets[i].date} opacity={hoverIndex === null || hoverIndex === i ? 1 : 0.45}>
+                {bucketedSeries.map((points, sIdx) => {
+                  const point = points[i];
+                  if (!point) return null;
+                  const magnitude = pointMagnitude(point, metric);
+                  if (magnitude <= 0) return null;
+                  const yTop = yAt(cursor + magnitude);
+                  const yBottom = yAt(cursor);
+                  cursor += magnitude;
+                  // 2px surface gap between stacked segments.
+                  const segH = Math.max(1, yBottom - yTop - 2);
+                  const s = visible[sIdx];
+                  const color =
+                    SERIES_COLORS[colorMap.get(`${s.appId}|${s.jobType}`) ?? sIdx];
+                  return (
+                    <rect
+                      key={`${s.appId}|${s.jobType}`}
+                      x={barX(i)}
+                      y={yTop}
+                      width={barW}
+                      height={segH}
+                      rx={2}
+                      fill={color}
+                    />
+                  );
+                })}
+              </g>
+            );
+          })}
         </svg>
 
         <div
@@ -252,20 +350,19 @@ export default function UsageBreakdownChart({
           style={{ left: padLeft, right: padRight, bottom: 6, height: 14 }}
           aria-hidden="true"
         >
-          {xLabelTicks.map((i) => {
-            const date = dates[i];
-            if (!date) return null;
+          {xLabelIndices.map((i) => {
+            const point = buckets[i];
+            if (!point) return null;
             return (
               <span
-                key={`${date}-${i}`}
-                className="absolute"
+                key={point.date}
+                className="absolute whitespace-nowrap"
                 style={{
-                  left: `${n <= 1 ? 50 : (i / (n - 1)) * 100}%`,
+                  left: `${((i + 0.5) / n) * 100}%`,
                   transform: "translateX(-50%)",
-                  whiteSpace: "nowrap",
                 }}
               >
-                {formatXTick(date, todayKey)}
+                {formatXTick(point, todayKey)}
               </span>
             );
           })}
@@ -291,14 +388,16 @@ export default function UsageBreakdownChart({
           onKeyDown={(e) => {
             const current = hoverIndex ?? 0;
             if (e.key === "ArrowLeft" && current > 0) setHoverIndex(current - 1);
-            else if (e.key === "ArrowRight" && current < n - 1) setHoverIndex(current + 1);
+            else if (e.key === "ArrowRight" && current < n - 1) {
+              setHoverIndex(current + 1);
+            }
           }}
         >
-          {hoverIndex !== null && dates[hoverIndex] && (
+          {hoverIndex !== null && buckets[hoverIndex] ? (
             <div
-              className="pointer-events-none absolute z-10 min-w-[160px] max-w-[240px] rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-2 shadow-lg"
+              className="pointer-events-none absolute z-10 min-w-[180px] max-w-[260px] rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-2 shadow-lg"
               style={{
-                left: `${Math.min(92, Math.max(8, tooltipLeftPct))}%`,
+                left: `${Math.min(90, Math.max(10, tooltipLeftPct))}%`,
                 bottom: "100%",
                 marginBottom: 8,
                 transform: "translateX(-50%)",
@@ -306,73 +405,84 @@ export default function UsageBreakdownChart({
               role="tooltip"
             >
               <p className="font-mono text-[10px] font-medium text-zinc-200">
-                {formatDayTooltipTitle(dates[hoverIndex], todayKey)}
+                {formatBucketTitle(buckets[hoverIndex], todayKey, bucket)}
               </p>
               <ul className="mt-1 space-y-0.5">
-                {visible.map((s, i) => {
-                  const value = s.points[hoverIndex]?.value ?? 0;
-                  if (value <= 0) return null;
+                {bucketedSeries.map((points, sIdx) => {
+                  const point = points[hoverIndex];
+                  if (!point || pointMagnitude(point, metric) <= 0) return null;
+                  const s = visible[sIdx];
+                  const color =
+                    SERIES_COLORS[colorMap.get(`${s.appId}|${s.jobType}`) ?? sIdx];
                   return (
                     <li
-                      key={s.appId + s.jobType}
+                      key={`${s.appId}|${s.jobType}`}
                       className="flex items-center gap-1.5 font-mono text-[10px] text-zinc-400"
                     >
                       <span
                         className="h-1.5 w-1.5 shrink-0 rounded-full"
-                        style={{ background: SERIES_COLORS[i % SERIES_COLORS.length] }}
+                        style={{ background: color }}
                       />
-                      <span className="truncate">{seriesLabel(s)}</span>
+                      <span className="truncate">
+                        {s.appName} · {s.jobType}
+                      </span>
                       <span className="ml-auto tabular-nums text-zinc-200">
-                        {value.toLocaleString("en-US")}
+                        {formatMetricValue(metric, point)}
                       </span>
                     </li>
                   );
                 })}
               </ul>
+              <div className="mt-1.5 flex items-center gap-2 border-t border-zinc-800 pt-1.5 font-mono text-[10px]">
+                <span className="text-zinc-400">Total</span>
+                <span className="ml-auto tabular-nums text-zinc-100">
+                  {metric === "requests"
+                    ? columnTotals[hoverIndex].toLocaleString("en-US")
+                    : formatUsdMicrosSummary(
+                        bucketedSeries
+                          .reduce(
+                            (sum, points) =>
+                              sum + BigInt(points[hoverIndex]?.feeUsdMicros ?? "0"),
+                            0n,
+                          )
+                          .toString(),
+                      )}
+                </span>
+              </div>
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 
-      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5">
-        {appsInLegend.map((group) => (
-          <div
-            key={group.appId}
-            className="inline-flex min-w-0 max-w-full flex-wrap items-center gap-x-2 gap-y-1"
-          >
-            <span className="shrink-0 text-[10px] font-semibold uppercase tracking-widest text-zinc-500">
-              {group.appName}
-            </span>
-            {group.series.map((s) => {
-              const colorIndex = visible.findIndex(
-                (v) => v.appId === s.appId && v.jobType === s.jobType,
-              );
-              return (
-                <span
-                  key={s.jobType}
-                  className="inline-flex items-center gap-1.5 text-[11px] text-zinc-400"
-                >
-                  <span
-                    className="h-1.5 w-1.5 shrink-0 rounded-full"
-                    style={{
-                      background: SERIES_COLORS[colorIndex % SERIES_COLORS.length],
-                    }}
-                  />
-                  {s.jobType}
-                  <span className="tabular-nums text-zinc-600">
-                    {s.totalRequests.toLocaleString("en-US")}
-                  </span>
-                </span>
-              );
-            })}
-          </div>
-        ))}
-      </div>
-      {series.length > maxSeries && (
+      <ul className="mt-3 grid grid-cols-1 gap-x-4 gap-y-1.5 sm:grid-cols-2 lg:grid-cols-3">
+        {visible.map((s) => {
+          const color = SERIES_COLORS[colorMap.get(`${s.appId}|${s.jobType}`) ?? 0];
+          return (
+            <li
+              key={`${s.appId}|${s.jobType}`}
+              className="flex min-w-0 items-center gap-1.5 text-[11px] text-zinc-400"
+            >
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ background: color }}
+              />
+              <span className="truncate" title={`${s.appName} · ${s.jobType}`}>
+                <span className="text-zinc-500">{s.appName}</span> · {s.jobType}
+              </span>
+              <span className="ml-auto shrink-0 tabular-nums text-zinc-600">
+                {metric === "requests"
+                  ? s.totalRequests.toLocaleString("en-US")
+                  : formatUsdMicrosSummary(s.totalFeeUsdMicros ?? "0")}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      {hiddenCount > 0 ? (
         <p className="mt-2 text-[11px] text-zinc-600">
-          Showing top {maxSeries} of {series.length} app × pipeline/model series
+          Showing top {maxSeries} of {series.length} series · {hiddenCount} not shown
         </p>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -7,6 +7,7 @@ import {
   usdMicrosToCentsDisplay,
 } from "@/lib/format-usd-micros";
 import { paymentsTabErrorMessage } from "@/lib/stripe/payments-tab-errors";
+import { resolvedInvoicingBehavior } from "@/lib/billing/invoicing-behavior";
 
 type ActivationInfo = {
   clientId: string;
@@ -55,6 +56,10 @@ type Props = {
   canManageBilling: boolean;
 };
 
+/** Primary action styling for this tab's save buttons. */
+const BUTTON_CLASS =
+  "inline-flex items-center rounded-md bg-emerald-500/15 px-3 py-2 text-sm font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/30 transition-colors hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-emerald-500/15";
+
 /** Only allow redirect to Stripe-hosted Connect / Account Link URLs. */
 function redirectToStripeConnectUrl(url: string): void {
   let parsed: URL;
@@ -76,11 +81,33 @@ function redirectToStripeConnectUrl(url: string): void {
   );
 }
 
-function PaymentsActivationBanner({
+function CapabilityValue({ allowed }: Readonly<{ allowed: boolean }>) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-sm ${
+        allowed ? "text-emerald-400" : "text-zinc-400"
+      }`}
+    >
+      <span aria-hidden>{allowed ? "✓" : "—"}</span>
+      {allowed ? "Allowed" : "Blocked"}
+    </span>
+  );
+}
+
+/**
+ * Activation status as a neutral definition grid, matching the Stripe Connect
+ * block above it.
+ *
+ * Warning styling is reserved for the blocked cases that need an action; a
+ * healthy app reads as information, not as a problem. The end-user count lives
+ * here only — the duplicate "End-user cap" field below was removed.
+ */
+function PaymentsActivationCard({
   activation,
 }: Readonly<{ activation: ActivationInfo }>) {
   const modeLabel =
-    activation.billingMode === "merchant" ? "merchant" : "owner roll-up";
+    activation.billingMode === "merchant" ? "Merchant" : "Owner roll-up";
+  const blocked = !activation.canProvisionEndUsers || !activation.canSellPaidPlans;
   const sellHint = activation.connectReady
     ? "Switch billing mode to merchant to unlock paid plan checkout."
     : "Connect Stripe and complete onboarding to sell paid plans.";
@@ -90,24 +117,45 @@ function PaymentsActivationBanner({
       : "Owner wallet is empty and no payment method is on file — add a card on the billing page or top up credits.";
 
   return (
-    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-2">
-      <h3 className="text-sm font-semibold text-amber-950">Activation</h3>
-      <p className="text-sm text-amber-900">
-        Mode: <span className="font-mono">{modeLabel}</span>
-        {" · "}
-        Provision end users: {activation.canProvisionEndUsers ? "allowed" : "blocked"}
-        {" · "}
-        Sell paid plans: {activation.canSellPaidPlans ? "allowed" : "blocked"}
-        {" · "}
-        Users {activation.appUserCount}/{activation.endUserCap}
-      </p>
-      {!activation.canSellPaidPlans && (
-        <p className="text-sm text-amber-900">{sellHint}</p>
-      )}
-      {!activation.canProvisionEndUsers && (
-        <p className="text-sm text-amber-900">{provisionHint}</p>
-      )}
-    </div>
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+      <h3 className="text-sm font-semibold text-zinc-200">Activation</h3>
+      <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2.5 sm:grid-cols-2">
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-xs text-zinc-500">Billing mode</dt>
+          <dd className="text-sm text-zinc-200">{modeLabel}</dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-xs text-zinc-500">End users</dt>
+          <dd className="font-mono text-sm tabular-nums text-zinc-200">
+            {activation.appUserCount.toLocaleString("en-US")} /{" "}
+            {activation.endUserCap.toLocaleString("en-US")}
+          </dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-xs text-zinc-500">Provision end users</dt>
+          <dd>
+            <CapabilityValue allowed={activation.canProvisionEndUsers} />
+          </dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-xs text-zinc-500">Sell paid plans</dt>
+          <dd>
+            <CapabilityValue allowed={activation.canSellPaidPlans} />
+          </dd>
+        </div>
+      </dl>
+
+      {blocked ? (
+        <div className="mt-3 space-y-1.5 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2">
+          {!activation.canProvisionEndUsers ? (
+            <p className="text-xs text-amber-300">{provisionHint}</p>
+          ) : null}
+          {!activation.canSellPaidPlans ? (
+            <p className="text-xs text-amber-300">{sellHint}</p>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
   );
 }
 
@@ -125,6 +173,22 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
   );
   const [endUserCap, setEndUserCap] = useState("25");
   const [settingsSaved, setSettingsSaved] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  /** Last persisted form values; save stays disabled until these change. */
+  const [savedForm, setSavedForm] = useState({
+    progressiveBilling: true,
+    thresholdDisplay: "",
+    applicationFeeBps: "0",
+    billingMode: "owner_rollup" as "owner_rollup" | "merchant",
+    endUserCap: "25",
+  });
+
+  const isDirty =
+    savedForm.progressiveBilling !== progressiveBilling ||
+    savedForm.thresholdDisplay !== thresholdDisplay ||
+    savedForm.applicationFeeBps !== applicationFeeBps ||
+    savedForm.billingMode !== billingMode ||
+    savedForm.endUserCap !== endUserCap;
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -145,11 +209,18 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
         nextStatus.billingMode === "merchant" ? "merchant" : "owner_rollup",
       );
       setEndUserCap(String(nextStatus.endUserCap ?? 25));
-      setThresholdDisplay(
-        nextStatus.invoiceThresholdUsdMicros
-          ? usdMicrosToCentsDisplay(nextStatus.invoiceThresholdUsdMicros)
-          : "",
-      );
+      const loadedThreshold = nextStatus.invoiceThresholdUsdMicros
+        ? usdMicrosToCentsDisplay(nextStatus.invoiceThresholdUsdMicros)
+        : "";
+      setThresholdDisplay(loadedThreshold);
+      setSavedForm({
+        progressiveBilling: nextStatus.progressiveBilling ?? true,
+        thresholdDisplay: loadedThreshold,
+        applicationFeeBps: String(nextStatus.applicationFeeBps ?? 0),
+        billingMode:
+          nextStatus.billingMode === "merchant" ? "merchant" : "owner_rollup",
+        endUserCap: String(nextStatus.endUserCap ?? 25),
+      });
       if (invoicesRes.ok) {
         const body = await invoicesRes.json();
         setInvoices(body.items ?? []);
@@ -241,6 +312,7 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
   async function saveBillingProfileSettings() {
     setBusy(true);
     setError(null);
+    setSaveError(null);
     setSettingsSaved(null);
     try {
       const trimmed = thresholdDisplay.trim();
@@ -276,16 +348,23 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
         throw new Error(body.error || "Failed to save billing settings");
       }
       setStatus((prev) => (prev ? { ...prev, ...body } : body));
+      setSavedForm({
+        progressiveBilling,
+        thresholdDisplay,
+        applicationFeeBps,
+        billingMode,
+        endUserCap,
+      });
       setSettingsSaved("Saved");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setSaveError(err instanceof Error ? err.message : String(err));
     } finally {
       setBusy(false);
     }
   }
 
   if (loading) {
-    return <p className="text-sm text-muted-foreground">Loading payments…</p>;
+    return <p className="text-sm text-zinc-500">Loading payments…</p>;
   }
 
   const hasAccount = Boolean(status?.stripeConnectedAccountId?.trim());
@@ -309,14 +388,14 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
   return (
     <div className="space-y-6">
       {status?.activation && (
-        <PaymentsActivationBanner activation={status.activation} />
+        <PaymentsActivationCard activation={status.activation} />
       )}
 
-      <div className="rounded-lg border p-4 space-y-3">
+      <div className="rounded-lg border border-white/[0.06] p-4 space-y-3">
         <div className="flex items-center justify-between gap-4">
           <div>
             <h3 className="text-base font-semibold">Merchant Stripe Connect</h3>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-zinc-500">
               Collect from your end users on a Stripe Connected Account (Plane B).
               OpenMeter Stripe billing (Plane A) meters usage and invoices you for
               network cost separately. Complete Stripe-hosted onboarding (Account Links)
@@ -345,25 +424,25 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
         {(hasAccount || hasLegacyOmLink || status?.connectedAt) && (
           <dl className="text-sm grid grid-cols-1 sm:grid-cols-2 gap-2">
             <div>
-              <dt className="text-muted-foreground">Connected account</dt>
+              <dt className="text-zinc-500">Connected account</dt>
               <dd className="font-mono text-xs break-all">
                 {status?.stripeConnectedAccountId ?? "—"}
               </dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">Onboarding</dt>
+              <dt className="text-zinc-500">Onboarding</dt>
               <dd>{status?.stripeOnboardingMethod ?? "—"}</dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">Charges</dt>
+              <dt className="text-zinc-500">Charges</dt>
               <dd>{status?.stripeChargesEnabled ? "Enabled" : "Paused / pending"}</dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">Payouts</dt>
+              <dt className="text-zinc-500">Payouts</dt>
               <dd>{status?.stripePayoutsEnabled ? "Enabled" : "Paused / pending"}</dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">OpenMeter Stripe billing</dt>
+              <dt className="text-zinc-500">OpenMeter Stripe billing</dt>
               <dd>
                 {status?.billingReady
                   ? "Ready"
@@ -373,13 +452,13 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
               </dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">OM billing profile</dt>
+              <dt className="text-zinc-500">OM billing profile</dt>
               <dd className="font-mono text-xs break-all">
                 {status?.openmeterBillingProfileId ?? "—"}
               </dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">Connected</dt>
+              <dt className="text-zinc-500">Connected</dt>
               <dd>{status?.connectedAt ?? "—"}</dd>
             </div>
           </dl>
@@ -390,7 +469,7 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
             {!hasAccount && (
               <button
                 type="button"
-                className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
+                className="rounded-md bg-emerald-500/15 px-3 py-2 text-sm text-emerald-300 disabled:opacity-50"
                 disabled={busy}
                 onClick={() => void startMerchantOnboarding()}
               >
@@ -400,7 +479,7 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
             {pendingOnboarding && (
               <button
                 type="button"
-                className="rounded-md border px-3 py-2 text-sm disabled:opacity-50"
+                className="rounded-md border border-white/10 px-3 py-2 text-sm text-zinc-200 transition-colors hover:border-emerald-500/40 hover:text-emerald-300 disabled:opacity-50"
                 disabled={busy}
                 onClick={() => void refreshAccountLink()}
               >
@@ -410,7 +489,7 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
             {canDisconnect && (
               <button
                 type="button"
-                className="rounded-md border px-3 py-2 text-sm disabled:opacity-50"
+                className="rounded-md border border-white/10 px-3 py-2 text-sm text-zinc-400 transition-colors hover:border-red-500/40 hover:text-red-300 disabled:opacity-50"
                 disabled={busy}
                 onClick={() => void disconnectStripe()}
               >
@@ -423,9 +502,9 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
         {canManageBilling && (
           <div className="pt-2 border-t space-y-3">
             <label className="block text-sm">
-              <span className="text-muted-foreground">Billing mode</span>
+              <span className="text-zinc-500">Billing mode</span>
               <select
-                className="mt-1 w-full max-w-xs rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+                className="mt-1 w-full max-w-xs rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
                 value={billingMode}
                 onChange={(e) =>
                   setBillingMode(
@@ -444,43 +523,53 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
               </select>
             </label>
             <label className="block text-sm">
-              <span className="text-muted-foreground">End-user cap (owner roll-up)</span>
+              <span className="text-zinc-400">End-user cap</span>
               <input
                 type="number"
                 min={1}
                 max={1000000}
-                className="mt-1 w-40 rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+                className="mt-1 w-40 rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
                 value={endUserCap}
                 onChange={(e) => setEndUserCap(e.target.value)}
                 disabled={busy}
               />
             </label>
             <label className="block text-sm">
-              <span className="text-muted-foreground">Platform application fee (bps)</span>
+              <span className="text-zinc-500">Platform application fee (bps)</span>
               <input
                 type="number"
                 min={0}
                 max={10000}
-                className="mt-1 w-40 rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+                className="mt-1 w-40 rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
                 value={applicationFeeBps}
                 onChange={(e) => setApplicationFeeBps(e.target.value)}
                 disabled={busy}
               />
             </label>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-zinc-500">
               100 bps = 1%. Applied on Connect payment intents / invoices.
             </p>
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <button
                 type="button"
-                className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
-                disabled={busy}
+                className={BUTTON_CLASS}
+                disabled={busy || !isDirty}
                 onClick={() => void saveBillingProfileSettings()}
               >
-                Save billing settings
+                {busy ? "Saving…" : "Save billing settings"}
               </button>
-              {settingsSaved ? (
-                <span className="text-xs text-emerald-600">{settingsSaved}</span>
+              {!isDirty && settingsSaved ? (
+                <span className="text-xs text-emerald-400" role="status">
+                  {settingsSaved}
+                </span>
+              ) : null}
+              {isDirty && !busy ? (
+                <span className="text-xs text-zinc-500">Unsaved changes</span>
+              ) : null}
+              {saveError ? (
+                <span className="text-xs text-rose-400" role="alert">
+                  {saveError}
+                </span>
               ) : null}
             </div>
           </div>
@@ -488,10 +577,10 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
       </div>
 
       {merchantReady && (
-        <div className="rounded-lg border p-4 space-y-3">
+        <div className="rounded-lg border border-white/[0.06] p-4 space-y-3">
           <div>
             <h3 className="text-base font-semibold">Mid-cycle invoicing</h3>
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-xs text-zinc-500">
               Progressive billing allows OpenMeter to invoice unpaid usage before the
               billing cycle ends. Set an optional dollar threshold; the clearinghouse
               worker charges when gathering invoices reach that amount.
@@ -510,17 +599,25 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
             />
             <span>
               Enable progressive billing
-              <span className="block text-xs text-muted-foreground">
+              <span className="block text-xs text-zinc-500">
                 Synced to this app&apos;s OpenMeter billing profile.
               </span>
             </span>
           </label>
+          {/*
+            Checked with a blank threshold is a valid but ambiguous state, so
+            state the behaviour it actually resolves to rather than leaving the
+            reader to infer it from an empty field.
+          */}
+          <p className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-xs text-zinc-400">
+            {resolvedInvoicingBehavior(progressiveBilling, thresholdDisplay)}
+          </p>
           <div>
-            <label htmlFor="invoice-threshold" className="block text-xs text-muted-foreground mb-1">
+            <label htmlFor="invoice-threshold" className="block text-xs text-zinc-500 mb-1">
               Invoice when unpaid usage reaches (USD)
             </label>
             <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">$</span>
+              <span className="text-sm text-zinc-500">$</span>
               <input
                 id="invoice-threshold"
                 type="text"
@@ -532,32 +629,42 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
                   setThresholdDisplay(sanitizeUsdCentsInput(e.target.value));
                   setSettingsSaved(null);
                 }}
-                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30 disabled:opacity-50"
+                className="w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30 disabled:opacity-50"
               />
             </div>
           </div>
           {canManageBilling && (
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <button
                 type="button"
-                className="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50"
-                disabled={busy}
+                className={BUTTON_CLASS}
+                disabled={busy || !isDirty}
                 onClick={() => void saveBillingProfileSettings()}
               >
-                Save invoicing settings
+                {busy ? "Saving…" : "Save invoicing settings"}
               </button>
-              {settingsSaved ? (
-                <span className="text-xs text-emerald-600">{settingsSaved}</span>
+              {!isDirty && settingsSaved ? (
+                <span className="text-xs text-emerald-400" role="status">
+                  {settingsSaved}
+                </span>
+              ) : null}
+              {isDirty && !busy ? (
+                <span className="text-xs text-zinc-500">Unsaved changes</span>
+              ) : null}
+              {saveError ? (
+                <span className="text-xs text-rose-400" role="alert">
+                  {saveError}
+                </span>
               ) : null}
             </div>
           )}
         </div>
       )}
 
-      <div className="rounded-lg border p-4 space-y-3">
+      <div className="rounded-lg border border-white/[0.06] p-4 space-y-3">
         <div>
           <h3 className="text-base font-semibold">Customer invoices</h3>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-xs text-zinc-500">
             End users billed through this app&apos;s Stripe Connect account. Platform invoices
             for your developer prepaid wallet are on{" "}
             <a href="/billing" className="text-emerald-500 hover:text-emerald-400">
@@ -567,7 +674,7 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
           </p>
         </div>
         {invoices.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No customer invoices yet.</p>
+          <p className="text-sm text-zinc-500">No customer invoices yet.</p>
         ) : (
           <ul className="divide-y text-sm">
             {invoices.map((inv) => (
@@ -575,7 +682,7 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
                 <div className="min-w-0">
                   <span className="font-mono">{inv.number ?? inv.id}</span>
                   {inv.customerKey ? (
-                    <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                    <p className="mt-0.5 truncate font-mono text-xs text-zinc-500">
                       {inv.customerKey}
                     </p>
                   ) : null}
@@ -589,7 +696,7 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
         )}
       </div>
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-rose-400">{error}</p>}
     </div>
   );
 }

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -39,6 +39,8 @@ type StripeStatus = {
   billingMode?: "owner_rollup" | "merchant";
   endUserCap?: number;
   activation?: ActivationInfo | null;
+  /** True when the viewer may edit platform-controlled fields. */
+  isPlatformAdmin?: boolean;
 };
 
 type InvoiceRow = {
@@ -55,6 +57,42 @@ type Props = {
   appId: string;
   canManageBilling: boolean;
 };
+
+/**
+ * Cost-rail values PymtHouse sets, shown read-only and attributed to the
+ * platform so they do not read as app configuration the Builder forgot to fill
+ * in. See docs/adr-owner-vs-app-billing.md.
+ */
+function PlatformLimits({
+  endUserCap,
+  applicationFeeBps,
+}: Readonly<{ endUserCap: string; applicationFeeBps: string }>) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-black/20 px-3 py-3">
+      <p className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-zinc-500">
+        Platform limits
+      </p>
+      <dl className="mt-2 grid grid-cols-1 gap-x-6 gap-y-1.5 sm:grid-cols-2">
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-xs text-zinc-500">End-user cap</dt>
+          <dd className="font-mono text-sm tabular-nums text-zinc-300">
+            {endUserCap}
+          </dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-xs text-zinc-500">Platform fee</dt>
+          <dd className="font-mono text-sm tabular-nums text-zinc-300">
+            {applicationFeeBps} bps
+          </dd>
+        </div>
+      </dl>
+      <p className="mt-2 text-[11px] text-zinc-600">
+        Set by PymtHouse. The cap protects against unbilled network spend; the fee
+        applies to Connect payments. Contact support to request a change.
+      </p>
+    </div>
+  );
+}
 
 /** Primary action styling for this tab's save buttons. */
 const BUTTON_CLASS =
@@ -183,12 +221,16 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
     endUserCap: "25",
   });
 
+  const isPlatformAdmin = status?.isPlatformAdmin === true;
+
   const isDirty =
     savedForm.progressiveBilling !== progressiveBilling ||
     savedForm.thresholdDisplay !== thresholdDisplay ||
-    savedForm.applicationFeeBps !== applicationFeeBps ||
     savedForm.billingMode !== billingMode ||
-    savedForm.endUserCap !== endUserCap;
+    // Only admins can move these, so only they can make the form dirty with them.
+    (isPlatformAdmin &&
+      (savedForm.applicationFeeBps !== applicationFeeBps ||
+        savedForm.endUserCap !== endUserCap));
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -324,24 +366,29 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
         }
         invoiceThresholdUsdMicros = micros;
       }
-      const parsedCap = Number.parseInt(endUserCap, 10);
-      if (
-        !Number.isFinite(parsedCap) ||
-        parsedCap < 1 ||
-        parsedCap > 1_000_000
-      ) {
-        throw new Error("End-user cap must be an integer between 1 and 1000000");
+      // Platform-controlled fields are admin-only server-side; sending them as
+      // an owner would be rejected with 403, so omit them entirely.
+      const payload: Record<string, unknown> = {
+        progressiveBilling,
+        invoiceThresholdUsdMicros,
+        billingMode,
+      };
+      if (isPlatformAdmin) {
+        const parsedCap = Number.parseInt(endUserCap, 10);
+        if (
+          !Number.isFinite(parsedCap) ||
+          parsedCap < 1 ||
+          parsedCap > 1_000_000
+        ) {
+          throw new Error("End-user cap must be an integer between 1 and 1000000");
+        }
+        payload.endUserCap = parsedCap;
+        payload.applicationFeeBps = Number.parseInt(applicationFeeBps, 10) || 0;
       }
       const res = await fetch(`/api/v1/apps/${appId}/billing/stripe`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          progressiveBilling,
-          invoiceThresholdUsdMicros,
-          applicationFeeBps: Number.parseInt(applicationFeeBps, 10) || 0,
-          billingMode,
-          endUserCap: parsedCap,
-        }),
+        body: JSON.stringify(payload),
       });
       const body = await res.json();
       if (!res.ok) {
@@ -522,33 +569,43 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
                 </option>
               </select>
             </label>
-            <label className="block text-sm">
-              <span className="text-zinc-400">End-user cap</span>
-              <input
-                type="number"
-                min={1}
-                max={1000000}
-                className="mt-1 w-40 rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
-                value={endUserCap}
-                onChange={(e) => setEndUserCap(e.target.value)}
-                disabled={busy}
+            {isPlatformAdmin ? (
+              <>
+                <label className="block text-sm">
+                  <span className="text-zinc-400">End-user cap</span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={1000000}
+                    className="mt-1 w-40 rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+                    value={endUserCap}
+                    onChange={(e) => setEndUserCap(e.target.value)}
+                    disabled={busy}
+                  />
+                </label>
+                <label className="block text-sm">
+                  <span className="text-zinc-500">Platform application fee (bps)</span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={10000}
+                    className="mt-1 w-40 rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
+                    value={applicationFeeBps}
+                    onChange={(e) => setApplicationFeeBps(e.target.value)}
+                    disabled={busy}
+                  />
+                </label>
+                <p className="text-xs text-zinc-500">
+                  100 bps = 1%. Applied on Connect payment intents / invoices.
+                  Platform-controlled — visible here because you are an admin.
+                </p>
+              </>
+            ) : (
+              <PlatformLimits
+                endUserCap={endUserCap}
+                applicationFeeBps={applicationFeeBps}
               />
-            </label>
-            <label className="block text-sm">
-              <span className="text-zinc-500">Platform application fee (bps)</span>
-              <input
-                type="number"
-                min={0}
-                max={10000}
-                className="mt-1 w-40 rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30"
-                value={applicationFeeBps}
-                onChange={(e) => setApplicationFeeBps(e.target.value)}
-                disabled={busy}
-              />
-            </label>
-            <p className="text-xs text-zinc-500">
-              100 bps = 1%. Applied on Connect payment intents / invoices.
-            </p>
+            )}
             <div className="flex flex-wrap items-center gap-3">
               <button
                 type="button"

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -371,8 +371,13 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
       const payload: Record<string, unknown> = {
         progressiveBilling,
         invoiceThresholdUsdMicros,
-        billingMode,
       };
+      // Only send billingMode when it changed — re-sending "merchant" re-runs
+      // Connect readiness validation and fails unrelated saves if Connect later
+      // becomes non-ready.
+      if (billingMode !== savedForm.billingMode) {
+        payload.billingMode = billingMode;
+      }
       if (isPlatformAdmin) {
         const parsedCap = Number.parseInt(endUserCap, 10);
         if (
@@ -383,7 +388,17 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
           throw new Error("End-user cap must be an integer between 1 and 1000000");
         }
         payload.endUserCap = parsedCap;
-        payload.applicationFeeBps = Number.parseInt(applicationFeeBps, 10) || 0;
+        const parsedFee = Number.parseInt(applicationFeeBps, 10);
+        if (
+          !Number.isFinite(parsedFee) ||
+          parsedFee < 0 ||
+          parsedFee > 10_000
+        ) {
+          throw new Error(
+            "Platform application fee must be an integer between 0 and 10000",
+          );
+        }
+        payload.applicationFeeBps = parsedFee;
       }
       const res = await fetch(`/api/v1/apps/${appId}/billing/stripe`, {
         method: "PATCH",
@@ -616,9 +631,9 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
                 {busy ? "Saving…" : "Save billing settings"}
               </button>
               {!isDirty && settingsSaved ? (
-                <span className="text-xs text-emerald-400" role="status">
+                <output className="text-xs text-emerald-400">
                   {settingsSaved}
-                </span>
+                </output>
               ) : null}
               {isDirty && !busy ? (
                 <span className="text-xs text-zinc-500">Unsaved changes</span>
@@ -654,8 +669,8 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
                 setSettingsSaved(null);
               }}
             />
-            <span>
-              Enable progressive billing
+            <span className="block">
+              <span className="block">Enable progressive billing</span>
               <span className="block text-xs text-zinc-500">
                 Synced to this app&apos;s OpenMeter billing profile.
               </span>
@@ -701,9 +716,9 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
                 {busy ? "Saving…" : "Save invoicing settings"}
               </button>
               {!isDirty && settingsSaved ? (
-                <span className="text-xs text-emerald-400" role="status">
+                <output className="text-xs text-emerald-400">
                   {settingsSaved}
-                </span>
+                </output>
               ) : null}
               {isDirty && !busy ? (
                 <span className="text-xs text-zinc-500">Unsaved changes</span>

--- a/src/components/billing/CycleRange.tsx
+++ b/src/components/billing/CycleRange.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { formatCycleRange } from "@/lib/billing-format";
+
+/**
+ * Billing cycle range, identical on every page that renders it.
+ *
+ * Cycle bounds are UTC at the data and API layer. The first render — server
+ * and client alike — formats them in UTC, so markup matches and hydration is
+ * clean. After mount it re-renders in the viewer's timezone.
+ *
+ * Rendering `toLocaleString(undefined, …)` directly is what made `/billing`
+ * (a server component, TZ=UTC) and `/usage` (a client component, viewer TZ)
+ * disagree about the same cycle. Doing the swap explicitly keeps both pages on
+ * the same convention at every point in the lifecycle.
+ */
+export default function CycleRange({
+  start,
+  end,
+  className,
+}: Readonly<{ start: string; end: string; className?: string }>) {
+  const [useViewerZone, setUseViewerZone] = useState(false);
+
+  useEffect(() => {
+    setUseViewerZone(true);
+  }, []);
+
+  // Locale stays fixed in both branches so only the zone changes; a locale
+  // swap would also shift date order and separators on rehydrate.
+  const label = useViewerZone
+    ? formatCycleRange(start, end)
+    : formatCycleRange(start, end, { timeZone: "UTC" });
+
+  return <span className={className}>{label}</span>;
+}

--- a/src/components/billing/TransactionsLedger.tsx
+++ b/src/components/billing/TransactionsLedger.tsx
@@ -231,7 +231,7 @@ export default function TransactionsLedger({
                     {entry.derived ? (
                       <span
                         className="ml-1.5 text-[10px] text-zinc-600"
-                        title="Derived from metered usage — OpenMeter does not expose per-event credit consumption."
+                        title="Derived from metered usage — the billing engine reports a consumed total, not per-event credit consumption."
                       >
                         (derived)
                       </span>

--- a/src/components/billing/TransactionsLedger.tsx
+++ b/src/components/billing/TransactionsLedger.tsx
@@ -253,9 +253,17 @@ export default function TransactionsLedger({
                   </td>
                   <td
                     className="px-4 py-3 text-right font-mono tabular-nums text-zinc-400"
-                    title={formatUsdMicrosExactTitle(entry.balanceUsdMicros)}
+                    title={
+                      entry.balanceUsdMicros === null
+                        ? "Balance unavailable — some billing history could not be loaded."
+                        : formatUsdMicrosExactTitle(entry.balanceUsdMicros)
+                    }
                   >
-                    {formatUsdMicrosSummary(entry.balanceUsdMicros)}
+                    {entry.balanceUsdMicros === null ? (
+                      <span className="text-zinc-600">—</span>
+                    ) : (
+                      formatUsdMicrosSummary(entry.balanceUsdMicros)
+                    )}
                   </td>
                 </tr>
               ))}

--- a/src/lib/billing-format.test.ts
+++ b/src/lib/billing-format.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatBillableDuration } from "@/lib/billing-format";
+import { formatBillableDuration, formatCycleRange } from "@/lib/billing-format";
 
 test("formatBillableDuration renders seconds, minutes and hours", () => {
   assert.equal(formatBillableDuration("45"), "45s");
@@ -22,4 +22,42 @@ test("formatBillableDuration renders empty states for missing or zero input", ()
   assert.equal(formatBillableDuration(undefined), "—");
   assert.equal(formatBillableDuration("not-a-number"), "—");
   assert.equal(formatBillableDuration("-5"), "—");
+});
+
+test("formatCycleRange labels the timezone it rendered in", () => {
+  const start = "2026-07-01T00:00:00.000Z";
+  const end = "2026-07-31T23:59:59.999Z";
+
+  const utc = formatCycleRange(start, end, { timeZone: "UTC" });
+  assert.match(utc, /UTC$/, "the zone is named, not implied");
+  assert.ok(utc.includes("Jul 1"), `expected Jul 1 in "${utc}"`);
+  assert.ok(utc.includes("Jul 31"), `expected Jul 31 in "${utc}"`);
+});
+
+test("formatCycleRange renders the same instant differently per zone", () => {
+  const start = "2026-07-01T00:00:00.000Z";
+  const end = "2026-07-31T23:59:59.999Z";
+
+  const utc = formatCycleRange(start, end, { timeZone: "UTC" });
+  const newYork = formatCycleRange(start, end, { timeZone: "America/New_York" });
+
+  // This divergence is exactly why the label is mandatory: without it these
+  // read as two different cycles.
+  assert.notEqual(utc, newYork);
+  assert.ok(newYork.includes("Jun 30"), `expected Jun 30 in "${newYork}"`);
+  assert.match(newYork, /EDT$/);
+});
+
+test("formatCycleRange is deterministic for a fixed zone", () => {
+  const a = formatCycleRange("2026-07-01T00:00:00Z", "2026-07-31T23:59:59Z", {
+    timeZone: "UTC",
+  });
+  const b = formatCycleRange("2026-07-01T00:00:00Z", "2026-07-31T23:59:59Z", {
+    timeZone: "UTC",
+  });
+  assert.equal(a, b, "server and client must agree on the same input");
+});
+
+test("formatCycleRange falls back to raw values for unparseable input", () => {
+  assert.equal(formatCycleRange("nope", "also-nope"), "nope — also-nope");
 });

--- a/src/lib/billing-format.test.ts
+++ b/src/lib/billing-format.test.ts
@@ -61,3 +61,16 @@ test("formatCycleRange is deterministic for a fixed zone", () => {
 test("formatCycleRange falls back to raw values for unparseable input", () => {
   assert.equal(formatCycleRange("nope", "also-nope"), "nope — also-nope");
 });
+
+test("formatCycleRange labels both bounds across a DST transition", () => {
+  // America/New_York springs forward on 2024-03-10: 05:00Z is EST, 07:00Z is EDT.
+  const start = "2024-03-10T05:00:00.000Z";
+  const end = "2024-03-10T07:00:00.000Z";
+  const range = formatCycleRange(start, end, { timeZone: "America/New_York" });
+  assert.match(range, /EST/);
+  assert.match(range, /EDT/);
+  assert.ok(
+    range.indexOf("EST") < range.indexOf("EDT"),
+    `expected EST before EDT in "${range}"`,
+  );
+});

--- a/src/lib/billing-format.ts
+++ b/src/lib/billing-format.ts
@@ -73,7 +73,12 @@ export function formatCycleRange(
       timeZone,
     }).format(date);
 
-  const zone = timeZoneLabel(end, locale, timeZone);
+  const startZone = timeZoneLabel(start, locale, timeZone);
+  const endZone = timeZoneLabel(end, locale, timeZone);
+  if (startZone && endZone && startZone !== endZone) {
+    return `${format(start)} ${startZone} — ${format(end)} ${endZone}`;
+  }
+  const zone = endZone || startZone;
   const range = `${format(start)} — ${format(end)}`;
   return zone ? `${range} ${zone}` : range;
 }

--- a/src/lib/billing-format.ts
+++ b/src/lib/billing-format.ts
@@ -32,6 +32,52 @@ export function formatBillingWei(wei: string): string {
   return `${whole}.${fracStr} ETH`;
 }
 
+/** Short timezone label for a formatted instant, e.g. `UTC`, `EDT`. */
+function timeZoneLabel(date: Date, locale: string, timeZone?: string): string {
+  const parts = new Intl.DateTimeFormat(locale, {
+    timeZone,
+    timeZoneName: "short",
+  }).formatToParts(date);
+  return parts.find((part) => part.type === "timeZoneName")?.value ?? "";
+}
+
+/**
+ * Billing cycle range, rendered in one timezone and labelled with it.
+ *
+ * Cycle bounds are computed in UTC. Passing `timeZone: "UTC"` renders them
+ * as stored — deterministic, so server and client agree. Omitting `timeZone`
+ * renders in the viewer's zone, which is only safe after mount.
+ *
+ * The label is not decoration: without it, `Jun 30, 8:00 PM — Jul 31, 7:59 PM`
+ * and `Jul 1, 12:00 AM — Jul 31, 11:59 PM` are the same cycle and look like
+ * different ones.
+ */
+export function formatCycleRange(
+  startIso: string,
+  endIso: string,
+  options?: Readonly<{ timeZone?: string; locale?: string }>,
+): string {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return `${startIso} — ${endIso}`;
+  }
+  const locale = options?.locale ?? BILLING_DATE_LOCALE;
+  const timeZone = options?.timeZone;
+  const format = (date: Date) =>
+    new Intl.DateTimeFormat(locale, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone,
+    }).format(date);
+
+  const zone = timeZoneLabel(end, locale, timeZone);
+  const range = `${format(start)} — ${format(end)}`;
+  return zone ? `${range} ${zone}` : range;
+}
+
 export function formatBillingPeriod(iso: string): string {
   try {
     return new Date(iso).toLocaleString(undefined, {

--- a/src/lib/billing-usage-dashboard-data.ts
+++ b/src/lib/billing-usage-dashboard-data.ts
@@ -131,7 +131,10 @@ export type BillingChartSeries = {
   /** Display label: pipeline capability + model/constraint (e.g. `byoc / transcode/ffmpeg`). */
   jobType: string;
   totalRequests: number;
-  points: { date: string; value: number }[];
+  /** Total network fee across the series (USD micros), for the cost metric. */
+  totalFeeUsdMicros?: string;
+  /** `value` is the request count; `feeUsdMicros` backs the $ metric. */
+  points: { date: string; value: number; feeUsdMicros?: string }[];
 };
 
 /** Chart legend label from OpenMeter pipeline + model_id (signer constraint). */
@@ -430,9 +433,12 @@ async function buildOpenMeterBillingDashboard(input: {
   const requestsByDay = new Map<string, number>();
   /** appId|pipeline|modelId → day → count */
   const seriesDayCounts = new Map<string, Map<string, number>>();
+  /** seriesKey -> day -> network fee (USD micros), for the chart's $ metric. */
+  const seriesDayFees = new Map<string, Map<string, bigint>>();
   const seriesMeta = new Map<string, { appId: string; appName: string; jobType: string }>();
   /** appId|externalUserId → day → count */
   const identitySeriesDayCounts = new Map<string, Map<string, number>>();
+  const identitySeriesDayFees = new Map<string, Map<string, bigint>>();
   const identitySeriesMeta = new Map<
     string,
     { appId: string; appName: string; jobType: string }
@@ -475,6 +481,13 @@ async function buildOpenMeterBillingDashboard(input: {
         const dayMap = seriesDayCounts.get(seriesKey) ?? new Map<string, number>();
         dayMap.set(row.date, (dayMap.get(row.date) ?? 0) + row.requestCount);
         seriesDayCounts.set(seriesKey, dayMap);
+
+        const feeMap = seriesDayFees.get(seriesKey) ?? new Map<string, bigint>();
+        feeMap.set(
+          row.date,
+          (feeMap.get(row.date) ?? 0n) + BigInt(row.networkFeeUsdMicros || "0"),
+        );
+        seriesDayFees.set(seriesKey, feeMap);
       }
 
       for (const row of om.byDailyUser ?? []) {
@@ -491,6 +504,14 @@ async function buildOpenMeterBillingDashboard(input: {
           identitySeriesDayCounts.get(seriesKey) ?? new Map<string, number>();
         dayMap.set(row.date, (dayMap.get(row.date) ?? 0) + row.requestCount);
         identitySeriesDayCounts.set(seriesKey, dayMap);
+
+        const feeMap =
+          identitySeriesDayFees.get(seriesKey) ?? new Map<string, bigint>();
+        feeMap.set(
+          row.date,
+          (feeMap.get(row.date) ?? 0n) + BigInt(row.networkFeeUsdMicros || "0"),
+        );
+        identitySeriesDayFees.set(seriesKey, feeMap);
       }
 
       let networkFeeUsdMicros = 0n;
@@ -583,20 +604,27 @@ async function buildOpenMeterBillingDashboard(input: {
   const buildChartSeries = (
     meta: Map<string, { appId: string; appName: string; jobType: string }>,
     dayCounts: Map<string, Map<string, number>>,
+    dayFees: Map<string, Map<string, bigint>>,
   ): BillingChartSeries[] =>
     [...meta.entries()]
       .map(([seriesKey, seriesMetaEntry]) => {
         const dayMap = dayCounts.get(seriesKey) ?? new Map<string, number>();
+        const feeMap = dayFees.get(seriesKey) ?? new Map<string, bigint>();
         const points = dateKeys.map((date) => ({
           date,
           value: dayMap.get(date) ?? 0,
+          feeUsdMicros: (feeMap.get(date) ?? 0n).toString(),
         }));
         const totalRequests = points.reduce((sum, point) => sum + point.value, 0);
+        const totalFeeUsdMicros = points
+          .reduce((sum, point) => sum + BigInt(point.feeUsdMicros), 0n)
+          .toString();
         return {
           appId: seriesMetaEntry.appId,
           appName: seriesMetaEntry.appName,
           jobType: seriesMetaEntry.jobType,
           totalRequests,
+          totalFeeUsdMicros,
           points,
         };
       })
@@ -608,12 +636,13 @@ async function buildOpenMeterBillingDashboard(input: {
         return a.jobType.localeCompare(b.jobType);
       });
 
-  const chartSeries = buildChartSeries(seriesMeta, seriesDayCounts);
+  const chartSeries = buildChartSeries(seriesMeta, seriesDayCounts, seriesDayFees);
   // Identity cardinality is unbounded — cap before serializing to the client.
   const MAX_IDENTITY_CHART_SERIES = 50;
   const chartSeriesByIdentity = buildChartSeries(
     identitySeriesMeta,
     identitySeriesDayCounts,
+    identitySeriesDayFees,
   ).slice(0, MAX_IDENTITY_CHART_SERIES);
 
   return {

--- a/src/lib/billing/invoicing-behavior.test.ts
+++ b/src/lib/billing/invoicing-behavior.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolvedInvoicingBehavior } from "@/lib/billing/invoicing-behavior";
+
+test("progressive billing on with no threshold states the resolved behaviour", () => {
+  // The ambiguous case: checkbox ticked, threshold field blank.
+  assert.equal(
+    resolvedInvoicingBehavior(true, ""),
+    "On — invoicing at cycle end (no mid-cycle threshold set).",
+  );
+});
+
+test("whitespace-only threshold counts as unset", () => {
+  assert.equal(
+    resolvedInvoicingBehavior(true, "   "),
+    "On — invoicing at cycle end (no mid-cycle threshold set).",
+  );
+});
+
+test("progressive billing on with a threshold names the trigger amount", () => {
+  assert.equal(
+    resolvedInvoicingBehavior(true, "10.00"),
+    "On — invoicing mid-cycle once unpaid usage reaches $10.00.",
+  );
+});
+
+test("progressive billing off ignores any leftover threshold", () => {
+  assert.equal(
+    resolvedInvoicingBehavior(false, "10.00"),
+    "Off — usage is invoiced once, at the end of each billing cycle.",
+  );
+  assert.equal(
+    resolvedInvoicingBehavior(false, ""),
+    "Off — usage is invoiced once, at the end of each billing cycle.",
+  );
+});

--- a/src/lib/billing/invoicing-behavior.ts
+++ b/src/lib/billing/invoicing-behavior.ts
@@ -1,0 +1,22 @@
+/**
+ * Plain-language reading of an app's mid-cycle invoicing settings.
+ *
+ * "Progressive billing on" with a blank threshold is a legal but ambiguous
+ * state — the checkbox alone does not say when invoicing happens. Rendering the
+ * resolved behaviour avoids the reader inferring it from an empty field.
+ *
+ * Client-safe (no DB/Node imports).
+ */
+export function resolvedInvoicingBehavior(
+  progressiveBilling: boolean,
+  thresholdDisplay: string,
+): string {
+  if (!progressiveBilling) {
+    return "Off — usage is invoiced once, at the end of each billing cycle.";
+  }
+  const threshold = thresholdDisplay.trim();
+  if (!threshold) {
+    return "On — invoicing at cycle end (no mid-cycle threshold set).";
+  }
+  return `On — invoicing mid-cycle once unpaid usage reaches $${threshold}.`;
+}

--- a/src/lib/billing/platform-billing-defaults.test.ts
+++ b/src/lib/billing/platform-billing-defaults.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  FALLBACK_APPLICATION_FEE_BPS,
+  FALLBACK_END_USER_CAP,
+  platformDefaultApplicationFeeBps,
+  platformDefaultEndUserCap,
+} from "@/lib/billing/platform-billing-defaults";
+
+test("defaults match the column defaults when env is unset", () => {
+  assert.equal(platformDefaultEndUserCap({}), FALLBACK_END_USER_CAP);
+  assert.equal(
+    platformDefaultApplicationFeeBps({}),
+    FALLBACK_APPLICATION_FEE_BPS,
+  );
+});
+
+test("env overrides platform policy without a migration", () => {
+  assert.equal(
+    platformDefaultEndUserCap({ PYMTHOUSE_DEFAULT_END_USER_CAP: "100" }),
+    100,
+  );
+  assert.equal(
+    platformDefaultApplicationFeeBps({
+      PYMTHOUSE_DEFAULT_APPLICATION_FEE_BPS: "250",
+    }),
+    250,
+  );
+});
+
+test("a zero fee is honoured, not treated as unset", () => {
+  // 0 bps is a legitimate platform policy; only env absence falls back.
+  assert.equal(
+    platformDefaultApplicationFeeBps({
+      PYMTHOUSE_DEFAULT_APPLICATION_FEE_BPS: "0",
+    }),
+    0,
+  );
+});
+
+test("out-of-range values fall back rather than applying", () => {
+  // A cap of 0 would block provisioning outright; a negative fee is nonsense.
+  assert.equal(
+    platformDefaultEndUserCap({ PYMTHOUSE_DEFAULT_END_USER_CAP: "0" }),
+    FALLBACK_END_USER_CAP,
+  );
+  assert.equal(
+    platformDefaultEndUserCap({ PYMTHOUSE_DEFAULT_END_USER_CAP: "9999999" }),
+    FALLBACK_END_USER_CAP,
+  );
+  assert.equal(
+    platformDefaultApplicationFeeBps({
+      PYMTHOUSE_DEFAULT_APPLICATION_FEE_BPS: "-1",
+    }),
+    FALLBACK_APPLICATION_FEE_BPS,
+  );
+  assert.equal(
+    platformDefaultApplicationFeeBps({
+      PYMTHOUSE_DEFAULT_APPLICATION_FEE_BPS: "10001",
+    }),
+    FALLBACK_APPLICATION_FEE_BPS,
+  );
+});
+
+test("malformed and blank values fall back", () => {
+  assert.equal(
+    platformDefaultEndUserCap({ PYMTHOUSE_DEFAULT_END_USER_CAP: "many" }),
+    FALLBACK_END_USER_CAP,
+  );
+  assert.equal(
+    platformDefaultEndUserCap({ PYMTHOUSE_DEFAULT_END_USER_CAP: "   " }),
+    FALLBACK_END_USER_CAP,
+  );
+});

--- a/src/lib/billing/platform-billing-defaults.ts
+++ b/src/lib/billing/platform-billing-defaults.ts
@@ -1,0 +1,67 @@
+/**
+ * Platform-set defaults for the cost-rail controls.
+ *
+ * `end_user_cap` and `application_fee_bps` protect PymtHouse, not the Builder,
+ * so they are admin-only on the API (see platform-controlled-fields). These are
+ * the values a new app inherits. Keeping them here rather than only as column
+ * defaults means changing platform policy is an env change, not a migration,
+ * and the per-app columns read as explicit admin overrides.
+ *
+ * See docs/adr-owner-vs-app-billing.md.
+ */
+
+/** Column default in `app_billing_config`; the floor if env is unset/invalid. */
+export const FALLBACK_END_USER_CAP = 25;
+export const FALLBACK_APPLICATION_FEE_BPS = 0;
+
+const MAX_END_USER_CAP = 1_000_000;
+/** 10_000 bps = 100%. */
+const MAX_APPLICATION_FEE_BPS = 10_000;
+
+/** Only the two keys below are read; a plain record keeps this testable. */
+type EnvSource = Readonly<Record<string, string | undefined>>;
+
+function readBoundedInt(
+  raw: string | undefined,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  const trimmed = raw?.trim();
+  if (!trimmed) return fallback;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * End-user cap a newly provisioned app starts on.
+ * `PYMTHOUSE_DEFAULT_END_USER_CAP`, clamped to [1, 1_000_000].
+ */
+export function platformDefaultEndUserCap(
+  env: EnvSource = process.env,
+): number {
+  return readBoundedInt(
+    env.PYMTHOUSE_DEFAULT_END_USER_CAP,
+    1,
+    MAX_END_USER_CAP,
+    FALLBACK_END_USER_CAP,
+  );
+}
+
+/**
+ * Platform fee a newly connected merchant starts on.
+ * `PYMTHOUSE_DEFAULT_APPLICATION_FEE_BPS`, clamped to [0, 10_000].
+ */
+export function platformDefaultApplicationFeeBps(
+  env: EnvSource = process.env,
+): number {
+  return readBoundedInt(
+    env.PYMTHOUSE_DEFAULT_APPLICATION_FEE_BPS,
+    0,
+    MAX_APPLICATION_FEE_BPS,
+    FALLBACK_APPLICATION_FEE_BPS,
+  );
+}

--- a/src/lib/billing/platform-controlled-fields.test.ts
+++ b/src/lib/billing/platform-controlled-fields.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PLATFORM_CONTROLLED_BILLING_FIELDS,
+  platformControlledFieldsError,
+  platformControlledFieldsInBody,
+} from "@/lib/billing/platform-controlled-fields";
+
+test("the platform reserves exactly the fee and the spend cap", () => {
+  // Both constrain the app owner, so neither may be set on the owner path.
+  assert.deepEqual([...PLATFORM_CONTROLLED_BILLING_FIELDS], [
+    "applicationFeeBps",
+    "endUserCap",
+  ]);
+});
+
+test("detects a reserved field in a patch body", () => {
+  assert.deepEqual(platformControlledFieldsInBody({ applicationFeeBps: 0 }), [
+    "applicationFeeBps",
+  ]);
+  assert.deepEqual(platformControlledFieldsInBody({ endUserCap: 1_000_000 }), [
+    "endUserCap",
+  ]);
+});
+
+test("zero and other falsy values still count as attempts to set", () => {
+  // Zeroing the platform fee is the exact abuse this guard exists for, so a
+  // falsy value must not read as "absent".
+  assert.deepEqual(platformControlledFieldsInBody({ applicationFeeBps: 0 }), [
+    "applicationFeeBps",
+  ]);
+  assert.deepEqual(platformControlledFieldsInBody({ endUserCap: null }), [
+    "endUserCap",
+  ]);
+});
+
+test("revenue-rail fields are not reserved", () => {
+  assert.deepEqual(
+    platformControlledFieldsInBody({
+      progressiveBilling: true,
+      invoiceThresholdUsdMicros: "1000",
+      billingMode: "merchant",
+    }),
+    [],
+  );
+});
+
+test("an explicit undefined is treated as absent", () => {
+  assert.deepEqual(
+    platformControlledFieldsInBody({ applicationFeeBps: undefined }),
+    [],
+  );
+});
+
+test("reports both reserved fields together", () => {
+  assert.deepEqual(
+    platformControlledFieldsInBody({ endUserCap: 50, applicationFeeBps: 10 }),
+    ["applicationFeeBps", "endUserCap"],
+  );
+});
+
+test("error message reads correctly for one and for both fields", () => {
+  assert.equal(
+    platformControlledFieldsError(["applicationFeeBps"]),
+    "applicationFeeBps is set by PymtHouse and cannot be changed here. Contact support to request a change.",
+  );
+  assert.equal(
+    platformControlledFieldsError(["applicationFeeBps", "endUserCap"]),
+    "applicationFeeBps and endUserCap are set by PymtHouse and cannot be changed here. Contact support to request a change.",
+  );
+});

--- a/src/lib/billing/platform-controlled-fields.ts
+++ b/src/lib/billing/platform-controlled-fields.ts
@@ -1,0 +1,33 @@
+/**
+ * Billing fields that protect PymtHouse rather than configure the Builder's app.
+ *
+ * `applicationFeeBps` is the platform's share of Connect payments and
+ * `endUserCap` is the cost-rail guard against unbounded network spend. Each one
+ * constrains the app owner, so neither may be set on the owner path — only by a
+ * platform admin. See docs/adr-owner-vs-app-billing.md.
+ */
+export const PLATFORM_CONTROLLED_BILLING_FIELDS = [
+  "applicationFeeBps",
+  "endUserCap",
+] as const;
+
+export type PlatformControlledBillingField =
+  (typeof PLATFORM_CONTROLLED_BILLING_FIELDS)[number];
+
+/** Platform-controlled fields present in a PATCH body, in declaration order. */
+export function platformControlledFieldsInBody(
+  body: Record<string, unknown>,
+): PlatformControlledBillingField[] {
+  return PLATFORM_CONTROLLED_BILLING_FIELDS.filter(
+    (field) => body[field] !== undefined,
+  );
+}
+
+/** Message for a non-admin attempting to set platform-controlled fields. */
+export function platformControlledFieldsError(
+  fields: readonly string[],
+): string {
+  const subject = fields.join(" and ");
+  const verb = fields.length === 1 ? "is" : "are";
+  return `${subject} ${verb} set by PymtHouse and cannot be changed here. Contact support to request a change.`;
+}

--- a/src/lib/billing/transactions-ledger.test.ts
+++ b/src/lib/billing/transactions-ledger.test.ts
@@ -212,3 +212,34 @@ test("formatInvoicePeriodLabel prefers the period start and falls back safely", 
   assert.equal(formatInvoicePeriodLabel(null, null), null);
   assert.equal(formatInvoicePeriodLabel("nonsense", null), null);
 });
+
+test("incomplete inputs suppress running balances instead of guessing", () => {
+  // A soft-timeout on grants or usage leaves holes in the event chain, so every
+  // balance derived by walking back from the live balance would be wrong.
+  const entries = buildLedgerEntries({
+    grants: [{ id: "g1", amountUsdMicros: "25000000", date: "2026-07-01T00:00:00Z" }],
+    dailyUsage: [{ date: "2026-07-05", usedUsdMicros: "6000000" }],
+    invoices: [],
+    planIncludedUsdMicros: "5000000",
+    endingCreditBalanceUsdMicros: "24000000",
+    inputsComplete: false,
+  });
+
+  assert.ok(entries.length > 0, "entries are still listed");
+  assert.ok(
+    entries.every((entry) => entry.balanceUsdMicros === null),
+    "no entry claims a balance it cannot substantiate",
+  );
+  // The events themselves are still accurate; only the derived column is withheld.
+  assert.equal(entries[0].creditDeltaUsdMicros, "-1000000");
+});
+
+test("inputsComplete defaults to true so existing callers are unaffected", () => {
+  const entries = buildLedgerEntries({
+    grants: [{ id: "g1", amountUsdMicros: "1000000", date: "2026-07-01T00:00:00Z" }],
+    dailyUsage: [],
+    invoices: [],
+    endingCreditBalanceUsdMicros: "1000000",
+  });
+  assert.equal(entries[0].balanceUsdMicros, "1000000");
+});

--- a/src/lib/billing/transactions-ledger.ts
+++ b/src/lib/billing/transactions-ledger.ts
@@ -29,8 +29,15 @@ export type LedgerEntry = {
   amountUsdMicros: string;
   /** Signed change to the prepaid credit balance (USD micros). */
   creditDeltaUsdMicros: string;
-  /** Prepaid credit balance after this entry (USD micros). */
-  balanceUsdMicros: string;
+  /**
+   * Prepaid credit balance after this entry (USD micros).
+   *
+   * Null when the ledger's inputs were incomplete: the running balance is
+   * derived by walking back from the live balance over the entries below it,
+   * so a missing grant or usage day makes every earlier figure wrong. Better
+   * to show nothing than a confidently incorrect balance.
+   */
+  balanceUsdMicros: string | null;
   /** True when the row is derived from meter data rather than a billing record. */
   derived: boolean;
   status?: string | null;
@@ -141,6 +148,12 @@ export function buildLedgerEntries(input: {
   invoices: LedgerInvoiceInput[];
   planIncludedUsdMicros?: string | null;
   endingCreditBalanceUsdMicros?: string | null;
+  /**
+   * False when any input source degraded (soft timeout, failed lookup), so the
+   * event chain may have holes. Running balances are suppressed rather than
+   * computed from a partial chain. Defaults to true.
+   */
+  inputsComplete?: boolean;
 }): LedgerEntry[] {
   type Draft = Omit<LedgerEntry, "balanceUsdMicros"> & {
     creditDelta: bigint;
@@ -211,6 +224,9 @@ export function buildLedgerEntries(input: {
     });
 
   // Walk backward from the live balance so the newest row reconciles exactly.
+  // This is only sound when every balance-moving event is present: a hole in
+  // the chain silently shifts every earlier balance by the missing delta.
+  const complete = input.inputsComplete !== false;
   const endingBalance = parseMicros(input.endingCreditBalanceUsdMicros);
   const balances = new Array<bigint>(ordered.length);
   let running = endingBalance;
@@ -222,7 +238,10 @@ export function buildLedgerEntries(input: {
   return ordered
     .map((draft, index) => {
       const { creditDelta: _creditDelta, ...rest } = draft;
-      return { ...rest, balanceUsdMicros: balances[index].toString() };
+      return {
+        ...rest,
+        balanceUsdMicros: complete ? balances[index].toString() : null,
+      };
     })
     .reverse();
 }

--- a/src/lib/dashboard-usage-summary.ts
+++ b/src/lib/dashboard-usage-summary.ts
@@ -10,7 +10,10 @@ export type DashboardUsageChartSeries = {
   appName: string;
   jobType: string;
   totalRequests: number;
-  points: { date: string; value: number }[];
+  /** Total network fee across the series (USD micros), for the cost metric. */
+  totalFeeUsdMicros?: string;
+  /** `value` is the request count; `feeUsdMicros` backs the $ metric. */
+  points: { date: string; value: number; feeUsdMicros?: string }[];
 };
 
 export type DashboardUsageSummary = {

--- a/src/lib/oidc/owner-wire-subject.test.ts
+++ b/src/lib/oidc/owner-wire-subject.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildOwnerCustomerKey,
+  buildOwnerWireSubject,
+  buildOpenMeterCustomerKey,
+  normalizePlatformUserId,
+} from "@/lib/openmeter/customer-key";
+
+/**
+ * The ingest chain that decides whether usage is billable:
+ *
+ *   token user_type  →  webhook usage_subject  →  collector CE subject
+ *
+ * The collector has no database. It decides "owner" purely from the `owner:`
+ * prefix the webhook applies when `user_type === "app_owner"`. If a token
+ * minter omits that claim, owner traffic lands on `app_…:{ownerId}` — a
+ * subject no customer is attributed, so OpenMeter never invoices it.
+ *
+ * These tests pin the contract in the same shape the collector implements
+ * (deploy/openmeter-collector/collector.yaml), so a change on either side
+ * that breaks attribution fails here.
+ */
+
+/** Mirrors `withOwnerBillingUsageSubject` in remote-signer-webhook-config. */
+function webhookUsageSubject(userType: string, bareSubject: string): string {
+  if (userType !== "app_owner") return bareSubject;
+  if (bareSubject.startsWith("owner:")) return bareSubject;
+  return buildOwnerWireSubject(bareSubject);
+}
+
+/** Mirrors the collector's owner-prefix strip in collector.yaml. */
+function collectorCloudEventSubject(clientId: string, usageSubject: string): string {
+  const authId = `${clientId}:${usageSubject}`;
+  const isOwner = usageSubject.startsWith("owner:");
+  return isOwner ? normalizePlatformUserId(usageSubject) : authId;
+}
+
+function ingestSubject(
+  userType: string,
+  clientId: string,
+  bareSubject: string,
+): string {
+  return collectorCloudEventSubject(
+    clientId,
+    webhookUsageSubject(userType, bareSubject),
+  );
+}
+
+test("an app_owner token lands on the canonical owner customer key", () => {
+  const subject = ingestSubject("app_owner", "app_demo", "user-1");
+  assert.equal(subject, buildOwnerCustomerKey("user-1"));
+  assert.equal(subject, "user-1");
+});
+
+test("an end-user token lands on the canonical compound customer key", () => {
+  const subject = ingestSubject("external_user", "app_demo", "ext-9");
+  assert.equal(subject, buildOpenMeterCustomerKey("app_demo", "ext-9"));
+});
+
+test("an app_user token for a non-owner is unchanged", () => {
+  const subject = ingestSubject("app_user", "app_demo", "ext-9");
+  assert.equal(subject, "app_demo:ext-9");
+});
+
+test("omitting app_owner sends owner traffic to an unattributed subject", () => {
+  // The programmatic-token bug: user_type hardcoded to "app_user" for an owner.
+  const wrong = ingestSubject("app_user", "app_demo", "user-1");
+  const canonical = buildOwnerCustomerKey("user-1");
+
+  assert.notEqual(
+    wrong,
+    canonical,
+    "an owner minted without user_type=app_owner must not reach the owner wallet",
+  );
+  assert.equal(wrong, "app_demo:user-1");
+  // That subject belongs to no customer, so OpenMeter would never invoice it.
+});
+
+test("an already-prefixed owner subject is not double-prefixed", () => {
+  const subject = ingestSubject("app_owner", "app_demo", "owner:user-1");
+  assert.equal(subject, buildOwnerCustomerKey("user-1"));
+});
+
+test("the wire marker never leaks into the customer key", () => {
+  const wire = buildOwnerWireSubject("user-1");
+  assert.equal(wire, "owner:user-1");
+  // The collector strips it; the customer key is always bare.
+  assert.equal(normalizePlatformUserId(wire), "user-1");
+  assert.equal(buildOwnerCustomerKey("user-1"), "user-1");
+});

--- a/src/lib/oidc/programmatic-tokens.ts
+++ b/src/lib/oidc/programmatic-tokens.ts
@@ -14,6 +14,7 @@ import { and, eq } from "drizzle-orm";
 import { validateClientSecret } from "./clients";
 import { billingPatternFromAllowedScopesString } from "@/lib/allowed-scopes";
 import { assertSignJobNotMixedWithAdmin, SignJobScopeExclusivityError } from "@/lib/oidc/scopes";
+import { resolveOpenMeterBillingIdentity } from "@/lib/openmeter/billing-identity";
 
 const ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
 const REFRESH_TOKEN_TTL_DAYS = 30;
@@ -104,12 +105,24 @@ export async function issueProgrammaticTokens(input: {
   const nowSeconds = Math.floor(Date.now() / 1000);
   const scope = input.scopes.join(" ").trim();
 
+  // An app owner may hold an app_users row on their own app, but their usage
+  // settles on the shared owner wallet. The identity webhook keys off
+  // user_type === "app_owner" to rewrite usage_subject to owner:{id}, which
+  // the collector strips to the canonical owner customer key. Hardcoding
+  // "app_user" here sent owner traffic to app_…:{ownerId}, a subject no
+  // customer is attributed — metered and displayed, but never invoiced.
+  // See docs/adr-owner-vs-app-billing.md.
+  const billingIdentity = await resolveOpenMeterBillingIdentity({
+    clientId: binding.oauthClientId,
+    externalUserId,
+  });
+
   const accessToken = await new SignJWT({
     scope,
     scp: input.scopes,
     client_id: binding.oauthClientId,
     external_user_id: externalUserId,
-    user_type: "app_user",
+    user_type: billingIdentity.isOwner ? "app_owner" : "app_user",
   })
     .setProtectedHeader({ alg: "RS256", kid: keyPair.kid, typ: ACCESS_TOKEN_JWT_TYP })
     .setIssuer(issuer)

--- a/src/lib/openmeter/billing-consistency.test.ts
+++ b/src/lib/openmeter/billing-consistency.test.ts
@@ -6,6 +6,7 @@ import {
   classifyPhaseOutPastDeadline,
   classifySpendableGateConsistency,
   classifyStarterPlanRemoteConsistency,
+  classifyUsageAttributionConsistency,
   readUsageDiscountUsdMicrosFromPlanBody,
   summarizeFindings,
   type LocalStarterPlanRef,
@@ -318,4 +319,66 @@ test("classifyPhaseOutPastDeadline ignores before deadline or zero subscribers",
     }).length,
     0,
   );
+});
+
+test("usage on a subject the customer is not attributed is an error", () => {
+  // OpenMeter invoices per customer over subjectKeys, so usage on any other
+  // subject is metered, shown in the UI, and never charged.
+  const findings = classifyUsageAttributionConsistency({
+    ownerId: "user-1",
+    customerKey: "user-1",
+    attributedSubjects: ["user-1"],
+    subjectsWithUsage: ["user-1", "owner:user-1", "app_x:user-1"],
+  });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].code, "usage_on_unattributed_subject");
+  assert.equal(findings[0].severity, "error");
+  assert.deepEqual(findings[0].details?.unattributed, [
+    "owner:user-1",
+    "app_x:user-1",
+  ]);
+});
+
+test("attributed subjects carrying all the usage produce no findings", () => {
+  const findings = classifyUsageAttributionConsistency({
+    ownerId: "user-1",
+    customerKey: "user-1",
+    attributedSubjects: ["user-1", "owner:user-1"],
+    subjectsWithUsage: ["user-1", "owner:user-1"],
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("attributed but idle subjects are harmless", () => {
+  const findings = classifyUsageAttributionConsistency({
+    ownerId: "user-1",
+    customerKey: "user-1",
+    attributedSubjects: ["user-1", "owner:user-1", "app_x:user-1"],
+    subjectsWithUsage: ["user-1"],
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("a customer with no attribution at all cannot be billed", () => {
+  const findings = classifyUsageAttributionConsistency({
+    ownerId: "user-1",
+    customerKey: "user-1",
+    attributedSubjects: [],
+    subjectsWithUsage: ["user-1"],
+  });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].code, "customer_has_no_usage_attribution");
+  assert.equal(findings[0].severity, "error");
+});
+
+test("usage attribution comparison ignores whitespace and duplicates", () => {
+  const findings = classifyUsageAttributionConsistency({
+    ownerId: "user-1",
+    customerKey: "user-1",
+    attributedSubjects: [" user-1 ", "user-1", ""],
+    subjectsWithUsage: ["user-1", " user-1"],
+  });
+  assert.deepEqual(findings, []);
 });

--- a/src/lib/openmeter/billing-consistency.ts
+++ b/src/lib/openmeter/billing-consistency.ts
@@ -15,6 +15,7 @@ import {
   isHostedAdminClientAvailable,
 } from "@/lib/openmeter/admin-client";
 import { buildOwnerCustomerKey, buildOwnerMeterSubjects } from "@/lib/openmeter/customer-key";
+import { ownerHasChargeablePaymentMethod } from "@/lib/openmeter/owner-payment-method";
 import {
   findOpenMeterCustomerByKey,
   listOwnedPublicClientIds,
@@ -802,14 +803,25 @@ async function auditOwnerSubscriptions(
 
   const stripeCus = await getStripeCustomerAppDataId({ client, customerId });
   if (!stripeCus) {
-    findings.push({
-      code: "owner_missing_stripe_app_data",
-      severity: "error",
-      ownerId,
-      message: `Owner customer ${customerKey} has no Stripe customer app data (cus_…)`,
-      details: { customerId, customerKey },
-      remediation: FIX_SANDBOX_TO_STRIPE,
-    });
+    // Missing Stripe app data is only a defect for an owner who has something
+    // chargeable. Owners without a payment method deliberately stay on the free
+    // billing profile — Konnect rejects a Starter subscription for a customer
+    // pinned to a Stripe profile with no default payment method — so
+    // migrate-sandbox-to-stripe skips them by design. Reporting those as errors
+    // pointed at a remediation that can never apply.
+    // `null` (Stripe/OpenMeter unreachable) is treated as not-chargeable, the
+    // same fail-open choice the migration makes.
+    const chargeable = await ownerHasChargeablePaymentMethod(ownerId);
+    if (chargeable === true) {
+      findings.push({
+        code: "owner_missing_stripe_app_data",
+        severity: "error",
+        ownerId,
+        message: `Owner customer ${customerKey} has a payment method but no Stripe customer app data (cus_…)`,
+        details: { customerId, customerKey },
+        remediation: FIX_SANDBOX_TO_STRIPE,
+      });
+    }
   }
 
   if (

--- a/src/lib/openmeter/billing-consistency.ts
+++ b/src/lib/openmeter/billing-consistency.ts
@@ -380,6 +380,68 @@ export function classifyOwnerSubscriptionMapping(input: {
  * Detect mint/signer gate mismatch: unused included allowance but spendable=0.
  * Pure — no I/O.
  */
+/**
+ * Compare the subjects a customer is *attributed* against the subjects that
+ * actually carry metered usage.
+ *
+ * OpenMeter invoices per customer over `usageAttribution.subjectKeys`. A
+ * subject carrying usage that is not attributed to any customer is metered,
+ * displayed, and **never billed** — a silent revenue leak that looks like
+ * normal operation. The reverse (attributed but idle) is harmless.
+ *
+ * See docs/adr-owner-vs-app-billing.md ("Usage reads follow customer id").
+ */
+export function classifyUsageAttributionConsistency(input: {
+  ownerId: string;
+  customerKey: string;
+  /** `usageAttribution.subjectKeys` from the OpenMeter customer record. */
+  attributedSubjects: string[];
+  /** Subjects observed carrying non-zero usage this cycle. */
+  subjectsWithUsage: string[];
+}): BillingConsistencyFinding[] {
+  const attributed = new Set(
+    input.attributedSubjects.map((key) => key.trim()).filter(Boolean),
+  );
+  const used = [
+    ...new Set(input.subjectsWithUsage.map((key) => key.trim()).filter(Boolean)),
+  ];
+
+  if (attributed.size === 0) {
+    return [
+      {
+        code: "customer_has_no_usage_attribution",
+        severity: "error",
+        ownerId: input.ownerId,
+        message: `Customer ${input.customerKey} has no attributed subjects; OpenMeter cannot bill any of its usage.`,
+        details: { customerKey: input.customerKey, subjectsWithUsage: used },
+        remediation:
+          "Re-run openmeter-migrate-owner-customers.ts to attach the settlement subject.",
+      },
+    ];
+  }
+
+  const unattributed = used.filter((subject) => !attributed.has(subject));
+  if (unattributed.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      code: "usage_on_unattributed_subject",
+      severity: "error",
+      ownerId: input.ownerId,
+      message: `Customer ${input.customerKey} has usage on ${unattributed.length} subject(s) it is not attributed: ${unattributed.join(", ")}. This usage is metered but will never be invoiced.`,
+      details: {
+        customerKey: input.customerKey,
+        unattributed,
+        attributed: [...attributed],
+      },
+      remediation:
+        "Attach the subject to the customer, or re-key ingest to the canonical customer subject. Until then PymtHouse shows usage the billing engine will not charge for.",
+    },
+  ];
+}
+
 export function classifySpendableGateConsistency(input: {
   ownerId: string;
   clientId: string;

--- a/src/lib/openmeter/billing-consistency.ts
+++ b/src/lib/openmeter/billing-consistency.ts
@@ -622,6 +622,54 @@ async function queryOwnerUsedUsdMicros(
   }
 }
 
+/**
+ * Which of `candidates` actually carried usage this cycle.
+ *
+ * Checks the whole set in one query first — the healthy case is "none", and
+ * this keeps the audit to a single round-trip for it. Only when that total is
+ * non-zero does it drill down per subject to name the offenders.
+ */
+async function findSubjectsWithUsage(
+  client: OpenMeter,
+  candidates: string[],
+): Promise<string[]> {
+  if (candidates.length === 0) return [];
+  const cycle = calendarMonthBoundsUtc(new Date());
+  const window = {
+    windowSize: "MONTH" as const,
+    from: new Date(cycle.start),
+    to: new Date(cycle.end),
+  };
+
+  const totalFor = async (subjects: string[]): Promise<bigint> => {
+    const result = await client.meters.query(NETWORK_FEE_USD_MICROS_METER, {
+      ...window,
+      subject: subjects,
+    });
+    let total = 0n;
+    for (const row of result.data || []) {
+      total += meterRowValueToBigInt(row.value);
+    }
+    return total;
+  };
+
+  try {
+    if ((await totalFor(candidates)) === 0n) {
+      return [];
+    }
+    const withUsage: string[] = [];
+    for (const subject of candidates) {
+      if ((await totalFor([subject])) > 0n) {
+        withUsage.push(subject);
+      }
+    }
+    return withUsage;
+  } catch {
+    // An audit that cannot read usage must not claim everything is attributed.
+    return [];
+  }
+}
+
 export type AuditBillingConsistencyOptions = {
   ownerId?: string;
   clientId?: string;
@@ -714,8 +762,18 @@ async function auditOwnerSubscriptions(
   const customerKey = buildOwnerCustomerKey(ownerId);
 
   let customerId: string;
+  let attributedSubjects: string[] = [];
   try {
-    const customer = await findOpenMeterCustomerByKey(client, customerKey);
+    const customer = (await findOpenMeterCustomerByKey(client, customerKey)) as
+      | { id?: string; usageAttribution?: { subjectKeys?: string[] } }
+      | null;
+    attributedSubjects = [
+      ...new Set(
+        (customer?.usageAttribution?.subjectKeys ?? [])
+          .map((key) => key.trim())
+          .filter(Boolean),
+      ),
+    ];
     if (!customer?.id) {
       return [
         {
@@ -809,6 +867,25 @@ async function auditOwnerSubscriptions(
       }),
     );
   }
+
+  // Gate for the transitional-subject cutover: usage on a subject the customer
+  // is not attributed is metered but never invoiced. This must report clean
+  // before buildOwnerMeterSubjects can be reduced to the canonical key.
+  // See docs/adr-owner-vs-app-billing.md.
+  const ownedPublicClientIds = await listOwnedPublicClientIds(ownerId);
+  const subjectsWithUsage = await findSubjectsWithUsage(
+    client,
+    buildOwnerMeterSubjects(ownerId, ownedPublicClientIds),
+  );
+  findings.push(
+    ...classifyUsageAttributionConsistency({
+      ownerId,
+      customerKey,
+      attributedSubjects,
+      subjectsWithUsage,
+    }),
+  );
+
   return findings;
 }
 

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -1,3 +1,7 @@
+import {
+  platformDefaultApplicationFeeBps,
+  platformDefaultEndUserCap,
+} from "@/lib/billing/platform-billing-defaults";
 import { eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db/index";
@@ -643,6 +647,12 @@ export async function upsertAppBillingConfig(
     clientId,
     stripeConnectStatus: "disconnected",
     defaultCurrency: "USD",
+    // Cost-rail controls come from platform policy, not from the app. Set
+    // explicitly (rather than leaning on the column defaults) so changing
+    // policy is an env change instead of a migration. An explicit value in
+    // `values` still wins — that path is admin-only.
+    endUserCap: platformDefaultEndUserCap(),
+    applicationFeeBps: platformDefaultApplicationFeeBps(),
     createdAt: now,
     updatedAt: now,
     ...values,

--- a/src/lib/openmeter/credit-allowance-summary.ts
+++ b/src/lib/openmeter/credit-allowance-summary.ts
@@ -309,12 +309,30 @@ export async function listOwnerCreditGrants(
       customerId: customer.id,
       apiKey,
     });
-    return grants.map((grant, index) => ({
-      id: grant.id || grant.key || `grant-${index}`,
-      amountUsdMicros: decimalDollarsToUsdMicros(grant.amount || "0").toString(),
-      date: konnectGrantTimestamp(grant),
-      name: grant.name?.trim() || null,
-    }));
+    // decimalDollarsToUsdMicros throws on a malformed amount. Parsing inside
+    // the shared try would let one bad row discard every valid grant, so each
+    // is parsed independently and only the bad row is dropped.
+    return grants.flatMap((grant, index) => {
+      let amountUsdMicros: string;
+      try {
+        amountUsdMicros = decimalDollarsToUsdMicros(grant.amount || "0").toString();
+      } catch (err) {
+        console.warn(
+          "credit-allowance-summary: skipping grant with unparseable amount",
+          grant.id || grant.key || `grant-${index}`,
+          err instanceof Error ? err.message : String(err),
+        );
+        return [];
+      }
+      return [
+        {
+          id: grant.id || grant.key || `grant-${index}`,
+          amountUsdMicros,
+          date: konnectGrantTimestamp(grant),
+          name: grant.name?.trim() || null,
+        },
+      ];
+    });
   } catch (err) {
     console.warn(
       "credit-allowance-summary: owner grant list failed",

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -285,6 +285,43 @@ export async function listOwnedPublicClientIds(ownerUserId: string): Promise<str
 }
 
 /** Lookup-only (never creates). Exact key match on Konnect; get() elsewhere. */
+/**
+ * Subjects OpenMeter attributes to a customer — `usageAttribution.subjectKeys`.
+ *
+ * This is the authority for both billing and reads. OpenMeter's invoicing runs
+ * per customer over exactly these subjects, so any usage query that reads a
+ * different set will disagree with the invoice it is meant to explain.
+ * Reading a *wider* set is the dangerous direction: it shows usage the billing
+ * engine will never charge for.
+ *
+ * Returns [] when the customer cannot be read, so callers can distinguish
+ * "no attributed subjects" from "lookup failed" and avoid silently widening.
+ *
+ * See docs/adr-owner-vs-app-billing.md ("Usage reads follow customer id").
+ */
+export async function resolveCustomerSubjectKeys(
+  client: OpenMeter,
+  customerKey: string,
+): Promise<string[]> {
+  const trimmed = customerKey.trim();
+  if (!trimmed) return [];
+  try {
+    const customer = (await findOpenMeterCustomerByKey(
+      client,
+      trimmed,
+    )) as OpenMeterCustomerRecord | null;
+    const keys = customer?.usageAttribution?.subjectKeys ?? [];
+    return [...new Set(keys.map((key) => key.trim()).filter(Boolean))];
+  } catch (err) {
+    console.warn(
+      "customers: subject key lookup failed",
+      trimmed,
+      err instanceof Error ? err.message : String(err),
+    );
+    return [];
+  }
+}
+
 export async function findOpenMeterCustomerByKey(
   client: OpenMeter,
   customerKey: string,

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -177,8 +177,15 @@ export async function ensureOwnerCustomerWireSubjects(
  * simply avoids attaching more. Transitional wire/compound subjects
  * (`owner:…`, `app_…:…`) are attached best-effort once at create time;
  * Konnect rejects later changes while a subscription is active (400) or when
- * a legacy wallet still claims them (409). Meter dual-read for usage does not
- * require those keys on the customer record.
+ * a legacy wallet still claims them (409).
+ *
+ * These keys are what OpenMeter bills over, and since
+ * `resolveCustomerSubjectKeys` they are also what PymtHouse reads. A subject
+ * missing here is therefore neither invoiced nor displayed —
+ * `classifyUsageAttributionConsistency` reports any that still carry usage.
+ * (This previously read "meter dual-read for usage does not require those keys
+ * on the customer record", which was true of reads and false of billing: usage
+ * on an unattributed subject was shown but never charged.)
  */
 export async function ensureOwnerCustomer(
   client: OpenMeter,

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import type { OpenMeter } from "@openmeter/sdk";
 
 import { db } from "@/db/index";
-import { developerApps, oidcClients, plans } from "@/db/schema";
+import { appBillingConfig, developerApps, oidcClients, plans } from "@/db/schema";
 import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
 import { authOptions } from "@/lib/next-auth-options";
 import {
@@ -85,6 +85,15 @@ export type OwnerBillingPayload = {
   /** Every attached Stripe payment method (Plane A), default flagged. */
   paymentMethods: OwnerPaymentMethodListItem[];
   subscriptions: OwnerBillingSubscriptionRow[];
+  /**
+   * Apps this owner owns, with how each one bills its end users. Every app
+   * here rolls its network cost up to the platform subscription above.
+   */
+  ownedApps: Array<{
+    id: string;
+    name: string;
+    billingMode: "owner_rollup" | "merchant";
+  }>;
   /** Platform → developer invoices for the shared owner prepaid wallet. */
   invoices: TenantInvoiceDto[];
   /**
@@ -108,6 +117,12 @@ type OwnedApp = {
   developerAppId: string;
   publicClientId: string;
   name: string;
+  /**
+   * owner_rollup — this app's end-user usage is paid by the owner's platform
+   * plan. merchant — the Builder also bills their own end users via Connect,
+   * but the owner still pays PymtHouse for the underlying network usage.
+   */
+  billingMode: "owner_rollup" | "merchant";
 };
 
 type CustomerCandidate = {
@@ -339,9 +354,11 @@ async function listOwnedApps(ownerUserId: string): Promise<OwnedApp[]> {
       developerAppId: developerApps.id,
       name: developerApps.name,
       publicClientId: oidcClients.clientId,
+      billingMode: appBillingConfig.billingMode,
     })
     .from(developerApps)
     .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .leftJoin(appBillingConfig, eq(appBillingConfig.clientId, developerApps.id))
     .where(eq(developerApps.ownerId, ownerUserId));
 
   return rows
@@ -349,6 +366,10 @@ async function listOwnedApps(ownerUserId: string): Promise<OwnedApp[]> {
       developerAppId: row.developerAppId,
       name: row.name,
       publicClientId: row.publicClientId?.trim() || row.developerAppId,
+      billingMode:
+        row.billingMode === "merchant"
+          ? ("merchant" as const)
+          : ("owner_rollup" as const),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -785,6 +806,11 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
       creditAllowance,
       paymentMethods,
       subscriptions,
+      ownedApps: ownedApps.map((app) => ({
+        id: app.developerAppId,
+        name: app.name,
+        billingMode: app.billingMode,
+      })),
       invoices: invoicesResult.items,
       ledger,
       openMeterConfigured: true,

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -542,6 +542,8 @@ async function mapSubscriptionRow(input: {
   ownerUserId: string;
   ownedApps: OwnedApp[];
   planKeyToLocalId: Map<string, string>;
+  /** Pre-resolved owner-wallet subjects; avoids a second OpenMeter lookup. */
+  ownerWalletSubjects?: string[];
 }): Promise<OwnerBillingSubscriptionRow> {
   const localPlanId = input.candidate.appPublicClientId
     ? await resolveLocalPlanIdFromOpenMeterSubscription(
@@ -573,11 +575,12 @@ async function mapSubscriptionRow(input: {
   // Read the subjects OpenMeter actually bills for this customer, so the
   // figure shown matches the invoice it explains.
   const usageSubjects = isSharedOwnerWallet
-    ? await resolveOwnerWalletReadSubjects({
+    ? (input.ownerWalletSubjects ??
+      (await resolveOwnerWalletReadSubjects({
         client: input.client,
         ownerUserId: input.ownerUserId,
         ownedApps: input.ownedApps,
-      })
+      })))
     : [input.candidate.customerKey];
 
   const usage = await querySubjectCycleUsage({
@@ -668,6 +671,10 @@ async function listActiveSubscriptionsForCustomer(input: {
  */
 export async function listOwnerActiveSubscriptions(
   userId: string,
+  options?: Readonly<{
+    ownedApps?: OwnedApp[];
+    ownerWalletSubjects?: string[];
+  }>,
 ): Promise<OwnerBillingSubscriptionRow[]> {
   const trimmed = userId.trim();
   if (!trimmed) {
@@ -680,7 +687,14 @@ export async function listOwnerActiveSubscriptions(
   const client = getHostedAdminClient();
   const cycleBounds = calendarMonthBoundsUtc(new Date());
   const cycle = { start: cycleBounds.start, end: cycleBounds.end };
-  const ownedApps = await listOwnedApps(trimmed);
+  const ownedApps = options?.ownedApps ?? (await listOwnedApps(trimmed));
+  const ownerWalletSubjects =
+    options?.ownerWalletSubjects ??
+    (await resolveOwnerWalletReadSubjects({
+      client,
+      ownerUserId: trimmed,
+      ownedApps,
+    }));
   const planKeyToLocalId = await loadPlanKeyToLocalId(
     ownedApps.map((app) => app.developerAppId),
   );
@@ -727,6 +741,7 @@ export async function listOwnerActiveSubscriptions(
         ownerUserId: trimmed,
         ownedApps,
         planKeyToLocalId,
+        ownerWalletSubjects,
       }),
     ),
   );
@@ -761,6 +776,15 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
   }
 
   const adminClient = getHostedAdminClient();
+  // Resolve owned apps + wallet subjects once: subscriptions and daily usage
+  // both read the same attributed subject set, and a second customer lookup
+  // would be a wasted round trip with a consistency risk between the two.
+  const ownedApps = await listOwnedApps(userId);
+  const ownerWalletSubjects = await resolveOwnerWalletReadSubjects({
+    client: adminClient,
+    ownerUserId: userId,
+    ownedApps,
+  });
   // Invoices hit Konnect /billing/invoices (often multi-second). Soft-timeout so
   // first paint is not blocked when the invoice index is large or slow.
   const emptyInvoices = { items: [] as TenantInvoiceDto[] };
@@ -772,7 +796,6 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
     creditAllowance,
     paymentMethods,
     subscriptions,
-    ownedApps,
     invoicesResult,
     creditGrants,
   ] = await Promise.all([
@@ -792,12 +815,14 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
         "payment method lookup",
       ),
       withSoftTimeout(
-        listOwnerActiveSubscriptions(userId),
+        listOwnerActiveSubscriptions(userId, {
+          ownedApps,
+          ownerWalletSubjects,
+        }),
         8_000,
         [] as OwnerBillingSubscriptionRow[],
         "subscription lookup",
       ),
-      listOwnedApps(userId),
       withSoftTimeout(
         listOwnerWalletInvoices({
           client: adminClient,
@@ -823,11 +848,7 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
   const dailyUsage = await withSoftTimeout(
     querySubjectDailyUsage({
       client: adminClient,
-      subjects: await resolveOwnerWalletReadSubjects({
-        client: adminClient,
-        ownerUserId: userId,
-        ownedApps,
-      }),
+      subjects: ownerWalletSubjects,
       start: cycle.start,
       end: cycle.end,
     }),

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -26,7 +26,10 @@ import {
   buildOwnerCustomerKey,
   buildOwnerMeterSubjects,
 } from "@/lib/openmeter/customer-key";
-import { ensureOpenMeterCustomer } from "@/lib/openmeter/customers";
+import {
+  ensureOpenMeterCustomer,
+  resolveCustomerSubjectKeys,
+} from "@/lib/openmeter/customers";
 import {
   defaultStarterIncludedUsdMicros,
   planDisplayNameWithStarter,
@@ -348,6 +351,33 @@ function buildOwnerWalletUsageSubjects(
   );
 }
 
+/**
+ * Subjects to read for the owner wallet.
+ *
+ * Prefers `usageAttribution.subjectKeys` from the OpenMeter customer, because
+ * that is the exact set OpenMeter's invoicing runs over — reading anything
+ * wider shows usage the billing engine will never charge for. Falls back to the
+ * transitional union only when the customer record cannot be read, so a lookup
+ * failure degrades to the old behaviour rather than reporting zero.
+ *
+ * `classifyUsageAttributionConsistency` reports the gap between the two.
+ * See docs/adr-owner-vs-app-billing.md.
+ */
+async function resolveOwnerWalletReadSubjects(input: {
+  client: OpenMeter;
+  ownerUserId: string;
+  ownedApps: OwnedApp[];
+}): Promise<string[]> {
+  const attributed = await resolveCustomerSubjectKeys(
+    input.client,
+    buildOwnerCustomerKey(input.ownerUserId),
+  );
+  if (attributed.length > 0) {
+    return attributed;
+  }
+  return buildOwnerWalletUsageSubjects(input.ownerUserId, input.ownedApps);
+}
+
 async function listOwnedApps(ownerUserId: string): Promise<OwnedApp[]> {
   const rows = await db
     .select({
@@ -529,8 +559,14 @@ async function mapSubscriptionRow(input: {
   });
 
   const isSharedOwnerWallet = input.candidate.appPublicClientId == null;
+  // Read the subjects OpenMeter actually bills for this customer, so the
+  // figure shown matches the invoice it explains.
   const usageSubjects = isSharedOwnerWallet
-    ? buildOwnerWalletUsageSubjects(input.ownerUserId, input.ownedApps)
+    ? await resolveOwnerWalletReadSubjects({
+        client: input.client,
+        ownerUserId: input.ownerUserId,
+        ownedApps: input.ownedApps,
+      })
     : [input.candidate.customerKey];
 
   const usage = await querySubjectCycleUsage({
@@ -769,7 +805,11 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
   const dailyUsage = await withSoftTimeout(
     querySubjectDailyUsage({
       client: adminClient,
-      subjects: buildOwnerWalletUsageSubjects(userId, ownedApps),
+      subjects: await resolveOwnerWalletReadSubjects({
+        client: adminClient,
+        ownerUserId: userId,
+        ownedApps,
+      }),
       start: cycle.start,
       end: cycle.end,
     }),

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -495,16 +495,27 @@ async function loadPlanKeyToLocalId(
   return index;
 }
 
+/**
+ * Resolve `fallback` on timeout or failure so first paint is never blocked.
+ *
+ * The fallback is indistinguishable from a genuine result, so callers that
+ * need to know whether data is complete must pass `onDegraded`.
+ */
 function withSoftTimeout<T>(
   promise: Promise<T>,
   ms: number,
   fallback: T,
   label: string,
+  onDegraded?: () => void,
 ): Promise<T> {
   return new Promise((resolve) => {
+    const degrade = (value: T) => {
+      onDegraded?.();
+      resolve(value);
+    };
     const timer = setTimeout(() => {
       console.warn(`owner-billing: ${label} timed out after ${ms}ms`);
-      resolve(fallback);
+      degrade(fallback);
     }, ms);
     promise.then(
       (value) => {
@@ -517,7 +528,7 @@ function withSoftTimeout<T>(
           `owner-billing: ${label} failed`,
           err instanceof Error ? err.message : String(err),
         );
-        resolve(fallback);
+        degrade(fallback);
       },
     );
   });
@@ -753,6 +764,10 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
   // Invoices hit Konnect /billing/invoices (often multi-second). Soft-timeout so
   // first paint is not blocked when the invoice index is large or slow.
   const emptyInvoices = { items: [] as TenantInvoiceDto[] };
+  // Grants and daily usage both move the prepaid balance, so a soft-timeout on
+  // either leaves holes in the ledger's event chain and its running balances
+  // cannot be trusted.
+  let ledgerInputsDegraded = false;
   const [
     creditAllowance,
     paymentMethods,
@@ -799,6 +814,9 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
         2_500,
         [] as OwnerCreditGrant[],
         "credit grant lookup",
+        () => {
+          ledgerInputsDegraded = true;
+        },
       ),
     ]);
 
@@ -816,6 +834,9 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
     3_000,
     [] as Array<{ date: string; usedUsdMicros: string }>,
     "daily usage lookup",
+    () => {
+      ledgerInputsDegraded = true;
+    },
   );
 
   // Allowance from the owner-wallet subscription (the one credits settle against).
@@ -836,6 +857,7 @@ export async function getOwnerBillingData(): Promise<OwnerBillingResult> {
     })),
     planIncludedUsdMicros: walletSubscription?.discountUsdMicros ?? null,
     endingCreditBalanceUsdMicros: creditAllowance?.balanceUsdMicros ?? null,
+    inputsComplete: !ledgerInputsDegraded,
   });
 
   return {

--- a/src/lib/usage/chart-scale.test.ts
+++ b/src/lib/usage/chart-scale.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  bucketPoints,
+  buildNiceTicks,
+  buildSeriesColorMap,
+  niceStep,
+  pointMagnitude,
+} from "@/lib/usage/chart-scale";
+
+test("buildNiceTicks produces round axis values, not 29/58/87/116", () => {
+  // The reported axis: a peak of 96 previously yielded 0/29/58/87/116.
+  const ticks = buildNiceTicks(96, { integerOnly: true });
+  assert.deepEqual(ticks, [0, 25, 50, 75, 100]);
+});
+
+test("buildNiceTicks snaps to 1/2/2.5/5/10 magnitudes", () => {
+  assert.deepEqual(buildNiceTicks(4, { integerOnly: true }), [0, 1, 2, 3, 4]);
+  assert.deepEqual(buildNiceTicks(40, { integerOnly: true }), [0, 10, 20, 30, 40]);
+  assert.deepEqual(buildNiceTicks(900, { integerOnly: true }), [0, 250, 500, 750, 1000]);
+});
+
+test("buildNiceTicks always spans the peak", () => {
+  for (const peak of [1, 7, 13, 96, 137, 1001, 45678]) {
+    const ticks = buildNiceTicks(peak, { integerOnly: true });
+    assert.ok(
+      (ticks.at(-1) ?? 0) >= peak,
+      `top tick ${ticks.at(-1)} must cover peak ${peak}`,
+    );
+    assert.equal(ticks[0], 0, "axis starts at zero");
+  }
+});
+
+test("buildNiceTicks keeps request axes on whole numbers", () => {
+  const ticks = buildNiceTicks(3, { integerOnly: true });
+  assert.ok(
+    ticks.every((tick) => Number.isInteger(tick)),
+    `expected integer ticks, got ${ticks.join(",")}`,
+  );
+});
+
+test("buildNiceTicks allows fractional steps for money axes", () => {
+  const ticks = buildNiceTicks(0.8);
+  assert.ok((ticks.at(-1) ?? 0) >= 0.8);
+  assert.ok(ticks.length > 1);
+});
+
+test("buildNiceTicks degrades gracefully for empty or invalid peaks", () => {
+  assert.deepEqual(buildNiceTicks(0), [0, 1, 2, 3, 4]);
+  assert.deepEqual(buildNiceTicks(Number.NaN), [0, 1, 2, 3, 4]);
+  assert.deepEqual(buildNiceTicks(-5), [0, 1, 2, 3, 4]);
+});
+
+test("niceStep rounds up to a readable magnitude", () => {
+  assert.equal(niceStep(24), 25);
+  assert.equal(niceStep(0.4), 0.5);
+  assert.equal(niceStep(6), 10);
+  assert.equal(niceStep(0), 1);
+});
+
+test("bucketPoints in day mode passes points through in date order", () => {
+  const out = bucketPoints(
+    [
+      { date: "2026-07-02", value: 2, feeUsdMicros: "200" },
+      { date: "2026-07-01", value: 1, feeUsdMicros: "100" },
+    ],
+    "day",
+  );
+  assert.deepEqual(
+    out.map((p) => p.date),
+    ["2026-07-01", "2026-07-02"],
+  );
+  assert.equal(out[0].feeUsdMicros, "100");
+});
+
+test("bucketPoints groups weeks into 7-day buckets and sums both measures", () => {
+  const points = Array.from({ length: 14 }, (_, i) => ({
+    date: `2026-07-${String(i + 1).padStart(2, "0")}`,
+    value: 1,
+    feeUsdMicros: "1000",
+  }));
+  const out = bucketPoints(points, "week");
+
+  assert.equal(out.length, 2);
+  assert.equal(out[0].date, "2026-07-01");
+  assert.equal(out[0].endDate, "2026-07-07");
+  assert.equal(out[0].value, 7);
+  assert.equal(out[0].feeUsdMicros, "7000");
+  assert.equal(out[1].date, "2026-07-08");
+  assert.equal(out[1].endDate, "2026-07-14");
+});
+
+test("bucketPoints keeps a short trailing week as its own bucket", () => {
+  const points = Array.from({ length: 9 }, (_, i) => ({
+    date: `2026-07-${String(i + 1).padStart(2, "0")}`,
+    value: 2,
+  }));
+  const out = bucketPoints(points, "week");
+
+  assert.equal(out.length, 2);
+  assert.equal(out[1].value, 4, "trailing partial week keeps its own total");
+  assert.equal(out[1].endDate, "2026-07-09");
+});
+
+test("bucketPoints sums fees beyond Number precision", () => {
+  const out = bucketPoints(
+    [
+      { date: "2026-07-01", value: 1, feeUsdMicros: "9007199254740991" },
+      { date: "2026-07-02", value: 1, feeUsdMicros: "9007199254740991" },
+    ],
+    "week",
+  );
+  assert.equal(out[0].feeUsdMicros, "18014398509481982");
+});
+
+test("pointMagnitude switches measure without a second axis", () => {
+  const point = {
+    date: "2026-07-01",
+    endDate: "2026-07-01",
+    value: 42,
+    feeUsdMicros: "2500000",
+  };
+  assert.equal(pointMagnitude(point, "requests"), 42);
+  assert.equal(pointMagnitude(point, "cost"), 2.5);
+});
+
+test("buildSeriesColorMap keeps colours stable when series are filtered out", () => {
+  const all = ["app1|a", "app1|b", "app2|c"];
+  const map = buildSeriesColorMap(all, 8);
+
+  // Filtering the chart must look up the same slots, not reassign by position.
+  assert.equal(map.get("app2|c"), 2);
+  assert.equal(map.get("app1|b"), 1);
+});
+
+test("buildSeriesColorMap assigns distinct slots within the palette size", () => {
+  const keys = Array.from({ length: 8 }, (_, i) => `k${i}`);
+  const map = buildSeriesColorMap(keys, 8);
+  assert.equal(new Set(map.values()).size, 8, "no two series share a slot");
+});
+
+test("buildSeriesColorMap dedupes repeated keys", () => {
+  const map = buildSeriesColorMap(["a", "a", "b"], 8);
+  assert.equal(map.size, 2);
+  assert.equal(map.get("b"), 1);
+});

--- a/src/lib/usage/chart-scale.ts
+++ b/src/lib/usage/chart-scale.ts
@@ -115,7 +115,7 @@ export function bucketPoints(
     }
     buckets.push({
       date: slice[0].date,
-      endDate: slice[slice.length - 1].date,
+      endDate: slice.at(-1)!.date,
       value,
       feeUsdMicros: fee.toString(),
     });

--- a/src/lib/usage/chart-scale.ts
+++ b/src/lib/usage/chart-scale.ts
@@ -1,0 +1,156 @@
+/**
+ * Pure scale/bucketing helpers for the usage chart.
+ *
+ * Client-safe (no DB/Node imports) and dependency-free so the tick and
+ * bucketing maths can be unit tested without rendering.
+ */
+
+/** Chart metric. Rendered as separate views — never as a second y-axis. */
+export type UsageChartMetric = "requests" | "cost";
+
+/** Time bucket for the x-axis. */
+export type UsageChartBucket = "day" | "week";
+
+/** Multipliers that read as "round" on an axis (…10, 20, 25, 50, 100…). */
+const NICE_MULTIPLIERS = [1, 2, 2.5, 5, 10];
+
+/**
+ * Round a rough step up to the nearest 1/2/2.5/5/10 × 10^n.
+ * Without this the axis lands on values like 29/58/87/116.
+ */
+export function niceStep(rough: number): number {
+  if (!Number.isFinite(rough) || rough <= 0) return 1;
+  const exponent = Math.floor(Math.log10(rough));
+  const magnitude = 10 ** exponent;
+  const normalized = rough / magnitude;
+  const multiplier =
+    NICE_MULTIPLIERS.find((candidate) => normalized <= candidate) ?? 10;
+  return multiplier * magnitude;
+}
+
+/**
+ * Axis ticks from 0 to a rounded top covering `maxValue`.
+ * `integerOnly` keeps request counts whole (no "2.5 requests" tick).
+ */
+export function buildNiceTicks(
+  maxValue: number,
+  options?: { tickCount?: number; integerOnly?: boolean },
+): number[] {
+  const tickCount = options?.tickCount ?? 4;
+  if (!Number.isFinite(maxValue) || maxValue <= 0) {
+    return Array.from({ length: tickCount + 1 }, (_, i) => i);
+  }
+
+  let step = niceStep(maxValue / tickCount);
+  if (options?.integerOnly && step < 1) {
+    step = 1;
+  }
+  if (options?.integerOnly && !Number.isInteger(step)) {
+    step = Math.ceil(step);
+  }
+
+  const top = Math.ceil(maxValue / step) * step;
+  const ticks: number[] = [];
+  // Guard against float drift accumulating across additions.
+  for (let i = 0; i * step <= top + step / 1000; i += 1) {
+    ticks.push(Number((i * step).toPrecision(12)));
+  }
+  return ticks;
+}
+
+export type ChartPoint = {
+  date: string;
+  /** Request count for the point. */
+  value: number;
+  /** Network fee for the point, in USD micros. */
+  feeUsdMicros?: string;
+};
+
+export type BucketedPoint = {
+  /** Bucket start date key (YYYY-MM-DD). */
+  date: string;
+  /** Last date covered by the bucket, for labelling ranges. */
+  endDate: string;
+  value: number;
+  feeUsdMicros: string;
+};
+
+function parseMicros(raw: string | undefined): bigint {
+  if (!raw) return 0n;
+  try {
+    return BigInt(raw);
+  } catch {
+    return 0n;
+  }
+}
+
+/**
+ * Group daily points into fixed 7-day buckets anchored at the first date.
+ *
+ * Anchoring at the series start (rather than ISO weeks) keeps every series in
+ * a chart aligned to the same boundaries and avoids a stub first bucket.
+ */
+export function bucketPoints(
+  points: ChartPoint[],
+  bucket: UsageChartBucket,
+): BucketedPoint[] {
+  const sorted = [...points].sort((a, b) => a.date.localeCompare(b.date));
+  if (bucket === "day" || sorted.length === 0) {
+    return sorted.map((point) => ({
+      date: point.date,
+      endDate: point.date,
+      value: point.value,
+      feeUsdMicros: parseMicros(point.feeUsdMicros).toString(),
+    }));
+  }
+
+  const buckets: BucketedPoint[] = [];
+  for (let i = 0; i < sorted.length; i += 7) {
+    const slice = sorted.slice(i, i + 7);
+    let value = 0;
+    let fee = 0n;
+    for (const point of slice) {
+      value += point.value;
+      fee += parseMicros(point.feeUsdMicros);
+    }
+    buckets.push({
+      date: slice[0].date,
+      endDate: slice[slice.length - 1].date,
+      value,
+      feeUsdMicros: fee.toString(),
+    });
+  }
+  return buckets;
+}
+
+/** Plotted magnitude for a bucket under the selected metric (dollars for cost). */
+export function pointMagnitude(
+  point: BucketedPoint,
+  metric: UsageChartMetric,
+): number {
+  if (metric === "requests") return point.value;
+  // Axis scale only — display money still formats from the micros string.
+  return Number(parseMicros(point.feeUsdMicros)) / 1_000_000;
+}
+
+/**
+ * Colour slot per series, assigned once from the **unfiltered** series list.
+ *
+ * Colour follows the entity, not its rank: filtering the chart down to a subset
+ * looks up the same slots, so surviving series keep their colour. Assigning by
+ * position would repaint them; hashing would risk two visible series colliding
+ * on one slot.
+ */
+export function buildSeriesColorMap(
+  allSeriesKeys: string[],
+  paletteSize: number,
+): Map<string, number> {
+  const map = new Map<string, number>();
+  let slot = 0;
+  for (const key of allSeriesKeys) {
+    if (map.has(key)) continue;
+    map.set(key, slot % paletteSize);
+    slot += 1;
+  }
+  return map;
+}

--- a/src/lib/usage/requests-csv.test.ts
+++ b/src/lib/usage/requests-csv.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { SignedTicketRequestRow } from "@/lib/openmeter/signed-ticket-events";
+import {
+  buildRequestsCsv,
+  buildRequestsCsvFilename,
+  escapeCsvField,
+  sumRequestFeeUsdMicros,
+} from "@/lib/usage/requests-csv";
+
+function row(overrides: Partial<SignedTicketRequestRow> = {}): SignedTicketRequestRow {
+  return {
+    time: "2026-07-20T10:00:00.000Z",
+    clientId: "app_1",
+    appName: "Demo",
+    externalUserId: "user-1",
+    gatewayRequestId: "req-1",
+    pipeline: "byoc",
+    modelId: "transcode/ffmpeg",
+    networkFeeUsdMicros: "1500",
+    eventId: "evt-1",
+    ...overrides,
+  };
+}
+
+test("escapeCsvField quotes fields containing delimiters", () => {
+  assert.equal(escapeCsvField("plain"), "plain");
+  assert.equal(escapeCsvField("has,comma"), '"has,comma"');
+  assert.equal(escapeCsvField("has\nnewline"), '"has\nnewline"');
+  assert.equal(escapeCsvField('has"quote'), '"has""quote"');
+});
+
+test("escapeCsvField neutralizes spreadsheet formula injection", () => {
+  // Pipeline/model ids are operator-controlled and land in a spreadsheet.
+  assert.equal(escapeCsvField("=1+1"), "'=1+1");
+  assert.equal(escapeCsvField("+SUM(A1)"), "'+SUM(A1)");
+  assert.equal(escapeCsvField("-2"), "'-2");
+  assert.equal(escapeCsvField("@import"), "'@import");
+});
+
+test("escapeCsvField guards and quotes a hostile field together", () => {
+  assert.equal(
+    escapeCsvField('=HYPERLINK("http://evil","x"),y'),
+    `"'=HYPERLINK(""http://evil"",""x""),y"`,
+  );
+});
+
+test("escapeCsvField renders empty and missing values as blank", () => {
+  assert.equal(escapeCsvField(null), "");
+  assert.equal(escapeCsvField(undefined), "");
+  assert.equal(escapeCsvField(""), "");
+});
+
+test("buildRequestsCsv writes a header and one line per request", () => {
+  const csv = buildRequestsCsv([row(), row({ eventId: "evt-2", gatewayRequestId: "req-2" })]);
+  const lines = csv.trimEnd().split("\n");
+
+  assert.equal(lines.length, 3);
+  assert.ok(lines[0].startsWith("time,app,identity,request_id"));
+  assert.ok(lines[1].includes("req-1"));
+  assert.ok(lines[2].includes("req-2"));
+  assert.ok(csv.endsWith("\n"), "file ends with a newline");
+});
+
+test("buildRequestsCsv falls back to clientId when the app has no name", () => {
+  const csv = buildRequestsCsv([row({ appName: undefined })]);
+  assert.ok(csv.includes("app_1"));
+});
+
+test("buildRequestsCsv emits only a header for no rows", () => {
+  assert.equal(buildRequestsCsv([]), "time,app,identity,request_id,pipeline,model_id,network_fee_usd_micros,fee_wei,manifest_id\n");
+});
+
+test("sumRequestFeeUsdMicros totals exactly beyond Number precision", () => {
+  const total = sumRequestFeeUsdMicros([
+    row({ networkFeeUsdMicros: "9007199254740991" }),
+    row({ networkFeeUsdMicros: "9007199254740991" }),
+  ]);
+  assert.equal(total, "18014398509481982");
+});
+
+test("sumRequestFeeUsdMicros truncates fractional micros from exact ingest", () => {
+  const total = sumRequestFeeUsdMicros([
+    row({ networkFeeUsdMicros: "10.932" }),
+    row({ networkFeeUsdMicros: "5" }),
+  ]);
+  assert.equal(total, "15");
+});
+
+test("sumRequestFeeUsdMicros skips unparseable rows instead of breaking", () => {
+  const total = sumRequestFeeUsdMicros([
+    row({ networkFeeUsdMicros: "100" }),
+    row({ networkFeeUsdMicros: "not-a-number" }),
+    row({ networkFeeUsdMicros: "" }),
+  ]);
+  assert.equal(total, "100");
+});
+
+test("buildRequestsCsvFilename is date-stamped", () => {
+  assert.equal(
+    buildRequestsCsvFilename(new Date("2026-07-31T18:00:00Z")),
+    "requests-2026-07-31.csv",
+  );
+});

--- a/src/lib/usage/requests-csv.ts
+++ b/src/lib/usage/requests-csv.ts
@@ -1,0 +1,85 @@
+import type { SignedTicketRequestRow } from "@/lib/openmeter/signed-ticket-events";
+
+/**
+ * CSV export for the requests table.
+ * Client-safe (no DB/Node imports) and pure so escaping can be unit tested.
+ */
+
+const COLUMNS = [
+  "time",
+  "app",
+  "identity",
+  "request_id",
+  "pipeline",
+  "model_id",
+  "network_fee_usd_micros",
+  "fee_wei",
+  "manifest_id",
+] as const;
+
+/**
+ * Escape one CSV field.
+ *
+ * Values that begin with a formula trigger (`= + - @`, or a leading tab/CR) are
+ * prefixed with a single quote: spreadsheet apps would otherwise execute them,
+ * and these fields carry operator-controlled data such as pipeline and model
+ * ids. Quotes are doubled and any field containing a delimiter is wrapped.
+ */
+export function escapeCsvField(value: string | number | null | undefined): string {
+  if (value == null) return "";
+  const raw = String(value);
+  if (raw === "") return "";
+
+  const needsFormulaGuard = /^[=+\-@\t\r]/.test(raw);
+  const guarded = needsFormulaGuard ? `'${raw}` : raw;
+
+  if (/[",\n\r]/.test(guarded)) {
+    return `"${guarded.replaceAll('"', '""')}"`;
+  }
+  return guarded;
+}
+
+/** One CSV row per request, with a header line. */
+export function buildRequestsCsv(rows: SignedTicketRequestRow[]): string {
+  const lines = [COLUMNS.join(",")];
+  for (const row of rows) {
+    lines.push(
+      [
+        row.time,
+        row.appName || row.clientId,
+        row.externalUserId,
+        row.gatewayRequestId,
+        row.pipeline,
+        row.modelId,
+        row.networkFeeUsdMicros,
+        row.feeWei ?? "",
+        row.manifestId ?? "",
+      ]
+        .map(escapeCsvField)
+        .join(","),
+    );
+  }
+  // Trailing newline so the file ends cleanly for line-oriented tools.
+  return `${lines.join("\n")}\n`;
+}
+
+/** Filename like `requests-2026-07-31.csv`. */
+export function buildRequestsCsvFilename(now: Date = new Date()): string {
+  return `requests-${now.toISOString().slice(0, 10)}.csv`;
+}
+
+/** Sum the network fee across loaded rows (USD micros, exact). */
+export function sumRequestFeeUsdMicros(rows: SignedTicketRequestRow[]): string {
+  let total = 0n;
+  for (const row of rows) {
+    const raw = row.networkFeeUsdMicros?.trim();
+    if (!raw) continue;
+    try {
+      // Ingest may store fractional micros; truncate toward zero for the sum.
+      total += BigInt(raw.includes(".") ? raw.slice(0, raw.indexOf(".")) : raw);
+    } catch {
+      // Skip unparseable rows rather than breaking the footer total.
+    }
+  }
+  return total.toString();
+}


### PR DESCRIPTION
Phases 3 and 4 of the Usage & Billing overhaul, one commit per phase.

> **Stacked on #347.** Base is `feat/usage-billing-phase1-identities`, so this diff shows only Phase 3–4 work. Merge #347 first; GitHub will retarget this to `main` automatically.

## Phase 3 — Usage page

The chart drew overlapping translucent areas, so a day's total was unreadable, and the y-axis landed on 29/58/87/116.

**Chart, rewritten as stacked bars**
- Segments stack, so column height reads as the day's total, with a 2px surface gap between them.
- Y-axis snaps to 1/2/2.5/5/10 magnitudes — a peak of 96 now yields **0/25/50/75/100** instead of 0/29/58/87/116.
- Tooltip lists each series plus a column total.
- Requests vs `$` are two selectable views, **never a second y-axis**; daily vs weekly bucketing.
- Legend is a wrapping grid instead of one crammed line.

**The palette was not colourblind-safe, so it was replaced.** The previous ad-hoc Tailwind ramp had teal and pink adjacent at CVD ΔE 5.0 — indistinguishable to deuteranopic readers — and every slot sat outside the lightness band for a dark surface. The new eight slots validate clean against `zinc-950` (worst adjacent ΔE 8.4 protan; all checks pass). Colour is now assigned from the **unfiltered** series list, so filtering the chart no longer repaints the surviving series.

**Requests table**
- "Your signed ticket requests" → **"Requests"**; the prose scope note is now a visible scope chip.
- Totals footer that states how many rows it summed and whether the range is complete, so it cannot silently imply a full-cycle total it hasn't loaded.
- CSV export and a date-range picker (the API gained bounded `from`/`to`, span-limited before hitting OpenMeter).
- Subscription card renders both quantities explicitly: `141 requests · $0.65 of $5.00 allowance used`.

CSV fields beginning `=` `+` `-` `@` are quote-prefixed — pipeline and model ids are operator-controlled and would otherwise execute when the file is opened in a spreadsheet.

## Phase 4 — App → Payments tab

- Activation is a **neutral definition grid** matching the Stripe Connect block above it. Amber is reserved for genuinely blocked states, each of which now says what to do.
- End-user count appears in the activation grid only; the field below is relabelled "End-user cap" (the grid already names the billing mode).
- Progressive billing renders its **resolved behaviour** — "on with no threshold" reads as `On — invoicing at cycle end (no mid-cycle threshold set)` rather than leaving it to be inferred from an empty field. Extracted to a lib and unit tested.
- Save actions are real buttons, disabled until the form is dirty, with distinct saved / unsaved / error feedback. Save errors no longer surface only in the page-level error slot.
- Disconnect is styled as a secondary danger action. It already required confirmation.

### Unscoped issue found

This tab was written against a **light theme**. It carried 23 occurrences of shadcn-style tokens (`text-muted-foreground`, `bg-background`, `bg-primary`, `text-primary-foreground`) that this repo never defines in its `@theme` block — so they rendered as nothing — plus `amber-50`/`amber-950` surfaces inside a dark app. Replaced with the zinc/emerald palette used elsewhere. This was beyond the brief's wording but is the same defect it describes.

## Verification

- Tests: **646 pass, 1 fail, 102 skipped**. The single failure is the pre-existing local Postgres connection refusal, identical to baseline. **+38 tests**, covering axis tick maths (including the exact 96 → 0/25/50/75/100 regression), weekly bucketing, colour-slot stability under filtering, CSV escaping and formula-injection guards, fee summation beyond `Number.MAX_SAFE_INTEGER`, and the invoicing-behaviour resolver.
- `tsc --noEmit` clean; `eslint` 0 errors (2 pre-existing warnings in an untouched file); `next build` compiles.

**Not visually verified.** The app needs Postgres to boot and none is available in this environment, so the chart geometry was checked through unit tests on the scale/bucketing maths rather than by eye. Worth a look in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-history date filtering, CSV export, and fee/count summaries.
  * Added usage chart toggles for requests or cost, with daily/weekly views and clearer totals.
  * Added owned-app billing coverage details and billing-mode visibility.
  * Added clearer invoicing, metering, allowance, and billing-cycle information.
* **Bug Fixes**
  * Restricted platform-controlled billing settings to authorized administrators.
  * Improved handling of incomplete billing data and malformed credit grants.
  * Improved usage attribution and owner billing fallbacks.
* **Documentation**
  * Added proposed guidance for separating platform costs from app revenue billing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->