### PR TITLE
chore(release): bump version to 0.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymthouse",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pymthouse",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@braintree/sanitize-url": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymthouse",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "private": true,
   "engines": {
     "node": ">=20.18.1"


### PR DESCRIPTION
## Summary
- Bump `package.json` / `package-lock.json` from 0.3.3 → 0.3.5 (v0.3.4 was tagged without a package version sync)
- Enables tagging GitHub release `v0.3.5` for billing/usage work since v0.3.4

## Test plan
- [x] Diff limited to version fields in package.json + package-lock.json
- [x] `tsc --noEmit` clean aside from pre-existing stale `.next` types
- [x] Snyk code scan: 0 issues
- [ ] Merge → tag `v0.3.5` + publish GitHub release (triggers production deploy if enabled)