### PR TITLE
refactor(signer): pass expiryTtl to the balance gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.228",
         "@pymthouse/builder-sdk": "^0.6.1",
-        "@pymthouse/clearinghouse-identity-webhook": "^0.4.2",
+        "@pymthouse/clearinghouse-identity-webhook": "0.5.0-rc.0",
         "@tailwindcss/postcss": "^4.1.18",
         "@turnkey/crypto": "^2.10.0",
         "@turnkey/react-wallet-kit": "^1.11.1",
@@ -47,7 +47,7 @@
         "typescript": "^5.7.0"
       },
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -2398,9 +2398,9 @@
       }
     },
     "node_modules/@pymthouse/clearinghouse-identity-webhook": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@pymthouse/clearinghouse-identity-webhook/-/clearinghouse-identity-webhook-0.4.2.tgz",
-      "integrity": "sha512-yHavpaadKSJex8+wRjgO/lDcySAvgeB8xHVXUUtn1c+e1w2XSlq8HboDMGK/ehFjwU7/xs/ECXRSm3dKeKmxSQ==",
+      "version": "0.5.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@pymthouse/clearinghouse-identity-webhook/-/clearinghouse-identity-webhook-0.5.0-rc.0.tgz",
+      "integrity": "sha512-tuuooCFmyUd9KiVklsO5V68bGFulxySJJKd5grlQQyKCjXEogFt+6jsvzyfX8YMmw40+OgFA5Oyy3N+wGQ5ADg==",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.9.6"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@braintree/sanitize-url": "^7.1.2",
     "@openmeter/sdk": "^1.0.0-beta.228",
     "@pymthouse/builder-sdk": "^0.6.1",
-    "@pymthouse/clearinghouse-identity-webhook": "^0.4.2",
+    "@pymthouse/clearinghouse-identity-webhook": "0.5.0-rc.0",
     "@tailwindcss/postcss": "^4.1.18",
     "@turnkey/crypto": "^2.10.0",
     "@turnkey/react-wallet-kit": "^1.11.1",

--- a/src/lib/oidc/signer-balance-gate.ts
+++ b/src/lib/oidc/signer-balance-gate.ts
@@ -7,7 +7,7 @@ import { createAsyncTtlCache } from "@/lib/async-ttl-cache";
 import { isHostedAdminClientAvailable } from "@/lib/openmeter/admin-client";
 import { getSpendableUsdMicros } from "@/lib/openmeter/spendable-allowance";
 
-const DEFAULT_REAUTH_TTL_SECONDS = 60;
+const DEFAULT_EXPIRY_TTL_SECONDS = 60;
 const DEFAULT_BALANCE_CACHE_TTL_SECONDS = 20;
 const BALANCE_CACHE_MAX_ENTRIES = 1000;
 
@@ -23,12 +23,13 @@ function resolvePositiveSecondsEnv(name: string, fallback: number): number {
   return parsed;
 }
 
-function resolveReauthTtlSeconds(): number {
+/** Whole seconds for the webhook `expiry` cap that forces go-livepeer to reauthorize. */
+function resolveExpiryTtlSeconds(): number {
   const ttl = resolvePositiveSecondsEnv(
     "SIGNER_BALANCE_REAUTH_TTL_SECONDS",
-    DEFAULT_REAUTH_TTL_SECONDS,
+    DEFAULT_EXPIRY_TTL_SECONDS,
   );
-  return ttl > 0 ? ttl : DEFAULT_REAUTH_TTL_SECONDS;
+  return Number.isInteger(ttl) && ttl > 0 ? ttl : DEFAULT_EXPIRY_TTL_SECONDS;
 }
 
 export type SpendableBalanceCache = {
@@ -121,7 +122,7 @@ export function buildSignerBalanceCheck(): BalanceCheck | undefined {
   const cache = getSharedSpendableCache();
   return createBalanceGate({
     getBalanceUsdMicros: (identity) => cache.get(identity),
-    reauthTtlSeconds: resolveReauthTtlSeconds(),
+    expiryTtl: { seconds: resolveExpiryTtlSeconds() },
     failClosed: true,
     onError: (err) => {
       console.warn(


### PR DESCRIPTION
## Summary

- `buildSignerBalanceCheck` now passes `expiryTtl: { seconds }` instead of `reauthTtlSeconds` to `createBalanceGate`.
- The identity webhook renamed that option after the webhook `expiry` field it sets and ships **no legacy alias** (livepeer/clearinghouse#64), so this is a required migration rather than a cleanup.
- Renamed the internal constant/helper to match (`DEFAULT_EXPIRY_TTL_SECONDS` / `resolveExpiryTtlSeconds`) and require whole seconds, since the new option rejects fractional values.
- Pinned `@pymthouse/clearinghouse-identity-webhook` to `0.5.0-rc.0` (RC from livepeer/clearinghouse#64) and refreshed the lockfile.

The operator-facing env var `SIGNER_BALANCE_REAUTH_TTL_SECONDS` is unchanged, so no deployment config has to move.

## Test plan

- [x] `npx tsx --test src/lib/oidc/signer-balance-gate.test.ts src/lib/oidc/signer-balance-gate-seed.test.ts` (9 passing)
- [x] `npm run build` clean with `0.5.0-rc.0` (`expiryTtl` types resolve)
- [ ] Webhook smoke: verified identity with credit returns `expiry ≈ now + 60s` so go-livepeer reauthorizes and re-checks balance mid-stream