### PR TITLE
fix(security): clear Sonar new_security_rating on owner payment methods

### DIFF
--- a/src/lib/openmeter/owner-payment-method.test.ts
+++ b/src/lib/openmeter/owner-payment-method.test.ts
@@ -6,6 +6,7 @@ import {
   collapseDuplicateLinkMethods,
   listOwnerPaymentMethods,
   toOwnerPaymentMethodItem,
+  toStripeApiUrl,
 } from "./owner-payment-method";
 
 type StripeRoute = Record<string, unknown>;
@@ -62,6 +63,19 @@ test("toOwnerPaymentMethodItem maps card fields", () => {
     expYear: 2028,
     isDefault: true,
   });
+});
+
+test("toStripeApiUrl accepts relative /v1 paths on api.stripe.com", () => {
+  assert.equal(
+    toStripeApiUrl("/v1/customers/cus_abc/payment_methods?limit=100"),
+    "https://api.stripe.com/v1/customers/cus_abc/payment_methods?limit=100",
+  );
+});
+
+test("toStripeApiUrl rejects absolute or non-/v1 paths", () => {
+  assert.throws(() => toStripeApiUrl("https://evil.example/v1/customers"));
+  assert.throws(() => toStripeApiUrl("/v2/customers"));
+  assert.throws(() => toStripeApiUrl("/v1/../admin"));
 });
 
 test("toOwnerPaymentMethodItem labels Link as brand-only (no last4 from Stripe)", () => {

--- a/src/lib/openmeter/owner-payment-method.ts
+++ b/src/lib/openmeter/owner-payment-method.ts
@@ -1,4 +1,5 @@
 import { getPublicOrigin } from "@/lib/oidc/issuer-urls";
+import { sanitizeForLog } from "@/lib/sanitize-for-log";
 import { getHostedAdminClient, isHostedAdminClientAvailable } from "./admin-client";
 import { prepareOwnerCustomerStripeBilling } from "./billing-profiles";
 import {
@@ -13,6 +14,25 @@ import {
   getStripeCustomerAppDataId,
   setKonnectStripeDefaultPaymentMethod,
 } from "./stripe-customer-data";
+
+const STRIPE_API_ORIGIN = "https://api.stripe.com";
+
+/**
+ * Build a Stripe REST URL from a relative `/v1/…` path only.
+ * Rejects scheme/host injection so path segments (customer ids, etc.) cannot
+ * redirect the request off api.stripe.com (tssecurity:S8476).
+ * @internal Exported for unit tests.
+ */
+export function toStripeApiUrl(path: string): string {
+  if (!/^\/v1\/[A-Za-z0-9/_.=?%&\-]+$/.test(path) || path.includes("..")) {
+    throw new Error("Invalid Stripe API path");
+  }
+  const url = new URL(path, STRIPE_API_ORIGIN);
+  if (url.origin !== STRIPE_API_ORIGIN || !url.pathname.startsWith("/v1/")) {
+    throw new Error("Stripe API origin mismatch");
+  }
+  return url.href;
+}
 
 export type OwnerPaymentMethodCheckoutResult = {
   checkoutUrl: string;
@@ -89,19 +109,18 @@ async function stripeRequestJson<T>(input: {
   }
   let response: Response;
   try {
-    response = await input.deps.fetchImpl(
-      `https://api.stripe.com${input.path}`,
-      {
-        method: input.method,
-        headers,
-        body: input.body?.toString(),
-        signal: input.deps.signal,
-      },
-    );
+    response = await input.deps.fetchImpl(toStripeApiUrl(input.path), {
+      method: input.method,
+      headers,
+      body: input.body?.toString(),
+      signal: input.deps.signal,
+    });
   } catch (err) {
     console.warn(
-      `owner-payment-method: Stripe ${input.method} ${input.path} failed`,
-      err instanceof Error ? err.message : String(err),
+      "owner-payment-method: Stripe request failed",
+      sanitizeForLog(input.method),
+      sanitizeForLog(input.path),
+      sanitizeForLog(err),
     );
     return null;
   }
@@ -113,8 +132,11 @@ async function stripeRequestJson<T>(input: {
       detail = "";
     }
     console.warn(
-      `owner-payment-method: Stripe ${input.method} ${input.path} → ${response.status}`,
-      detail,
+      "owner-payment-method: Stripe request not ok",
+      sanitizeForLog(input.method),
+      sanitizeForLog(input.path),
+      sanitizeForLog(response.status),
+      sanitizeForLog(detail),
     );
     return null;
   }
@@ -361,10 +383,7 @@ export async function listOwnerPaymentMethods(
     });
     return items;
   } catch (err) {
-    console.warn(
-      "owner-payment-method: lookup failed",
-      err instanceof Error ? err.message : String(err),
-    );
+    console.warn("owner-payment-method: lookup failed", sanitizeForLog(err));
     return [];
   }
 }
@@ -403,7 +422,7 @@ export async function ownerHasChargeablePaymentMethod(
   } catch (err) {
     console.warn(
       "owner-payment-method: chargeability lookup failed",
-      err instanceof Error ? err.message : String(err),
+      sanitizeForLog(err),
     );
     return null;
   }
@@ -494,7 +513,7 @@ export async function unlinkOwnerPaymentMethod(
     } catch (err) {
       console.warn(
         "owner-payment-method: Konnect default clear failed",
-        err instanceof Error ? err.message : String(err),
+        sanitizeForLog(err),
       );
     }
   }
@@ -544,7 +563,7 @@ export async function setOwnerDefaultPaymentMethod(
   } catch (err) {
     console.warn(
       "owner-payment-method: Konnect default sync failed",
-      err instanceof Error ? err.message : String(err),
+      sanitizeForLog(err),
     );
   }
 

--- a/src/lib/openmeter/owner-payment-method.ts
+++ b/src/lib/openmeter/owner-payment-method.ts
@@ -24,7 +24,7 @@ const STRIPE_API_ORIGIN = "https://api.stripe.com";
  * @internal Exported for unit tests.
  */
 export function toStripeApiUrl(path: string): string {
-  if (!/^\/v1\/[A-Za-z0-9/_.=?%&\-]+$/.test(path) || path.includes("..")) {
+  if (!/^\/v1\/[A-Za-z0-9/_.=?%&-]+$/.test(path) || path.includes("..")) {
     throw new Error("Invalid Stripe API path");
   }
   const url = new URL(path, STRIPE_API_ORIGIN);


### PR DESCRIPTION
## Summary
- Fixes the failing [SonarCloud new code quality gate](https://sonarcloud.io/summary/new_code?id=pymthouse_pymthouse&branch=main) (`new_security_rating` B → expected A)
- Closes open vulnerabilities in `owner-payment-method.ts`:
  - **tssecurity:S8476** — validate relative `/v1/…` Stripe paths and pin origin to `api.stripe.com` before `fetch`
  - **tssecurity:S5145** — route method/path/status/error/detail through existing `sanitizeForLog` before `console.warn`

## Test plan
- [x] `owner-payment-method.test.ts` (12 tests) including `toStripeApiUrl` allow/deny cases
- [x] Snyk code scan on `src/lib/openmeter` (no new issues in changed files)
- [ ] SonarCloud PR analysis reports no open security issues on this file
- [ ] After merge, main [new code summary](https://sonarcloud.io/summary/new_code?id=pymthouse_pymthouse&branch=main) quality gate is green