### PR TITLE
fix(sonar): clear leak-period OPEN issues on main

### DIFF
--- a/scripts/lib/railway-auth.sh
+++ b/scripts/lib/railway-auth.sh
@@ -9,6 +9,7 @@
 
 railway_default_project_id() {
   echo "${RAILWAY_PROJECT_ID:-dab233aa-dd5f-429d-8cc4-9042e8735e2b}"
+  return 0
 }
 
 railway_export_auth() {
@@ -45,7 +46,9 @@ railway_export_auth() {
 
 # Args: environment name (e.g. production)
 railway_pe_flags() {
-  echo "-p $(railway_default_project_id) -e $1"
+  local env_name="$1"
+  echo "-p $(railway_default_project_id) -e ${env_name}"
+  return 0
 }
 
 railway_stack_json() {

--- a/scripts/load-dotenv.ts
+++ b/scripts/load-dotenv.ts
@@ -14,9 +14,7 @@ export function loadDotenvFiles(cwd: string = process.cwd()) {
     parseEnvInto(readFileSync(p, "utf-8"), merged);
   }
   for (const [k, v] of Object.entries(merged)) {
-    if (process.env[k] === undefined) {
-      process.env[k] = v;
-    }
+    process.env[k] ??= v;
   }
 }
 

--- a/src/app/api/v1/apps/[id]/credentials/route.ts
+++ b/src/app/api/v1/apps/[id]/credentials/route.ts
@@ -13,10 +13,123 @@ import {
 
 type CredentialsTarget = "m2m" | "web" | "primary";
 
+type CredentialsOidcResolveResult =
+  | { ok: true; targetOidcRowId: string }
+  | { ok: false; response: NextResponse };
+
 function parseTarget(request: NextRequest): CredentialsTarget {
   const raw = new URL(request.url).searchParams.get("target");
   if (raw === "web" || raw === "m2m" || raw === "primary") return raw;
   return "m2m";
+}
+
+async function resolveCredentialsOidcRowId(
+  app: NonNullable<Awaited<ReturnType<typeof getAuthorizedProviderApp>>>["app"],
+  oidcClientId: string,
+  target: CredentialsTarget,
+): Promise<CredentialsOidcResolveResult> {
+  if (target === "web") {
+    return resolveWebTargetOidcRowId(app);
+  }
+  if (target === "m2m") {
+    return resolveM2mTargetOidcRowId(app, oidcClientId);
+  }
+  return resolvePrimaryTargetOidcRowId(app, oidcClientId);
+}
+
+function resolveWebTargetOidcRowId(
+  app: NonNullable<Awaited<ReturnType<typeof getAuthorizedProviderApp>>>["app"],
+): CredentialsOidcResolveResult {
+  const targetOidcRowId = app.webOidcClientId ?? null;
+  if (!targetOidcRowId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: "confidential_web_not_enabled",
+          error_description:
+            "Enable Confidential web RP on App profile, then generate a secret for the web_ client.",
+        },
+        { status: 400 },
+      ),
+    };
+  }
+  return { ok: true, targetOidcRowId };
+}
+
+async function resolveM2mTargetOidcRowId(
+  app: NonNullable<Awaited<ReturnType<typeof getAuthorizedProviderApp>>>["app"],
+  oidcClientId: string,
+): Promise<CredentialsOidcResolveResult> {
+  const targetOidcRowId = app.m2mOidcClientId ?? null;
+  if (targetOidcRowId) {
+    return { ok: true, targetOidcRowId };
+  }
+
+  // Legacy: if no M2M, allow rotating primary when it is confidential and no siblings.
+  if (app.webOidcClientId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: "interactive_public_no_secret",
+          error_description:
+            "Public apps cannot hold a client secret. Enable Confidential M2M backend for machine credentials, or use ?target=web for the confidential web RP.",
+        },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const primaryRows = await db
+    .select()
+    .from(oidcClients)
+    .where(eq(oidcClients.id, oidcClientId))
+    .limit(1);
+  const primary = primaryRows[0];
+  if (!primary) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "OIDC client not found" },
+        { status: 500 },
+      ),
+    };
+  }
+  if (primary.tokenEndpointAuthMethod === "none") {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: "interactive_public_no_secret",
+          error_description:
+            "Public apps cannot hold a client secret. Enable Confidential M2M backend for machine credentials, or Confidential web RP for portal SSO (auth code + secret + redirects).",
+        },
+        { status: 400 },
+      ),
+    };
+  }
+  return { ok: true, targetOidcRowId: oidcClientId };
+}
+
+function resolvePrimaryTargetOidcRowId(
+  app: NonNullable<Awaited<ReturnType<typeof getAuthorizedProviderApp>>>["app"],
+  oidcClientId: string,
+): CredentialsOidcResolveResult {
+  if (app.m2mOidcClientId || app.webOidcClientId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: "public_client_no_secret",
+          error_description:
+            "The public app_ client cannot hold a secret while a confidential sibling exists. Use ?target=m2m or ?target=web.",
+        },
+        { status: 400 },
+      ),
+    };
+  }
+  return { ok: true, targetOidcRowId: oidcClientId };
 }
 
 export async function POST(
@@ -48,72 +161,11 @@ export async function POST(
   }
 
   const target = parseTarget(request);
-  let targetOidcRowId: string | null = null;
-
-  if (target === "web") {
-    targetOidcRowId = app.webOidcClientId ?? null;
-    if (!targetOidcRowId) {
-      return NextResponse.json(
-        {
-          error: "confidential_web_not_enabled",
-          error_description:
-            "Enable Confidential web RP on App profile, then generate a secret for the web_ client.",
-        },
-        { status: 400 },
-      );
-    }
-  } else if (target === "m2m") {
-    targetOidcRowId = app.m2mOidcClientId ?? null;
-    if (!targetOidcRowId) {
-      // Legacy: if no M2M, allow rotating primary when it is confidential and no siblings.
-      if (app.webOidcClientId) {
-        return NextResponse.json(
-          {
-            error: "interactive_public_no_secret",
-            error_description:
-              "Public apps cannot hold a client secret. Enable Confidential M2M backend for machine credentials, or use ?target=web for the confidential web RP.",
-          },
-          { status: 400 },
-        );
-      }
-      const primaryRows = await db
-        .select()
-        .from(oidcClients)
-        .where(eq(oidcClients.id, app.oidcClientId))
-        .limit(1);
-      const primary = primaryRows[0];
-      if (!primary) {
-        return NextResponse.json(
-          { error: "OIDC client not found" },
-          { status: 500 },
-        );
-      }
-      if (primary.tokenEndpointAuthMethod === "none") {
-        return NextResponse.json(
-          {
-            error: "interactive_public_no_secret",
-            error_description:
-              "Public apps cannot hold a client secret. Enable Confidential M2M backend for machine credentials, or Confidential web RP for portal SSO (auth code + secret + redirects).",
-          },
-          { status: 400 },
-        );
-      }
-      targetOidcRowId = app.oidcClientId;
-    }
-  } else {
-    // target === primary — only when no confidential siblings
-    if (app.m2mOidcClientId || app.webOidcClientId) {
-      return NextResponse.json(
-        {
-          error: "public_client_no_secret",
-          error_description:
-            "The public app_ client cannot hold a secret while a confidential sibling exists. Use ?target=m2m or ?target=web.",
-        },
-        { status: 400 },
-      );
-    }
-    targetOidcRowId = app.oidcClientId;
+  const resolved = await resolveCredentialsOidcRowId(app, app.oidcClientId, target);
+  if (!resolved.ok) {
+    return resolved.response;
   }
+  const targetOidcRowId = resolved.targetOidcRowId;
 
   const clientRows = await db
     .select()

--- a/src/app/api/v1/apps/[id]/me/usage/balance/route.test.ts
+++ b/src/app/api/v1/apps/[id]/me/usage/balance/route.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 
 import { NextRequest } from "next/server";
 
-import { run } from "@/test-utils/db-guard";
+import { test } from "@/test-utils/db-guard";
 import {
   cleanupTestApp,
   createAppUser,
@@ -13,7 +13,7 @@ import { db } from "@/db/index";
 import { apiKeys } from "@/db/schema";
 import { hashToken } from "@/lib/token-hash";
 
-run("me usage balance rejects externalUserId override with bare Bearer", async (t) => {
+test("me usage balance rejects externalUserId override with bare Bearer", async (t) => {
   const { GET } = await import("./route");
   const app = await seedDeveloperAppWithClient({ status: "approved" });
   t.after(() => cleanupTestApp(app));

--- a/src/app/api/v1/apps/[id]/plans/[planId]/sync/route.ts
+++ b/src/app/api/v1/apps/[id]/plans/[planId]/sync/route.ts
@@ -29,7 +29,7 @@ export async function POST(
     .where(eq(plans.id, planId))
     .limit(1);
   const plan = planRows[0];
-  if (!plan || plan.clientId !== auth.app.id) {
+  if (plan?.clientId !== auth.app.id) {
     return NextResponse.json({ error: "Plan not found" }, { status: 404 });
   }
 

--- a/src/app/api/v1/apps/[id]/usage/route.test.ts
+++ b/src/app/api/v1/apps/[id]/usage/route.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { run } from "@/test-utils/db-guard";
+import { test } from "@/test-utils/db-guard";
 import {
   basicAuthHeader,
   cleanupTestApp,
@@ -13,7 +13,7 @@ import {
   __testSetOpenMeterUsageRows,
 } from "@/lib/openmeter/usage-read";
 
-run("usage API requires matching M2M client (provider session rejected)", async (t) => {
+test("usage API requires matching M2M client (provider session rejected)", async (t) => {
   const { GET } = await import("./route");
   const app = await seedDeveloperAppWithClient({ status: "approved" });
   t.after(() => cleanupTestApp(app));
@@ -60,7 +60,7 @@ run("usage API requires matching M2M client (provider session rejected)", async 
   assert.equal(ok.status, 200);
 });
 
-run("usage API aggregates OpenMeter meter rows and validates input", async (t) => {
+test("usage API aggregates OpenMeter meter rows and validates input", async (t) => {
   const { GET } = await import("./route");
 
   const app = await seedDeveloperAppWithClient({ status: "approved" });
@@ -126,7 +126,7 @@ run("usage API aggregates OpenMeter meter rows and validates input", async (t) =
   assert.equal(badStart.status, 400);
 });
 
-run("usage API groupBy=pipeline_model reads OpenMeter dashboard meters", async (t) => {
+test("usage API groupBy=pipeline_model reads OpenMeter dashboard meters", async (t) => {
   const { GET } = await import("./route");
 
   const app = await seedDeveloperAppWithClient({ status: "approved" });
@@ -218,7 +218,7 @@ run("usage API groupBy=pipeline_model reads OpenMeter dashboard meters", async (
   assert.equal(byPipelineModel.byPipelineModel.length, 2);
 });
 
-run("usage API groupBy=daily_pipeline requires userId and returns day buckets", async (t) => {
+test("usage API groupBy=daily_pipeline requires userId and returns day buckets", async (t) => {
   const { GET } = await import("./route");
 
   const app = await seedDeveloperAppWithClient({ status: "approved" });

--- a/src/app/api/v1/user/usage/route.test.ts
+++ b/src/app/api/v1/user/usage/route.test.ts
@@ -10,14 +10,14 @@ import {
   __testSetOpenMeterUsageRows,
 } from "@/lib/openmeter/usage-read";
 import { hashToken } from "@/lib/token-hash";
-import { run } from "@/test-utils/db-guard";
+import { test } from "@/test-utils/db-guard";
 import {
   cleanupTestApp,
   createAppUser,
   seedDeveloperAppWithClient,
 } from "@/test-utils/fixtures";
 
-run("/user/usage accepts bare Bearer and scopes to that user", async (t) => {
+test("/user/usage accepts bare Bearer and scopes to that user", async (t) => {
   const { GET } = await import("./route");
   const app = await seedDeveloperAppWithClient({ status: "approved" });
   t.after(() => cleanupTestApp(app));

--- a/src/app/auth/github/complete/github-complete-client.tsx
+++ b/src/app/auth/github/complete/github-complete-client.tsx
@@ -21,14 +21,12 @@ import {
 let githubHandoffPromise: Promise<string | null> | null = null;
 
 function consumeGithubHandoffSession(): Promise<string | null> {
-  if (!githubHandoffPromise) {
-    githubHandoffPromise = (async () => {
-      const res = await fetch("/api/auth/github/session", { method: "POST" });
-      if (!res.ok) return null;
-      const data = (await res.json()) as { sessionToken?: string };
-      return data.sessionToken ?? null;
-    })().catch(() => null);
-  }
+  githubHandoffPromise ??= (async () => {
+    const res = await fetch("/api/auth/github/session", { method: "POST" });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { sessionToken?: string };
+    return data.sessionToken ?? null;
+  })().catch(() => null);
   return githubHandoffPromise;
 }
 

--- a/src/app/oidc/device/device-verify-form.tsx
+++ b/src/app/oidc/device/device-verify-form.tsx
@@ -124,7 +124,7 @@ export default function DeviceVerifyForm() {
     });
   }, [prefilled, deviceInfo, step, status, authorize]);
 
-  function handleSubmitCode(e: React.FormEvent) {
+  function handleSubmitCode(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     const cleaned = normalizeUserCode(userCode.trim());
     setUserCode(cleaned);

--- a/src/app/webhooks/stripe/route.ts
+++ b/src/app/webhooks/stripe/route.ts
@@ -53,10 +53,11 @@ export async function POST(request: Request): Promise<Response> {
   } catch {
     return NextResponse.json({ error: "invalid_json" }, { status: 400 });
   }
-  const type =
+  const rawType =
     parsed && typeof parsed === "object" && "type" in parsed
-      ? String((parsed as { type?: unknown }).type ?? "")
-      : "";
+      ? (parsed as { type?: unknown }).type
+      : undefined;
+  const type = typeof rawType === "string" ? rawType : "";
 
   if (type === "account.updated") {
     const account = parseStripeAccountUpdated(rawBody);

--- a/src/components/CreateEndUserForm.tsx
+++ b/src/components/CreateEndUserForm.tsx
@@ -13,7 +13,7 @@ export default function CreateEndUserForm() {
     email: "",
   });
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     setCreating(true);
     setError(null);

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -567,6 +567,188 @@ function downloadRequestsCsv(requests: SignedTicketRequestRow[]): void {
   setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
+function HistoryToolbar({
+  copy,
+  fromDate,
+  toDate,
+  rangeActive,
+  viewMode,
+  requests,
+  onFromDateChange,
+  onToDateChange,
+  onClearRange,
+  onDownloadCsv,
+  onViewModeChange,
+}: Readonly<{
+  copy: ReturnType<typeof historyCopy>;
+  fromDate: string;
+  toDate: string;
+  rangeActive: boolean;
+  viewMode: ViewMode;
+  requests: SignedTicketRequestRow[];
+  onFromDateChange: (value: string) => void;
+  onToDateChange: (value: string) => void;
+  onClearRange: () => void;
+  onDownloadCsv: () => void;
+  onViewModeChange: (mode: ViewMode) => void;
+}>) {
+  return (
+    <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-sm font-semibold text-zinc-200">{copy.title}</h2>
+          <span
+            className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-black/20 px-2 py-0.5 text-[11px] text-zinc-400"
+            title="Rows are limited to this identity scope. Change it with the identity filter above."
+          >
+            <span className="text-zinc-600">Scope</span>
+            {copy.scopeChip}
+          </span>
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <label className="flex items-center gap-1 text-[11px] text-zinc-500">
+            <span className="sr-only">From date</span>
+            <input
+              type="date"
+              value={fromDate}
+              max={toDate || undefined}
+              onChange={(e) => onFromDateChange(e.target.value)}
+              className="rounded-md border border-zinc-700 bg-black/20 px-2 py-1 text-[11px] text-zinc-300"
+            />
+          </label>
+          <span className="text-[11px] text-zinc-600">→</span>
+          <label className="flex items-center gap-1 text-[11px] text-zinc-500">
+            <span className="sr-only">To date</span>
+            <input
+              type="date"
+              value={toDate}
+              min={fromDate || undefined}
+              onChange={(e) => onToDateChange(e.target.value)}
+              className="rounded-md border border-zinc-700 bg-black/20 px-2 py-1 text-[11px] text-zinc-300"
+            />
+          </label>
+          {rangeActive ? (
+            <button
+              type="button"
+              onClick={onClearRange}
+              className="text-[11px] text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline"
+            >
+              Clear range
+            </button>
+          ) : null}
+          {viewMode === "request" && requests.length > 0 ? (
+            <button
+              type="button"
+              onClick={onDownloadCsv}
+              className="rounded-md border border-zinc-700 px-2 py-1 text-[11px] text-zinc-300 transition-colors hover:border-emerald-500/40 hover:text-emerald-300"
+            >
+              Export CSV
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <div className="inline-flex rounded-lg border border-zinc-700 p-0.5 self-start">
+        <button
+          type="button"
+          onClick={() => onViewModeChange("session")}
+          className={`px-3 py-1.5 rounded-md text-xs font-semibold ${
+            viewMode === "session"
+              ? "bg-zinc-700 text-zinc-100"
+              : "text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          Sessions
+        </button>
+        <button
+          type="button"
+          onClick={() => onViewModeChange("request")}
+          className={`px-3 py-1.5 rounded-md text-xs font-semibold ${
+            viewMode === "request"
+              ? "bg-zinc-700 text-zinc-100"
+              : "text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          All requests
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function HistoryBody({
+  openMeterConfigured,
+  loading,
+  error,
+  itemsEmpty,
+  emptyCopy,
+  viewMode,
+  sessions,
+  requests,
+  nextCursor,
+  loadingMore,
+  onLoadMore,
+  historyScope,
+  resolvedClientIds,
+}: Readonly<{
+  openMeterConfigured: boolean;
+  loading: boolean;
+  error: string | null;
+  itemsEmpty: boolean;
+  emptyCopy: string;
+  viewMode: ViewMode;
+  sessions: SignedTicketSessionRow[];
+  requests: SignedTicketRequestRow[];
+  nextCursor: string | null;
+  loadingMore: boolean;
+  onLoadMore: () => void;
+  historyScope: HistoryScope;
+  resolvedClientIds: string[];
+}>) {
+  if (!openMeterConfigured) {
+    return (
+      <p className="text-sm text-zinc-500 py-6 text-center">
+        Usage metering is not configured, so per-request history is unavailable.
+      </p>
+    );
+  }
+  if (loading) {
+    return (
+      <div className="animate-pulse space-y-3 py-2">
+        {["a", "b", "c"].map((key) => (
+          <div key={key} className="h-10 rounded-lg bg-zinc-800/80" />
+        ))}
+      </div>
+    );
+  }
+  if (error) {
+    return <p className="text-sm text-rose-400 py-4 text-center">{error}</p>;
+  }
+  if (itemsEmpty) {
+    return <p className="text-sm text-zinc-500 py-6 text-center">{emptyCopy}</p>;
+  }
+  if (viewMode === "session") {
+    return (
+      <SessionTable
+        items={sessions}
+        nextCursor={nextCursor}
+        loadingMore={loadingMore}
+        onLoadMore={onLoadMore}
+        historyScope={historyScope}
+        resolvedClientIds={resolvedClientIds}
+      />
+    );
+  }
+  return (
+    <RequestTable
+      items={requests}
+      nextCursor={nextCursor}
+      loadingMore={loadingMore}
+      onLoadMore={onLoadMore}
+      showIdentity
+    />
+  );
+}
+
 export default function SignedTicketRequestHistory({
   clientId,
   clientIds,
@@ -714,126 +896,38 @@ export default function SignedTicketRequestHistory({
 
   return (
     <section className="rounded-xl border border-zinc-800 bg-zinc-900/30 p-4 sm:p-5">
-      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-sm font-semibold text-zinc-200">{copy.title}</h2>
-            <span
-              className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-black/20 px-2 py-0.5 text-[11px] text-zinc-400"
-              title="Rows are limited to this identity scope. Change it with the identity filter above."
-            >
-              <span className="text-zinc-600">Scope</span>
-              {copy.scopeChip}
-            </span>
-          </div>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <label className="flex items-center gap-1 text-[11px] text-zinc-500">
-              <span className="sr-only">From date</span>
-              <input
-                type="date"
-                value={fromDate}
-                max={toDate || undefined}
-                onChange={(e) => setFromDate(e.target.value)}
-                className="rounded-md border border-zinc-700 bg-black/20 px-2 py-1 text-[11px] text-zinc-300"
-              />
-            </label>
-            <span className="text-[11px] text-zinc-600">→</span>
-            <label className="flex items-center gap-1 text-[11px] text-zinc-500">
-              <span className="sr-only">To date</span>
-              <input
-                type="date"
-                value={toDate}
-                min={fromDate || undefined}
-                onChange={(e) => setToDate(e.target.value)}
-                className="rounded-md border border-zinc-700 bg-black/20 px-2 py-1 text-[11px] text-zinc-300"
-              />
-            </label>
-            {rangeActive ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setFromDate("");
-                  setToDate("");
-                }}
-                className="text-[11px] text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline"
-              >
-                Clear range
-              </button>
-            ) : null}
-            {viewMode === "request" && requests.length > 0 ? (
-              <button
-                type="button"
-                onClick={downloadCsv}
-                className="rounded-md border border-zinc-700 px-2 py-1 text-[11px] text-zinc-300 transition-colors hover:border-emerald-500/40 hover:text-emerald-300"
-              >
-                Export CSV
-              </button>
-            ) : null}
-          </div>
-        </div>
-        <div className="inline-flex rounded-lg border border-zinc-700 p-0.5 self-start">
-          <button
-            type="button"
-            onClick={() => setViewMode("session")}
-            className={`px-3 py-1.5 rounded-md text-xs font-semibold ${
-              viewMode === "session"
-                ? "bg-zinc-700 text-zinc-100"
-                : "text-zinc-400 hover:text-zinc-200"
-            }`}
-          >
-            Sessions
-          </button>
-          <button
-            type="button"
-            onClick={() => setViewMode("request")}
-            className={`px-3 py-1.5 rounded-md text-xs font-semibold ${
-              viewMode === "request"
-                ? "bg-zinc-700 text-zinc-100"
-                : "text-zinc-400 hover:text-zinc-200"
-            }`}
-          >
-            All requests
-          </button>
-        </div>
-      </div>
+      <HistoryToolbar
+        copy={copy}
+        fromDate={fromDate}
+        toDate={toDate}
+        rangeActive={rangeActive}
+        viewMode={viewMode}
+        requests={requests}
+        onFromDateChange={setFromDate}
+        onToDateChange={setToDate}
+        onClearRange={() => {
+          setFromDate("");
+          setToDate("");
+        }}
+        onDownloadCsv={downloadCsv}
+        onViewModeChange={setViewMode}
+      />
 
-      {!openMeterConfigured ? (
-        <p className="text-sm text-zinc-500 py-6 text-center">
-          Usage metering is not configured, so per-request history is unavailable.
-        </p>
-      ) : null}
-      {openMeterConfigured && loading ? (
-        <div className="animate-pulse space-y-3 py-2">
-          {["a", "b", "c"].map((key) => (
-            <div key={key} className="h-10 rounded-lg bg-zinc-800/80" />
-          ))}
-        </div>
-      ) : null}
-      {openMeterConfigured && !loading && error ? (
-        <p className="text-sm text-rose-400 py-4 text-center">{error}</p>
-      ) : null}
-      {openMeterConfigured && !loading && !error && itemsEmpty ? (
-        <p className="text-sm text-zinc-500 py-6 text-center">{emptyCopy}</p>
-      ) : null}
-      {openMeterConfigured && !loading && !error && !itemsEmpty && viewMode === "session" ? (
-        <SessionTable
-          items={sessions}
-          nextCursor={nextCursor}
-          loadingMore={loadingMore}
-          onLoadMore={() => void onLoadMore()}
-          historyScope={historyScope}
-          resolvedClientIds={resolvedClientIds}
-        />
-      ) : null}
-      {openMeterConfigured && !loading && !error && !itemsEmpty && viewMode === "request" ? (
-        <RequestTable
-          items={requests}
-          nextCursor={nextCursor}
-          loadingMore={loadingMore}
-          onLoadMore={() => void onLoadMore()}
-          showIdentity
-        />
-      ) : null}
+      <HistoryBody
+        openMeterConfigured={openMeterConfigured}
+        loading={loading}
+        error={error}
+        itemsEmpty={itemsEmpty}
+        emptyCopy={emptyCopy}
+        viewMode={viewMode}
+        sessions={sessions}
+        requests={requests}
+        nextCursor={nextCursor}
+        loadingMore={loadingMore}
+        onLoadMore={() => void onLoadMore()}
+        historyScope={historyScope}
+        resolvedClientIds={resolvedClientIds}
+      />
     </section>
   );
 }

--- a/src/components/SignerConfigForm.tsx
+++ b/src/components/SignerConfigForm.tsx
@@ -127,7 +127,7 @@ export default function SignerConfigForm({ config }: Readonly<SignerConfigFormPr
     liveAICapReportInterval: config.liveAICapReportInterval || "5m",
   });
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     if (saveStateResetTimerRef.current !== null) {
       clearTimeout(saveStateResetTimerRef.current);

--- a/src/components/apps/AppWizard.tsx
+++ b/src/components/apps/AppWizard.tsx
@@ -187,14 +187,16 @@ export default function AppWizard({ initialData }: Readonly<Props>) {
     set("allowedScopes", ensureOpenIdScope(joinScopes(next)));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSaving(true);
     setError(null);
     try {
-      const webRedirects = formData.confidentialWebHelper
-        ? (webRedirectDraft.trim() ? [webRedirectDraft.trim()] : [])
-        : [];
+      let webRedirects: string[] = [];
+      if (formData.confidentialWebHelper) {
+        const trimmed = webRedirectDraft.trim();
+        webRedirects = trimmed ? [trimmed] : [];
+      }
 
       const payload: AppFormData = {
         ...formData,

--- a/src/components/apps/FundAccountOnRampPanel.tsx
+++ b/src/components/apps/FundAccountOnRampPanel.tsx
@@ -188,6 +188,92 @@ async function settleOnRampPurchase(input: {
     : null;
 }
 
+type MoonPayFundFlowInput = {
+  turnkeyClient: TurnkeyHttpClient;
+  clientId: string;
+  ownerExternalUserId: string;
+  wallets: { accounts: { address: string }[] }[];
+  refreshWallets: () => Promise<{ accounts: { address: string }[] }[]>;
+  getSession: () => Promise<{ organizationId?: string | null } | null | undefined>;
+  pollUntilTerminal: (
+    client: TurnkeyHttpClient,
+    transactionId: string,
+    organizationId: string,
+    signal: AbortSignal,
+  ) => Promise<string>;
+  pollAbort: AbortSignal;
+  checkoutWindow: Window | null;
+  setCheckoutUrl: (url: string) => void;
+  setStatusMessage: (message: string) => void;
+  setPhase: (phase: FundPhase) => void;
+};
+
+async function runMoonPayFundFlow(input: MoonPayFundFlowInput): Promise<string | null> {
+  const amount = SANDBOX_ONRAMP_USD_AMOUNT;
+  input.setPhase("funding");
+  input.setStatusMessage("Preparing MoonPay checkout…");
+
+  const walletAddress = await resolveDepositWallet({
+    wallets: input.wallets,
+    refreshWallets: input.refreshWallets,
+  });
+  const session = await input.getSession();
+  const organizationId = session?.organizationId;
+  if (!organizationId) {
+    throw new Error("Turnkey session is missing organization context.");
+  }
+
+  const initResult = await input.turnkeyClient.initFiatOnRamp({
+    organizationId,
+    onrampProvider: FiatOnRampProvider.MOONPAY,
+    walletAddress,
+    network: FiatOnRampBlockchainNetwork.ETHEREUM,
+    cryptoCurrencyCode: FiatOnRampCryptoCurrency.ETHEREUM,
+    fiatCurrencyCode: FiatOnRampCurrency.USD,
+    fiatCurrencyAmount: amount,
+    sandboxMode: true,
+  });
+  if (!initResult.onRampUrl || !initResult.onRampTransactionId) {
+    throw new Error("Turnkey did not return an on-ramp URL or transaction id.");
+  }
+
+  const onRampUrl = assertSafeOnRampUrl(initResult.onRampUrl);
+  input.setCheckoutUrl(onRampUrl);
+
+  const sessionId = await registerOnRampSession({
+    clientId: input.clientId,
+    ownerExternalUserId: input.ownerExternalUserId,
+    walletAddress,
+    onRampTransactionId: initResult.onRampTransactionId,
+    organizationId,
+    amount,
+  });
+
+  if (input.checkoutWindow && !input.checkoutWindow.closed) {
+    input.checkoutWindow.location.href = onRampUrl;
+    input.setStatusMessage("Complete the purchase in the MoonPay window…");
+  } else {
+    input.setStatusMessage(
+      "Checkout ready — open the MoonPay link below, then wait here for confirmation.",
+    );
+  }
+
+  const terminalStatus = await input.pollUntilTerminal(
+    input.turnkeyClient,
+    initResult.onRampTransactionId,
+    organizationId,
+    input.pollAbort,
+  );
+  closeCheckoutWindow(input.checkoutWindow);
+  if (terminalStatus !== "COMPLETED") {
+    throw new Error(`MoonPay purchase ${terminalStatus.toLowerCase()}.`);
+  }
+
+  input.setPhase("settling");
+  input.setStatusMessage("Purchase completed. Crediting your account…");
+  return settleOnRampPurchase({ clientId: input.clientId, sessionId });
+}
+
 const POLL_INTERVAL_MS = 3000;
 /** Stop waiting for a stuck Turnkey status after this long. */
 const POLL_DEADLINE_MS = 15 * 60 * 1000;
@@ -315,68 +401,23 @@ export default function FundAccountOnRampPanel({
     const pollAbort = new AbortController();
     pollAbortRef.current = pollAbort;
 
-    const amount = SANDBOX_ONRAMP_USD_AMOUNT;
     const checkoutWindow = openMoonPayCheckoutWindow();
-    setPhase("funding");
-    setStatusMessage("Preparing MoonPay checkout…");
 
     try {
-      const walletAddress = await resolveDepositWallet({ wallets, refreshWallets });
-      const session = await getSession();
-      const organizationId = session?.organizationId;
-      if (!organizationId) {
-        throw new Error("Turnkey session is missing organization context.");
-      }
-
-      const initResult = await turnkeyClient.initFiatOnRamp({
-        organizationId,
-        onrampProvider: FiatOnRampProvider.MOONPAY,
-        walletAddress,
-        network: FiatOnRampBlockchainNetwork.ETHEREUM,
-        cryptoCurrencyCode: FiatOnRampCryptoCurrency.ETHEREUM,
-        fiatCurrencyCode: FiatOnRampCurrency.USD,
-        fiatCurrencyAmount: amount,
-        sandboxMode: true,
-      });
-      if (!initResult.onRampUrl || !initResult.onRampTransactionId) {
-        throw new Error("Turnkey did not return an on-ramp URL or transaction id.");
-      }
-
-      const onRampUrl = assertSafeOnRampUrl(initResult.onRampUrl);
-      setCheckoutUrl(onRampUrl);
-
-      const sessionId = await registerOnRampSession({
+      const granted = await runMoonPayFundFlow({
+        turnkeyClient,
         clientId,
         ownerExternalUserId,
-        walletAddress,
-        onRampTransactionId: initResult.onRampTransactionId,
-        organizationId,
-        amount,
+        wallets,
+        refreshWallets,
+        getSession,
+        pollUntilTerminal,
+        pollAbort: pollAbort.signal,
+        checkoutWindow,
+        setCheckoutUrl,
+        setStatusMessage,
+        setPhase,
       });
-
-      if (checkoutWindow && !checkoutWindow.closed) {
-        checkoutWindow.location.href = onRampUrl;
-        setStatusMessage("Complete the purchase in the MoonPay window…");
-      } else {
-        setStatusMessage(
-          "Checkout ready — open the MoonPay link below, then wait here for confirmation.",
-        );
-      }
-
-      const terminalStatus = await pollUntilTerminal(
-        turnkeyClient,
-        initResult.onRampTransactionId,
-        organizationId,
-        pollAbort.signal,
-      );
-      closeCheckoutWindow(checkoutWindow);
-      if (terminalStatus !== "COMPLETED") {
-        throw new Error(`MoonPay purchase ${terminalStatus.toLowerCase()}.`);
-      }
-
-      setPhase("settling");
-      setStatusMessage("Purchase completed. Crediting your account…");
-      const granted = await settleOnRampPurchase({ clientId, sessionId });
       setLastGrantedUsdMicros(granted);
       setPhase("done");
       setStatusMessage("Prepaid credits updated.");

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -873,7 +873,7 @@ function PaymentsTabLoaded(props: Readonly<{
             <a href="/billing" className="text-emerald-400 hover:text-emerald-300">
               Billing
             </a>
-            .
+            {"."}
           </p>
         </div>
         <PaymentsInvoicesList invoices={invoices} />

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -897,7 +897,7 @@ function M2mTokenTestResult({
           remote signer, or as <span className="font-mono text-sky-200/80">subject_token</span> at <span className="font-mono text-sky-200/80">
             POST /api/v1/apps/{`{clientId}`}/oidc/token
           </span>
-          .
+          {"."}
         </p>
       ) : null}
       {tokenKind === "signer_session" ? (

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -20,16 +20,12 @@ const globalForDb = globalThis as unknown as {
 };
 
 function getPostgresClient() {
-  if (!globalForDb.pymthousePostgres) {
-    globalForDb.pymthousePostgres = postgres(requireDatabaseUrl(), { max: 10 });
-  }
+  globalForDb.pymthousePostgres ??= postgres(requireDatabaseUrl(), { max: 10 });
   return globalForDb.pymthousePostgres;
 }
 
 function getDb(): Db {
-  if (!globalForDb.pymthouseDb) {
-    globalForDb.pymthouseDb = drizzle(getPostgresClient(), { schema });
-  }
+  globalForDb.pymthouseDb ??= drizzle(getPostgresClient(), { schema });
   return globalForDb.pymthouseDb;
 }
 

--- a/src/lib/billing-runtime.test.ts
+++ b/src/lib/billing-runtime.test.ts
@@ -203,13 +203,15 @@ test("computeUsdMicrosFromWei: small wei amount stays exact fractional", () => {
   const smallWei = 1_000_000n; // 0.000_000_000_001 ETH
   const result = computeUsdMicrosFromWei(smallWei, 3000);
   assert.ok(typeof result === "number");
-  assert.ok(result > 0 && result < 1);
+  assert.ok(result > 0);
+  assert.ok(result < 1);
 });
 
 test("computeUsdMicrosFromWei: sub-micro fees stay fractional (no per-ticket ceil)", () => {
   // 1 wei at $1 → exact micros = 1e-18; must not round up here.
   const exact = computeUsdMicrosFromWei(1n, 1);
-  assert.ok(exact > 0 && exact < 1);
+  assert.ok(exact > 0);
+  assert.ok(exact < 1);
   assert.equal(ceilExactUsdMicros(exact), 1n);
 });
 

--- a/src/lib/billing/billing.test.ts
+++ b/src/lib/billing/billing.test.ts
@@ -59,8 +59,9 @@ test("deriveSyncState maps pending when active plan has no OM id", () => {
   assert.equal(sync.status, "pending");
 });
 
-test("stable feature keys when flag enabled", () => {
+test("stable feature keys when flag enabled", (t) => {
   if (!billingStableFeatureKeysEnabled()) {
+    t.skip("billing stable feature keys disabled");
     return;
   }
   const key = resolveCapabilityFeatureKey({

--- a/src/lib/billing/retail-usage.ts
+++ b/src/lib/billing/retail-usage.ts
@@ -23,9 +23,10 @@ export async function loadActiveRetailRatesForApp(
   const paid = activePlans.filter(
     (p) => !p.isNetworkDefault && !p.isStarterDefault && p.type !== "free",
   );
-  const plan = paid.sort(
+  const sortedPaid = paid.toSorted(
     (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-  )[0];
+  );
+  const plan = sortedPaid[0];
 
   if (!plan) {
     const fallback = resolveEffectiveRetailRateUsd({

--- a/src/lib/network-catalog.ts
+++ b/src/lib/network-catalog.ts
@@ -58,34 +58,36 @@ export function splitCapability(capability: string): {
   };
 }
 
-/**
- * Aggregate discover-orchestrators rows into catalog entries.
- * Exported for unit tests.
- */
-export function catalogFromDiscoveryRaw(raw: unknown): PipelineCatalogEntry[] {
-  if (!Array.isArray(raw)) {
-    throw new Error("Discovery raw response is not an array");
+function addCapabilityToCatalog(
+  byPipeline: Map<string, Set<string>>,
+  capability: string,
+): void {
+  const split = splitCapability(capability);
+  if (!split) return;
+  let models = byPipeline.get(split.pipeline);
+  if (!models) {
+    models = new Set();
+    byPipeline.set(split.pipeline, models);
   }
+  models.add(split.model);
+}
 
-  const byPipeline = new Map<string, Set<string>>();
-
-  for (const item of raw) {
-    if (!item || typeof item !== "object") continue;
-    const caps = (item as { capabilities?: unknown }).capabilities;
-    if (!Array.isArray(caps)) continue;
-    for (const cap of caps) {
-      if (typeof cap !== "string") continue;
-      const split = splitCapability(cap);
-      if (!split) continue;
-      let models = byPipeline.get(split.pipeline);
-      if (!models) {
-        models = new Set();
-        byPipeline.set(split.pipeline, models);
-      }
-      models.add(split.model);
-    }
+function ingestDiscoveryItem(
+  byPipeline: Map<string, Set<string>>,
+  item: unknown,
+): void {
+  if (!item || typeof item !== "object") return;
+  const caps = (item as { capabilities?: unknown }).capabilities;
+  if (!Array.isArray(caps)) return;
+  for (const cap of caps) {
+    if (typeof cap !== "string") continue;
+    addCapabilityToCatalog(byPipeline, cap);
   }
+}
 
+function entriesFromPipelineMap(
+  byPipeline: Map<string, Set<string>>,
+): PipelineCatalogEntry[] {
   const entries: PipelineCatalogEntry[] = [];
   for (const [id, models] of [...byPipeline.entries()].sort((a, b) =>
     a[0].localeCompare(b[0]),
@@ -97,6 +99,22 @@ export function catalogFromDiscoveryRaw(raw: unknown): PipelineCatalogEntry[] {
     });
   }
   return entries;
+}
+
+/**
+ * Aggregate discover-orchestrators rows into catalog entries.
+ * Exported for unit tests.
+ */
+export function catalogFromDiscoveryRaw(raw: unknown): PipelineCatalogEntry[] {
+  if (!Array.isArray(raw)) {
+    throw new TypeError("Discovery raw response is not an array");
+  }
+
+  const byPipeline = new Map<string, Set<string>>();
+  for (const item of raw) {
+    ingestDiscoveryItem(byPipeline, item);
+  }
+  return entriesFromPipelineMap(byPipeline);
 }
 
 async function fetchDiscoveryJson(): Promise<unknown> {

--- a/src/lib/oidc/confidential-web.ts
+++ b/src/lib/oidc/confidential-web.ts
@@ -67,16 +67,16 @@ export function validateConfidentialWebShape(
   const redirects = input.redirectUris
     .map((u) => u.trim())
     .filter((u) => u.length > 0);
-  const grants = input.grantTypes.flatMap((g) => parseGrantTypes(g));
+  const grants = new Set(input.grantTypes.flatMap((g) => parseGrantTypes(g)));
 
-  if (grants.includes(CLIENT_CREDENTIALS_GRANT)) {
+  if (grants.has(CLIENT_CREDENTIALS_GRANT)) {
     return {
       error: "confidential_web_invalid_shape",
       error_description:
         "Confidential web clients cannot use client_credentials. Use the M2M backend helper for machine tokens.",
     };
   }
-  if (grants.includes(DEVICE_CODE_GRANT)) {
+  if (grants.has(DEVICE_CODE_GRANT)) {
     return {
       error: "confidential_web_invalid_shape",
       error_description:
@@ -86,7 +86,7 @@ export function validateConfidentialWebShape(
 
   const requireRedirects =
     options?.requireRedirects === true ||
-    grants.includes(AUTHORIZATION_CODE_GRANT);
+    grants.has(AUTHORIZATION_CODE_GRANT);
   if (requireRedirects && redirects.length === 0) {
     return {
       error: "confidential_web_invalid_shape",

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -46,6 +46,27 @@ type OpenApiDoc = ReturnType<typeof generateOpenApiDocument> & {
 
 type PathItem = NonNullable<OpenApiDoc["paths"]>[string];
 
+function filterPathItem(
+  path: string,
+  item: PathItem,
+  allowed: Set<OpenApiAudience>,
+): PathItem | null {
+  const filtered: Record<string, unknown> = { ...item };
+  let keep = false;
+  for (const method of HTTP_METHODS) {
+    if (!(method in filtered)) {
+      continue;
+    }
+    const audience = classifyOpenApiOperation(method, path);
+    if (audience && allowed.has(audience)) {
+      keep = true;
+    } else {
+      delete filtered[method];
+    }
+  }
+  return keep ? (filtered as PathItem) : null;
+}
+
 function filterOperations(
   paths: OpenApiDoc["paths"],
   audiences: OpenApiAudience[],
@@ -59,21 +80,9 @@ function filterOperations(
     if (!item || typeof item !== "object") {
       continue;
     }
-    const filtered: Record<string, unknown> = { ...item };
-    let keep = false;
-    for (const method of HTTP_METHODS) {
-      if (!(method in filtered)) {
-        continue;
-      }
-      const audience = classifyOpenApiOperation(method, path);
-      if (audience && allowed.has(audience)) {
-        keep = true;
-      } else {
-        delete filtered[method];
-      }
-    }
-    if (keep) {
-      next[path] = filtered as PathItem;
+    const filtered = filterPathItem(path, item, allowed);
+    if (filtered) {
+      next[path] = filtered;
     }
   }
   return next;

--- a/src/lib/openapi/registry.ts
+++ b/src/lib/openapi/registry.ts
@@ -3,7 +3,7 @@ import {
   OpenApiGeneratorV3,
   type RouteConfig,
 } from "@asteasolutions/zod-to-openapi";
-import type { ZodTypeAny } from "zod";
+import type { z } from "zod";
 
 import { BUILDER_INFO_DESCRIPTION } from "@/lib/openapi/tags";
 
@@ -32,7 +32,7 @@ export function defineRoute(input: DefineRouteInput): void {
   openApiRegistry.registerPath(input);
 }
 
-export function registerSchema<T extends ZodTypeAny>(
+export function registerSchema<T extends z.ZodType>(
   name: string,
   schema: T,
 ): T {

--- a/src/lib/openapi/routes/misc.ts
+++ b/src/lib/openapi/routes/misc.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/openapi/schemas/misc";
 import { z } from "@/lib/openapi/zod";
 
-const jsonObject = z.object({}).passthrough();
+const jsonObject = z.looseObject({});
 
 defineRouteMetadata("get", "/api/v1/health", {
   tags: ["Platform"],

--- a/src/lib/openapi/routes/shared.ts
+++ b/src/lib/openapi/routes/shared.ts
@@ -4,7 +4,7 @@ import { defineRouteMetadata } from "@/lib/openapi/route-metadata";
 import { OAuthErrorSchema } from "@/lib/openapi/schemas/common";
 import { z } from "@/lib/openapi/zod";
 
-export const genericJsonObject = z.object({}).passthrough().openapi("GenericJsonObject");
+export const genericJsonObject = z.looseObject({}).openapi("GenericJsonObject");
 
 export const jsonSuccess = {
   description: "Success",

--- a/src/lib/openapi/schemas/common.ts
+++ b/src/lib/openapi/schemas/common.ts
@@ -1,7 +1,6 @@
 import { z } from "@/lib/openapi/zod";
 
 export const CorrelationIdSchema = z
-  .string()
   .uuid()
   .openapi({ description: "Request correlation id for support and audit." });
 

--- a/src/lib/openapi/schemas/credentials.ts
+++ b/src/lib/openapi/schemas/credentials.ts
@@ -61,10 +61,10 @@ export const SignerSessionSchema = z
     lifetimeGrantedUsdMicros: z.string().optional().openapi({
       description: "PymtHouse extension: lifetime granted balance in USD micros.",
     }),
-    signer_url: z.string().url().optional().openapi({
+    signer_url: z.url().optional().openapi({
       description: "Public remote-signer base URL.",
     }),
-    discovery_url: z.string().url().optional().openapi({
+    discovery_url: z.url().optional().openapi({
       description:
         "Remote-signer discover-orchestrators URL (default `{signer_url}/discover-orchestrators`). Not OIDC issuer metadata.",
     }),

--- a/src/lib/openapi/signer-session.ts
+++ b/src/lib/openapi/signer-session.ts
@@ -10,7 +10,7 @@ export function buildSignerSessionEnvelope(input: {
   signer_url?: string;
   discovery_url?: string;
   caps?: readonly string[];
-  issued_token_type?: SignerSession["issued_token_type"];
+  issued_token_type?: NonNullable<SignerSession["issued_token_type"]>;
   correlation_id?: string;
 }): SignerSession {
   const scope = input.scope.trim() || "sign:job";

--- a/src/lib/openmeter/billing-consistency.ts
+++ b/src/lib/openmeter/billing-consistency.ts
@@ -804,25 +804,21 @@ async function auditOwnerStarterPlans(
   return findings;
 }
 
-type OwnerCustomerAuditContext = {
-  customerId: string;
-  customerKey: string;
-  attributedSubjects: string[];
-};
-
-async function resolveOwnerCustomerForAudit(
+async function auditOwnerSubscriptions(
   client: OpenMeter,
   ownerId: string,
-): Promise<
-  | { ok: true; context: OwnerCustomerAuditContext }
-  | { ok: false; findings: BillingConsistencyFinding[] }
-> {
+  starters: LocalStarterPlanRef[],
+): Promise<BillingConsistencyFinding[]> {
+  const findings: BillingConsistencyFinding[] = [];
   const customerKey = buildOwnerCustomerKey(ownerId);
+
+  let customerId: string;
+  let attributedSubjects: string[] = [];
   try {
     const customer = (await findOpenMeterCustomerByKey(client, customerKey)) as
       | { id?: string; usageAttribution?: { subjectKeys?: string[] } }
       | null;
-    const attributedSubjects = [
+    attributedSubjects = [
       ...new Set(
         (customer?.usageAttribution?.subjectKeys ?? [])
           .map((key) => key.trim())
@@ -830,194 +826,97 @@ async function resolveOwnerCustomerForAudit(
       ),
     ];
     if (!customer?.id) {
-      return {
-        ok: false,
-        findings: [
-          {
-            code: "owner_customer_missing",
-            severity: "error",
-            ownerId,
-            message: `No Konnect customer for bare key ${customerKey}`,
-            details: { customerKey },
-            remediation: FIX_MIGRATE,
-          },
-        ],
-      };
-    }
-    return {
-      ok: true,
-      context: { customerId: customer.id, customerKey, attributedSubjects },
-    };
-  } catch (err) {
-    return {
-      ok: false,
-      findings: [
+      return [
         {
-          code: "owner_customer_lookup_failed",
+          code: "owner_customer_missing",
           severity: "error",
           ownerId,
-          message:
-            err instanceof Error ? err.message : "Failed to look up owner customer",
+          message: `No Konnect customer for bare key ${customerKey}`,
           details: { customerKey },
+          remediation: FIX_MIGRATE,
         },
-      ],
-    };
-  }
-}
-
-async function missingStripeAppDataFindings(input: {
-  client: OpenMeter;
-  ownerId: string;
-  customerId: string;
-  customerKey: string;
-}): Promise<BillingConsistencyFinding[]> {
-  const stripeCus = await getStripeCustomerAppDataId({
-    client: input.client,
-    customerId: input.customerId,
-  });
-  if (stripeCus) {
-    return [];
-  }
-
-  // Missing Stripe app data is only a defect for an owner who has something
-  // chargeable. Owners without a payment method deliberately stay on the free
-  // billing profile — Konnect rejects a Starter subscription for a customer
-  // pinned to a Stripe profile with no default payment method — so
-  // migrate-sandbox-to-stripe skips them by design. Reporting those as errors
-  // pointed at a remediation that can never apply.
-  // `null` (Stripe/OpenMeter unreachable) is treated as not-chargeable, the
-  // same fail-open choice the migration makes.
-  const chargeable = await ownerHasChargeablePaymentMethod(input.ownerId);
-  if (chargeable !== true) {
-    return [];
-  }
-
-  return [
-    {
-      code: "owner_missing_stripe_app_data",
-      severity: "error",
-      ownerId: input.ownerId,
-      message: `Owner customer ${input.customerKey} has a payment method but no Stripe customer app data (cus_…)`,
-      details: { customerId: input.customerId, customerKey: input.customerKey },
-      remediation: FIX_SANDBOX_TO_STRIPE,
-    },
-  ];
-}
-
-async function sandboxProfileFindings(input: {
-  ownerId: string;
-  customerId: string;
-  customerKey: string;
-}): Promise<BillingConsistencyFinding[]> {
-  if (
-    !shouldUseKonnectRoutes(getHostedOpenMeterUrl(), process.env.OPENMETER_API_KEY)
-  ) {
-    return [];
-  }
-
-  const profileId = await getKonnectCustomerBillingProfileId(input.customerId);
-  const sandboxId = process.env.OPENMETER_FREE_BILLING_PROFILE_ID?.trim();
-  if (!profileId || !sandboxId || profileId !== sandboxId) {
-    return [];
-  }
-
-  // Sandbox is correct for Owner Sandbox Starter. Flag only when the owner
-  // already has a chargeable card (should be on owners Stripe / Paid).
-  const chargeable = await ownerHasChargeablePaymentMethod(input.ownerId);
-  if (chargeable !== true) {
-    return [];
-  }
-
-  return [
-    {
-      code: "owner_sandbox_billing_profile",
-      severity: "warn",
-      ownerId: input.ownerId,
-      message: `Owner customer ${input.customerKey} has a payment method but still uses sandbox billing profile ${profileId}`,
-      details: { customerId: input.customerId, profileId },
-      remediation: FIX_SANDBOX_TO_STRIPE,
-    },
-  ];
-}
-
-function activeSubsFindings(input: {
-  ownerId: string;
-  customerKey: string;
-  active: OpenMeterSubscriptionView[];
-}): BillingConsistencyFinding[] {
-  if (input.active.length === 0) {
+      ];
+    }
+    customerId = customer.id;
+  } catch (err) {
     return [
       {
-        code: "owner_no_active_subscription",
+        code: "owner_customer_lookup_failed",
         severity: "error",
-        ownerId: input.ownerId,
-        message: `No active subscription on ${input.customerKey}`,
-        remediation: FIX_STARTER,
+        ownerId,
+        message:
+          err instanceof Error ? err.message : "Failed to look up owner customer",
+        details: { customerKey },
       },
     ];
   }
-  if (input.active.length <= 1) {
-    return [];
-  }
-  return [
-    {
-      code: "owner_multiple_active_subscriptions",
-      severity: "warn",
-      ownerId: input.ownerId,
-      message: `${input.active.length} active subscriptions on ${input.customerKey}`,
-      details: { subscriptionIds: input.active.map((s) => s.id) },
-      remediation: FIX_DEDUPE,
-    },
-  ];
-}
 
-async function usageAttributionFindings(input: {
-  client: OpenMeter;
-  ownerId: string;
-  customerKey: string;
-  attributedSubjects: string[];
-}): Promise<BillingConsistencyFinding[]> {
-  const ownedPublicClientIds = await listOwnedPublicClientIds(input.ownerId);
-  const subjectsWithUsage = await findSubjectsWithUsage(
-    input.client,
-    buildOwnerMeterSubjects(input.ownerId, ownedPublicClientIds),
-  );
-  return classifyUsageAttributionConsistency({
-    ownerId: input.ownerId,
-    customerKey: input.customerKey,
-    attributedSubjects: input.attributedSubjects,
-    subjectsWithUsage,
-  });
-}
-
-async function auditOwnerSubscriptions(
-  client: OpenMeter,
-  ownerId: string,
-  starters: LocalStarterPlanRef[],
-): Promise<BillingConsistencyFinding[]> {
-  const resolved = await resolveOwnerCustomerForAudit(client, ownerId);
-  if (!resolved.ok) {
-    return resolved.findings;
+  const stripeCus = await getStripeCustomerAppDataId({ client, customerId });
+  if (!stripeCus) {
+    // Missing Stripe app data is only a defect for an owner who has something
+    // chargeable. Owners without a payment method deliberately stay on the free
+    // billing profile — Konnect rejects a Starter subscription for a customer
+    // pinned to a Stripe profile with no default payment method — so
+    // migrate-sandbox-to-stripe skips them by design. Reporting those as errors
+    // pointed at a remediation that can never apply.
+    // `null` (Stripe/OpenMeter unreachable) is treated as not-chargeable, the
+    // same fail-open choice the migration makes.
+    const chargeable = await ownerHasChargeablePaymentMethod(ownerId);
+    if (chargeable === true) {
+      findings.push({
+        code: "owner_missing_stripe_app_data",
+        severity: "error",
+        ownerId,
+        message: `Owner customer ${customerKey} has a payment method but no Stripe customer app data (cus_…)`,
+        details: { customerId, customerKey },
+        remediation: FIX_SANDBOX_TO_STRIPE,
+      });
+    }
   }
 
-  const { customerId, customerKey, attributedSubjects } = resolved.context;
-  const findings: BillingConsistencyFinding[] = [];
-
-  findings.push(
-    ...(await missingStripeAppDataFindings({
-      client,
-      ownerId,
-      customerId,
-      customerKey,
-    })),
-  );
-  findings.push(
-    ...(await sandboxProfileFindings({ ownerId, customerId, customerKey })),
-  );
+  if (
+    shouldUseKonnectRoutes(getHostedOpenMeterUrl(), process.env.OPENMETER_API_KEY)
+  ) {
+    const profileId = await getKonnectCustomerBillingProfileId(customerId);
+    const sandboxId = process.env.OPENMETER_FREE_BILLING_PROFILE_ID?.trim();
+    if (profileId && sandboxId && profileId === sandboxId) {
+      // Sandbox is correct for Owner Sandbox Starter. Flag only when the owner
+      // already has a chargeable card (should be on owners Stripe / Paid).
+      const chargeable = await ownerHasChargeablePaymentMethod(ownerId);
+      if (chargeable === true) {
+        findings.push({
+          code: "owner_sandbox_billing_profile",
+          severity: "warn",
+          ownerId,
+          message: `Owner customer ${customerKey} has a payment method but still uses sandbox billing profile ${profileId}`,
+          details: { customerId, profileId },
+          remediation: FIX_SANDBOX_TO_STRIPE,
+        });
+      }
+    }
+  }
 
   const subs = await listOpenMeterSubscriptionsForCustomer(client, customerId);
   const active = subs.filter((s) => isOpenMeterSubscriptionActive(s.status));
-  findings.push(...activeSubsFindings({ ownerId, customerKey, active }));
+
+  if (active.length === 0) {
+    findings.push({
+      code: "owner_no_active_subscription",
+      severity: "error",
+      ownerId,
+      message: `No active subscription on ${customerKey}`,
+      remediation: FIX_STARTER,
+    });
+  } else if (active.length > 1) {
+    findings.push({
+      code: "owner_multiple_active_subscriptions",
+      severity: "warn",
+      ownerId,
+      message: `${active.length} active subscriptions on ${customerKey}`,
+      details: { subscriptionIds: active.map((s) => s.id) },
+      remediation: FIX_DEDUPE,
+    });
+  }
 
   for (const sub of active) {
     const remote = sub.planId
@@ -1040,13 +939,18 @@ async function auditOwnerSubscriptions(
   // is not attributed is metered but never invoiced. This must report clean
   // before buildOwnerMeterSubjects can be reduced to the canonical key.
   // See docs/adr-owner-vs-app-billing.md.
+  const ownedPublicClientIds = await listOwnedPublicClientIds(ownerId);
+  const subjectsWithUsage = await findSubjectsWithUsage(
+    client,
+    buildOwnerMeterSubjects(ownerId, ownedPublicClientIds),
+  );
   findings.push(
-    ...(await usageAttributionFindings({
-      client,
+    ...classifyUsageAttributionConsistency({
       ownerId,
       customerKey,
       attributedSubjects,
-    })),
+      subjectsWithUsage,
+    }),
   );
 
   return findings;

--- a/src/lib/openmeter/billing-consistency.ts
+++ b/src/lib/openmeter/billing-consistency.ts
@@ -804,21 +804,25 @@ async function auditOwnerStarterPlans(
   return findings;
 }
 
-async function auditOwnerSubscriptions(
+type OwnerCustomerAuditContext = {
+  customerId: string;
+  customerKey: string;
+  attributedSubjects: string[];
+};
+
+async function resolveOwnerCustomerForAudit(
   client: OpenMeter,
   ownerId: string,
-  starters: LocalStarterPlanRef[],
-): Promise<BillingConsistencyFinding[]> {
-  const findings: BillingConsistencyFinding[] = [];
+): Promise<
+  | { ok: true; context: OwnerCustomerAuditContext }
+  | { ok: false; findings: BillingConsistencyFinding[] }
+> {
   const customerKey = buildOwnerCustomerKey(ownerId);
-
-  let customerId: string;
-  let attributedSubjects: string[] = [];
   try {
     const customer = (await findOpenMeterCustomerByKey(client, customerKey)) as
       | { id?: string; usageAttribution?: { subjectKeys?: string[] } }
       | null;
-    attributedSubjects = [
+    const attributedSubjects = [
       ...new Set(
         (customer?.usageAttribution?.subjectKeys ?? [])
           .map((key) => key.trim())
@@ -826,97 +830,194 @@ async function auditOwnerSubscriptions(
       ),
     ];
     if (!customer?.id) {
-      return [
+      return {
+        ok: false,
+        findings: [
+          {
+            code: "owner_customer_missing",
+            severity: "error",
+            ownerId,
+            message: `No Konnect customer for bare key ${customerKey}`,
+            details: { customerKey },
+            remediation: FIX_MIGRATE,
+          },
+        ],
+      };
+    }
+    return {
+      ok: true,
+      context: { customerId: customer.id, customerKey, attributedSubjects },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      findings: [
         {
-          code: "owner_customer_missing",
+          code: "owner_customer_lookup_failed",
           severity: "error",
           ownerId,
-          message: `No Konnect customer for bare key ${customerKey}`,
+          message:
+            err instanceof Error ? err.message : "Failed to look up owner customer",
           details: { customerKey },
-          remediation: FIX_MIGRATE,
         },
-      ];
-    }
-    customerId = customer.id;
-  } catch (err) {
+      ],
+    };
+  }
+}
+
+async function missingStripeAppDataFindings(input: {
+  client: OpenMeter;
+  ownerId: string;
+  customerId: string;
+  customerKey: string;
+}): Promise<BillingConsistencyFinding[]> {
+  const stripeCus = await getStripeCustomerAppDataId({
+    client: input.client,
+    customerId: input.customerId,
+  });
+  if (stripeCus) {
+    return [];
+  }
+
+  // Missing Stripe app data is only a defect for an owner who has something
+  // chargeable. Owners without a payment method deliberately stay on the free
+  // billing profile — Konnect rejects a Starter subscription for a customer
+  // pinned to a Stripe profile with no default payment method — so
+  // migrate-sandbox-to-stripe skips them by design. Reporting those as errors
+  // pointed at a remediation that can never apply.
+  // `null` (Stripe/OpenMeter unreachable) is treated as not-chargeable, the
+  // same fail-open choice the migration makes.
+  const chargeable = await ownerHasChargeablePaymentMethod(input.ownerId);
+  if (chargeable !== true) {
+    return [];
+  }
+
+  return [
+    {
+      code: "owner_missing_stripe_app_data",
+      severity: "error",
+      ownerId: input.ownerId,
+      message: `Owner customer ${input.customerKey} has a payment method but no Stripe customer app data (cus_…)`,
+      details: { customerId: input.customerId, customerKey: input.customerKey },
+      remediation: FIX_SANDBOX_TO_STRIPE,
+    },
+  ];
+}
+
+async function sandboxProfileFindings(input: {
+  ownerId: string;
+  customerId: string;
+  customerKey: string;
+}): Promise<BillingConsistencyFinding[]> {
+  if (
+    !shouldUseKonnectRoutes(getHostedOpenMeterUrl(), process.env.OPENMETER_API_KEY)
+  ) {
+    return [];
+  }
+
+  const profileId = await getKonnectCustomerBillingProfileId(input.customerId);
+  const sandboxId = process.env.OPENMETER_FREE_BILLING_PROFILE_ID?.trim();
+  if (!profileId || !sandboxId || profileId !== sandboxId) {
+    return [];
+  }
+
+  // Sandbox is correct for Owner Sandbox Starter. Flag only when the owner
+  // already has a chargeable card (should be on owners Stripe / Paid).
+  const chargeable = await ownerHasChargeablePaymentMethod(input.ownerId);
+  if (chargeable !== true) {
+    return [];
+  }
+
+  return [
+    {
+      code: "owner_sandbox_billing_profile",
+      severity: "warn",
+      ownerId: input.ownerId,
+      message: `Owner customer ${input.customerKey} has a payment method but still uses sandbox billing profile ${profileId}`,
+      details: { customerId: input.customerId, profileId },
+      remediation: FIX_SANDBOX_TO_STRIPE,
+    },
+  ];
+}
+
+function activeSubsFindings(input: {
+  ownerId: string;
+  customerKey: string;
+  active: OpenMeterSubscriptionView[];
+}): BillingConsistencyFinding[] {
+  if (input.active.length === 0) {
     return [
       {
-        code: "owner_customer_lookup_failed",
+        code: "owner_no_active_subscription",
         severity: "error",
-        ownerId,
-        message:
-          err instanceof Error ? err.message : "Failed to look up owner customer",
-        details: { customerKey },
+        ownerId: input.ownerId,
+        message: `No active subscription on ${input.customerKey}`,
+        remediation: FIX_STARTER,
       },
     ];
   }
+  if (input.active.length <= 1) {
+    return [];
+  }
+  return [
+    {
+      code: "owner_multiple_active_subscriptions",
+      severity: "warn",
+      ownerId: input.ownerId,
+      message: `${input.active.length} active subscriptions on ${input.customerKey}`,
+      details: { subscriptionIds: input.active.map((s) => s.id) },
+      remediation: FIX_DEDUPE,
+    },
+  ];
+}
 
-  const stripeCus = await getStripeCustomerAppDataId({ client, customerId });
-  if (!stripeCus) {
-    // Missing Stripe app data is only a defect for an owner who has something
-    // chargeable. Owners without a payment method deliberately stay on the free
-    // billing profile — Konnect rejects a Starter subscription for a customer
-    // pinned to a Stripe profile with no default payment method — so
-    // migrate-sandbox-to-stripe skips them by design. Reporting those as errors
-    // pointed at a remediation that can never apply.
-    // `null` (Stripe/OpenMeter unreachable) is treated as not-chargeable, the
-    // same fail-open choice the migration makes.
-    const chargeable = await ownerHasChargeablePaymentMethod(ownerId);
-    if (chargeable === true) {
-      findings.push({
-        code: "owner_missing_stripe_app_data",
-        severity: "error",
-        ownerId,
-        message: `Owner customer ${customerKey} has a payment method but no Stripe customer app data (cus_…)`,
-        details: { customerId, customerKey },
-        remediation: FIX_SANDBOX_TO_STRIPE,
-      });
-    }
+async function usageAttributionFindings(input: {
+  client: OpenMeter;
+  ownerId: string;
+  customerKey: string;
+  attributedSubjects: string[];
+}): Promise<BillingConsistencyFinding[]> {
+  const ownedPublicClientIds = await listOwnedPublicClientIds(input.ownerId);
+  const subjectsWithUsage = await findSubjectsWithUsage(
+    input.client,
+    buildOwnerMeterSubjects(input.ownerId, ownedPublicClientIds),
+  );
+  return classifyUsageAttributionConsistency({
+    ownerId: input.ownerId,
+    customerKey: input.customerKey,
+    attributedSubjects: input.attributedSubjects,
+    subjectsWithUsage,
+  });
+}
+
+async function auditOwnerSubscriptions(
+  client: OpenMeter,
+  ownerId: string,
+  starters: LocalStarterPlanRef[],
+): Promise<BillingConsistencyFinding[]> {
+  const resolved = await resolveOwnerCustomerForAudit(client, ownerId);
+  if (!resolved.ok) {
+    return resolved.findings;
   }
 
-  if (
-    shouldUseKonnectRoutes(getHostedOpenMeterUrl(), process.env.OPENMETER_API_KEY)
-  ) {
-    const profileId = await getKonnectCustomerBillingProfileId(customerId);
-    const sandboxId = process.env.OPENMETER_FREE_BILLING_PROFILE_ID?.trim();
-    if (profileId && sandboxId && profileId === sandboxId) {
-      // Sandbox is correct for Owner Sandbox Starter. Flag only when the owner
-      // already has a chargeable card (should be on owners Stripe / Paid).
-      const chargeable = await ownerHasChargeablePaymentMethod(ownerId);
-      if (chargeable === true) {
-        findings.push({
-          code: "owner_sandbox_billing_profile",
-          severity: "warn",
-          ownerId,
-          message: `Owner customer ${customerKey} has a payment method but still uses sandbox billing profile ${profileId}`,
-          details: { customerId, profileId },
-          remediation: FIX_SANDBOX_TO_STRIPE,
-        });
-      }
-    }
-  }
+  const { customerId, customerKey, attributedSubjects } = resolved.context;
+  const findings: BillingConsistencyFinding[] = [];
+
+  findings.push(
+    ...(await missingStripeAppDataFindings({
+      client,
+      ownerId,
+      customerId,
+      customerKey,
+    })),
+  );
+  findings.push(
+    ...(await sandboxProfileFindings({ ownerId, customerId, customerKey })),
+  );
 
   const subs = await listOpenMeterSubscriptionsForCustomer(client, customerId);
   const active = subs.filter((s) => isOpenMeterSubscriptionActive(s.status));
-
-  if (active.length === 0) {
-    findings.push({
-      code: "owner_no_active_subscription",
-      severity: "error",
-      ownerId,
-      message: `No active subscription on ${customerKey}`,
-      remediation: FIX_STARTER,
-    });
-  } else if (active.length > 1) {
-    findings.push({
-      code: "owner_multiple_active_subscriptions",
-      severity: "warn",
-      ownerId,
-      message: `${active.length} active subscriptions on ${customerKey}`,
-      details: { subscriptionIds: active.map((s) => s.id) },
-      remediation: FIX_DEDUPE,
-    });
-  }
+  findings.push(...activeSubsFindings({ ownerId, customerKey, active }));
 
   for (const sub of active) {
     const remote = sub.planId
@@ -939,18 +1040,13 @@ async function auditOwnerSubscriptions(
   // is not attributed is metered but never invoiced. This must report clean
   // before buildOwnerMeterSubjects can be reduced to the canonical key.
   // See docs/adr-owner-vs-app-billing.md.
-  const ownedPublicClientIds = await listOwnedPublicClientIds(ownerId);
-  const subjectsWithUsage = await findSubjectsWithUsage(
-    client,
-    buildOwnerMeterSubjects(ownerId, ownedPublicClientIds),
-  );
   findings.push(
-    ...classifyUsageAttributionConsistency({
+    ...(await usageAttributionFindings({
+      client,
       ownerId,
       customerKey,
       attributedSubjects,
-      subjectsWithUsage,
-    }),
+    })),
   );
 
   return findings;

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -596,17 +596,13 @@ export async function updateAppBillingProfileSettings(input: {
   }
 
   const progressiveBilling =
-    input.progressiveBilling === undefined
-      ? existing.progressiveBilling
-      : input.progressiveBilling;
+    input.progressiveBilling ?? existing.progressiveBilling;
   const invoiceThresholdUsdMicros =
-    input.invoiceThresholdUsdMicros === undefined
-      ? existing.invoiceThresholdUsdMicros
-      : input.invoiceThresholdUsdMicros;
+    input.invoiceThresholdUsdMicros !== undefined
+      ? input.invoiceThresholdUsdMicros
+      : existing.invoiceThresholdUsdMicros;
   const applicationFeeBps =
-    input.applicationFeeBps === undefined
-      ? (existing.applicationFeeBps ?? 0)
-      : input.applicationFeeBps;
+    input.applicationFeeBps ?? existing.applicationFeeBps ?? 0;
 
   const progressiveChanged =
     input.progressiveBilling !== undefined &&
@@ -662,9 +658,9 @@ async function syncProgressiveBillingToOpenMeterProfile(input: {
     default: profile.default ?? false,
     supplier: profile.supplier,
     workflow: {
-      ...(profile.workflow ?? {}),
+      ...profile.workflow,
       invoicing: {
-        ...(profile.workflow?.invoicing ?? {}),
+        ...profile.workflow?.invoicing,
         progressiveBilling: input.progressiveBilling,
       },
     },

--- a/src/lib/openmeter/capability-features.test.ts
+++ b/src/lib/openmeter/capability-features.test.ts
@@ -30,8 +30,9 @@ test("buildAppCapabilityFeatureKey matches OpenMeter slug pattern", () => {
   assert.match(key, OPENMETER_SLUG_KEY_PATTERN);
 });
 
-test("resolveCapabilityFeatureKey uses app-scoped key when stable keys enabled", () => {
+test("resolveCapabilityFeatureKey uses app-scoped key when stable keys enabled", (t) => {
   if (!billingStableFeatureKeysEnabled()) {
+    t.skip("billing stable feature keys disabled");
     return;
   }
   assert.equal(

--- a/src/lib/openmeter/owner-starter-plan.ts
+++ b/src/lib/openmeter/owner-starter-plan.ts
@@ -266,233 +266,6 @@ async function findExistingOwnerWalletSubscription(input: {
  * Subscribe the shared owner customer to the Owner Starter plan for their
  * resolved allowance (platform default or per-owner override).
  */
-type OwnerWalletSubscriptionRef = {
-  id: string;
-  planKey: string;
-  openmeterPlanId: string;
-};
-
-type OwnerStarterSubscriptionResult = {
-  openmeterSubscriptionId: string | null;
-  planKey: string;
-  openmeterPlanId: string;
-  created: boolean;
-};
-
-async function recreateOwnerStarterAfterChangeFailure(input: {
-  client: OpenMeter;
-  customerId: string;
-  plan: OwnerStarterPlanRef;
-  existingId: string;
-  changeErr: unknown;
-}): Promise<OwnerStarterSubscriptionResult> {
-  try {
-    const createdSub = await createOwnerStarterSubscriptionWithBillingRecovery({
-      client: input.client,
-      customerId: input.customerId,
-      planKey: input.plan.key,
-    });
-    try {
-      await input.client.subscriptions.cancel(input.existingId, {
-        timing: "immediate",
-      });
-    } catch (cancelErr) {
-      console.warn(
-        "openmeter: owner starter old subscription cancel after recreate failed",
-        cancelErr,
-      );
-    }
-    return {
-      openmeterSubscriptionId: createdSub.id,
-      planKey: input.plan.key,
-      openmeterPlanId: input.plan.openmeterPlanId,
-      created: true,
-    };
-  } catch {
-    // Keep the existing subscription; surface the original change failure.
-    throw input.changeErr;
-  }
-}
-
-async function changeOrRecreateOwnerStarter(input: {
-  client: OpenMeter;
-  customerId: string;
-  plan: OwnerStarterPlanRef;
-  existing: OwnerWalletSubscriptionRef;
-}): Promise<OwnerStarterSubscriptionResult> {
-  await applyFreeBillingProfileToCustomer({
-    client: input.client,
-    customerId: input.customerId,
-  });
-  try {
-    await changeKonnectSubscription({
-      subscriptionId: input.existing.id,
-      customerId: input.customerId,
-      planId: input.plan.openmeterPlanId,
-      timing: "immediate",
-    });
-    return {
-      openmeterSubscriptionId: input.existing.id,
-      planKey: input.plan.key,
-      openmeterPlanId: input.plan.openmeterPlanId,
-      created: false,
-    };
-  } catch (changeErr) {
-    console.warn(
-      "openmeter: owner starter subscription change failed; recreating without cancel-first",
-      changeErr,
-    );
-    // Create the replacement first; cancel the old subscription only after
-    // the new one exists so a create failure cannot leave the owner with none.
-    return recreateOwnerStarterAfterChangeFailure({
-      client: input.client,
-      customerId: input.customerId,
-      plan: input.plan,
-      existingId: input.existing.id,
-      changeErr,
-    });
-  }
-}
-
-async function reconcileExistingOwnerWalletSubscription(input: {
-  client: OpenMeter;
-  customerId: string;
-  plan: OwnerStarterPlanRef;
-  existing: OwnerWalletSubscriptionRef;
-}): Promise<OwnerStarterSubscriptionResult | null> {
-  // Already on Owner Paid — do not recreate Sandbox Starter or re-pin sandbox.
-  if (isOwnerPaidPlanKey(input.existing.planKey)) {
-    return {
-      openmeterSubscriptionId: input.existing.id,
-      planKey: input.existing.planKey,
-      openmeterPlanId: input.existing.openmeterPlanId,
-      created: false,
-    };
-  }
-
-  if (
-    isOwnerStarterPlanKey(input.existing.planKey) &&
-    input.existing.planKey === input.plan.key &&
-    input.existing.openmeterPlanId === input.plan.openmeterPlanId
-  ) {
-    // Keep Sandbox Starter on the free profile (org default may be Stripe).
-    await applyFreeBillingProfileToCustomer({
-      client: input.client,
-      customerId: input.customerId,
-    });
-    return {
-      openmeterSubscriptionId: input.existing.id,
-      planKey: input.existing.planKey,
-      openmeterPlanId: input.existing.openmeterPlanId,
-      created: false,
-    };
-  }
-
-  if (isOwnerStarterPlanKey(input.existing.planKey)) {
-    return changeOrRecreateOwnerStarter({
-      client: input.client,
-      customerId: input.customerId,
-      plan: input.plan,
-      existing: input.existing,
-    });
-  }
-
-  if (input.existing.id) {
-    // Unknown active wallet subscription — leave it alone.
-    return {
-      openmeterSubscriptionId: input.existing.id,
-      planKey: input.existing.planKey,
-      openmeterPlanId: input.existing.openmeterPlanId,
-      created: false,
-    };
-  }
-
-  return null;
-}
-
-async function createOwnerStarterSubscriptionFresh(input: {
-  client: OpenMeter;
-  customerId: string;
-  plan: OwnerStarterPlanRef;
-  includedUsdMicros: string;
-}): Promise<OwnerStarterSubscriptionResult> {
-  // New Sandbox Starter must not inherit the org Stripe default without cus_….
-  await applyFreeBillingProfileToCustomer({
-    client: input.client,
-    customerId: input.customerId,
-  });
-
-  try {
-    const createdSub = await input.client.subscriptions.create({
-      customerId: input.customerId,
-      plan: { key: input.plan.key },
-    });
-    if (!createdSub?.id) {
-      throw new Error("Failed to create Owner Starter subscription");
-    }
-    return {
-      openmeterSubscriptionId: createdSub.id,
-      planKey: input.plan.key,
-      openmeterPlanId: input.plan.openmeterPlanId,
-      created: true,
-    };
-  } catch (err) {
-    if (isOpenMeterPlanNotFoundError(err)) {
-      invalidateOwnerStarterPlanCache();
-      const resynced = await ensureOwnerStarterPlanSynced(input.includedUsdMicros);
-      const createdSub = await createOwnerStarterSubscriptionWithBillingRecovery({
-        client: input.client,
-        customerId: input.customerId,
-        planKey: resynced.key,
-      });
-      return {
-        openmeterSubscriptionId: createdSub.id,
-        planKey: resynced.key,
-        openmeterPlanId: resynced.openmeterPlanId,
-        created: true,
-      };
-    }
-    if (isOpenMeterConflictError(err)) {
-      const raced = await findOpenMeterSubscriptionByPlanKey(
-        input.client,
-        input.customerId,
-        input.plan.key,
-        { openmeterPlanId: input.plan.openmeterPlanId },
-      );
-      if (raced?.id) {
-        return {
-          openmeterSubscriptionId: raced.id,
-          planKey: input.plan.key,
-          openmeterPlanId: input.plan.openmeterPlanId,
-          created: false,
-        };
-      }
-    }
-    if (isOpenMeterStripeBillingError(err)) {
-      await applyFreeBillingProfileToCustomer({
-        client: input.client,
-        customerId: input.customerId,
-      });
-      const createdSub = await input.client.subscriptions.create({
-        customerId: input.customerId,
-        plan: { key: input.plan.key },
-      });
-      if (!createdSub?.id) {
-        throw new Error(
-          "Failed to create Owner Starter subscription after billing profile apply",
-        );
-      }
-      return {
-        openmeterSubscriptionId: createdSub.id,
-        planKey: input.plan.key,
-        openmeterPlanId: input.plan.openmeterPlanId,
-        created: true,
-      };
-    }
-    throw err;
-  }
-}
-
 export async function ensureOwnerStarterSubscription(input: {
   ownerUserId: string;
   publicClientIds?: string[];
@@ -534,14 +307,94 @@ export async function ensureOwnerStarterSubscription(input: {
   });
 
   if (existing) {
-    const reconciled = await reconcileExistingOwnerWalletSubscription({
-      client,
-      customerId: customer.id,
-      plan,
-      existing,
-    });
-    if (reconciled) {
-      return reconciled;
+    // Already on Owner Paid — do not recreate Sandbox Starter or re-pin sandbox.
+    if (isOwnerPaidPlanKey(existing.planKey)) {
+      return {
+        openmeterSubscriptionId: existing.id,
+        planKey: existing.planKey,
+        openmeterPlanId: existing.openmeterPlanId,
+        created: false,
+      };
+    }
+
+    if (
+      isOwnerStarterPlanKey(existing.planKey) &&
+      existing.planKey === plan.key &&
+      existing.openmeterPlanId === plan.openmeterPlanId
+    ) {
+      // Keep Sandbox Starter on the free profile (org default may be Stripe).
+      await applyFreeBillingProfileToCustomer({
+        client,
+        customerId: customer.id,
+      });
+      return {
+        openmeterSubscriptionId: existing.id,
+        planKey: existing.planKey,
+        openmeterPlanId: existing.openmeterPlanId,
+        created: false,
+      };
+    }
+
+    if (isOwnerStarterPlanKey(existing.planKey)) {
+      await applyFreeBillingProfileToCustomer({
+        client,
+        customerId: customer.id,
+      });
+      try {
+        await changeKonnectSubscription({
+          subscriptionId: existing.id,
+          customerId: customer.id,
+          planId: plan.openmeterPlanId,
+          timing: "immediate",
+        });
+        return {
+          openmeterSubscriptionId: existing.id,
+          planKey: plan.key,
+          openmeterPlanId: plan.openmeterPlanId,
+          created: false,
+        };
+      } catch (changeErr) {
+        console.warn(
+          "openmeter: owner starter subscription change failed; recreating without cancel-first",
+          changeErr,
+        );
+        // Create the replacement first; cancel the old subscription only after
+        // the new one exists so a create failure cannot leave the owner with none.
+        try {
+          const createdSub = await createOwnerStarterSubscriptionWithBillingRecovery({
+            client,
+            customerId: customer.id,
+            planKey: plan.key,
+          });
+          try {
+            await client.subscriptions.cancel(existing.id, {
+              timing: "immediate",
+            });
+          } catch (cancelErr) {
+            console.warn(
+              "openmeter: owner starter old subscription cancel after recreate failed",
+              cancelErr,
+            );
+          }
+          return {
+            openmeterSubscriptionId: createdSub.id,
+            planKey: plan.key,
+            openmeterPlanId: plan.openmeterPlanId,
+            created: true,
+          };
+        } catch {
+          // Keep the existing subscription; surface the original change failure.
+          throw changeErr;
+        }
+      }
+    } else if (existing.id) {
+      // Unknown active wallet subscription — leave it alone.
+      return {
+        openmeterSubscriptionId: existing.id,
+        planKey: existing.planKey,
+        openmeterPlanId: existing.openmeterPlanId,
+        created: false,
+      };
     }
   }
 
@@ -554,12 +407,81 @@ export async function ensureOwnerStarterSubscription(input: {
     };
   }
 
-  return createOwnerStarterSubscriptionFresh({
+  // New Sandbox Starter must not inherit the org Stripe default without cus_….
+  await applyFreeBillingProfileToCustomer({
     client,
     customerId: customer.id,
-    plan,
-    includedUsdMicros,
   });
+
+  try {
+    const createdSub = await client.subscriptions.create({
+      customerId: customer.id,
+      plan: { key: plan.key },
+    });
+    if (!createdSub?.id) {
+      throw new Error("Failed to create Owner Starter subscription");
+    }
+    return {
+      openmeterSubscriptionId: createdSub.id,
+      planKey: plan.key,
+      openmeterPlanId: plan.openmeterPlanId,
+      created: true,
+    };
+  } catch (err) {
+    if (isOpenMeterPlanNotFoundError(err)) {
+      invalidateOwnerStarterPlanCache();
+      const resynced = await ensureOwnerStarterPlanSynced(includedUsdMicros);
+      const createdSub = await createOwnerStarterSubscriptionWithBillingRecovery({
+        client,
+        customerId: customer.id,
+        planKey: resynced.key,
+      });
+      return {
+        openmeterSubscriptionId: createdSub.id,
+        planKey: resynced.key,
+        openmeterPlanId: resynced.openmeterPlanId,
+        created: true,
+      };
+    }
+    if (isOpenMeterConflictError(err)) {
+      const raced = await findOpenMeterSubscriptionByPlanKey(
+        client,
+        customer.id,
+        plan.key,
+        { openmeterPlanId: plan.openmeterPlanId },
+      );
+      if (raced?.id) {
+        return {
+          openmeterSubscriptionId: raced.id,
+          planKey: plan.key,
+          openmeterPlanId: plan.openmeterPlanId,
+          created: false,
+        };
+      }
+    }
+    if (isOpenMeterStripeBillingError(err)) {
+      await applyFreeBillingProfileToCustomer({
+        client,
+        customerId: customer.id,
+      });
+      const createdSub = await client.subscriptions.create({
+        customerId: customer.id,
+        plan: { key: plan.key },
+      });
+      if (!createdSub?.id) {
+        throw new Error(
+          "Failed to create Owner Starter subscription after billing profile apply",
+        );
+      }
+      return {
+        openmeterSubscriptionId: createdSub.id,
+        planKey: plan.key,
+        openmeterPlanId: plan.openmeterPlanId,
+        created: true,
+      };
+    }
+    throw err;
+  }
 }
 
 async function createOwnerStarterSubscriptionWithBillingRecovery(input: {

--- a/src/lib/openmeter/owner-starter-plan.ts
+++ b/src/lib/openmeter/owner-starter-plan.ts
@@ -266,6 +266,233 @@ async function findExistingOwnerWalletSubscription(input: {
  * Subscribe the shared owner customer to the Owner Starter plan for their
  * resolved allowance (platform default or per-owner override).
  */
+type OwnerWalletSubscriptionRef = {
+  id: string;
+  planKey: string;
+  openmeterPlanId: string;
+};
+
+type OwnerStarterSubscriptionResult = {
+  openmeterSubscriptionId: string | null;
+  planKey: string;
+  openmeterPlanId: string;
+  created: boolean;
+};
+
+async function recreateOwnerStarterAfterChangeFailure(input: {
+  client: OpenMeter;
+  customerId: string;
+  plan: OwnerStarterPlanRef;
+  existingId: string;
+  changeErr: unknown;
+}): Promise<OwnerStarterSubscriptionResult> {
+  try {
+    const createdSub = await createOwnerStarterSubscriptionWithBillingRecovery({
+      client: input.client,
+      customerId: input.customerId,
+      planKey: input.plan.key,
+    });
+    try {
+      await input.client.subscriptions.cancel(input.existingId, {
+        timing: "immediate",
+      });
+    } catch (cancelErr) {
+      console.warn(
+        "openmeter: owner starter old subscription cancel after recreate failed",
+        cancelErr,
+      );
+    }
+    return {
+      openmeterSubscriptionId: createdSub.id,
+      planKey: input.plan.key,
+      openmeterPlanId: input.plan.openmeterPlanId,
+      created: true,
+    };
+  } catch {
+    // Keep the existing subscription; surface the original change failure.
+    throw input.changeErr;
+  }
+}
+
+async function changeOrRecreateOwnerStarter(input: {
+  client: OpenMeter;
+  customerId: string;
+  plan: OwnerStarterPlanRef;
+  existing: OwnerWalletSubscriptionRef;
+}): Promise<OwnerStarterSubscriptionResult> {
+  await applyFreeBillingProfileToCustomer({
+    client: input.client,
+    customerId: input.customerId,
+  });
+  try {
+    await changeKonnectSubscription({
+      subscriptionId: input.existing.id,
+      customerId: input.customerId,
+      planId: input.plan.openmeterPlanId,
+      timing: "immediate",
+    });
+    return {
+      openmeterSubscriptionId: input.existing.id,
+      planKey: input.plan.key,
+      openmeterPlanId: input.plan.openmeterPlanId,
+      created: false,
+    };
+  } catch (changeErr) {
+    console.warn(
+      "openmeter: owner starter subscription change failed; recreating without cancel-first",
+      changeErr,
+    );
+    // Create the replacement first; cancel the old subscription only after
+    // the new one exists so a create failure cannot leave the owner with none.
+    return recreateOwnerStarterAfterChangeFailure({
+      client: input.client,
+      customerId: input.customerId,
+      plan: input.plan,
+      existingId: input.existing.id,
+      changeErr,
+    });
+  }
+}
+
+async function reconcileExistingOwnerWalletSubscription(input: {
+  client: OpenMeter;
+  customerId: string;
+  plan: OwnerStarterPlanRef;
+  existing: OwnerWalletSubscriptionRef;
+}): Promise<OwnerStarterSubscriptionResult | null> {
+  // Already on Owner Paid — do not recreate Sandbox Starter or re-pin sandbox.
+  if (isOwnerPaidPlanKey(input.existing.planKey)) {
+    return {
+      openmeterSubscriptionId: input.existing.id,
+      planKey: input.existing.planKey,
+      openmeterPlanId: input.existing.openmeterPlanId,
+      created: false,
+    };
+  }
+
+  if (
+    isOwnerStarterPlanKey(input.existing.planKey) &&
+    input.existing.planKey === input.plan.key &&
+    input.existing.openmeterPlanId === input.plan.openmeterPlanId
+  ) {
+    // Keep Sandbox Starter on the free profile (org default may be Stripe).
+    await applyFreeBillingProfileToCustomer({
+      client: input.client,
+      customerId: input.customerId,
+    });
+    return {
+      openmeterSubscriptionId: input.existing.id,
+      planKey: input.existing.planKey,
+      openmeterPlanId: input.existing.openmeterPlanId,
+      created: false,
+    };
+  }
+
+  if (isOwnerStarterPlanKey(input.existing.planKey)) {
+    return changeOrRecreateOwnerStarter({
+      client: input.client,
+      customerId: input.customerId,
+      plan: input.plan,
+      existing: input.existing,
+    });
+  }
+
+  if (input.existing.id) {
+    // Unknown active wallet subscription — leave it alone.
+    return {
+      openmeterSubscriptionId: input.existing.id,
+      planKey: input.existing.planKey,
+      openmeterPlanId: input.existing.openmeterPlanId,
+      created: false,
+    };
+  }
+
+  return null;
+}
+
+async function createOwnerStarterSubscriptionFresh(input: {
+  client: OpenMeter;
+  customerId: string;
+  plan: OwnerStarterPlanRef;
+  includedUsdMicros: string;
+}): Promise<OwnerStarterSubscriptionResult> {
+  // New Sandbox Starter must not inherit the org Stripe default without cus_….
+  await applyFreeBillingProfileToCustomer({
+    client: input.client,
+    customerId: input.customerId,
+  });
+
+  try {
+    const createdSub = await input.client.subscriptions.create({
+      customerId: input.customerId,
+      plan: { key: input.plan.key },
+    });
+    if (!createdSub?.id) {
+      throw new Error("Failed to create Owner Starter subscription");
+    }
+    return {
+      openmeterSubscriptionId: createdSub.id,
+      planKey: input.plan.key,
+      openmeterPlanId: input.plan.openmeterPlanId,
+      created: true,
+    };
+  } catch (err) {
+    if (isOpenMeterPlanNotFoundError(err)) {
+      invalidateOwnerStarterPlanCache();
+      const resynced = await ensureOwnerStarterPlanSynced(input.includedUsdMicros);
+      const createdSub = await createOwnerStarterSubscriptionWithBillingRecovery({
+        client: input.client,
+        customerId: input.customerId,
+        planKey: resynced.key,
+      });
+      return {
+        openmeterSubscriptionId: createdSub.id,
+        planKey: resynced.key,
+        openmeterPlanId: resynced.openmeterPlanId,
+        created: true,
+      };
+    }
+    if (isOpenMeterConflictError(err)) {
+      const raced = await findOpenMeterSubscriptionByPlanKey(
+        input.client,
+        input.customerId,
+        input.plan.key,
+        { openmeterPlanId: input.plan.openmeterPlanId },
+      );
+      if (raced?.id) {
+        return {
+          openmeterSubscriptionId: raced.id,
+          planKey: input.plan.key,
+          openmeterPlanId: input.plan.openmeterPlanId,
+          created: false,
+        };
+      }
+    }
+    if (isOpenMeterStripeBillingError(err)) {
+      await applyFreeBillingProfileToCustomer({
+        client: input.client,
+        customerId: input.customerId,
+      });
+      const createdSub = await input.client.subscriptions.create({
+        customerId: input.customerId,
+        plan: { key: input.plan.key },
+      });
+      if (!createdSub?.id) {
+        throw new Error(
+          "Failed to create Owner Starter subscription after billing profile apply",
+        );
+      }
+      return {
+        openmeterSubscriptionId: createdSub.id,
+        planKey: input.plan.key,
+        openmeterPlanId: input.plan.openmeterPlanId,
+        created: true,
+      };
+    }
+    throw err;
+  }
+}
+
 export async function ensureOwnerStarterSubscription(input: {
   ownerUserId: string;
   publicClientIds?: string[];
@@ -307,94 +534,14 @@ export async function ensureOwnerStarterSubscription(input: {
   });
 
   if (existing) {
-    // Already on Owner Paid — do not recreate Sandbox Starter or re-pin sandbox.
-    if (isOwnerPaidPlanKey(existing.planKey)) {
-      return {
-        openmeterSubscriptionId: existing.id,
-        planKey: existing.planKey,
-        openmeterPlanId: existing.openmeterPlanId,
-        created: false,
-      };
-    }
-
-    if (
-      isOwnerStarterPlanKey(existing.planKey) &&
-      existing.planKey === plan.key &&
-      existing.openmeterPlanId === plan.openmeterPlanId
-    ) {
-      // Keep Sandbox Starter on the free profile (org default may be Stripe).
-      await applyFreeBillingProfileToCustomer({
-        client,
-        customerId: customer.id,
-      });
-      return {
-        openmeterSubscriptionId: existing.id,
-        planKey: existing.planKey,
-        openmeterPlanId: existing.openmeterPlanId,
-        created: false,
-      };
-    }
-
-    if (isOwnerStarterPlanKey(existing.planKey)) {
-      await applyFreeBillingProfileToCustomer({
-        client,
-        customerId: customer.id,
-      });
-      try {
-        await changeKonnectSubscription({
-          subscriptionId: existing.id,
-          customerId: customer.id,
-          planId: plan.openmeterPlanId,
-          timing: "immediate",
-        });
-        return {
-          openmeterSubscriptionId: existing.id,
-          planKey: plan.key,
-          openmeterPlanId: plan.openmeterPlanId,
-          created: false,
-        };
-      } catch (changeErr) {
-        console.warn(
-          "openmeter: owner starter subscription change failed; recreating without cancel-first",
-          changeErr,
-        );
-        // Create the replacement first; cancel the old subscription only after
-        // the new one exists so a create failure cannot leave the owner with none.
-        try {
-          const createdSub = await createOwnerStarterSubscriptionWithBillingRecovery({
-            client,
-            customerId: customer.id,
-            planKey: plan.key,
-          });
-          try {
-            await client.subscriptions.cancel(existing.id, {
-              timing: "immediate",
-            });
-          } catch (cancelErr) {
-            console.warn(
-              "openmeter: owner starter old subscription cancel after recreate failed",
-              cancelErr,
-            );
-          }
-          return {
-            openmeterSubscriptionId: createdSub.id,
-            planKey: plan.key,
-            openmeterPlanId: plan.openmeterPlanId,
-            created: true,
-          };
-        } catch {
-          // Keep the existing subscription; surface the original change failure.
-          throw changeErr;
-        }
-      }
-    } else if (existing.id) {
-      // Unknown active wallet subscription — leave it alone.
-      return {
-        openmeterSubscriptionId: existing.id,
-        planKey: existing.planKey,
-        openmeterPlanId: existing.openmeterPlanId,
-        created: false,
-      };
+    const reconciled = await reconcileExistingOwnerWalletSubscription({
+      client,
+      customerId: customer.id,
+      plan,
+      existing,
+    });
+    if (reconciled) {
+      return reconciled;
     }
   }
 
@@ -407,81 +554,12 @@ export async function ensureOwnerStarterSubscription(input: {
     };
   }
 
-  // New Sandbox Starter must not inherit the org Stripe default without cus_….
-  await applyFreeBillingProfileToCustomer({
+  return createOwnerStarterSubscriptionFresh({
     client,
     customerId: customer.id,
+    plan,
+    includedUsdMicros,
   });
-
-  try {
-    const createdSub = await client.subscriptions.create({
-      customerId: customer.id,
-      plan: { key: plan.key },
-    });
-    if (!createdSub?.id) {
-      throw new Error("Failed to create Owner Starter subscription");
-    }
-    return {
-      openmeterSubscriptionId: createdSub.id,
-      planKey: plan.key,
-      openmeterPlanId: plan.openmeterPlanId,
-      created: true,
-    };
-  } catch (err) {
-    if (isOpenMeterPlanNotFoundError(err)) {
-      invalidateOwnerStarterPlanCache();
-      const resynced = await ensureOwnerStarterPlanSynced(includedUsdMicros);
-      const createdSub = await createOwnerStarterSubscriptionWithBillingRecovery({
-        client,
-        customerId: customer.id,
-        planKey: resynced.key,
-      });
-      return {
-        openmeterSubscriptionId: createdSub.id,
-        planKey: resynced.key,
-        openmeterPlanId: resynced.openmeterPlanId,
-        created: true,
-      };
-    }
-    if (isOpenMeterConflictError(err)) {
-      const raced = await findOpenMeterSubscriptionByPlanKey(
-        client,
-        customer.id,
-        plan.key,
-        { openmeterPlanId: plan.openmeterPlanId },
-      );
-      if (raced?.id) {
-        return {
-          openmeterSubscriptionId: raced.id,
-          planKey: plan.key,
-          openmeterPlanId: plan.openmeterPlanId,
-          created: false,
-        };
-      }
-    }
-    if (isOpenMeterStripeBillingError(err)) {
-      await applyFreeBillingProfileToCustomer({
-        client,
-        customerId: customer.id,
-      });
-      const createdSub = await client.subscriptions.create({
-        customerId: customer.id,
-        plan: { key: plan.key },
-      });
-      if (!createdSub?.id) {
-        throw new Error(
-          "Failed to create Owner Starter subscription after billing profile apply",
-        );
-      }
-      return {
-        openmeterSubscriptionId: createdSub.id,
-        planKey: plan.key,
-        openmeterPlanId: plan.openmeterPlanId,
-        created: true,
-      };
-    }
-    throw err;
-  }
 }
 
 async function createOwnerStarterSubscriptionWithBillingRecovery(input: {

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -147,6 +147,54 @@ function subscriptionViewFromCreateResult(
   };
 }
 
+async function createStarterSubscriptionOnce(input: {
+  client: OpenMeter;
+  customerId: string;
+  starter: typeof plans.$inferSelect;
+  planKey: string;
+}): Promise<OpenMeterSubscriptionView> {
+  const createdSub = await createStarterOpenMeterSubscription(input);
+  if (!createdSub?.id) {
+    throw new Error("Failed to create OpenMeter Starter subscription");
+  }
+  return subscriptionViewFromCreateResult(
+    createdSub,
+    input.planKey,
+    input.starter.openmeterPlanId,
+  );
+}
+
+async function existingStarterOnConflict(input: {
+  client: OpenMeter;
+  customerId: string;
+  starter: typeof plans.$inferSelect;
+  planKey: string;
+}): Promise<OpenMeterSubscriptionView | null> {
+  const existing = await findOpenMeterSubscriptionByPlanKey(
+    input.client,
+    input.customerId,
+    input.planKey,
+    { openmeterPlanId: input.starter.openmeterPlanId },
+  );
+  return existing ?? null;
+}
+
+async function starterSubscriptionOnConflict(input: {
+  client: OpenMeter;
+  customerId: string;
+  starter: typeof plans.$inferSelect;
+  planKey: string;
+}): Promise<{
+  subscription: OpenMeterSubscriptionView;
+  created: boolean;
+} | null> {
+  const existing = await existingStarterOnConflict(input);
+  if (!existing) {
+    return null;
+  }
+  return { subscription: existing, created: false };
+}
+
 /**
  * Create a Starter subscription. On the Konnect Stripe-setup 409
  * ({@link isOpenMeterStripeBillingError}), apply the sandbox free billing
@@ -164,29 +212,14 @@ async function createStarterSubscriptionWithBillingRecovery(input: {
   created: boolean;
 }> {
   try {
-    const createdSub = await createStarterOpenMeterSubscription(input);
-    if (!createdSub?.id) {
-      throw new Error("Failed to create OpenMeter Starter subscription");
-    }
-    return {
-      subscription: subscriptionViewFromCreateResult(
-        createdSub,
-        input.planKey,
-        input.starter.openmeterPlanId,
-      ),
-      created: true,
-    };
+    const subscription = await createStarterSubscriptionOnce(input);
+    return { subscription, created: true };
   } catch (err) {
-    if (isOpenMeterConflictError(err)) {
-      const existing = await findOpenMeterSubscriptionByPlanKey(
-        input.client,
-        input.customerId,
-        input.planKey,
-        { openmeterPlanId: input.starter.openmeterPlanId },
-      );
-      if (existing) {
-        return { subscription: existing, created: false };
-      }
+    const conflictResult = isOpenMeterConflictError(err)
+      ? await starterSubscriptionOnConflict(input)
+      : null;
+    if (conflictResult) {
+      return conflictResult;
     }
 
     if (!isOpenMeterStripeBillingError(err)) {
@@ -198,31 +231,14 @@ async function createStarterSubscriptionWithBillingRecovery(input: {
       customerId: input.customerId,
     });
     try {
-      const createdSub = await createStarterOpenMeterSubscription(input);
-      if (!createdSub?.id) {
-        throw new Error(
-          "Failed to create OpenMeter Starter subscription after billing profile apply",
-        );
-      }
-      return {
-        subscription: subscriptionViewFromCreateResult(
-          createdSub,
-          input.planKey,
-          input.starter.openmeterPlanId,
-        ),
-        created: true,
-      };
+      const subscription = await createStarterSubscriptionOnce(input);
+      return { subscription, created: true };
     } catch (retryErr) {
-      if (isOpenMeterConflictError(retryErr)) {
-        const existingAfterRetry = await findOpenMeterSubscriptionByPlanKey(
-          input.client,
-          input.customerId,
-          input.planKey,
-          { openmeterPlanId: input.starter.openmeterPlanId },
-        );
-        if (existingAfterRetry) {
-          return { subscription: existingAfterRetry, created: false };
-        }
+      const retryConflict = isOpenMeterConflictError(retryErr)
+        ? await starterSubscriptionOnConflict(input)
+        : null;
+      if (retryConflict) {
+        return retryConflict;
       }
       throw retryErr;
     }

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -147,54 +147,6 @@ function subscriptionViewFromCreateResult(
   };
 }
 
-async function createStarterSubscriptionOnce(input: {
-  client: OpenMeter;
-  customerId: string;
-  starter: typeof plans.$inferSelect;
-  planKey: string;
-}): Promise<OpenMeterSubscriptionView> {
-  const createdSub = await createStarterOpenMeterSubscription(input);
-  if (!createdSub?.id) {
-    throw new Error("Failed to create OpenMeter Starter subscription");
-  }
-  return subscriptionViewFromCreateResult(
-    createdSub,
-    input.planKey,
-    input.starter.openmeterPlanId,
-  );
-}
-
-async function existingStarterOnConflict(input: {
-  client: OpenMeter;
-  customerId: string;
-  starter: typeof plans.$inferSelect;
-  planKey: string;
-}): Promise<OpenMeterSubscriptionView | null> {
-  const existing = await findOpenMeterSubscriptionByPlanKey(
-    input.client,
-    input.customerId,
-    input.planKey,
-    { openmeterPlanId: input.starter.openmeterPlanId },
-  );
-  return existing ?? null;
-}
-
-async function starterSubscriptionOnConflict(input: {
-  client: OpenMeter;
-  customerId: string;
-  starter: typeof plans.$inferSelect;
-  planKey: string;
-}): Promise<{
-  subscription: OpenMeterSubscriptionView;
-  created: boolean;
-} | null> {
-  const existing = await existingStarterOnConflict(input);
-  if (!existing) {
-    return null;
-  }
-  return { subscription: existing, created: false };
-}
-
 /**
  * Create a Starter subscription. On the Konnect Stripe-setup 409
  * ({@link isOpenMeterStripeBillingError}), apply the sandbox free billing
@@ -212,14 +164,29 @@ async function createStarterSubscriptionWithBillingRecovery(input: {
   created: boolean;
 }> {
   try {
-    const subscription = await createStarterSubscriptionOnce(input);
-    return { subscription, created: true };
+    const createdSub = await createStarterOpenMeterSubscription(input);
+    if (!createdSub?.id) {
+      throw new Error("Failed to create OpenMeter Starter subscription");
+    }
+    return {
+      subscription: subscriptionViewFromCreateResult(
+        createdSub,
+        input.planKey,
+        input.starter.openmeterPlanId,
+      ),
+      created: true,
+    };
   } catch (err) {
-    const conflictResult = isOpenMeterConflictError(err)
-      ? await starterSubscriptionOnConflict(input)
-      : null;
-    if (conflictResult) {
-      return conflictResult;
+    if (isOpenMeterConflictError(err)) {
+      const existing = await findOpenMeterSubscriptionByPlanKey(
+        input.client,
+        input.customerId,
+        input.planKey,
+        { openmeterPlanId: input.starter.openmeterPlanId },
+      );
+      if (existing) {
+        return { subscription: existing, created: false };
+      }
     }
 
     if (!isOpenMeterStripeBillingError(err)) {
@@ -231,14 +198,31 @@ async function createStarterSubscriptionWithBillingRecovery(input: {
       customerId: input.customerId,
     });
     try {
-      const subscription = await createStarterSubscriptionOnce(input);
-      return { subscription, created: true };
+      const createdSub = await createStarterOpenMeterSubscription(input);
+      if (!createdSub?.id) {
+        throw new Error(
+          "Failed to create OpenMeter Starter subscription after billing profile apply",
+        );
+      }
+      return {
+        subscription: subscriptionViewFromCreateResult(
+          createdSub,
+          input.planKey,
+          input.starter.openmeterPlanId,
+        ),
+        created: true,
+      };
     } catch (retryErr) {
-      const retryConflict = isOpenMeterConflictError(retryErr)
-        ? await starterSubscriptionOnConflict(input)
-        : null;
-      if (retryConflict) {
-        return retryConflict;
+      if (isOpenMeterConflictError(retryErr)) {
+        const existingAfterRetry = await findOpenMeterSubscriptionByPlanKey(
+          input.client,
+          input.customerId,
+          input.planKey,
+          { openmeterPlanId: input.starter.openmeterPlanId },
+        );
+        if (existingAfterRetry) {
+          return { subscription: existingAfterRetry, created: false };
+        }
       }
       throw retryErr;
     }

--- a/src/lib/openmeter/stripe-app-install.ts
+++ b/src/lib/openmeter/stripe-app-install.ts
@@ -415,11 +415,14 @@ export async function getStripeConnectStatus(clientId: string) {
   const accountId = config?.stripeConnectedAccountId?.trim() || null;
   // Merchant Connect only — do not treat legacy OpenMeter Stripe-app installs
   // (stripe_connect_status=connected, no acct_…) as merchant-ready.
-  const status = accountId
-    ? config?.stripeChargesEnabled
-      ? "connected"
-      : "pending"
-    : "disconnected";
+  let status: "connected" | "pending" | "disconnected";
+  if (!accountId) {
+    status = "disconnected";
+  } else if (config?.stripeChargesEnabled) {
+    status = "connected";
+  } else {
+    status = "pending";
+  }
 
   const openmeterStripeAppId = config?.openmeterStripeAppId ?? null;
   const openmeterBillingProfileId = config?.openmeterBillingProfileId ?? null;

--- a/src/lib/openmeter/stripe-customer-data.ts
+++ b/src/lib/openmeter/stripe-customer-data.ts
@@ -16,7 +16,7 @@ type KonnectCustomerBillingData = {
 function requireStripeSecretKey(): string {
   const key =
     process.env.STRIPE_SECRET_KEY?.trim() || process.env.STRIPE_API_KEY?.trim();
-  if (!key || !key.startsWith("sk_")) {
+  if (!key?.startsWith("sk_")) {
     throw new Error(
       "STRIPE_SECRET_KEY is required to provision Stripe customer data " +
         "(must be sk_… for the same Stripe account installed in Konnect/OpenMeter).",

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -69,6 +69,68 @@ export function neonSubscriptionStatusAfterPlanChange(input: {
   return input.checkoutUrl ? "pending" : "active";
 }
 
+async function checkoutUrlAfterPlanChange(input: {
+  client: ReturnType<typeof getHostedAdminClient>;
+  clientId: string;
+  externalUserId: string;
+  targetPlan: Awaited<ReturnType<typeof loadActiveTargetPlan>>;
+  customer: { id: string; key: string };
+  successUrl?: string;
+  cancelUrl?: string;
+}): Promise<{ checkoutUrl?: string; stripeCheckoutSessionId?: string | null }> {
+  if (!planRequiresPaymentMethod(input.targetPlan)) {
+    return {};
+  }
+
+  const billingConfig = await getAppBillingConfig(input.clientId);
+  const origin = getPublicOrigin();
+  const success =
+    input.successUrl ||
+    billingConfig?.checkoutSuccessUrl ||
+    appSettingsAbsoluteUrl(origin, input.clientId, "payments");
+  const cancel =
+    input.cancelUrl ||
+    billingConfig?.checkoutCancelUrl ||
+    appSettingsAbsoluteUrl(origin, input.clientId, "payments");
+
+  if (isMerchantConnectPaymentsReady(billingConfig)) {
+    const connectCheckout = await createMerchantConnectCheckoutForUser({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+      successUrl: success,
+      cancelUrl: cancel,
+      openmeterCustomerId: input.customer.id,
+      openmeterCustomerKey: input.customer.key,
+    });
+    return {
+      checkoutUrl: connectCheckout.checkoutUrl,
+      stripeCheckoutSessionId: connectCheckout.sessionId,
+    };
+  }
+
+  const paymentMethodId = await getKonnectDefaultPaymentMethodId(input.customer.id);
+  if (paymentMethodId) {
+    return {};
+  }
+
+  if (connectPaymentsOnlyEnabled(billingConfig)) {
+    throw new Error(
+      "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
+    );
+  }
+
+  const checkout = await createOpenMeterStripeCheckoutSession({
+    client: input.client,
+    customerId: input.customer.id,
+    successUrl: success,
+    cancelUrl: cancel,
+  });
+  return {
+    checkoutUrl: checkout.checkoutUrl,
+    stripeCheckoutSessionId: checkout.sessionId,
+  };
+}
+
 async function upsertNeonSubscriptionCache(input: {
   clientId: string;
   externalUserId: string;
@@ -350,51 +412,15 @@ export async function changeAppUserSubscriptionPlan(input: {
     current.id;
   const effectiveAt = new Date().toISOString();
 
-  let checkoutUrl: string | undefined;
-  let stripeCheckoutSessionId: string | null | undefined;
-
-  if (planRequiresPaymentMethod(targetPlan)) {
-    const billingConfig = await getAppBillingConfig(input.clientId);
-    const origin = getPublicOrigin();
-    const success =
-      input.successUrl ||
-      billingConfig?.checkoutSuccessUrl ||
-      appSettingsAbsoluteUrl(origin, input.clientId, "payments");
-    const cancel =
-      input.cancelUrl ||
-      billingConfig?.checkoutCancelUrl ||
-      appSettingsAbsoluteUrl(origin, input.clientId, "payments");
-
-    if (isMerchantConnectPaymentsReady(billingConfig)) {
-      const connectCheckout = await createMerchantConnectCheckoutForUser({
-        clientId: input.clientId,
-        externalUserId: input.externalUserId,
-        successUrl: success,
-        cancelUrl: cancel,
-        openmeterCustomerId: customer.id,
-        openmeterCustomerKey: customer.key,
-      });
-      checkoutUrl = connectCheckout.checkoutUrl;
-      stripeCheckoutSessionId = connectCheckout.sessionId;
-    } else {
-      const paymentMethodId = await getKonnectDefaultPaymentMethodId(customer.id);
-      if (!paymentMethodId) {
-        if (connectPaymentsOnlyEnabled(billingConfig)) {
-          throw new Error(
-            "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
-          );
-        }
-        const checkout = await createOpenMeterStripeCheckoutSession({
-          client,
-          customerId: customer.id,
-          successUrl: success,
-          cancelUrl: cancel,
-        });
-        checkoutUrl = checkout.checkoutUrl;
-        stripeCheckoutSessionId = checkout.sessionId;
-      }
-    }
-  }
+  const { checkoutUrl, stripeCheckoutSessionId } = await checkoutUrlAfterPlanChange({
+    client,
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+    targetPlan,
+    customer,
+    successUrl: input.successUrl,
+    cancelUrl: input.cancelUrl,
+  });
 
   await upsertNeonSubscriptionCache({
     clientId: input.clientId,

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -69,68 +69,6 @@ export function neonSubscriptionStatusAfterPlanChange(input: {
   return input.checkoutUrl ? "pending" : "active";
 }
 
-async function checkoutUrlAfterPlanChange(input: {
-  client: ReturnType<typeof getHostedAdminClient>;
-  clientId: string;
-  externalUserId: string;
-  targetPlan: Awaited<ReturnType<typeof loadActiveTargetPlan>>;
-  customer: { id: string; key: string };
-  successUrl?: string;
-  cancelUrl?: string;
-}): Promise<{ checkoutUrl?: string; stripeCheckoutSessionId?: string | null }> {
-  if (!planRequiresPaymentMethod(input.targetPlan)) {
-    return {};
-  }
-
-  const billingConfig = await getAppBillingConfig(input.clientId);
-  const origin = getPublicOrigin();
-  const success =
-    input.successUrl ||
-    billingConfig?.checkoutSuccessUrl ||
-    appSettingsAbsoluteUrl(origin, input.clientId, "payments");
-  const cancel =
-    input.cancelUrl ||
-    billingConfig?.checkoutCancelUrl ||
-    appSettingsAbsoluteUrl(origin, input.clientId, "payments");
-
-  if (isMerchantConnectPaymentsReady(billingConfig)) {
-    const connectCheckout = await createMerchantConnectCheckoutForUser({
-      clientId: input.clientId,
-      externalUserId: input.externalUserId,
-      successUrl: success,
-      cancelUrl: cancel,
-      openmeterCustomerId: input.customer.id,
-      openmeterCustomerKey: input.customer.key,
-    });
-    return {
-      checkoutUrl: connectCheckout.checkoutUrl,
-      stripeCheckoutSessionId: connectCheckout.sessionId,
-    };
-  }
-
-  const paymentMethodId = await getKonnectDefaultPaymentMethodId(input.customer.id);
-  if (paymentMethodId) {
-    return {};
-  }
-
-  if (connectPaymentsOnlyEnabled(billingConfig)) {
-    throw new Error(
-      "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
-    );
-  }
-
-  const checkout = await createOpenMeterStripeCheckoutSession({
-    client: input.client,
-    customerId: input.customer.id,
-    successUrl: success,
-    cancelUrl: cancel,
-  });
-  return {
-    checkoutUrl: checkout.checkoutUrl,
-    stripeCheckoutSessionId: checkout.sessionId,
-  };
-}
-
 async function upsertNeonSubscriptionCache(input: {
   clientId: string;
   externalUserId: string;
@@ -412,15 +350,51 @@ export async function changeAppUserSubscriptionPlan(input: {
     current.id;
   const effectiveAt = new Date().toISOString();
 
-  const { checkoutUrl, stripeCheckoutSessionId } = await checkoutUrlAfterPlanChange({
-    client,
-    clientId: input.clientId,
-    externalUserId: input.externalUserId,
-    targetPlan,
-    customer,
-    successUrl: input.successUrl,
-    cancelUrl: input.cancelUrl,
-  });
+  let checkoutUrl: string | undefined;
+  let stripeCheckoutSessionId: string | null | undefined;
+
+  if (planRequiresPaymentMethod(targetPlan)) {
+    const billingConfig = await getAppBillingConfig(input.clientId);
+    const origin = getPublicOrigin();
+    const success =
+      input.successUrl ||
+      billingConfig?.checkoutSuccessUrl ||
+      appSettingsAbsoluteUrl(origin, input.clientId, "payments");
+    const cancel =
+      input.cancelUrl ||
+      billingConfig?.checkoutCancelUrl ||
+      appSettingsAbsoluteUrl(origin, input.clientId, "payments");
+
+    if (isMerchantConnectPaymentsReady(billingConfig)) {
+      const connectCheckout = await createMerchantConnectCheckoutForUser({
+        clientId: input.clientId,
+        externalUserId: input.externalUserId,
+        successUrl: success,
+        cancelUrl: cancel,
+        openmeterCustomerId: customer.id,
+        openmeterCustomerKey: customer.key,
+      });
+      checkoutUrl = connectCheckout.checkoutUrl;
+      stripeCheckoutSessionId = connectCheckout.sessionId;
+    } else {
+      const paymentMethodId = await getKonnectDefaultPaymentMethodId(customer.id);
+      if (!paymentMethodId) {
+        if (connectPaymentsOnlyEnabled(billingConfig)) {
+          throw new Error(
+            "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
+          );
+        }
+        const checkout = await createOpenMeterStripeCheckoutSession({
+          client,
+          customerId: customer.id,
+          successUrl: success,
+          cancelUrl: cancel,
+        });
+        checkoutUrl = checkout.checkoutUrl;
+        stripeCheckoutSessionId = checkout.sessionId;
+      }
+    }
+  }
 
   await upsertNeonSubscriptionCache({
     clientId: input.clientId,

--- a/src/lib/sanitize-for-log.ts
+++ b/src/lib/sanitize-for-log.ts
@@ -15,5 +15,14 @@ export function sanitizeForLog(value: unknown): string {
       return "[unserializable]";
     }
   }
-  return String(value).replace(/[\n\r]/g, "");
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    typeof value === "symbol"
+  ) {
+    return String(value).replace(/[\n\r]/g, "");
+  }
+  return "";
 }

--- a/src/lib/stripe/connect-accounts.ts
+++ b/src/lib/stripe/connect-accounts.ts
@@ -117,7 +117,7 @@ export const __testMapAccountIdentity = mapAccountIdentity;
 function requireStripeSecretKey(): string {
   const key =
     process.env.STRIPE_SECRET_KEY?.trim() || process.env.STRIPE_API_KEY?.trim();
-  if (!key || !key.startsWith("sk_")) {
+  if (!key?.startsWith("sk_")) {
     throw new Error(
       "STRIPE_SECRET_KEY is required for Stripe Connect (must be sk_… platform key)",
     );

--- a/src/lib/stripe/webhook.ts
+++ b/src/lib/stripe/webhook.ts
@@ -17,7 +17,7 @@ export type StripeAccountUpdatedPayload = {
 
 export function requireStripeWebhookSecret(): string {
   const secret = process.env.STRIPE_WEBHOOK_SECRET?.trim();
-  if (!secret || !secret.startsWith("whsec_")) {
+  if (!secret?.startsWith("whsec_")) {
     throw new Error(
       "STRIPE_WEBHOOK_SECRET is required (whsec_… from Stripe Dashboard → Webhooks)",
     );

--- a/src/lib/turnkey-github-oidc.test.ts
+++ b/src/lib/turnkey-github-oidc.test.ts
@@ -148,9 +148,13 @@ describe("Turnkey GitHub OIDC issuer", () => {
 });
 
 describe("mintTurnkeyGithubOidcToken", () => {
-  it("issues a verifiable RS256 id token with nonce binding", async () => {
+  it("issues a verifiable RS256 id token with nonce binding", async (t) => {
     // Uses DB-backed signing keys when a real DATABASE_URL is available.
-    if (process.env.PYMTHOUSE_TEST_DATABASE_URL_UNSET === "1") {
+    if (
+      process.env.PYMTHOUSE_TEST_DATABASE_URL_UNSET === "1" ||
+      !process.env.DATABASE_URL?.trim()
+    ) {
+      t.skip("DATABASE_URL unset for this job");
       return;
     }
 

--- a/src/lib/turnkey-github-oidc.ts
+++ b/src/lib/turnkey-github-oidc.ts
@@ -15,7 +15,11 @@ export const TURNKEY_GITHUB_PROVIDER_NAME = "GitHub";
 const ID_TOKEN_TTL_SECONDS = 5 * 60;
 
 function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, "");
+  let out = value;
+  while (out.endsWith("/")) {
+    out = out.slice(0, -1);
+  }
+  return out;
 }
 
 /** Public issuer URL Turnkey fetches for discovery + JWKS. Must be internet-reachable. */

--- a/src/lib/usage/builder-usage.route.test.ts
+++ b/src/lib/usage/builder-usage.route.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { run } from "@/test-utils/db-guard";
+import { test } from "@/test-utils/db-guard";
 import {
   basicAuthHeader,
   cleanupTestApp,
@@ -11,7 +11,7 @@ import {
   __testSetOpenMeterUsageRows,
 } from "@/lib/openmeter/usage-read";
 
-run("builder usage API is M2M-only and returns OpenMeter rows", async (t) => {
+test("builder usage API is M2M-only and returns OpenMeter rows", async (t) => {
   const { GET } = await import("@/app/api/v1/builder/apps/[id]/usage/route");
   const app = await seedDeveloperAppWithClient({ status: "approved" });
   t.after(() => cleanupTestApp(app));


### PR DESCRIPTION
## Summary

Clears the SonarCloud leak-period OPEN/CONFIRMED backlog on `main`, without failing the **Coverage on New Code ≥ 60%** gate.

* **BLOCKER S2187**: rename `run` → `test` from `@/test-utils/db-guard` so analyzers recognize tests
* **CRITICAL S3776** (coverage-safe): extract helpers in network-catalog, credentials route, FundAccountOnRamp, SignedTicketRequestHistory, OpenAPI filter, etc. (`src/app` / `src/components` are coverage-excluded)
* **MAJOR/MINOR smells**: optional chaining, `??=`/`??`, nested ternaries, `toSorted`, `Set` for grants, FormEvent→SyntheticEvent, Zod 4 (`z.uuid`/`z.url`/`z.looseObject`), `t.skip()`, shell `return`, ReDoS-safe slash trim, JSX spacing, split composite asserts
* Security fixes from #383 (`toKonnectApiUrl`, TLS 1.2, entrypoint `*`) already on main

### Deferred (follow-up)

Untested S3776 helper extrated in low-coverage billing modules were **reverted** after they dropped new_coverage to 24.8%:

* `owner-starter-plan.ts`
* `starter-subscription.ts`
* `subscriptions-billing.ts`
* `billing-consistency.ts`

Those CRITICAL complexity issues remain OPEN until a follow-up lands extracts + unit tests together.

## Test plan

* [x] Targeted unit tests (network-catalog, subscriptions-billing helpers, turnkey)
* [x] CI `test` / Snyk / CodeQL green on prior revision
* [ ] Confirm SonarCloud Code Analysis: **Coverage on New Code ≥ 60%**
* [ ] Post-merge: leak-period issue count drops for addressed smells (billing S3776 deferred)