### PR TITLE
chore(release): bump version to 0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymthouse",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pymthouse",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@braintree/sanitize-url": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymthouse",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "engines": {
     "node": ">=20.19.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `package.json` / `package-lock.json` from **0.3.5 → 0.3.6**
- GitHub release **[v0.3.6](https://github.com/pymthouse/pymthouse/releases/tag/v0.3.6)** tagged and published
- Production deploys succeeded (Vercel + Railway)
- Please **merge this PR** so `main`’s package version matches the release tag (branch protection requires review)

## What's in 0.3.6 (since v0.3.5)
- Owner Paid Upgrade / billing admin (#352, #365)
- Bare personal keys, issuer API-key exchange, Builder composite mint (#353)
- Builder / End-user / Internal API surface split (#234)
- Signer balance-gate expiry TTL, collector price_warm, nanoid CVE, Railway preview signer wiring, go-livepeer image bump

## Test plan
- [x] Diff limited to version fields in `package.json` + `package-lock.json`
- [x] `npx tsc --noEmit` clean
- [x] PR CI passed (Test / Sonar / Snyk / CodeQL)
- [x] Tagged `v0.3.6` + GitHub release published
- [x] Production Vercel + Railway deploys succeeded
- [ ] Merge to `main` so package version stays in sync with the tag
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68181289-aba2-4a4b-a9e3-9f8bd4d95dd9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68181289-aba2-4a4b-a9e3-9f8bd4d95dd9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

