### PR TITLE
fix(api): personal sdkToken must use composite Bearer for signer

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -86,13 +86,14 @@ Newly issued **personal** keys are returned as bare `pmth_<hex>`. Builder-minted
 - Self-serve usage (path-scoped app): `GET /api/v1/apps/{clientId}/me/usage*` with bare or composite Bearer
 - Signer session exchange (RFC 8693): `POST /api/v1/oidc/token` or `POST /api/v1/apps/{clientId}/oidc/token` with `subject_token` = bare `pmth_…` or composite
 
-Composite remains the default presentation for Builder keys so pathless callers (e.g. remote-signer identity webhook) can recover the public client id from a single Bearer.
+Composite remains the default presentation for Builder keys so pathless callers (e.g. remote-signer identity webhook) can recover the public client id from a single Bearer. Personal network keys keep a bare `apiKey` for usage, but mint `sdkToken` with the same composite Authorization header.
 
 **Design notes**
 
-- Personal keys stay bare; Builder app-user mint returns composite so pathless signer webhooks can recover `{clientId}`.
+- Personal keys stay bare for usage/self-serve; `sdkToken` (livepeer-python-sdk `--token`) embeds the composite `app_*_*` form so pathless signer webhooks can recover `{clientId}`.
+- Builder app-user mint returns composite as the presented `apiKey` (and in `sdkToken`) for the same reason.
 - Tenancy also lives in the URL for Builder and end-user self-serve routes; the bare secret segment alone is enough there.
-- `formatCompositeApiKey` / `splitCompositeApiKey` parse the Builder presentation form.
+- `formatCompositeApiKey` / `splitCompositeApiKey` parse the composite presentation form.
 
 Do not pass M2M client secrets as `subject_token` on the signer session exchange route — use M2M HTTP Basic instead.
 

--- a/src/lib/onboarding.test.ts
+++ b/src/lib/onboarding.test.ts
@@ -70,6 +70,14 @@ test("mintDefaultAppNetworkKey creates app_users not provider_admins", async (t)
     assert.equal(result.clientId, app.clientId);
     assert.ok(result.apiKey.startsWith("pmth_"));
     assert.equal(result.apiKey.includes(app.clientId), false);
+    assert.ok(result.sdkToken);
+    const sdkPayload = JSON.parse(
+      Buffer.from(result.sdkToken!, "base64").toString("utf8"),
+    ) as { signer_headers?: { Authorization?: string } };
+    assert.equal(
+      sdkPayload.signer_headers?.Authorization,
+      `Bearer ${app.clientId}_${result.apiKey}`,
+    );
 
     const membership = await db
       .select()

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -2,7 +2,10 @@ import { and, eq, isNull, ne } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db/index";
 import { appUsers, developerApps, users } from "@/db/schema";
-import { createAppUserApiKey } from "@/lib/app-api-keys";
+import {
+  createAppUserApiKey,
+  formatCompositeApiKey,
+} from "@/lib/app-api-keys";
 import { createCorrelationId, writeAuditLog } from "@/lib/audit";
 import { provisionAppUserBilling } from "@/lib/billing/provision-app-user";
 import { createLivepeerPythonSdkToken } from "@/lib/livepeer-python-sdk-token";
@@ -232,10 +235,13 @@ export async function mintDefaultAppNetworkKey(input: {
     });
   }
 
+  // Personal apiKey stays bare for usage/self-serve; sdkToken must use the
+  // composite presentation so pathless remote-signer webhooks can recover
+  // {clientId} and exchange to a JWT (bare pmth_* → 401 "not a JWT").
   let sdkToken: string | null = null;
   try {
     sdkToken = createLivepeerPythonSdkToken({
-      apiKey: created.apiKey,
+      apiKey: formatCompositeApiKey(clientId, created.apiKey),
       signer: getClientSignerApiUrl(clientId),
     });
   } catch {


### PR DESCRIPTION
## Summary
- Personal network keys still return bare `pmth_*` for usage/self-serve, but `sdkToken` now embeds composite `app_<clientId>_<pmth_…>` so pathless remote-signer webhooks can exchange to a JWT.
- Fixes prod `401 not a JWT` from `signer.pymthouse.com/generate-live-payment` when using Explorer network key `--token` payloads.
- Docs + onboarding test updated to match.

## Why a new PR
[#361](https://github.com/pymthouse/pymthouse/pull/361) was opened from the `eliteprox` fork (`isCrossRepository: true`), so Actions could not inject `SONAR_TOKEN` and SonarQube Cloud failed with auth errors unrelated to the code. This PR uses the same branch on `pymthouse/pymthouse`.

## Test plan
- [ ] Mint a personal network key after deploy; decode `sdkToken` and confirm `Authorization` is `Bearer app_…_pmth_…`
- [ ] Use new `sdkToken` with livepeer-python-gateway against prod signer; confirm payment generation succeeds
- [ ] Confirm bare `apiKey` still works on `/api/v1/user/usage*`
- [ ] CI: test + SonarQube Cloud green