### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,38 @@ This version has breaking changes — APIs, conventions, and file structure may 
 This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
 
 <!-- END:nextjs-agent-rules -->
+
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+pymthouse is a single **Next.js 16 app that serves both the UI and the API** on `http://localhost:3001`. It is a control plane for a Livepeer remote-signer clearinghouse: OIDC issuer, developer/app "Builder", signer proxy, and usage/billing surface. See `README.md` for the full quick-start; the notes below only cover non-obvious, cloud-specific gotchas.
+
+### Services
+
+| Service | Scope | How to run | Notes |
+| --- | --- | --- | --- |
+| Next.js app (UI + API) | MUST-RUN | `npm run dev` (port 3001; `predev` runs migrations) | The product. Lint `npm run lint`, tests `npm test`, build `npm run build`. |
+| PostgreSQL | MUST-RUN | Local cluster (see below) | `DATABASE_URL` in `.env`. Migrations run automatically on `predev`. |
+| signer-dmz (Apache JWT + go-livepeer) | OPTIONAL | `docker compose up -d signer-dmz` | Not run in this env: needs Docker + a go-livepeer image/binary + Arbitrum RPC. App loads, logs in, and manages apps/tokens without it; health just reports `signer: stopped`. |
+| OpenMeter / Clearinghouse stacks | OPTIONAL | `docker compose -f docker-compose.openmeter.yml up -d` etc. | Metering/billing only; need Docker + Kafka + ClickHouse. Not required for core control-plane actions. |
+
+### Node version (important)
+
+- `npm test` runs `node --import ./src/test-env.ts --import tsx ...`, which relies on Node's native TypeScript type-stripping (default in **Node >= 22.18**) to load `src/test-env.ts`. The harness's default `/exec-daemon/node` is 22.14.0, which lacks this and makes every test file fail with `ERR_UNKNOWN_FILE_EXTENSION ".ts"`.
+- Setup installs Node 22 via `nvm` (`nvm alias default 22`) and appends a PATH prepend to `~/.bashrc` so `node` resolves to the nvm version (>= 22.18) in new shells. If tests suddenly fail with the `.ts` extension error, check `node --version` is >= 22.18 and that the nvm bin is ahead of `/exec-daemon` on `PATH`.
+
+### Local Postgres
+
+- Postgres 16 is installed locally (not Docker). Start it with `sudo pg_ctlcluster 16 main start` if it is not already running (`pg_isready`). Dev DB: `postgresql://postgres:postgres@127.0.0.1:5432/pymthouse` (already in `.env`).
+
+### First-login flow (control-plane "hello world")
+
+1. `npm run oidc:seed` — one-time; creates the OIDC signing key so `/api/v1/oidc/jwks` works. **This script does its work then hangs without exiting** (it never closes the Postgres pool). Run it with a timeout, e.g. `timeout 60 npm run oidc:seed`; seeing `[oidc:seed] Done.` means success even though the process is then killed by the timeout. The same "prints result then hangs" behavior applies to some other one-off `scripts/*.ts` (e.g. `bootstrap`).
+2. `timeout 60 npm run bootstrap [email]` — mints a 1-year `pmth_...` admin bearer token and creates the platform default app.
+3. Log in by pasting the `pmth_...` token at `http://localhost:3001/login` (no OAuth/Turnkey needed locally). API calls can use `Authorization: Bearer pmth_...`.
+
+### Env notes
+
+- `.env` is gitignored; it is created during setup. Required minimum: `NEXTAUTH_SECRET`, `AUTH_TOKEN_PEPPER` (both >= 32 chars), `DATABASE_URL`.
+- OAuth (Google/GitHub), Turnkey, Stripe, and OpenMeter vars are all optional for local dev — token login replaces OAuth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ pymthouse is a single **Next.js 16 app that serves both the UI and the API** on 
 
 1. `npm run oidc:seed` — one-time; creates the OIDC signing key so `/api/v1/oidc/jwks` works. **This script does its work then hangs without exiting** (it never closes the Postgres pool). Run it with a timeout, e.g. `timeout 60 npm run oidc:seed`; seeing `[oidc:seed] Done.` means success even though the process is then killed by the timeout. The same "prints result then hangs" behavior applies to some other one-off `scripts/*.ts` (e.g. `bootstrap`).
 2. `timeout 60 npm run bootstrap [email]` — mints a 1-year `pmth_...` admin bearer token and creates the platform default app.
-3. Log in by pasting the `pmth_...` token at `http://localhost:3001/login` (no OAuth/Turnkey needed locally). API calls can use `Authorization: Bearer pmth_...`.
+3. Log in by pasting the `pmth_...` token at **`http://localhost:3001/login/admin`** (the token/admin login page). The default `http://localhost:3001/login` renders a Turnkey wallet login and throws a runtime error unless the `NEXT_PUBLIC_ORGANIZATION_ID` / `NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID` Turnkey vars are set, so use `/login/admin` for token login locally. API calls can use `Authorization: Bearer pmth_...`.
 
 ### Env notes
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for pymthouse (Next.js 16 UI + API) in Cursor Cloud and documents non-obvious startup caveats for future agents.

The only committed change is a new `AGENTS.md` with a `## Cursor Cloud specific instructions` section. Everything else (Node/Postgres install, `.env`, migrations, seed) is environment setup captured outside the repo.

## What was set up

- **PostgreSQL 16** installed locally; dev DB `pymthouse` created (`DATABASE_URL` in gitignored `.env`).
- **Node 22.23.2** via `nvm` (the harness default `/exec-daemon/node` is 22.14.0, which breaks `npm test` — see below).
- `npm install`, DB migrations (`npm run db:prepare`), OIDC signing key (`npm run oidc:seed`), and admin token (`npm run bootstrap`).
- **Update script:** `npm install` (dependency refresh only).

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Lint | `npm run lint` | Pass (0 errors, 2 pre-existing warnings) |
| Tests | `npm test` | 942 passed, 1 skipped, 0 failed |
| Run | `npm run dev` | Ready on `http://localhost:3001`; `/api/v1/health` reports `database: connected` |

## Hello-world (core action)

Logged in with the admin `pmth_...` token at `/login/admin` and created a new developer app **"Hello World App"** (`app_4a69a70668eefa50b230e448`), confirmed persisted in `developer_apps`.

## Key gotchas documented in AGENTS.md

- `npm test` needs Node >= 22.18 (native TS type-stripping) — the default harness Node 22.14 fails every test with `ERR_UNKNOWN_FILE_EXTENSION ".ts"`.
- `npm run oidc:seed` / `bootstrap` print their result then hang (they don't close the DB pool) — run with a `timeout`.
- Token login is at `/login/admin`; `/login` throws a Turnkey runtime error unless Turnkey env vars are set.
- signer-dmz / OpenMeter are optional (need Docker + go-livepeer/Kafka) and not run locally.

[pymthouse_login_and_create_app.mp4](https://cursor.com/agents/bc-9ad04b84-16f0-4b26-946a-400fbf2c2e14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpymthouse_login_and_create_app.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ad04b84-16f0-4b26-946a-400fbf2c2e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ad04b84-16f0-4b26-946a-400fbf2c2e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

