### PR TITLE
feat(api): bare personal keys + issuer API-key token exchange

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -20,7 +20,7 @@ For issuer-level OIDC behavior and token endpoint details, see [NaaP OIDC integr
 - `client_id` is the canonical app identifier in Builder API URLs.
 - **API surfaces:**
   - **Builder (M2M):** canonical `/api/v1/builder/…` for usage; integrator `/api/v1/apps/{clientId}/…` for users, tokens, billing reads (legacy `/apps/…/usage*` aliases remain M2M-only)
-  - **End-user:** `/api/v1/apps/{clientId}/me/…` — bare `pmth_*` key or end-user/signer JWT (path `{clientId}` must match)
+  - **End-user:** `/api/v1/user/usage*` (app from Bearer) or `/api/v1/apps/{clientId}/me/…` (path `{clientId}` must match) — bare `pmth_*` key or end-user/signer JWT
   - **Internal:** PymtHouse dashboard/session under canonical `/api/v1/internal/…` (unpublished from the public Scalar UI)
 - OIDC issuer stays at `/api/v1/oidc/*`. Public catalog/health stay under `/api/v1/*` without a product prefix.
 - Internal database IDs are implementation details and are not part of the public API contract.
@@ -34,11 +34,11 @@ Machine-readable contract and interactive reference:
 | **Public (Builder + End-user)** | `GET /api/v1/openapi.json` | `GET /api/v1/docs` |
 | **Internal (dashboard/session)** | `GET /api/v1/internal/openapi.json` | `GET /api/v1/internal/docs` |
 
-The public document includes M2M integrator routes and `/api/v1/apps/{clientId}/me/usage*`. Internal is available at the paths above but is not linked from `/api/v1/docs`.
+The public document includes M2M integrator routes and end-user `/api/v1/user/usage*` plus `/api/v1/apps/{clientId}/me/usage*`. Internal is available at the paths above but is not linked from `/api/v1/docs`.
 
 Regenerate the route inventory after adding handlers: `npm run openapi:generate`. CI runs `npm run check:openapi` to fail on metadata drift.
 
-OIDC issuer metadata remains at `{issuer}/.well-known/openid-configuration`. Signer session exchange is documented at `POST /api/v1/apps/{clientId}/oidc/token`. The OIDC provider token endpoint (`POST /api/v1/oidc/token`) covers standard OAuth grants only.
+OIDC issuer metadata remains at `{issuer}/.well-known/openid-configuration`. Signer session exchange accepts a bare `pmth_*` API key as RFC 8693 `subject_token` on both `POST /api/v1/oidc/token` (app resolved from the credential) and `POST /api/v1/apps/{clientId}/oidc/token` (path-scoped).
 
 ### Breaking changes (API cleanup)
 
@@ -61,8 +61,8 @@ M2M secret rotation remains at `POST /api/v1/apps/{clientId}/credentials` (provi
 
 | Prefix | Role | RFC usage |
 | --- | --- | --- |
-| Stored API key (`pmth_<hex>`) | Per-app-user **API key** (hashed at rest; presented bare at mint) | `Authorization: Bearer` on `/api/v1/apps/{clientId}/me/usage*`; `subject_token` on `POST /api/v1/apps/{clientId}/oidc/token` |
-| `app_<24hex>_<secret>` | Optional **composite** presentation (not issued by default) | Pathless remote-signer webhooks that must recover `{clientId}` from a single Bearer |
+| Stored API key (`pmth_<hex>`) | Per-app-user **API key** (hashed at rest) | Personal mint returns bare `pmth_*`; Builder mint returns composite presentation of the same secret |
+| `app_<24hex>_<secret>` | **Presented** Builder API key (issuance + remote-signer Bearer) | Same secret as the stored key; `app_*` segment routes pathless exchange / webhooks |
 | Client secret (`*_cs_*`) | Confidential client secret | HTTP Basic / `client_secret_post` with the matching client id (RFC 6749 §2.3.1) — never the API-key bearer exchange |
 | `app_…` | Public interactive client | Path params and token endpoint `client_id`; `token_endpoint_auth_method=none` (device / SDK; **no** authorization-code redirects) |
 | `m2m_…` | Confidential M2M sibling | `client_credentials` only — Builder API / machine tokens |
@@ -80,26 +80,27 @@ Authorization-code (browser / portal) login is registered **only** on the confid
 
 Enable **Confidential web RP** on App profile (same pattern as Confidential M2M backend). Rotate the `web_` secret with `POST /api/v1/apps/{clientId}/credentials?target=web`. Do not put portal SSO credentials on the public SDK client or the M2M helper.
 
-Newly issued keys are returned as bare `pmth_<hex>`. Prefer REST paths that carry `{clientId}`:
+Newly issued **personal** keys are returned as bare `pmth_<hex>`. Builder-minted app-user keys are returned as composite `app_<24hex>_<secret>` (same stored secret):
 
-- Self-serve usage: `GET /api/v1/apps/{clientId}/me/usage*`
-- Signer session exchange: `POST /api/v1/apps/{clientId}/oidc/token` with `subject_token=pmth_…`
+- Self-serve usage (credential-scoped app): `GET /api/v1/user/usage*` with bare Bearer
+- Self-serve usage (path-scoped app): `GET /api/v1/apps/{clientId}/me/usage*` with bare or composite Bearer
+- Signer session exchange (RFC 8693): `POST /api/v1/oidc/token` or `POST /api/v1/apps/{clientId}/oidc/token` with `subject_token` = bare `pmth_…` or composite
 
-Composite `app_<24hex>_<secret>` is still **accepted** where a pathless caller (e.g. remote-signer identity webhook) must recover the public client id from a single Bearer. Prefer app-scoped signer URLs + bare Bearer when possible.
+Composite remains the default presentation for Builder keys so pathless callers (e.g. remote-signer identity webhook) can recover the public client id from a single Bearer.
 
 **Design notes**
 
-- Tenancy lives in the URL for Builder and end-user self-serve routes; the secret stays bare.
-- Composite remains a convenience for pathless webhooks; underscore separator keeps copy/select UX intact when used.
-- `formatCompositeApiKey` / `splitCompositeApiKey` remain available for webhook parsers.
+- Personal keys stay bare; Builder app-user mint returns composite so pathless signer webhooks can recover `{clientId}`.
+- Tenancy also lives in the URL for Builder and end-user self-serve routes; the bare secret segment alone is enough there.
+- `formatCompositeApiKey` / `splitCompositeApiKey` parse the Builder presentation form.
 
 Do not pass M2M client secrets as `subject_token` on the signer session exchange route — use M2M HTTP Basic instead.
 
 ### Implementation tasks
 
-- [x] Issue bare `pmth_*` from key creation APIs (composite optional / pathless only).
+- [x] Issue bare `pmth_*` from personal key mint; composite `app_*_*` from Builder app-user key mint.
 - [x] Publish `@pymthouse/clearinghouse-identity-webhook` with the matching composite parser (`0.4.2`).
-- [x] Canonical end-user usage at `/api/v1/apps/{clientId}/me/usage*` (pathless `/api/v1/user/usage*` kept as a deprecated alias).
+- [x] End-user usage at `/api/v1/user/usage*` (app from credential) and `/api/v1/apps/{clientId}/me/usage*` (path-scoped).
 
 ## Authentication
 
@@ -152,9 +153,14 @@ Authorization: Basic base64(client_id:client_secret)
 
 ## Signer session exchange (RFC 8693)
 
-`POST /api/v1/apps/{clientId}/oidc/token`
+Exchange a user access JWT **or** a per-app-user API key (`pmth_*`) for a short-lived signer JWT (`SignerSession`).
 
-Clearinghouse-compatible signer session issuance. `Content-Type: application/x-www-form-urlencoded`.
+| Endpoint | App resolution |
+| --- | --- |
+| `POST /api/v1/oidc/token` | From the `subject_token` credential (bare `pmth_*` or composite) |
+| `POST /api/v1/apps/{clientId}/oidc/token` | Path `{clientId}` must match the credential |
+
+`Content-Type: application/x-www-form-urlencoded`.
 
 | Field | Value |
 | --- | --- |
@@ -163,11 +169,22 @@ Clearinghouse-compatible signer session issuance. `Content-Type: application/x-w
 | `subject_token_type` | `urn:ietf:params:oauth:token-type:access_token` |
 | `audience` / `resource` | Optional; when provided must match configured signer audience (issuer URL, `SIGNER_TOKEN_AUDIENCE`, or legacy `livepeer-clearinghouse` / `livepeer-remote-signer`) |
 
-Optional HTTP Basic with the M2M client (`m2m_*` + secret). When omitted, the `subject_token` alone authenticates the exchange.
+Optional HTTP Basic with the M2M client (`m2m_*` + secret). When omitted, the `subject_token` alone authenticates the exchange. Do not use client secrets (`pmth_cs_*`) as `subject_token`.
 
 Returns the canonical **`SignerSession`** envelope: `access_token`, `token_type`, `expires_in`, `scope`, optional `signer_url`, optional `discovery_url` (Livepeer network discovery, not OIDC metadata), optional `issued_token_type`, optional `correlation_id`, and optional PymtHouse extensions `balanceUsdMicros` / `lifetimeGrantedUsdMicros`.
 
-Example (API key as `subject_token`):
+Example (bare API key on the issuer token endpoint — personal key, no `{clientId}` in the URL):
+
+```bash
+curl -sS \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  --data-urlencode "subject_token=pmth_..." \
+  --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \
+  "https://your-pymthouse.example/api/v1/oidc/token"
+```
+
+Example (API key on the app-scoped route):
 
 ```bash
 curl -sS \
@@ -414,23 +431,28 @@ End users can read **their own** usage with the credential they already hold (no
 
 | Endpoint | Description |
 | --- | --- |
-| `GET /api/v1/apps/{clientId}/me/usage` | Aggregates for the authenticated subject (`groupBy`, `startDate`, `endDate` as on Builder usage) |
-| `GET /api/v1/apps/{clientId}/me/usage/balance` | Plan included-usage allowance for that subject |
-| `GET /api/v1/apps/{clientId}/me/usage/requests` | Signed-ticket history (`groupBy=session\|request`, `manifestId`, `cursor`, `limit`) |
+| `GET /api/v1/user/usage` | Aggregates for the authenticated subject; app resolved from the Bearer credential |
+| `GET /api/v1/user/usage/balance` | Plan included-usage allowance for that subject |
+| `GET /api/v1/user/usage/requests` | Signed-ticket history (`groupBy=session\|request`, `manifestId`, `cursor`, `limit`) |
+| `GET /api/v1/apps/{clientId}/me/usage` | Same aggregates with path-scoped app (`{clientId}` must match the credential) |
+| `GET /api/v1/apps/{clientId}/me/usage/balance` | Same balance, path-scoped |
+| `GET /api/v1/apps/{clientId}/me/usage/requests` | Same request history, path-scoped |
 
-The pathless `GET /api/v1/user/usage*` routes remain as **deprecated aliases** with identical behavior — they resolve the app from the Bearer credential instead of the path. Prefer the app-scoped routes for new integrations.
-
-**Auth:** `Authorization: Bearer` with a bare `pmth_*` app-user key, a programmatic user JWT, or a signer JWT (`external_user_id` + `client_id`). Optional composite `app_*_*` is still accepted. Path `{clientId}` must match the credential’s public app. Identity is taken **only** from the token — do **not** pass `externalUserId` (rejected with 400).
+**Auth:** `Authorization: Bearer` with a bare `pmth_*` app-user key, a programmatic user JWT, or a signer JWT (`external_user_id` + `client_id`). Optional composite `app_*_*` is still accepted. On `/apps/{clientId}/me/…`, path `{clientId}` must match the credential’s public app. Identity is taken **only** from the token — do **not** pass `externalUserId` (rejected with 400).
 
 ```bash
 curl -sS -H "Authorization: Bearer ${API_KEY}" \
+  "${BASE_URL}/api/v1/user/usage?groupBy=pipeline_model"
+
+curl -sS -H "Authorization: Bearer ${API_KEY}" \
+  "${BASE_URL}/api/v1/user/usage/balance"
+
+curl -sS -H "Authorization: Bearer ${API_KEY}" \
+  "${BASE_URL}/api/v1/user/usage/requests?limit=25"
+
+# Path-scoped equivalent when the client id is already known:
+curl -sS -H "Authorization: Bearer ${API_KEY}" \
   "${BASE_URL}/api/v1/apps/${CLIENT_ID}/me/usage?groupBy=pipeline_model"
-
-curl -sS -H "Authorization: Bearer ${API_KEY}" \
-  "${BASE_URL}/api/v1/apps/${CLIENT_ID}/me/usage/balance"
-
-curl -sS -H "Authorization: Bearer ${API_KEY}" \
-  "${BASE_URL}/api/v1/apps/${CLIENT_ID}/me/usage/requests?limit=25"
 ```
 
 ### Builder Usage API (M2M)
@@ -470,15 +492,15 @@ Per-request fees in the UI are valued exactly from `feeWei × ethUsdPrice` (full
 
 Integrators (e.g. Livepeer Dashboard / `@pymthouse/builder-sdk`) mint a user JWT via Builder `POST .../users/{externalUserId}/token`, then call these routes. Subject is forced from the credential — do **not** pass `userId` / `externalUserId` query params (rejected with 400).
 
-**Endpoint:** `GET /api/v1/apps/{clientId}/me/usage`
+**Endpoint:** `GET /api/v1/user/usage` (or `GET /api/v1/apps/{clientId}/me/usage`)
 
 Same OpenMeter usage shape as `GET /api/v1/builder/apps/{clientId}/usage`, always scoped to the Bearer subject. Supports `startDate`, `endDate`, `groupBy` (`none` / `user` / `pipeline_model` / `daily_pipeline` / `manifest`), and `include=retail`.
 
-**Endpoint:** `GET /api/v1/apps/{clientId}/me/usage/balance`
+**Endpoint:** `GET /api/v1/user/usage/balance` (or `GET /api/v1/apps/{clientId}/me/usage/balance`)
 
 Plan included-usage allowance for the Bearer subject (`balanceUsdMicros` / `remainingUsdMicros` = remaining plan discount, `lifetimeGrantedUsdMicros` = included total for the cycle, `consumedUsdMicros` = granted − remaining, `hasAccess` from spendable). Prepaid credits settle invoices/charges and are not the meter source. Builder M2M equivalent: `GET /api/v1/builder/apps/{clientId}/usage/balance?externalUserId=...` (legacy `/api/v1/apps/.../usage/balance` alias is M2M-only too).
 
-**Endpoint:** `GET /api/v1/apps/{clientId}/me/usage/requests`
+**Endpoint:** `GET /api/v1/user/usage/requests` (or `GET /api/v1/apps/{clientId}/me/usage/requests`)
 
 Lists signed-ticket CloudEvents for the **token subject only** — newest first. Supports `groupBy=session|request` and `manifestId` (same semantics as `/api/v1/me/usage/requests`).
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -30,7 +30,7 @@ curl -X POST "$BASE/api/v1/network/key" \
   -H "Cookie: …"
 ```
 
-Response includes `clientId` (public `app_…` only), bare `apiKey` (`pmth_*`), and optional `sdkToken` for livepeer-python-sdk. Use the key as `Authorization: Bearer` on `/api/v1/apps/{clientId}/me/usage*`.
+Response includes `clientId` (public `app_…` only), bare `apiKey` (`pmth_*`), and optional `sdkToken` for livepeer-python-sdk. Use the key as `Authorization: Bearer` on `/api/v1/user/usage*` (or `/api/v1/apps/{clientId}/me/usage*`).
 
 Do **not** treat the default `clientId` as a target for confidential Builder API backends. The Personal Access Token card on My Apps exposes the same flow in the dashboard.
 

--- a/src/app/api/v1/apps/[id]/users/[externalUserId]/keys/route.ts
+++ b/src/app/api/v1/apps/[id]/users/[externalUserId]/keys/route.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/provider-apps";
 import { createCorrelationId, writeAuditLog } from "@/lib/audit";
 import {
-  APP_USER_API_KEY_STORE_MESSAGE,
+  BUILDER_API_KEY_STORE_MESSAGE,
   createAppUserApiKey,
   listAppUserApiKeys,
   revokeAppUserApiKey,
@@ -117,6 +117,7 @@ export async function POST(
   const created = await createAppUserApiKey({
     developerAppId: access.app.id,
     appUserId: appUser.id,
+    publicClientId: clientId,
     label,
   });
 
@@ -151,7 +152,7 @@ export async function POST(
       suffix: created.suffix,
       label: created.label,
       createdAt: created.createdAt,
-      message: APP_USER_API_KEY_STORE_MESSAGE,
+      message: BUILDER_API_KEY_STORE_MESSAGE,
       correlation_id: correlationId,
     },
     { status: 201 },

--- a/src/app/api/v1/network/key/route.ts
+++ b/src/app/api/v1/network/key/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/next-auth-options";
 import { mintDefaultAppNetworkKey } from "@/lib/onboarding";
-import { APP_USER_API_KEY_STORE_MESSAGE } from "@/lib/app-api-keys";
+import { PERSONAL_API_KEY_STORE_MESSAGE } from "@/lib/app-api-keys";
 import {
   isPersonalKeysSessionResult,
   requirePersonalKeysSession,
@@ -42,7 +42,7 @@ export async function POST() {
         prefix: result.prefix,
         suffix: result.suffix,
         label: result.label,
-        message: APP_USER_API_KEY_STORE_MESSAGE,
+        message: PERSONAL_API_KEY_STORE_MESSAGE,
         correlation_id: result.correlationId,
       },
       { status: 201 },

--- a/src/app/api/v1/oidc/[...oidc]/route.ts
+++ b/src/app/api/v1/oidc/[...oidc]/route.ts
@@ -41,6 +41,12 @@ import {
 } from "@/lib/oidc/scopes";
 import { handleSignerJwtTokenExchange, isSignerJwtTokenExchangeRequest } from "@/lib/oidc/signer-jwt-token-exchange";
 import { rotateProgrammaticRefreshToken } from "@/lib/oidc/programmatic-tokens";
+import { createCorrelationId } from "@/lib/audit";
+import {
+  AppScopedSignerTokenExchangeError,
+  handleIssuerApiKeySignerTokenExchange,
+  looksLikeAppApiKeySubjectToken,
+} from "@/lib/oidc/app-scoped-signer-token-exchange";
 
 const RESOURCE_REQUIRED_GRANTS = new Set([
   "urn:ietf:params:oauth:grant-type:device_code",
@@ -192,6 +198,7 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
         request,
         exchangeParams,
       );
+      const subjectToken = exchangeParams.get("subject_token") || "";
       const subjectTokenType = exchangeParams.get("subject_token_type") || "";
       const resourceParam = exchangeParams.get("resource");
       try {
@@ -205,11 +212,31 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
           const result = await handleDeviceApprovalTokenExchange({
             clientId,
             clientSecret,
-            subjectToken: exchangeParams.get("subject_token") || "",
+            subjectToken,
             subjectTokenType,
             resource: resourceParam,
             requestedTokenType: exchangeParams.get("requested_token_type"),
             audience: exchangeParams.getAll("audience"),
+          });
+          return NextResponse.json(result, {
+            headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
+          });
+        }
+
+        // Bare / composite API key → SignerSession (same envelope as app-scoped).
+        // Resolve app from the credential so pathless personal keys work on the
+        // issuer token endpoint under RFC 8693.
+        if (looksLikeAppApiKeySubjectToken(subjectToken)) {
+          const result = await handleIssuerApiKeySignerTokenExchange({
+            clientId,
+            clientSecret,
+            grantType,
+            subjectToken,
+            subjectTokenType,
+            requestedTokenType: exchangeParams.get("requested_token_type") || "",
+            resource: resourceParam || "",
+            audiences: exchangeParams.getAll("audience"),
+            correlationId: createCorrelationId(),
           });
           return NextResponse.json(result, {
             headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
@@ -227,7 +254,7 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
           const result = await handleSignerJwtTokenExchange({
             clientId,
             clientSecret,
-            subjectToken: exchangeParams.get("subject_token") || "",
+            subjectToken,
             subjectTokenType,
             resource: resourceParam,
             audience: exchangeParams.getAll("audience"),
@@ -255,7 +282,7 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
           const result = await handleGatewayTokenExchange({
             clientId,
             clientSecret,
-            subjectToken: exchangeParams.get("subject_token") || "",
+            subjectToken,
             subjectTokenType,
             resource: resourceParam,
             requestedTokenType: exchangeParams.get("requested_token_type"),
@@ -269,7 +296,7 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
         const result = await handleTokenExchange({
           clientId,
           clientSecret,
-          subjectToken: exchangeParams.get("subject_token") || "",
+          subjectToken,
           subjectTokenType,
           scope: exchangeParams.get("scope") || undefined,
           resource: exchangeParams.get("resource") || undefined,
@@ -278,6 +305,23 @@ async function handleOIDC(request: NextRequest): Promise<NextResponse> {
           headers: { "Cache-Control": "no-store", Pragma: "no-cache" },
         });
       } catch (err) {
+        if (err instanceof AppScopedSignerTokenExchangeError) {
+          console.warn("[OIDC] api-key token exchange rejected", {
+            code: err.code,
+            detail: err.message,
+          });
+          const headers: Record<string, string> = {
+            "Cache-Control": "no-store",
+            Pragma: "no-cache",
+          };
+          if (err.status === 401 && err.code === "invalid_client") {
+            headers["WWW-Authenticate"] = 'Basic realm="token"';
+          }
+          return NextResponse.json(
+            { error: err.code, error_description: err.message },
+            { status: err.status, headers },
+          );
+        }
         if (err instanceof TokenExchangeError) {
           console.warn("[OIDC] token exchange rejected", {
             code: err.code,

--- a/src/app/api/v1/user/usage/balance/route.ts
+++ b/src/app/api/v1/user/usage/balance/route.ts
@@ -3,8 +3,9 @@ import { NextRequest } from "next/server";
 import { handleEndUserMeUsageBalanceGet } from "@/lib/usage/end-user-usage-handlers";
 
 /**
- * Deprecated alias for `GET /api/v1/apps/{clientId}/me/usage/balance`.
- * Same behavior; the app is derived from the Bearer credential instead of the path.
+ * End-user plan allowance for the Bearer subject.
+ * Auth: bare `pmth_*` API key, optional composite `app_*_*`, or end-user/signer JWT.
+ * App is derived from the credential (no `{clientId}` in the path).
  */
 export async function GET(request: NextRequest) {
   return handleEndUserMeUsageBalanceGet(request);

--- a/src/app/api/v1/user/usage/requests/route.ts
+++ b/src/app/api/v1/user/usage/requests/route.ts
@@ -3,8 +3,9 @@ import { NextRequest } from "next/server";
 import { handleEndUserMeUsageRequestsGet } from "@/lib/usage/end-user-usage-handlers";
 
 /**
- * Deprecated alias for `GET /api/v1/apps/{clientId}/me/usage/requests`.
- * Same behavior; the app is derived from the Bearer credential instead of the path.
+ * End-user signed-ticket history for the Bearer subject.
+ * Auth: bare `pmth_*` API key, optional composite `app_*_*`, or end-user/signer JWT.
+ * App is derived from the credential (no `{clientId}` in the path).
  */
 export async function GET(request: NextRequest) {
   return handleEndUserMeUsageRequestsGet(request);

--- a/src/app/api/v1/user/usage/route.test.ts
+++ b/src/app/api/v1/user/usage/route.test.ts
@@ -17,7 +17,7 @@ import {
   seedDeveloperAppWithClient,
 } from "@/test-utils/fixtures";
 
-run("deprecated /user/usage alias resolves the app from the credential", async (t) => {
+run("/user/usage accepts bare Bearer and scopes to that user", async (t) => {
   const { GET } = await import("./route");
   const app = await seedDeveloperAppWithClient({ status: "approved" });
   t.after(() => cleanupTestApp(app));

--- a/src/app/api/v1/user/usage/route.ts
+++ b/src/app/api/v1/user/usage/route.ts
@@ -3,8 +3,9 @@ import { NextRequest } from "next/server";
 import { handleEndUserMeUsageGet } from "@/lib/usage/end-user-usage-handlers";
 
 /**
- * Deprecated alias for `GET /api/v1/apps/{clientId}/me/usage`.
- * Same behavior; the app is derived from the Bearer credential instead of the path.
+ * End-user usage aggregates for the Bearer subject.
+ * Auth: bare `pmth_*` API key, optional composite `app_*_*`, or end-user/signer JWT.
+ * App is derived from the credential (no `{clientId}` in the path).
  */
 export async function GET(request: NextRequest) {
   return handleEndUserMeUsageGet(request);

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -140,13 +140,24 @@ const TOKEN_EXCHANGE_GRANT =
 const SUBJECT_ACCESS_TOKEN_TYPE =
   "urn:ietf:params:oauth:token-type:access_token";
 
-function buildSignerTokenExchangeCurl(origin: string, publicClientId: string): string {
-  const encodedClientId = encodeURIComponent(publicClientId);
-  return String.raw`curl -sS -X POST ${origin}/api/v1/apps/${encodedClientId}/oidc/token \
+function buildSignerTokenExchangeCurl(origin: string, publicClientId?: string): string {
+  // Pathless issuer exchange resolves the app from the bare API key (RFC 8693).
+  // App-scoped URL remains available when the client id is already known.
+  if (!publicClientId) {
+    return String.raw`curl -sS -X POST ${origin}/api/v1/oidc/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=${TOKEN_EXCHANGE_GRANT}" \
   -d "subject_token=pmth_YOUR_BARE_API_KEY" \
   -d "subject_token_type=${SUBJECT_ACCESS_TOKEN_TYPE}"`;
+  }
+  const encodedClientId = encodeURIComponent(publicClientId);
+  return String.raw`curl -sS -X POST ${origin}/api/v1/oidc/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=${TOKEN_EXCHANGE_GRANT}" \
+  -d "subject_token=pmth_YOUR_BARE_API_KEY" \
+  -d "subject_token_type=${SUBJECT_ACCESS_TOKEN_TYPE}"
+
+# Or path-scoped: POST ${origin}/api/v1/apps/${encodedClientId}/oidc/token`;
 }
 
 function buildDeviceAuthorizeCurl(origin: string, publicClientId: string): string {

--- a/src/lib/app-api-keys.test.ts
+++ b/src/lib/app-api-keys.test.ts
@@ -166,3 +166,31 @@ test("resolveActiveAppApiKey accepts composite app_*_* subject tokens", async (t
   );
   assert.equal(mismatched, null);
 });
+
+test("createAppUserApiKey returns bare personal keys and composite Builder keys", async (t) => {
+  const { createAppUserApiKey } = await import("@/lib/app-api-keys");
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  t.after(() => cleanupTestApp(app));
+
+  const appUser = await createAppUser({
+    clientId: app.clientId,
+    externalUserId: `user-${randomUUID()}`,
+  });
+
+  const personal = await createAppUserApiKey({
+    developerAppId: app.clientId,
+    appUserId: appUser.id,
+    label: "personal",
+  });
+  assert.ok(personal.apiKey.startsWith("pmth_"));
+  assert.equal(personal.apiKey.includes(app.clientId), false);
+
+  const builder = await createAppUserApiKey({
+    developerAppId: app.clientId,
+    appUserId: appUser.id,
+    publicClientId: app.clientId,
+    label: "builder",
+  });
+  assert.ok(builder.apiKey.startsWith(`${app.clientId}_`));
+  assert.ok(builder.apiKey.includes("pmth_"));
+});

--- a/src/lib/app-api-keys.ts
+++ b/src/lib/app-api-keys.ts
@@ -30,9 +30,16 @@ export function maskApiKeySuffix(keyPrefix: string | null | undefined): string {
   return raw.slice(-4);
 }
 
-/** Shown once at mint time for personal and Builder-issued app-user keys. */
-export const APP_USER_API_KEY_STORE_MESSAGE =
-  "Store this API key securely. It will not be shown again. Use Authorization: Bearer <pmth_…> on /api/v1/apps/{clientId}/me/usage* and as subject_token on POST /api/v1/apps/{clientId}/oidc/token, or use sdkToken as --token with livepeer-python-sdk.";
+/** Shown once at mint time for personal / network bare `pmth_*` keys. */
+export const PERSONAL_API_KEY_STORE_MESSAGE =
+  "Store this API key securely. It will not be shown again. Use Authorization: Bearer <pmth_…> on /api/v1/user/usage* (or /api/v1/apps/{clientId}/me/usage*), and as subject_token on POST /api/v1/oidc/token or POST /api/v1/apps/{clientId}/oidc/token, or use sdkToken as --token with livepeer-python-sdk.";
+
+/**
+ * Shown once at mint time for Builder-issued app-user keys (composite
+ * `app_<24hex>_<secret>` presentation).
+ */
+export const BUILDER_API_KEY_STORE_MESSAGE =
+  "Store this API key securely. It will not be shown again. Use the full app_<24hex>_<secret> value as Authorization: Bearer <token> for the remote signer, as subject_token on POST /api/v1/apps/{clientId}/oidc/token (or the bare pmth_… segment), or use sdkToken as --token with livepeer-python-sdk.";
 
 /** Presented composite: `app_<24hex>_<secret>` (underscore separator for copy UX). */
 const COMPOSITE_API_KEY_RE = /^(app_[a-f0-9]{24})_(.+)$/;
@@ -230,6 +237,12 @@ export async function listAppUserApiKeys(input: {
 export async function createAppUserApiKey(input: {
   developerAppId: string;
   appUserId: string;
+  /**
+   * Public OIDC client id (`app_*`). When set, returned `apiKey` is the
+   * composite `app_<24hex>_<secret>` for Builder / pathless signer use.
+   * Omit for personal keys (bare `pmth_*`).
+   */
+  publicClientId?: string | null;
   label?: string | null;
 }) {
   const apiKeyValue = generateApiKeyValue();
@@ -250,9 +263,14 @@ export async function createAppUserApiKey(input: {
     revokedAt: null,
   });
 
+  const publicClientId = input.publicClientId?.trim() || "";
+  const presented = publicClientId
+    ? formatCompositeApiKey(publicClientId, apiKeyValue)
+    : apiKeyValue;
+
   return {
     id,
-    apiKey: apiKeyValue,
+    apiKey: presented,
     prefix: maskApiKeyPrefix(apiKeyValue.slice(0, 16)),
     suffix: maskApiKeySuffix(apiKeyValue),
     label: input.label?.trim() || null,

--- a/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
@@ -6,6 +6,8 @@ import {
   AppScopedSignerTokenExchangeError,
   GRANT_TYPE_TOKEN_EXCHANGE,
   handleAppScopedSignerTokenExchange,
+  handleIssuerApiKeySignerTokenExchange,
+  looksLikeAppApiKeySubjectToken,
   resolveAppScopedSubjectToken,
   SUBJECT_ACCESS_TOKEN_TYPE,
   validateOptionalM2mClient,
@@ -250,4 +252,99 @@ test("handleAppScopedSignerTokenExchange mints from user JWT with sign:job scope
   );
 
   assert.equal(session.access_token, "eyJ.signer.jwt");
+});
+
+test("looksLikeAppApiKeySubjectToken accepts bare pmth_ and composite", () => {
+  assert.equal(looksLikeAppApiKeySubjectToken("pmth_abc"), true);
+  assert.equal(
+    looksLikeAppApiKeySubjectToken(`${PUBLIC_ID}_${"a".repeat(64)}`),
+    true,
+  );
+  assert.equal(looksLikeAppApiKeySubjectToken("a".repeat(64)), true);
+  assert.equal(looksLikeAppApiKeySubjectToken("pmth_cs_secret"), false);
+  assert.equal(looksLikeAppApiKeySubjectToken("header.payload.sig"), false);
+});
+
+test("handleIssuerApiKeySignerTokenExchange resolves app from bare pmth_ subject", async () => {
+  const bare = "pmth_7c3d2ae03dcca8cfa04223523301b8b29f81a883294492c7e07a2333cb3d24d5";
+  const session = await handleIssuerApiKeySignerTokenExchange(
+    {
+      clientId: "",
+      clientSecret: "",
+      grantType: GRANT_TYPE_TOKEN_EXCHANGE,
+      subjectToken: bare,
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+      requestedTokenType: "",
+      resource: "",
+      audiences: [],
+      correlationId: "corr-issuer",
+    },
+    {
+      resolveActiveAppApiKeyFromBearer: async (token) => {
+        assert.equal(token, bare);
+        return {
+          apiKeyId: "key-1",
+          developerAppId: "dev-app-1",
+          publicClientId: PUBLIC_ID,
+          appUserId: "au-1",
+          externalUserId: "ext-1",
+          label: null,
+        };
+      },
+      resolveActiveAppApiKey: async () => ({
+        apiKeyId: "key-1",
+        developerAppId: "dev-app-1",
+        publicClientId: PUBLIC_ID,
+        appUserId: "au-1",
+        externalUserId: "ext-1",
+        label: null,
+      }),
+      mintSignerJwtForExternalUser: async (input) => {
+        assert.equal(input.publicClientId, PUBLIC_ID);
+        assert.equal(input.externalUserId, "ext-1");
+        return {
+          access_token: "eyJ.personal.signer",
+          token_type: "Bearer" as const,
+          expires_in: 300,
+          scope: "sign:job",
+          balanceUsdMicros: "0",
+          lifetimeGrantedUsdMicros: "0",
+        };
+      },
+      getClientSignerApiUrl: () => "https://signer.example",
+      getSignerDiscoveryUrl: () => undefined,
+    },
+  );
+
+  assert.equal(session.access_token, "eyJ.personal.signer");
+  assert.equal(session.token_type, "Bearer");
+  assert.equal(session.issued_token_type, SUBJECT_ACCESS_TOKEN_TYPE);
+  assert.equal(session.correlation_id, "corr-issuer");
+});
+
+test("handleIssuerApiKeySignerTokenExchange rejects unknown bare key", async () => {
+  await assert.rejects(
+    () =>
+      handleIssuerApiKeySignerTokenExchange(
+        {
+          clientId: "",
+          clientSecret: "",
+          grantType: GRANT_TYPE_TOKEN_EXCHANGE,
+          subjectToken: "pmth_deadbeef",
+          subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+          requestedTokenType: "",
+          resource: "",
+          audiences: [],
+          correlationId: "corr-miss",
+        },
+        {
+          resolveActiveAppApiKeyFromBearer: async () => null,
+        },
+      ),
+    (err: unknown) => {
+      assert.ok(err instanceof AppScopedSignerTokenExchangeError);
+      assert.equal(err.code, "invalid_grant");
+      return true;
+    },
+  );
 });

--- a/src/lib/oidc/app-scoped-signer-token-exchange.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.ts
@@ -1,6 +1,7 @@
 import { hasScope } from "@/lib/auth";
 import {
   resolveActiveAppApiKey,
+  resolveActiveAppApiKeyFromBearer,
 } from "@/lib/app-api-keys";
 import { getDiscoveryRawUrl } from "@/lib/discovery-service-url";
 import { validateClientSecret } from "@/lib/oidc/clients";
@@ -40,6 +41,24 @@ const COMPOSITE_APP_API_KEY_PREFIX_RE = /^app_[a-f0-9]{24}_/;
 const COMPOSITE_APP_API_KEY_RE = /^app_[a-f0-9]{24}_.+/;
 /** Opaque hex secret from a composite exchange (subject_token after split). */
 const OPAQUE_HEX_SECRET_RE = /^[a-f0-9]{32,}$/i;
+
+/**
+ * True when `subject_token` is a stored app-user API key shape (not a JWT).
+ * Includes bare `pmth_*`, composite `app_*_*`, and opaque hex secrets.
+ */
+export function looksLikeAppApiKeySubjectToken(subjectToken: string): boolean {
+  const token = subjectToken.trim();
+  if (!token) {
+    return false;
+  }
+  if (token.startsWith("pmth_") && !token.startsWith("pmth_cs_")) {
+    return true;
+  }
+  if (COMPOSITE_APP_API_KEY_RE.test(token)) {
+    return true;
+  }
+  return OPAQUE_HEX_SECRET_RE.test(token);
+}
 
 export class AppScopedSignerTokenExchangeError extends Error {
   code: string;
@@ -218,11 +237,7 @@ export async function resolveAppScopedSubjectToken(
   }
 
   // Bare stored API key, composite app_*_*, or opaque hex secret segment.
-  const looksLikeApiKey =
-    (token.startsWith("pmth_") && !token.startsWith("pmth_cs_")) ||
-    COMPOSITE_APP_API_KEY_RE.test(token) ||
-    OPAQUE_HEX_SECRET_RE.test(token);
-  if (!looksLikeApiKey) {
+  if (!looksLikeAppApiKeySubjectToken(token)) {
     throw new AppScopedSignerTokenExchangeError(
       "invalid_grant",
       "subject_token is not a valid access token for this issuer",
@@ -363,4 +378,68 @@ export async function handleAppScopedSignerTokenExchange(
     issued_token_type: ISSUED_ACCESS_TOKEN_TYPE,
     correlation_id: input.correlationId,
   });
+}
+
+/**
+ * Issuer-path RFC 8693 exchange when `subject_token` is a bare/composite API
+ * key. Resolves the app from the credential (no `{clientId}` in the URL), then
+ * mints the same SignerSession as the app-scoped route.
+ */
+export async function handleIssuerApiKeySignerTokenExchange(
+  input: {
+    clientId: string;
+    clientSecret: string;
+    grantType: string;
+    subjectToken: string;
+    subjectTokenType: string;
+    requestedTokenType: string;
+    resource: string;
+    audiences: string[];
+    correlationId: string;
+  },
+  inject: Partial<AppScopedSignerTokenExchangeDeps> & {
+    resolveActiveAppApiKeyFromBearer?: typeof resolveActiveAppApiKeyFromBearer;
+  } = {},
+): Promise<SignerSession> {
+  const resolveFromBearer =
+    inject.resolveActiveAppApiKeyFromBearer ?? resolveActiveAppApiKeyFromBearer;
+  const subjectToken = input.subjectToken.trim();
+
+  if (!looksLikeAppApiKeySubjectToken(subjectToken)) {
+    throw new AppScopedSignerTokenExchangeError(
+      "invalid_grant",
+      "subject_token is not a valid access token for this issuer",
+    );
+  }
+
+  if (subjectToken.startsWith("pmth_cs_")) {
+    throw new AppScopedSignerTokenExchangeError(
+      "invalid_grant",
+      "client secrets cannot be used as subject_token",
+    );
+  }
+
+  const resolved = await resolveFromBearer(subjectToken);
+  if (!resolved) {
+    throw new AppScopedSignerTokenExchangeError(
+      "invalid_grant",
+      "subject_token is not a valid access token for this issuer",
+    );
+  }
+
+  return handleAppScopedSignerTokenExchange(
+    {
+      publicClientId: resolved.publicClientId,
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+      grantType: input.grantType,
+      subjectToken,
+      subjectTokenType: input.subjectTokenType,
+      requestedTokenType: input.requestedTokenType,
+      resource: input.resource,
+      audiences: input.audiences,
+      correlationId: input.correlationId,
+    },
+    inject,
+  );
 }

--- a/src/lib/openapi/openapi-document.test.ts
+++ b/src/lib/openapi/openapi-document.test.ts
@@ -28,7 +28,8 @@ test("buildPublicOpenApiDocument includes Builder + End-user and omits Internal"
   assert.ok(doc.paths["/api/v1/apps/{clientId}/me/usage"]?.get);
   assert.ok(doc.paths["/api/v1/apps/{clientId}/me/usage/balance"]?.get);
   assert.ok(doc.paths["/api/v1/apps/{clientId}/me/usage/requests"]?.get);
-  assert.equal(doc.paths["/api/v1/user/usage"]?.get?.deprecated, true);
+  assert.ok(doc.paths["/api/v1/user/usage"]?.get);
+  assert.equal(doc.paths["/api/v1/user/usage"]?.get?.deprecated, undefined);
   assert.equal(doc.paths["/api/v1/signer"], undefined);
 
   assert.ok(doc.components?.securitySchemes?.m2mBasic);

--- a/src/lib/openapi/routes/credentials.ts
+++ b/src/lib/openapi/routes/credentials.ts
@@ -23,7 +23,8 @@ defineRouteMetadata("post", "/api/v1/apps/{clientId}/oidc/token", {
     "(`pmth_*` or composite `app_*_*`) for a short-lived signer JWT. The `{clientId}` path segment is the public " +
     "OAuth app client id. Authenticate with the end-user `subject_token`; optional HTTP Basic " +
     "with the M2M client is supported for server-side callers. " +
-    "For self-serve usage reads, prefer `GET /api/v1/apps/{clientId}/me/usage*` with bare Bearer `pmth_*`.",
+    "For self-serve usage reads, use `GET /api/v1/user/usage*` with bare Bearer `pmth_*` " +
+    "(or `GET /api/v1/apps/{clientId}/me/usage*` when the path already supplies the app).",
   request: {
     params: z.object({ clientId: clientIdParam }),
     body: {
@@ -109,7 +110,9 @@ defineRouteMetadata("post", "/api/v1/oidc/token", {
     "Served by oidc-provider at `/api/v1/oidc/token`. Standard OAuth/OIDC grants: " +
     "`authorization_code`, `refresh_token`, `client_credentials`, device code, and " +
     "pymthouse-specific exchanges (device approval, gateway session). " +
-    "Signer session exchange uses `POST /api/v1/apps/{clientId}/oidc/token` instead. " +
+    "RFC 8693 token exchange also accepts a bare `pmth_*` (or composite) API key as " +
+    "`subject_token` with `subject_token_type=urn:ietf:params:oauth:token-type:access_token` " +
+    "and returns a SignerSession (same as `POST /api/v1/apps/{clientId}/oidc/token`). " +
     "See OpenID Configuration for the full parameter matrix.",
   responses: {
     200: { description: "Token response per OAuth/OIDC." },

--- a/src/lib/openapi/routes/end-user.ts
+++ b/src/lib/openapi/routes/end-user.ts
@@ -144,22 +144,22 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
 });
 
 /**
- * Deprecated pathless aliases. Identical behavior, but the app is derived from
- * the Bearer credential instead of `{clientId}`.
+ * Pathless end-user usage. App is resolved from the Bearer credential
+ * (`pmth_*`, optional composite, or user/signer JWT).
  */
-const legacyAlias = (
+const defineUserUsageRoute = (
   suffix: string,
   summary: string,
   query?: typeof endUserUsageQueryParams | typeof endUserRequestsQueryParams,
 ) => {
   defineRouteMetadata("get", `/api/v1/user/usage${suffix}`, {
     tags: [OPENAPI_TAGS.endUserUsage],
-    summary: `${summary} (deprecated)`,
+    summary,
     description:
-      `Deprecated alias for \`GET ${meUsagePath(suffix)}\`. ` +
-      "Behavior is identical; the app is resolved from the Bearer credential " +
-      "instead of the path. Prefer the app-scoped route for new integrations.",
-    deprecated: true,
+      "Usage for the authenticated subject. The app is resolved from the " +
+      "Bearer credential (bare `pmth_*` key, optional composite, or user/signer JWT). " +
+      "Do not pass `userId` / `externalUserId`. " +
+      `App-scoped equivalent: \`GET ${meUsagePath(suffix)}\`.`,
     security: endUserSecurity,
     ...(query ? { request: { query } } : {}),
     responses: {
@@ -170,9 +170,9 @@ const legacyAlias = (
   });
 };
 
-legacyAlias("", "End-user usage summary", endUserUsageQueryParams);
-legacyAlias("/balance", "End-user usage balance");
-legacyAlias(
+defineUserUsageRoute("", "End-user usage summary", endUserUsageQueryParams);
+defineUserUsageRoute("/balance", "End-user usage balance");
+defineUserUsageRoute(
   "/requests",
   "End-user signed-ticket request history",
   endUserRequestsQueryParams,

--- a/src/lib/openapi/tags.ts
+++ b/src/lib/openapi/tags.ts
@@ -65,7 +65,7 @@ const END_USER_OPERATION_KEYS = new Set([
   "GET /api/v1/apps/{clientId}/me/usage",
   "GET /api/v1/apps/{clientId}/me/usage/balance",
   "GET /api/v1/apps/{clientId}/me/usage/requests",
-  // Deprecated pathless aliases, kept for existing integrations.
+  // Pathless: app resolved from Bearer credential.
   "GET /api/v1/user/usage",
   "GET /api/v1/user/usage/balance",
   "GET /api/v1/user/usage/requests",
@@ -181,7 +181,9 @@ export const BUILDER_TAG_DEFINITIONS: Array<{
   {
     name: OPENAPI_TAGS.endUserUsage,
     description:
-      "Self-serve usage for the authenticated end user on an app. Bearer = bare `pmth_*` API key (or user/signer JWT). Path `{clientId}` must match the credential.",
+      "Self-serve usage for the authenticated end user. Bearer = bare `pmth_*` API key (or user/signer JWT). " +
+      "`GET /api/v1/user/usage*` resolves the app from the credential; " +
+      "`GET /api/v1/apps/{clientId}/me/usage*` requires path `{clientId}` to match.",
   },
   {
     name: OPENAPI_TAGS.billing,
@@ -295,12 +297,12 @@ export const BUILDER_INFO_DESCRIPTION = `PymtHouse **public API** — Builder (M
 
 **Builder (M2M):** HTTP Basic (\`m2m_*\` + \`pmth_cs_*\`) for integrator backends — users, keys, tokens, app usage, billing reads, discovery.
 
-**End-user:** \`Authorization: Bearer\` with a bare \`pmth_*\` API key, programmatic user JWT, or signer JWT (optional composite \`app_*_*\` still accepted). Identity comes **only** from the token — do not pass \`externalUserId\`. Path \`{clientId}\` must match the credential’s public app.
+**End-user:** \`Authorization: Bearer\` with a bare \`pmth_*\` API key, programmatic user JWT, or signer JWT (optional composite \`app_*_*\` still accepted). Identity comes **only** from the token — do not pass \`externalUserId\`.
 
 OIDC discovery: \`{issuer}/.well-known/openid-configuration\`.
 
 Canonical Builder usage: \`GET /api/v1/builder/apps/{clientId}/usage*\`.
-Canonical End-user usage: \`GET /api/v1/apps/{clientId}/me/usage*\`.
+End-user usage: \`GET /api/v1/user/usage*\` (app from credential) or \`GET /api/v1/apps/{clientId}/me/usage*\` (path must match).
 `;
 
 export const INTERNAL_INFO_DESCRIPTION = `PymtHouse **Internal API** — dashboard, admin, and platform ops for the PymtHouse application (not linked from public docs).

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -15,8 +15,8 @@ import {
 
 /**
  * `publicClientId` is the app the credential must belong to. Omit it for the
- * deprecated pathless `/api/v1/user/usage*` aliases, where the app is derived
- * from the credential itself.
+ * pathless `/api/v1/user/usage*` routes, where the app is derived from the
+ * credential itself.
  */
 async function requireEndUserAuth(
   request: NextRequest,


### PR DESCRIPTION
## Summary
- Keep `/api/v1/user/usage*` first-class (not deprecated) with bare `pmth_*` Bearer auth; app-scoped `/apps/{clientId}/me/usage*` remains available.
- Accept bare/composite API keys as RFC 8693 `subject_token` on issuer `POST /api/v1/oidc/token`, returning the same SignerSession as the app-scoped exchange.
- Personal/network mint returns bare `pmth_*`; Builder `POST /apps/{clientId}/users/…/keys` returns composite `app_*_*` again for pathless signer use.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run check:openapi`
- [x] `npm test` (808 pass)
- [x] Snyk Code on changed OIDC/app-api-keys paths (no prod issues; test-only hardcoded fake JWTs)
- [ ] Manually: `curl` bare `pmth_*` against `/api/v1/user/usage` and RFC 8693 exchange against `/api/v1/oidc/token`
- [ ] Manually: mint Builder app-user key and confirm composite `apiKey` + `sdkToken`