### PR TITLE
fix(security): clear Sonar new-security-rating failure on main

### DIFF
--- a/docker/signer-dmz/entrypoint.sh
+++ b/docker/signer-dmz/entrypoint.sh
@@ -159,6 +159,7 @@ if [ -z "${SIGNER_UPSTREAM:-}" ] && [ -x /usr/local/bin/livepeer ]; then
   _byoc_default=0
   case "${RAILWAY_SERVICE_NAME:-}" in
     pymthouse-signer-test|pymthouse-signer-test-preview-only) _byoc_default=1 ;;
+    *) _byoc_default=0 ;;
   esac
   _byoc="${BYOC_PER_CAP_PRICING:-$_byoc_default}"
   if [ "$_byoc" = "1" ] || [ "$_byoc" = "true" ]; then

--- a/docker/signer-dmz/scripts/jwks_to_pem.py
+++ b/docker/signer-dmz/scripts/jwks_to_pem.py
@@ -119,7 +119,9 @@ def _build_opener(parsed: urllib.parse.ParseResult) -> urllib.request.OpenerDire
     if parsed.scheme == "https":
         # Always verify certificates and hostnames (no CERT_NONE / check_hostname=False).
         # Local/dev JWKS should use http://localhost or http://host.docker.internal.
+        # Pin TLS ≥ 1.2 so weak SSL/TLS protocols cannot be negotiated (python:S4423).
         ctx = ssl.create_default_context()
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         return urllib.request.build_opener(
             redirect_handler,
             urllib.request.HTTPHandler(),

--- a/src/lib/openmeter/konnect-admin-client.test.ts
+++ b/src/lib/openmeter/konnect-admin-client.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { toKonnectApiUrl } from "./konnect-admin-client";
+
+test("toKonnectApiUrl resolves relative paths on the configured origin", () => {
+  assert.equal(
+    toKonnectApiUrl("https://us.api.konghq.com/v3/openmeter", "/customers/c_1"),
+    "https://us.api.konghq.com/v3/openmeter/customers/c_1",
+  );
+  assert.equal(
+    toKonnectApiUrl("https://us.api.konghq.com/metering/v1", "/subscriptions/s_1"),
+    "https://us.api.konghq.com/metering/v1/subscriptions/s_1",
+  );
+});
+
+test("toKonnectApiUrl allows local OpenMeter hosts", () => {
+  assert.equal(
+    toKonnectApiUrl("http://127.0.0.1:48888/v3/openmeter", "/meters"),
+    "http://127.0.0.1:48888/v3/openmeter/meters",
+  );
+});
+
+test("toKonnectApiUrl rejects host/scheme injection", () => {
+  assert.throws(
+    () => toKonnectApiUrl("https://us.api.konghq.com/v3/openmeter", "https://evil.example/x"),
+    /Invalid Konnect API path/,
+  );
+  assert.throws(
+    () => toKonnectApiUrl("https://us.api.konghq.com/v3/openmeter", "//evil.example/x"),
+    /Invalid Konnect API path/,
+  );
+  assert.throws(
+    () => toKonnectApiUrl("https://us.api.konghq.com/v3/openmeter", "/../escape"),
+    /Invalid Konnect API path/,
+  );
+  assert.throws(
+    () => toKonnectApiUrl("https://us.api.konghq.com/v3/openmeter", "customers"),
+    /Invalid Konnect API path/,
+  );
+});
+
+test("toKonnectApiUrl rejects non-Konnect remote hosts", () => {
+  assert.throws(
+    () => toKonnectApiUrl("https://evil.example/v3/openmeter", "/customers"),
+    /not allowlisted/,
+  );
+});

--- a/src/lib/openmeter/konnect-admin-client.ts
+++ b/src/lib/openmeter/konnect-admin-client.ts
@@ -1,5 +1,6 @@
 import {
   getHostedOpenMeterUrl,
+  isKonnectMeteringUrl,
   normalizeKonnectMeteringUrl,
 } from "./constants";
 
@@ -22,6 +23,57 @@ export function konnectAdminConfig(): { baseUrl: string; apiKey: string } {
 export function konnectMeteringV1BaseUrl(): string {
   const openmeterBase = normalizeKonnectMeteringUrl(getHostedOpenMeterUrl());
   return `${new URL(openmeterBase).origin}/metering/v1`;
+}
+
+/**
+ * Resolve a Konnect API path against a configured base URL.
+ * Rejects scheme/host injection so path segments cannot redirect the request
+ * off the configured OpenMeter / Konnect origin (tssecurity:S8476).
+ * @internal Exported for unit tests.
+ */
+export function toKonnectApiUrl(baseUrl: string, path: string): string {
+  const trimmedPath = path.trim();
+  if (
+    !trimmedPath.startsWith("/") ||
+    trimmedPath.startsWith("//") ||
+    trimmedPath.includes("://") ||
+    trimmedPath.includes("\\") ||
+    trimmedPath.includes("..")
+  ) {
+    throw new Error("Invalid Konnect API path");
+  }
+
+  let base: URL;
+  try {
+    // Trailing slash so a leading-/ path is joined under the base pathname
+    // (`…/v3/openmeter` + `/customers` → `…/v3/openmeter/customers`), not
+    // replaced at the origin root.
+    base = new URL(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
+  } catch {
+    throw new Error("Invalid Konnect API base URL");
+  }
+
+  const url = new URL(trimmedPath.slice(1), base);
+  if (url.origin !== base.origin) {
+    throw new Error("Konnect API origin mismatch");
+  }
+
+  const basePathPrefix = base.pathname.replace(/\/$/, "") || "";
+  if (basePathPrefix && !url.pathname.startsWith(`${basePathPrefix}/`) && url.pathname !== basePathPrefix) {
+    throw new Error("Konnect API path escaped configured base path");
+  }
+
+  // Pin to Kong Konnect (or local OpenMeter in tests/dev). Env-configured
+  // OPENMETER_URL must already be a Konnect metering URL in production; this
+  // is a second belt so a mis-set env cannot send the Bearer token elsewhere.
+  const host = url.hostname.toLowerCase();
+  const isLocal =
+    host === "127.0.0.1" || host === "localhost" || host === "host.docker.internal";
+  if (!isLocal && !isKonnectMeteringUrl(url.origin)) {
+    throw new Error("Konnect API host is not allowlisted");
+  }
+
+  return url.href;
 }
 
 async function konnectFetchJson<T>(
@@ -61,7 +113,8 @@ export async function konnectAdminFetch<T>(
   label = "admin",
 ): Promise<T> {
   const { baseUrl } = konnectAdminConfig();
-  return konnectFetchJson<T>(`${baseUrl}${path}`, path, init, label);
+  const url = toKonnectApiUrl(baseUrl, path);
+  return konnectFetchJson<T>(url, path, init, label);
 }
 
 export async function konnectMeteringV1Fetch<T>(
@@ -70,5 +123,6 @@ export async function konnectMeteringV1Fetch<T>(
   label = "metering-v1",
 ): Promise<T> {
   const baseUrl = konnectMeteringV1BaseUrl();
-  return konnectFetchJson<T>(`${baseUrl}${path}`, path, init, label);
+  const url = toKonnectApiUrl(baseUrl, path);
+  return konnectFetchJson<T>(url, path, init, label);
 }


### PR DESCRIPTION
## Summary
- Fixes the [SonarCloud quality gate on `main`](https://sonarcloud.io/dashboard?id=pymthouse_pymthouse&branch=main), which was failing on **new security rating** (B / 2, needs A / 1).
- Root cause: `tssecurity:S8476` on `konnectAdminFetch` — path was concatenated into `fetch(url)` without origin/host pinning. Added `toKonnectApiUrl()` (same pattern as `toStripeApiUrl`) that joins under the configured base path, rejects scheme/host/`..` injection, and allowlists Kong Konnect / local OpenMeter hosts.
- Also clears the older overall-security CRITICAL `python:S4423` by pinning JWKS HTTPS to TLS ≥ 1.2, and adds a `*)` default in `entrypoint.sh` (`shelldre:S131`).

## Test plan
- [x] `npx tsx --test src/lib/openmeter/konnect-admin-client.test.ts` (path join + injection rejection)
- [x] Related konnect subscription tests still pass
- [x] `tsc --noEmit` clean for changed files
- [x] Snyk Code on `konnect-admin-client.ts`: 0 issues
- [x] Sonar `analyze_code_snippet` on updated client: 0 issues
- [x] After merge: confirm quality gate on `main` returns to OK for `new_security_rating`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved validation of Konnect API URLs to prevent unsafe host, scheme, traversal, and cross-origin requests.
  - Enforced TLS 1.2 or newer when retrieving JWKS data.

- **Configuration**
  - Clarified default BYOC per-cap pricing behavior while preserving explicit configuration overrides.

- **Tests**
  - Added coverage for API URL resolution and security validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->