### PR TITLE
fix(railway): wire preview-only signer into stack env apply

### DIFF
--- a/config/railway/stack.json
+++ b/config/railway/stack.json
@@ -9,9 +9,12 @@
     "kafka",
     "openmeter-collector",
     "pymthouse",
-    "pymthouse-signer-test"
+    "pymthouse-signer-test",
+    "pymthouse-signer-test-preview-only"
   ],
-  "previewOnlyServices": [],
+  "previewOnlyServices": [
+    "pymthouse-signer-test-preview-only"
+  ],
   "services": {
     "kafka": { "kind": "image" },
     "openmeter-collector": { "kind": "image" },
@@ -25,6 +28,14 @@
       "manifest": "deploy/pymthouse-signer-test/railway.json",
       "environments": ["preview", "production"],
       "description": "A/B 'latest' remote signer DMZ, deployed in both preview and production. Same webhook/OIDC/Kafka and signing identity as pymthouse (the 'stable' signer); LIVEPEER_IMAGE matches the prod Dockerfile default. Entrypoint defaults BYOC_PER_CAP_PRICING=on for this service name. Apps opt in via LATEST_SIGNER_APPS on the Next app.",
+      "livepeerImage": "livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78",
+      "byocPerCapPricing": true
+    },
+    "pymthouse-signer-test-preview-only": {
+      "kind": "repo",
+      "manifest": "deploy/pymthouse-signer-test-preview-only/railway.json",
+      "environments": ["preview"],
+      "description": "Preview-only A/B signer DMZ. Shares pymthouse signing identity; must receive the same ETH_RPC_URL / OIDC / webhook env as other signers via railway-apply-stack-env.sh. Never deploy to production.",
       "livepeerImage": "livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78",
       "byocPerCapPricing": true
     }

--- a/deploy/pymthouse-signer-test-preview-only/railway.json
+++ b/deploy/pymthouse-signer-test-preview-only/railway.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "docker/signer-dmz/Dockerfile",
+    "watchPatterns": [
+      "docker/signer-dmz/**",
+      "deploy/pymthouse-signer-test-preview-only/**",
+      "scripts/jwks_to_pem.py",
+      "scripts/cleanup-ephemeral-keystore.sh"
+    ]
+  },
+  "deploy": {
+    "numReplicas": 1,
+    "sleepApplication": false,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10,
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 300
+  }
+}

--- a/docker/signer-dmz/entrypoint.sh
+++ b/docker/signer-dmz/entrypoint.sh
@@ -155,11 +155,11 @@ if [ -z "${SIGNER_UPSTREAM:-}" ] && [ -x /usr/local/bin/livepeer ]; then
     [ -n "${ORCH_WEBHOOK_URL:-}" ] && ARGS="$ARGS -orchWebhookUrl=${ORCH_WEBHOOK_URL}"
     [ -n "${LIVE_AI_CAP_REPORT_INTERVAL:-}" ] && ARGS="$ARGS -liveAICapReportInterval=${LIVE_AI_CAP_REPORT_INTERVAL}"
   fi
-  # Default ON for preview A/B signer-test only; OFF elsewhere. Override with BYOC_PER_CAP_PRICING=0|1.
+  # Default ON for A/B signer-test services only; OFF elsewhere. Override with BYOC_PER_CAP_PRICING=0|1.
   _byoc_default=0
-  if [ "${RAILWAY_SERVICE_NAME:-}" = "pymthouse-signer-test" ]; then
-    _byoc_default=1
-  fi
+  case "${RAILWAY_SERVICE_NAME:-}" in
+    pymthouse-signer-test|pymthouse-signer-test-preview-only) _byoc_default=1 ;;
+  esac
   _byoc="${BYOC_PER_CAP_PRICING:-$_byoc_default}"
   if [ "$_byoc" = "1" ] || [ "$_byoc" = "true" ]; then
     if /usr/local/bin/livepeer -help 2>&1 | grep -q 'byocPerCapPricing'; then

--- a/scripts/railway-apply-stack-env.sh
+++ b/scripts/railway-apply-stack-env.sh
@@ -104,4 +104,11 @@ if railway_service_in_environment pymthouse-signer-test "$ENV"; then
   railway_apply_signer_env pymthouse-signer-test "$PE_FLAGS"
 fi
 
+# Preview-only A/B signer (Railway service pymthouse-signer-test-preview-only).
+# Must get the same ETH_RPC_URL as pymthouse — a stale private router URL fails
+# livepeer chain-ID lookup (HTTP 521) and blocks /healthz.
+if railway_service_in_environment pymthouse-signer-test-preview-only "$ENV"; then
+  railway_apply_signer_env pymthouse-signer-test-preview-only "$PE_FLAGS"
+fi
+
 echo "Done. Run scripts/railway-deploy-stack.sh $ENV to deploy."

--- a/scripts/railway-deploy-stack.sh
+++ b/scripts/railway-deploy-stack.sh
@@ -41,5 +41,10 @@ if railway_service_in_environment pymthouse-signer-test "$ENV"; then
   bash "$ROOT/scripts/railway-deploy-signer.sh" pymthouse-signer-test "$ENV"
 fi
 
+# Preview-only A/B signer (never production — stack.json previewOnlyServices).
+if railway_service_in_environment pymthouse-signer-test-preview-only "$ENV"; then
+  bash "$ROOT/scripts/railway-deploy-signer.sh" pymthouse-signer-test-preview-only "$ENV"
+fi
+
 echo "=== Stack deploy triggered for $ENV ==="
 echo "After deploy, run a signed-ticket request and confirm collector events in OpenMeter."


### PR DESCRIPTION
## Summary
- Preview Railway service `pymthouse-signer-test-preview-only` was failing `/healthz` because livepeer could not read chain ID from a stale `ETH_RPC_URL` (`http://nyc-router.eliteencoder.net:3517` → HTTP 521).
- Ops: pointed that service at the same Alchemy RPC as `pymthouse` preview and redeployed successfully.
- Durable fix: register the service in `config/railway/stack.json` (`previewOnlyServices` + preview-only environments), apply the same signer env in `railway-apply-stack-env.sh`, deploy it from `railway-deploy-stack.sh`, and default `BYOC_PER_CAP_PRICING` for that service name in the DMZ entrypoint.

## Test plan
- [x] Redeploy `pymthouse-signer-test-preview-only` after ETH_RPC fix → Railway deploy SUCCESS
- [x] `GET https://pymthouse-signer-test-preview.up.railway.app/healthz` → 200 OK
- [x] `railway_is_preview_only_service` / `railway_service_in_environment` helpers agree (preview yes, production no)
- [ ] Merge triggers GitHub check for `pymthouse-signer-test-preview-only` green on subsequent PRs
- [ ] Optional: `RAILWAY_ENVIRONMENT=preview bash scripts/railway-apply-stack-env.sh` includes the preview-only service