### PR TITLE
fix(collector): use interval 0s for price_warm generate

### DIFF
--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -58,7 +58,7 @@ input:
       - label: price_warm
         generate:
           count: 1
-          interval: ""
+          interval: 0s
           mapping: 'root = {}'
         processors:
           - resource: fetch_eth_usd_price


### PR DESCRIPTION
## Summary
- Replace `price_warm` `generate.interval: ""` with `interval: 0s` so Benthos gets a valid duration.
- Keeps the one-shot startup warm (`count: 1`) explicit; aligns with livepeer/clearinghouse#70 after Copilot flagged empty-string intervals.

## Test plan
- [ ] Confirm collector config still warms ETH/USD before Kafka (one-shot generate)
- [ ] Optional: `benthos-collector lint ./deploy/openmeter-collector/collector.yaml` on pinned image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the startup price-warming process to run immediately instead of using an undefined interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->