### PR TITLE
test(sonar): cover the new code in #384 to clear the new_coverage gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "validate:env": "node scripts/validate-env.js",
     "openapi:generate": "npx tsx scripts/generate-openapi-routes.ts",
     "check:openapi": "npm run openapi:generate && npx tsx scripts/check-openapi.ts",
-    "test": "node --import ./src/test-env.ts --import tsx --test --test-force-exit \"src/**/*.test.ts\" \"src/**/*.test.mjs\"",
-    "test:coverage": "mkdir -p coverage && c8 --reporter=text --reporter=lcov --report-dir=coverage --include='src/**' --exclude='**/*.test.ts' --exclude='**/*.test.mjs' node --import ./src/test-env.ts --import tsx --test --test-force-exit \"src/**/*.test.ts\" \"src/**/*.test.mjs\""
+    "test": "node --experimental-test-module-mocks --import ./src/test-env.ts --import tsx --test --test-force-exit \"src/**/*.test.ts\" \"src/**/*.test.mjs\"",
+    "test:coverage": "mkdir -p coverage && c8 --reporter=text --reporter=lcov --report-dir=coverage --include='src/**' --exclude='**/*.test.ts' --exclude='**/*.test.mjs' node --experimental-test-module-mocks --import ./src/test-env.ts --import tsx --test --test-force-exit \"src/**/*.test.ts\" \"src/**/*.test.mjs\""
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^9.1.0",

--- a/src/lib/openmeter/billing-consistency.audit.test.ts
+++ b/src/lib/openmeter/billing-consistency.audit.test.ts
@@ -192,6 +192,29 @@ function codes(findings: Array<{ code: string }>): string[] {
   return findings.map((f) => f.code);
 }
 
+/** Audit scoped to one seeded owner + app so parallel test files cannot bleed in. */
+function auditOwnerApp(app: SeededDeveloperApp) {
+  return sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+}
+
+async function seedPhaseOutPlan(
+  app: SeededDeveloperApp,
+  overrides: Partial<typeof plans.$inferInsert> = {},
+): Promise<void> {
+  await db.insert(plans).values({
+    id: `plan-phaseout-${randomUUID()}`,
+    clientId: app.clientId,
+    name: `Legacy ${randomUUID().slice(0, 8)}`,
+    status: "phase_out",
+    phaseOutAt: "2020-01-01T00:00:00.000Z",
+    openmeterPlanId: "plan_legacy_pro",
+    ...overrides,
+  });
+}
+
 dbTest("auditBillingConsistency reports an unconfigured OpenMeter", async () => {
   adminClient.isHostedAdminClientAvailable = () => false;
   const findings = await sut.auditBillingConsistency({ ownerId: "user-anything" });
@@ -248,10 +271,7 @@ dbTest("auditBillingConsistency is quiet for a healthy owner wallet", async (t) 
     usageDiscountUsdMicros: STARTER_MICROS,
   });
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.deepEqual(codes(findings), []);
 });
 
@@ -263,10 +283,7 @@ dbTest("auditBillingConsistency flags a Starter plan missing from Konnect", asyn
     { id: "sub_owner", status: "active", planId: null, planKey: null },
   ];
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("starter_openmeter_plan_missing"));
   assert.ok(codes(findings).includes("owner_subscription_missing_plan_id"));
   assert.ok(starter.openmeterPlanId);
@@ -280,10 +297,7 @@ dbTest("auditBillingConsistency flags an unsynced Starter row", async (t) => {
     .set({ openmeterPlanId: null })
     .where(eq(plans.id, starter.id));
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("starter_openmeter_plan_id_missing"));
 });
 
@@ -307,10 +321,7 @@ dbTest("auditBillingConsistency reports a missing owner customer", async (t) => 
   t.after(() => cleanupTestApp(app));
   customers.findOpenMeterCustomerByKey = async () => null;
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("owner_customer_missing"));
 });
 
@@ -321,10 +332,7 @@ dbTest("auditBillingConsistency reports a failed owner customer lookup", async (
     throw new Error("konnect customers list failed");
   };
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   const lookup = findings.find((f) => f.code === "owner_customer_lookup_failed");
   assert.equal(lookup?.message, "konnect customers list failed");
 });
@@ -335,10 +343,7 @@ dbTest("auditBillingConsistency flags a chargeable owner without Stripe app data
   stripeCustomerData.getStripeCustomerAppDataId = async () => null;
   paymentMethod.ownerHasChargeablePaymentMethod = async () => true;
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("owner_missing_stripe_app_data"));
 });
 
@@ -348,10 +353,7 @@ dbTest("auditBillingConsistency ignores missing Stripe app data without a card",
   stripeCustomerData.getStripeCustomerAppDataId = async () => null;
   paymentMethod.ownerHasChargeablePaymentMethod = async () => null;
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(!codes(findings).includes("owner_missing_stripe_app_data"));
 });
 
@@ -363,10 +365,7 @@ dbTest("auditBillingConsistency warns about a sandbox profile with a card", asyn
   stripeCustomerData.getKonnectCustomerBillingProfileId = async () => "bp_sandbox";
   paymentMethod.ownerHasChargeablePaymentMethod = async () => true;
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("owner_sandbox_billing_profile"));
 });
 
@@ -378,10 +377,7 @@ dbTest("auditBillingConsistency ignores a non-sandbox billing profile", async (t
   stripeCustomerData.getKonnectCustomerBillingProfileId = async () => "bp_stripe";
   paymentMethod.ownerHasChargeablePaymentMethod = async () => true;
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(!codes(findings).includes("owner_sandbox_billing_profile"));
 });
 
@@ -392,10 +388,7 @@ dbTest("auditBillingConsistency reports no active owner subscription", async (t)
     { id: "sub_cancelled", status: "canceled" },
   ];
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("owner_no_active_subscription"));
 });
 
@@ -412,10 +405,7 @@ dbTest("auditBillingConsistency warns on duplicate active owner subscriptions", 
     { id: "sub_b", status: "trialing", planId: "plan_owner_starter", planKey: null },
   ];
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   const duplicate = findings.find(
     (f) => f.code === "owner_multiple_active_subscriptions",
   );
@@ -428,10 +418,7 @@ dbTest("auditBillingConsistency names subjects carrying unattributed usage", asy
   customers.listOwnedPublicClientIds = async () => [app.clientId];
   usageBySubject.set(`owner:${app.userId}`, 250_000n);
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   const leak = findings.find((f) => f.code === "usage_on_unattributed_subject");
   assert.deepEqual(leak?.details?.unattributed, [`owner:${app.userId}`]);
 });
@@ -441,10 +428,7 @@ dbTest("auditBillingConsistency treats an unreadable meter as no usage", async (
   t.after(() => cleanupTestApp(app));
   meterQueryFails = true;
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(!codes(findings).includes("usage_on_unattributed_subject"));
 });
 
@@ -457,10 +441,7 @@ dbTest("auditBillingConsistency flags a blocking spendable gate", async (t) => {
     usageAttribution: { subjectKeys: [key, `owner:${key}`] },
   });
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   const gate = findings.find(
     (f) => f.code === "spendable_gate_blocks_with_unused_allowance",
   );
@@ -476,10 +457,7 @@ dbTest("auditBillingConsistency reads credit balances into the gate check", asyn
   spendable.getRemainingPlanDiscountUsdMicros = async () => 3_000_000n;
   spendable.getSpendableUsdMicros = async () => "5000000";
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(!codes(findings).includes("spendable_sum_mismatch"));
   assert.ok(!codes(findings).includes("spendable_gate_blocks_with_unused_allowance"));
 });
@@ -487,15 +465,7 @@ dbTest("auditBillingConsistency reads credit balances into the gate check", asyn
 dbTest("auditBillingConsistency reports phase-out plans past their deadline", async (t) => {
   const { app } = await seedOwnerWithStarter();
   t.after(() => cleanupTestApp(app));
-  const phaseOutId = `plan-phaseout-${randomUUID()}`;
-  await db.insert(plans).values({
-    id: phaseOutId,
-    clientId: app.clientId,
-    name: "Legacy Pro",
-    status: "phase_out",
-    phaseOutAt: "2020-01-01T00:00:00.000Z",
-    openmeterPlanId: "plan_legacy_pro",
-  });
+  await seedPhaseOutPlan(app);
   konnectSubscriptions.countActiveKonnectSubscriptionsForPlan = async () => 4;
 
   const findings = await sut.auditBillingConsistency({ clientId: app.clientId });
@@ -508,14 +478,7 @@ dbTest("auditBillingConsistency reports phase-out plans past their deadline", as
 dbTest("auditBillingConsistency warns when the subscriber count is unreadable", async (t) => {
   const { app } = await seedOwnerWithStarter();
   t.after(() => cleanupTestApp(app));
-  await db.insert(plans).values({
-    id: `plan-phaseout-${randomUUID()}`,
-    clientId: app.clientId,
-    name: "Legacy Pro",
-    status: "phase_out",
-    phaseOutAt: "2020-01-01T00:00:00.000Z",
-    openmeterPlanId: "plan_legacy_pro",
-  });
+  await seedPhaseOutPlan(app);
   konnectSubscriptions.countActiveKonnectSubscriptionsForPlan = async () => {
     throw new Error("konnect subscriptions list failed");
   };
@@ -530,21 +493,8 @@ dbTest("auditBillingConsistency warns when the subscriber count is unreadable", 
 dbTest("auditBillingConsistency ignores phase-out plans before the deadline", async (t) => {
   const { app } = await seedOwnerWithStarter();
   t.after(() => cleanupTestApp(app));
-  await db.insert(plans).values({
-    id: `plan-phaseout-${randomUUID()}`,
-    clientId: app.clientId,
-    name: "Future Pro",
-    status: "phase_out",
-    phaseOutAt: "2099-01-01T00:00:00.000Z",
-    openmeterPlanId: "plan_future_pro",
-  });
-  await db.insert(plans).values({
-    id: `plan-phaseout-${randomUUID()}`,
-    clientId: app.clientId,
-    name: "Unsynced Pro",
-    status: "phase_out",
-    phaseOutAt: "2020-01-01T00:00:00.000Z",
-  });
+  await seedPhaseOutPlan(app, { phaseOutAt: "2099-01-01T00:00:00.000Z" });
+  await seedPhaseOutPlan(app, { openmeterPlanId: null });
 
   const findings = await sut.auditBillingConsistency({ clientId: app.clientId });
   assert.ok(!codes(findings).includes("phase_out_subscribers_past_deadline"));
@@ -558,10 +508,7 @@ dbTest("auditBillingConsistency warns when the Owner Paid plan is unpublished", 
     throw new Error("konnect plans list failed");
   };
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("owner_paid_plan_missing"));
 });
 
@@ -577,10 +524,7 @@ dbTest("auditBillingConsistency flags Owner Paid allowance drift", async (t) => 
     usageDiscountUsdMicros: STARTER_MICROS,
   });
 
-  const findings = await sut.auditBillingConsistency({
-    ownerId: app.userId,
-    clientId: app.clientId,
-  });
+  const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("owner_paid_plan_allowance_drift"));
 });
 

--- a/src/lib/openmeter/billing-consistency.audit.test.ts
+++ b/src/lib/openmeter/billing-consistency.audit.test.ts
@@ -1,0 +1,593 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { before, beforeEach } from "node:test";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import { plans } from "@/db/schema";
+import { buildOpenMeterPlanKey } from "@/lib/openmeter/plan-naming";
+import { includedDiscountUsdMicrosForPlan } from "@/lib/openmeter/spendable-allowance";
+import { test as dbTest } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  seedDeveloperAppWithClient,
+  type SeededDeveloperApp,
+} from "@/test-utils/fixtures";
+import { createStubRegistry } from "@/test-utils/module-stubs";
+
+type MeterRow = { subject?: string; value: number | string };
+
+type FakeSubscription = {
+  id: string;
+  status: string;
+  planId?: string | null;
+  planKey?: string | null;
+};
+
+type FakePlan = {
+  id: string;
+  key?: string | null;
+  version?: number;
+  usageDiscountUsdMicros?: string | null;
+};
+
+const remotePlans = new Map<string, FakePlan>();
+/** Total usage per meter subject; drives the attribution drill-down. */
+const usageBySubject = new Map<string, bigint>();
+let planGetFails = false;
+let meterQueryFails = false;
+
+const fakeClient = {
+  plans: {
+    get: async (planId: string) => {
+      if (planGetFails) {
+        throw new Error("konnect plans.get failed");
+      }
+      const found = remotePlans.get(planId);
+      if (!found) {
+        return null;
+      }
+      return {
+        id: found.id,
+        key: found.key ?? null,
+        version: found.version,
+        phases: [
+          {
+            rateCards: [
+              ...(found.usageDiscountUsdMicros == null
+                ? []
+                : [{ discounts: { usage: found.usageDiscountUsdMicros } }]),
+            ],
+          },
+        ],
+      };
+    },
+  },
+  meters: {
+    query: async (
+      _meter: string,
+      options: { subject?: string[] },
+    ): Promise<{ data: MeterRow[] }> => {
+      if (meterQueryFails) {
+        throw new Error("konnect meters.query failed");
+      }
+      const data: MeterRow[] = [];
+      for (const subject of options.subject ?? []) {
+        const value = usageBySubject.get(subject);
+        if (value != null && value > 0n) {
+          data.push({ subject, value: value.toString() });
+        }
+      }
+      return { data };
+    },
+  },
+};
+
+const stubs = createStubRegistry();
+
+const adminClient = stubs.module("@/lib/openmeter/admin-client", {
+  isHostedAdminClientAvailable: (): boolean => true,
+  getHostedAdminClient: (): unknown => fakeClient,
+});
+
+const paymentMethod = stubs.module("@/lib/openmeter/owner-payment-method", {
+  ownerHasChargeablePaymentMethod: async (): Promise<boolean | null> => false,
+});
+
+const customers = stubs.module("@/lib/openmeter/customers", {
+  findOpenMeterCustomerByKey: async (
+    _client: unknown,
+    key: string,
+  ): Promise<unknown> => ({
+    id: `cust_${key}`,
+    usageAttribution: { subjectKeys: [key] },
+  }),
+  listOwnedPublicClientIds: async (): Promise<string[]> => [],
+});
+
+const entitlements = stubs.module("@/lib/openmeter/entitlements", {
+  getTrialCreditBalance: async (): Promise<{ balanceUsdMicros: string } | null> =>
+    null,
+});
+
+const spendable = stubs.module("@/lib/openmeter/spendable-allowance", {
+  includedDiscountUsdMicrosForPlan,
+  getRemainingPlanDiscountUsdMicros: async (): Promise<bigint> => 0n,
+  getSpendableUsdMicros: async (): Promise<string> => "0",
+});
+
+const subscriptionRead = stubs.module("@/lib/openmeter/subscription-read", {
+  isOpenMeterSubscriptionActive: (status: string): boolean =>
+    status === "active" || status === "trialing",
+  listOpenMeterSubscriptionsForCustomer: async (): Promise<FakeSubscription[]> => [],
+});
+
+const stripeCustomerData = stubs.module("@/lib/openmeter/stripe-customer-data", {
+  getStripeCustomerAppDataId: async (): Promise<string | null> => "cus_test",
+  getKonnectCustomerBillingProfileId: async (): Promise<string | null> => null,
+});
+
+const konnectSubscriptions = stubs.module(
+  "@/lib/openmeter/konnect-subscriptions",
+  {
+    countActiveKonnectSubscriptionsForPlan: async (): Promise<number> => 0,
+  },
+);
+
+const allowancePlan = stubs.module("@/lib/openmeter/owner-allowance-plan", {
+  findOpenMeterPlanByKey: async (): Promise<{ id: string } | null> => null,
+  readUsageDiscountUsdMicrosFromPlanBody: (plan: unknown): string | null => {
+    const phases = (plan as { phases?: Array<{ rateCards?: Array<{ discounts?: { usage?: unknown } }> }> })
+      .phases;
+    const usage = phases?.[0]?.rateCards?.[0]?.discounts?.usage;
+    return usage == null ? null : String(usage);
+  },
+});
+
+const platformDefault = stubs.module(
+  "@/lib/billing/platform-owner-starter-default",
+  {
+    resolvePlatformOwnerStarterIncludedUsdMicros: async (): Promise<string> =>
+      "5000000",
+  },
+);
+
+const STARTER_MICROS = "5000000";
+
+let sut: typeof import("@/lib/openmeter/billing-consistency");
+
+before(async () => {
+  sut = await import("@/lib/openmeter/billing-consistency");
+});
+
+beforeEach(() => {
+  stubs.reset();
+  remotePlans.clear();
+  usageBySubject.clear();
+  planGetFails = false;
+  meterQueryFails = false;
+  process.env.OPENMETER_ROUTE_MODE = "self_hosted";
+  delete process.env.OPENMETER_FREE_BILLING_PROFILE_ID;
+});
+
+async function seedOwnerWithStarter(): Promise<{
+  app: SeededDeveloperApp;
+  starter: typeof plans.$inferSelect;
+}> {
+  const app = await seedDeveloperAppWithClient();
+  const rows = await db.select().from(plans).where(eq(plans.clientId, app.clientId));
+  const starter = rows.find((row) => row.isStarterDefault);
+  if (!starter) {
+    throw new Error("seeded app has no Starter plan row");
+  }
+  await db
+    .update(plans)
+    .set({ includedUsdMicros: STARTER_MICROS, openmeterPlanId: `plan_${starter.id}` })
+    .where(eq(plans.id, starter.id));
+  const refreshed = await db.select().from(plans).where(eq(plans.id, starter.id));
+  return { app, starter: refreshed[0]! };
+}
+
+function codes(findings: Array<{ code: string }>): string[] {
+  return findings.map((f) => f.code);
+}
+
+dbTest("auditBillingConsistency reports an unconfigured OpenMeter", async () => {
+  adminClient.isHostedAdminClientAvailable = () => false;
+  const findings = await sut.auditBillingConsistency({ ownerId: "user-anything" });
+  assert.deepEqual(codes(findings), ["openmeter_unconfigured"]);
+});
+
+dbTest("auditBillingConsistency reports an unknown clientId filter", async () => {
+  const findings = await sut.auditBillingConsistency({
+    clientId: `app_missing_${randomUUID().slice(0, 8)}`,
+  });
+  assert.deepEqual(codes(findings), ["client_not_found"]);
+});
+
+dbTest("auditBillingConsistency warns when an owner has no Starter plans", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  await db
+    .update(plans)
+    .set({ status: "draft" })
+    .where(eq(plans.clientId, app.clientId));
+
+  const findings = await sut.auditBillingConsistency({ ownerId: app.userId });
+  assert.ok(codes(findings).includes("owner_no_starter_plans"));
+});
+
+dbTest("auditBillingConsistency is quiet for a healthy owner wallet", async (t) => {
+  const { app, starter } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+
+  remotePlans.set(starter.openmeterPlanId!, {
+    id: starter.openmeterPlanId!,
+    key: buildOpenMeterPlanKey(app.clientId, starter.id),
+    usageDiscountUsdMicros: STARTER_MICROS,
+  });
+  remotePlans.set("plan_owner_starter", {
+    id: "plan_owner_starter",
+    key: "pymthouse_owner_starter",
+    usageDiscountUsdMicros: STARTER_MICROS,
+  });
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    {
+      id: "sub_owner",
+      status: "active",
+      planId: "plan_owner_starter",
+      planKey: "pymthouse_owner_starter",
+    },
+  ];
+  spendable.getRemainingPlanDiscountUsdMicros = async () => 5_000_000n;
+  spendable.getSpendableUsdMicros = async () => "5000000";
+  allowancePlan.findOpenMeterPlanByKey = async () => ({ id: "plan_owner_paid" });
+  remotePlans.set("plan_owner_paid", {
+    id: "plan_owner_paid",
+    key: "pymthouse_owner_paid",
+    usageDiscountUsdMicros: STARTER_MICROS,
+  });
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.deepEqual(codes(findings), []);
+});
+
+dbTest("auditBillingConsistency flags a Starter plan missing from Konnect", async (t) => {
+  const { app, starter } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  planGetFails = true;
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_owner", status: "active", planId: null, planKey: null },
+  ];
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(codes(findings).includes("starter_openmeter_plan_missing"));
+  assert.ok(codes(findings).includes("owner_subscription_missing_plan_id"));
+  assert.ok(starter.openmeterPlanId);
+});
+
+dbTest("auditBillingConsistency flags an unsynced Starter row", async (t) => {
+  const { app, starter } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  await db
+    .update(plans)
+    .set({ openmeterPlanId: null })
+    .where(eq(plans.id, starter.id));
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(codes(findings).includes("starter_openmeter_plan_id_missing"));
+});
+
+dbTest("auditBillingConsistency skips Starters outside the clientId filter", async (t) => {
+  const { app, starter } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  await db
+    .update(plans)
+    .set({ openmeterPlanId: null })
+    .where(eq(plans.id, starter.id));
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: "app_some_other_app",
+  });
+  assert.ok(!codes(findings).includes("starter_openmeter_plan_id_missing"));
+});
+
+dbTest("auditBillingConsistency reports a missing owner customer", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  customers.findOpenMeterCustomerByKey = async () => null;
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(codes(findings).includes("owner_customer_missing"));
+});
+
+dbTest("auditBillingConsistency reports a failed owner customer lookup", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  customers.findOpenMeterCustomerByKey = async () => {
+    throw new Error("konnect customers list failed");
+  };
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  const lookup = findings.find((f) => f.code === "owner_customer_lookup_failed");
+  assert.equal(lookup?.message, "konnect customers list failed");
+});
+
+dbTest("auditBillingConsistency flags a chargeable owner without Stripe app data", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  stripeCustomerData.getStripeCustomerAppDataId = async () => null;
+  paymentMethod.ownerHasChargeablePaymentMethod = async () => true;
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(codes(findings).includes("owner_missing_stripe_app_data"));
+});
+
+dbTest("auditBillingConsistency ignores missing Stripe app data without a card", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  stripeCustomerData.getStripeCustomerAppDataId = async () => null;
+  paymentMethod.ownerHasChargeablePaymentMethod = async () => null;
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(!codes(findings).includes("owner_missing_stripe_app_data"));
+});
+
+dbTest("auditBillingConsistency warns about a sandbox profile with a card", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  process.env.OPENMETER_ROUTE_MODE = "hosted";
+  process.env.OPENMETER_FREE_BILLING_PROFILE_ID = "bp_sandbox";
+  stripeCustomerData.getKonnectCustomerBillingProfileId = async () => "bp_sandbox";
+  paymentMethod.ownerHasChargeablePaymentMethod = async () => true;
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(codes(findings).includes("owner_sandbox_billing_profile"));
+});
+
+dbTest("auditBillingConsistency ignores a non-sandbox billing profile", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  process.env.OPENMETER_ROUTE_MODE = "hosted";
+  process.env.OPENMETER_FREE_BILLING_PROFILE_ID = "bp_sandbox";
+  stripeCustomerData.getKonnectCustomerBillingProfileId = async () => "bp_stripe";
+  paymentMethod.ownerHasChargeablePaymentMethod = async () => true;
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(!codes(findings).includes("owner_sandbox_billing_profile"));
+});
+
+dbTest("auditBillingConsistency reports no active owner subscription", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_cancelled", status: "canceled" },
+  ];
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(codes(findings).includes("owner_no_active_subscription"));
+});
+
+dbTest("auditBillingConsistency warns on duplicate active owner subscriptions", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  remotePlans.set("plan_owner_starter", {
+    id: "plan_owner_starter",
+    key: "pymthouse_owner_starter",
+    usageDiscountUsdMicros: STARTER_MICROS,
+  });
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_a", status: "active", planId: "plan_owner_starter", planKey: null },
+    { id: "sub_b", status: "trialing", planId: "plan_owner_starter", planKey: null },
+  ];
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  const duplicate = findings.find(
+    (f) => f.code === "owner_multiple_active_subscriptions",
+  );
+  assert.deepEqual(duplicate?.details?.subscriptionIds, ["sub_a", "sub_b"]);
+});
+
+dbTest("auditBillingConsistency names subjects carrying unattributed usage", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  customers.listOwnedPublicClientIds = async () => [app.clientId];
+  usageBySubject.set(`owner:${app.userId}`, 250_000n);
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  const leak = findings.find((f) => f.code === "usage_on_unattributed_subject");
+  assert.deepEqual(leak?.details?.unattributed, [`owner:${app.userId}`]);
+});
+
+dbTest("auditBillingConsistency treats an unreadable meter as no usage", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  meterQueryFails = true;
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(!codes(findings).includes("usage_on_unattributed_subject"));
+});
+
+dbTest("auditBillingConsistency flags a blocking spendable gate", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  usageBySubject.set(app.userId, 138_382n);
+  customers.findOpenMeterCustomerByKey = async (_client: unknown, key: string) => ({
+    id: `cust_${key}`,
+    usageAttribution: { subjectKeys: [key, `owner:${key}`] },
+  });
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  const gate = findings.find(
+    (f) => f.code === "spendable_gate_blocks_with_unused_allowance",
+  );
+  assert.equal(gate?.details?.usedUsdMicros, "138382");
+});
+
+dbTest("auditBillingConsistency reads credit balances into the gate check", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  entitlements.getTrialCreditBalance = async () => ({
+    balanceUsdMicros: "2000000",
+  });
+  spendable.getRemainingPlanDiscountUsdMicros = async () => 3_000_000n;
+  spendable.getSpendableUsdMicros = async () => "5000000";
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(!codes(findings).includes("spendable_sum_mismatch"));
+  assert.ok(!codes(findings).includes("spendable_gate_blocks_with_unused_allowance"));
+});
+
+dbTest("auditBillingConsistency reports phase-out plans past their deadline", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  const phaseOutId = `plan-phaseout-${randomUUID()}`;
+  await db.insert(plans).values({
+    id: phaseOutId,
+    clientId: app.clientId,
+    name: "Legacy Pro",
+    status: "phase_out",
+    phaseOutAt: "2020-01-01T00:00:00.000Z",
+    openmeterPlanId: "plan_legacy_pro",
+  });
+  konnectSubscriptions.countActiveKonnectSubscriptionsForPlan = async () => 4;
+
+  const findings = await sut.auditBillingConsistency({ clientId: app.clientId });
+  const phaseOut = findings.find(
+    (f) => f.code === "phase_out_subscribers_past_deadline",
+  );
+  assert.equal(phaseOut?.details?.activeSubscriberCount, 4);
+});
+
+dbTest("auditBillingConsistency warns when the subscriber count is unreadable", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  await db.insert(plans).values({
+    id: `plan-phaseout-${randomUUID()}`,
+    clientId: app.clientId,
+    name: "Legacy Pro",
+    status: "phase_out",
+    phaseOutAt: "2020-01-01T00:00:00.000Z",
+    openmeterPlanId: "plan_legacy_pro",
+  });
+  konnectSubscriptions.countActiveKonnectSubscriptionsForPlan = async () => {
+    throw new Error("konnect subscriptions list failed");
+  };
+
+  const findings = await sut.auditBillingConsistency({ clientId: app.clientId });
+  const failed = findings.find(
+    (f) => f.code === "phase_out_subscriber_check_failed",
+  );
+  assert.equal(failed?.details?.error, "konnect subscriptions list failed");
+});
+
+dbTest("auditBillingConsistency ignores phase-out plans before the deadline", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  await db.insert(plans).values({
+    id: `plan-phaseout-${randomUUID()}`,
+    clientId: app.clientId,
+    name: "Future Pro",
+    status: "phase_out",
+    phaseOutAt: "2099-01-01T00:00:00.000Z",
+    openmeterPlanId: "plan_future_pro",
+  });
+  await db.insert(plans).values({
+    id: `plan-phaseout-${randomUUID()}`,
+    clientId: app.clientId,
+    name: "Unsynced Pro",
+    status: "phase_out",
+    phaseOutAt: "2020-01-01T00:00:00.000Z",
+  });
+
+  const findings = await sut.auditBillingConsistency({ clientId: app.clientId });
+  assert.ok(!codes(findings).includes("phase_out_subscribers_past_deadline"));
+  assert.ok(!codes(findings).includes("phase_out_subscriber_check_failed"));
+});
+
+dbTest("auditBillingConsistency warns when the Owner Paid plan is unpublished", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  allowancePlan.findOpenMeterPlanByKey = async () => {
+    throw new Error("konnect plans list failed");
+  };
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(codes(findings).includes("owner_paid_plan_missing"));
+});
+
+dbTest("auditBillingConsistency flags Owner Paid allowance drift", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+  platformDefault.resolvePlatformOwnerStarterIncludedUsdMicros = async () =>
+    "9000000";
+  allowancePlan.findOpenMeterPlanByKey = async () => ({ id: "plan_owner_paid" });
+  remotePlans.set("plan_owner_paid", {
+    id: "plan_owner_paid",
+    key: "pymthouse_owner_paid",
+    usageDiscountUsdMicros: STARTER_MICROS,
+  });
+
+  const findings = await sut.auditBillingConsistency({
+    ownerId: app.userId,
+    clientId: app.clientId,
+  });
+  assert.ok(codes(findings).includes("owner_paid_plan_allowance_drift"));
+});
+
+dbTest("auditBillingConsistency scans a bounded set of owners with no filter", async (t) => {
+  const { app } = await seedOwnerWithStarter();
+  t.after(() => cleanupTestApp(app));
+
+  const findings = await sut.auditBillingConsistency({ limit: 1 });
+  assert.ok(Array.isArray(findings));
+});

--- a/src/lib/openmeter/billing-consistency.audit.test.ts
+++ b/src/lib/openmeter/billing-consistency.audit.test.ts
@@ -276,7 +276,7 @@ dbTest("auditBillingConsistency is quiet for a healthy owner wallet", async (t) 
 });
 
 dbTest("auditBillingConsistency flags a Starter plan missing from Konnect", async (t) => {
-  const { app, starter } = await seedOwnerWithStarter();
+  const { app } = await seedOwnerWithStarter();
   t.after(() => cleanupTestApp(app));
   planGetFails = true;
   subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
@@ -286,7 +286,6 @@ dbTest("auditBillingConsistency flags a Starter plan missing from Konnect", asyn
   const findings = await auditOwnerApp(app);
   assert.ok(codes(findings).includes("starter_openmeter_plan_missing"));
   assert.ok(codes(findings).includes("owner_subscription_missing_plan_id"));
-  assert.ok(starter.openmeterPlanId);
 });
 
 dbTest("auditBillingConsistency flags an unsynced Starter row", async (t) => {
@@ -533,5 +532,10 @@ dbTest("auditBillingConsistency scans a bounded set of owners with no filter", a
   t.after(() => cleanupTestApp(app));
 
   const findings = await sut.auditBillingConsistency({ limit: 1 });
-  assert.ok(Array.isArray(findings));
+  // The owner picked by the limit is whichever row Postgres returns first, so
+  // assert on the shape rather than on this app's findings.
+  for (const finding of findings) {
+    assert.ok(["error", "warn", "info"].includes(finding.severity));
+    assert.ok(finding.message.length > 0);
+  }
 });

--- a/src/lib/openmeter/billing-profiles.test.ts
+++ b/src/lib/openmeter/billing-profiles.test.ts
@@ -3,10 +3,15 @@ import test from "node:test";
 import type { OpenMeter } from "@openmeter/sdk";
 import {
   ensureOwnersBillingProfile,
+  getAppBillingConfig,
   isAppBillingReady,
   resetOwnersBillingProfileCacheForTests,
+  updateAppBillingProfileSettings,
+  upsertAppBillingConfig,
 } from "./billing-profiles";
 import { __testSetHostedOpenMeterClient, resetHostedOpenMeterClientForTests } from "./client";
+import { test as dbTest } from "@/test-utils/db-guard";
+import { cleanupTestApp, seedDeveloperAppWithClient } from "@/test-utils/fixtures";
 
 test("isAppBillingReady requires Stripe app id and billing profile id", () => {
   assert.equal(isAppBillingReady(null), false);
@@ -118,4 +123,113 @@ test("ensureOwnersBillingProfile creates Stripe profile when missing", async (t)
   });
   const cachedAgain = await ensureOwnersBillingProfile(client);
   assert.equal(cachedAgain, "prof_new_owners");
+});
+
+dbTest("updateAppBillingProfileSettings creates the config row with platform defaults", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+
+  const result = await updateAppBillingProfileSettings({ clientId: app.clientId });
+  assert.equal(result.invoiceThresholdUsdMicros, null);
+  assert.equal(typeof result.applicationFeeBps, "number");
+
+  const stored = await getAppBillingConfig(app.clientId);
+  assert.equal(stored?.progressiveBilling, result.progressiveBilling);
+});
+
+dbTest("updateAppBillingProfileSettings clears an invoice threshold when passed null", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  await upsertAppBillingConfig(app.clientId, {
+    invoiceThresholdUsdMicros: "2500000",
+  });
+
+  const kept = await updateAppBillingProfileSettings({ clientId: app.clientId });
+  assert.equal(kept.invoiceThresholdUsdMicros, "2500000");
+
+  const cleared = await updateAppBillingProfileSettings({
+    clientId: app.clientId,
+    invoiceThresholdUsdMicros: null,
+    applicationFeeBps: 250,
+  });
+  assert.equal(cleared.invoiceThresholdUsdMicros, null);
+  assert.equal(cleared.applicationFeeBps, 250);
+});
+
+dbTest("updateAppBillingProfileSettings pushes progressive billing to the OpenMeter profile", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  const previousRouteMode = process.env.OPENMETER_ROUTE_MODE;
+  process.env.OPENMETER_ROUTE_MODE = "self_hosted";
+  t.after(async () => {
+    if (previousRouteMode === undefined) delete process.env.OPENMETER_ROUTE_MODE;
+    else process.env.OPENMETER_ROUTE_MODE = previousRouteMode;
+    resetHostedOpenMeterClientForTests();
+    await cleanupTestApp(app);
+  });
+  await upsertAppBillingConfig(app.clientId, {
+    openmeterStripeAppId: "stripe_app",
+    openmeterBillingProfileId: "prof_tenant",
+    progressiveBilling: false,
+  });
+
+  const updates: Array<{ profileId: string; body: unknown }> = [];
+  __testSetHostedOpenMeterClient({
+    billing: {
+      profiles: {
+        get: async (profileId: string) => ({
+          id: profileId,
+          name: "tenant",
+          default: false,
+          supplier: { name: "PymtHouse" },
+          workflow: { collection: { alignment: "subscription" }, invoicing: { autoAdvance: true } },
+        }),
+        update: async (profileId: string, body: unknown) => {
+          updates.push({ profileId, body });
+          return { id: profileId };
+        },
+      },
+    },
+  } as unknown as OpenMeter);
+
+  const result = await updateAppBillingProfileSettings({
+    clientId: app.clientId,
+    progressiveBilling: true,
+  });
+  assert.equal(result.progressiveBilling, true);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0]?.profileId, "prof_tenant");
+  assert.deepEqual((updates[0]?.body as { workflow: unknown }).workflow, {
+    collection: { alignment: "subscription" },
+    invoicing: { autoAdvance: true, progressiveBilling: true },
+  });
+});
+
+dbTest("updateAppBillingProfileSettings rejects a missing OpenMeter profile", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  const previousRouteMode = process.env.OPENMETER_ROUTE_MODE;
+  process.env.OPENMETER_ROUTE_MODE = "self_hosted";
+  t.after(async () => {
+    if (previousRouteMode === undefined) delete process.env.OPENMETER_ROUTE_MODE;
+    else process.env.OPENMETER_ROUTE_MODE = previousRouteMode;
+    resetHostedOpenMeterClientForTests();
+    await cleanupTestApp(app);
+  });
+  await upsertAppBillingConfig(app.clientId, {
+    openmeterStripeAppId: "stripe_app",
+    openmeterBillingProfileId: "prof_missing",
+    progressiveBilling: false,
+  });
+
+  __testSetHostedOpenMeterClient({
+    billing: { profiles: { get: async () => null } },
+  } as unknown as OpenMeter);
+
+  await assert.rejects(
+    () =>
+      updateAppBillingProfileSettings({
+        clientId: app.clientId,
+        progressiveBilling: true,
+      }),
+    /OpenMeter billing profile not found/,
+  );
 });

--- a/src/lib/openmeter/owner-starter-plan.test.ts
+++ b/src/lib/openmeter/owner-starter-plan.test.ts
@@ -166,6 +166,42 @@ const conflictError = () => new Error("conflict error: subscription already exis
 const planNotFoundError = () => new Error("plan not found");
 const stripeBillingError = () => new Error("invalid billing setup");
 
+/** The common case: the Owner Starter plan for the resolved amount is published. */
+function withPublishedPlan(planId = PLAN_ID): void {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: planId,
+    status: "active",
+  });
+}
+
+/** Owner is on the base Starter plan but their allowance now maps elsewhere. */
+function withOffAmountStarter(): void {
+  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
+  withPublishedPlan("plan_amount_keyed");
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
+  ];
+}
+
+/** Konnect refuses the in-place subscription change. */
+function withFailingChange(): void {
+  konnectSubscriptions.changeKonnectSubscription = async () => {
+    throw new Error("change rejected");
+  };
+}
+
+/** Drive `subscriptions.create` through one outcome per attempt (last repeats). */
+function createSequence(
+  ...steps: Array<() => Promise<{ id?: string } | null>>
+): void {
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    const step = steps[Math.min(attempt, steps.length - 1)]!;
+    attempt += 1;
+    return step();
+  };
+}
+
 test("ensureOwnerStarterPlanSynced rejects when OpenMeter is unavailable", async () => {
   adminClient.isHostedAdminClientAvailable = () => false;
   await assert.rejects(
@@ -192,10 +228,7 @@ test("ensureOwnerStarterPlanSynced rejects when the trial feature is missing", a
 
 test("ensureOwnerStarterPlanSynced reuses a published plan without publishing", async () => {
   let published = 0;
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   allowancePlan.publishOpenMeterPlanBestEffort = async (
     _client: unknown,
     planId: string,
@@ -253,10 +286,7 @@ test("ensureOwnerStarterPlanSynced creates and publishes an amount-keyed plan", 
 test("ensureOwnerStarterPlanSynced falls back to the platform default amount", async () => {
   platformDefault.resolvePlatformOwnerStarterIncludedUsdMicros = async () =>
     "7000000";
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
 
   const ref = await sut.ensureOwnerStarterPlanSynced();
   assert.equal(ref.key, STARTER_KEY);
@@ -311,10 +341,7 @@ test("ensureOwnerStarterSubscription returns empty when OpenMeter is unavailable
 });
 
 test("ensureOwnerStarterSubscription keeps a matching Starter on the free profile", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => ({
     id: "sub_starter",
     planKey: STARTER_KEY,
@@ -333,10 +360,7 @@ test("ensureOwnerStarterSubscription keeps a matching Starter on the free profil
 });
 
 test("ensureOwnerStarterSubscription trusts a verified hint subscription", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   subscriptionRead.verifyOpenMeterSubscriptionId = async () => ({
     id: "sub_hint",
     customerId: CUSTOMER_ID,
@@ -361,10 +385,7 @@ test("ensureOwnerStarterSubscription trusts a verified hint subscription", async
 });
 
 test("ensureOwnerStarterSubscription ignores a hint owned by another customer", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   subscriptionRead.verifyOpenMeterSubscriptionId = async () => ({
     id: "sub_other",
     customerId: "cust_someone_else",
@@ -385,10 +406,7 @@ test("ensureOwnerStarterSubscription ignores a hint owned by another customer", 
 });
 
 test("ensureOwnerStarterSubscription leaves an unknown wallet subscription alone", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
     { id: "sub_expired", status: "expired", planKey: STARTER_KEY, planId: PLAN_ID },
     { id: "sub_unknown", status: "pending", planKey: "some_app_plan", planId: "p9" },
@@ -404,14 +422,7 @@ test("ensureOwnerStarterSubscription leaves an unknown wallet subscription alone
 });
 
 test("ensureOwnerStarterSubscription changes an off-amount Starter in place", async () => {
-  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: "plan_amount_keyed",
-    status: "active",
-  });
-  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
-    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
-  ];
+  withOffAmountStarter();
 
   const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
   assert.deepEqual(result, {
@@ -427,17 +438,8 @@ test("ensureOwnerStarterSubscription changes an off-amount Starter in place", as
 });
 
 test("ensureOwnerStarterSubscription recreates then cancels when the change fails", async () => {
-  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: "plan_amount_keyed",
-    status: "active",
-  });
-  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
-    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
-  ];
-  konnectSubscriptions.changeKonnectSubscription = async () => {
-    throw new Error("change rejected");
-  };
+  withOffAmountStarter();
+  withFailingChange();
   subscriptionsCreate = async () => ({ id: "sub_recreated" });
 
   const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
@@ -451,17 +453,8 @@ test("ensureOwnerStarterSubscription recreates then cancels when the change fail
 });
 
 test("ensureOwnerStarterSubscription keeps the recreated subscription when cancel fails", async () => {
-  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: "plan_amount_keyed",
-    status: "active",
-  });
-  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
-    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
-  ];
-  konnectSubscriptions.changeKonnectSubscription = async () => {
-    throw new Error("change rejected");
-  };
+  withOffAmountStarter();
+  withFailingChange();
   subscriptionsCancel = async () => {
     throw new Error("cancel rejected");
   };
@@ -472,17 +465,8 @@ test("ensureOwnerStarterSubscription keeps the recreated subscription when cance
 });
 
 test("ensureOwnerStarterSubscription surfaces the change error when recreate fails", async () => {
-  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: "plan_amount_keyed",
-    status: "active",
-  });
-  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
-    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
-  ];
-  konnectSubscriptions.changeKonnectSubscription = async () => {
-    throw new Error("change rejected");
-  };
+  withOffAmountStarter();
+  withFailingChange();
   subscriptionsCreate = async () => {
     throw new Error("recreate rejected");
   };
@@ -495,10 +479,7 @@ test("ensureOwnerStarterSubscription surfaces the change error when recreate fai
 });
 
 test("ensureOwnerStarterSubscription tolerates a failing subscription list", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => {
     throw new Error("list unavailable");
   };
@@ -514,10 +495,7 @@ test("ensureOwnerStarterSubscription tolerates a failing subscription list", asy
 });
 
 test("ensureOwnerStarterSubscription skips creation when createIfMissing is false", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
 
   const result = await sut.ensureOwnerStarterSubscription({
     ownerUserId: OWNER_ID,
@@ -533,10 +511,7 @@ test("ensureOwnerStarterSubscription skips creation when createIfMissing is fals
 });
 
 test("ensureOwnerStarterSubscription rejects when create returns no id", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   subscriptionsCreate = async () => null;
 
   await assert.rejects(
@@ -554,14 +529,12 @@ test("ensureOwnerStarterSubscription resyncs the plan on a plan-not-found create
     lookups.push(planKey);
     return { id: PLAN_ID, status: "active" };
   };
-  let attempt = 0;
-  subscriptionsCreate = async () => {
-    attempt += 1;
-    if (attempt === 1) {
+  createSequence(
+    async () => {
       throw planNotFoundError();
-    }
-    return { id: "sub_after_resync" };
-  };
+    },
+    async () => ({ id: "sub_after_resync" }),
+  );
 
   const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
   assert.deepEqual(result, {
@@ -574,10 +547,7 @@ test("ensureOwnerStarterSubscription resyncs the plan on a plan-not-found create
 });
 
 test("ensureOwnerStarterSubscription adopts the winner of a create race", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   let queried = 0;
   subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => {
     queried += 1;
@@ -597,10 +567,7 @@ test("ensureOwnerStarterSubscription adopts the winner of a create race", async 
 });
 
 test("ensureOwnerStarterSubscription rethrows a conflict with no winning subscription", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   subscriptionsCreate = async () => {
     throw conflictError();
   };
@@ -612,18 +579,13 @@ test("ensureOwnerStarterSubscription rethrows a conflict with no winning subscri
 });
 
 test("ensureOwnerStarterSubscription retries a Stripe billing error on the free profile", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
-  let attempt = 0;
-  subscriptionsCreate = async () => {
-    attempt += 1;
-    if (attempt === 1) {
+  withPublishedPlan();
+  createSequence(
+    async () => {
       throw stripeBillingError();
-    }
-    return { id: "sub_after_profile" };
-  };
+    },
+    async () => ({ id: "sub_after_profile" }),
+  );
 
   const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
   assert.equal(result.openmeterSubscriptionId, "sub_after_profile");
@@ -632,18 +594,13 @@ test("ensureOwnerStarterSubscription retries a Stripe billing error on the free 
 });
 
 test("ensureOwnerStarterSubscription rejects when the billing retry returns no id", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
-  let attempt = 0;
-  subscriptionsCreate = async () => {
-    attempt += 1;
-    if (attempt === 1) {
+  withPublishedPlan();
+  createSequence(
+    async () => {
       throw stripeBillingError();
-    }
-    return {};
-  };
+    },
+    async () => ({}),
+  );
 
   await assert.rejects(
     () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
@@ -652,10 +609,7 @@ test("ensureOwnerStarterSubscription rejects when the billing retry returns no i
 });
 
 test("ensureOwnerStarterSubscription rethrows an unrecognized create error", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   subscriptionsCreate = async () => {
     throw new Error("openmeter exploded");
   };
@@ -667,18 +621,13 @@ test("ensureOwnerStarterSubscription rethrows an unrecognized create error", asy
 });
 
 test("plan-sync recovery rejects when the resynced create returns no id", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
-  let attempt = 0;
-  subscriptionsCreate = async () => {
-    attempt += 1;
-    if (attempt === 1) {
+  withPublishedPlan();
+  createSequence(
+    async () => {
       throw planNotFoundError();
-    }
-    return {};
-  };
+    },
+    async () => ({}),
+  );
 
   await assert.rejects(
     () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
@@ -687,17 +636,16 @@ test("plan-sync recovery rejects when the resynced create returns no id", async 
 });
 
 test("plan-sync recovery applies the free profile on a Stripe billing error", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
-  let attempt = 0;
-  subscriptionsCreate = async () => {
-    attempt += 1;
-    if (attempt === 1) throw planNotFoundError();
-    if (attempt === 2) throw stripeBillingError();
-    return { id: "sub_recovered" };
-  };
+  withPublishedPlan();
+  createSequence(
+    async () => {
+      throw planNotFoundError();
+    },
+    async () => {
+      throw stripeBillingError();
+    },
+    async () => ({ id: "sub_recovered" }),
+  );
 
   const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
   assert.equal(result.openmeterSubscriptionId, "sub_recovered");
@@ -705,17 +653,16 @@ test("plan-sync recovery applies the free profile on a Stripe billing error", as
 });
 
 test("plan-sync recovery rejects when the profile retry returns no id", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
-  let attempt = 0;
-  subscriptionsCreate = async () => {
-    attempt += 1;
-    if (attempt === 1) throw planNotFoundError();
-    if (attempt === 2) throw stripeBillingError();
-    return null;
-  };
+  withPublishedPlan();
+  createSequence(
+    async () => {
+      throw planNotFoundError();
+    },
+    async () => {
+      throw stripeBillingError();
+    },
+    async () => null,
+  );
 
   await assert.rejects(
     () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
@@ -724,16 +671,15 @@ test("plan-sync recovery rejects when the profile retry returns no id", async ()
 });
 
 test("plan-sync recovery rethrows a non-billing create error", async () => {
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
-  let attempt = 0;
-  subscriptionsCreate = async () => {
-    attempt += 1;
-    if (attempt === 1) throw planNotFoundError();
-    throw new Error("second create exploded");
-  };
+  withPublishedPlan();
+  createSequence(
+    async () => {
+      throw planNotFoundError();
+    },
+    async () => {
+      throw new Error("second create exploded");
+    },
+  );
 
   await assert.rejects(
     () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
@@ -743,10 +689,7 @@ test("plan-sync recovery rethrows a non-billing create error", async () => {
 
 test("ensureOwnerStarterSubscription forwards owned client ids to the customer ensure", async () => {
   const seen: Array<string[]> = [];
-  allowancePlan.findOpenMeterPlanByKey = async () => ({
-    id: PLAN_ID,
-    status: "active",
-  });
+  withPublishedPlan();
   customers.ensureOwnerCustomer = async (
     _client: unknown,
     _ownerUserId: string,

--- a/src/lib/openmeter/owner-starter-plan.test.ts
+++ b/src/lib/openmeter/owner-starter-plan.test.ts
@@ -94,11 +94,14 @@ const konnectSubscriptions = stubs.module(
 );
 
 const allowancePlan = stubs.module("@/lib/openmeter/owner-allowance-plan", {
-  findOpenMeterPlanByKey: async (): Promise<{
-    id: string;
-    status?: string;
-  } | null> => null,
-  createOwnerAllowancePlan: async (): Promise<string> => PLAN_ID,
+  findOpenMeterPlanByKey: async (
+    _client: unknown,
+    _planKey: string,
+  ): Promise<{ id: string; status?: string } | null> => null,
+  createOwnerAllowancePlan: async (_input: {
+    planKey: string;
+    includedUsdMicros: string;
+  }): Promise<string> => PLAN_ID,
   publishOpenMeterPlanBestEffort: async (
     _client: unknown,
     planId: string,
@@ -107,6 +110,7 @@ const allowancePlan = stubs.module("@/lib/openmeter/owner-allowance-plan", {
     status === "draft",
   forceSyncOwnerAllowancePlan: async (input: {
     planKey: string;
+    planName: string;
     includedUsdMicros: string;
   }): Promise<{
     key: string;
@@ -120,7 +124,11 @@ const allowancePlan = stubs.module("@/lib/openmeter/owner-allowance-plan", {
 });
 
 const customers = stubs.module("@/lib/openmeter/customers", {
-  ensureOwnerCustomer: async (): Promise<{ id: string }> => ({ id: CUSTOMER_ID }),
+  ensureOwnerCustomer: async (
+    _client: unknown,
+    _ownerUserId: string,
+    _publicClientIds: string[],
+  ): Promise<{ id: string }> => ({ id: CUSTOMER_ID }),
 });
 
 const subscriptionRead = stubs.module("@/lib/openmeter/subscription-read", {

--- a/src/lib/openmeter/owner-starter-plan.test.ts
+++ b/src/lib/openmeter/owner-starter-plan.test.ts
@@ -1,41 +1,756 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { before, beforeEach } from "node:test";
 
-import {
-  ensureOwnerStarterPlanSynced,
-  ensureOwnerStarterSubscription,
-  forceSyncOwnerStarterPlan,
-  invalidateOwnerStarterPlanCache,
-  resetOwnerStarterPlanCacheForTests,
-} from "@/lib/openmeter/owner-starter-plan";
-import { OWNER_STARTER_PLAN_KEY } from "@/lib/openmeter/owner-starter-key";
-import { test as dbTest } from "@/test-utils/db-guard";
+import { createStubRegistry } from "@/test-utils/module-stubs";
 
-test("ensureOwnerStarterSubscription returns empty when OpenMeter is unavailable", async () => {
-  // NODE_ENV=test without OPENMETER_TEST_LIVE → admin client unavailable.
-  resetOwnerStarterPlanCacheForTests();
-  invalidateOwnerStarterPlanCache();
-  const result = await ensureOwnerStarterSubscription({
-    ownerUserId: "user_test_owner",
-  });
-  assert.equal(result.openmeterSubscriptionId, null);
-  assert.equal(result.planKey, OWNER_STARTER_PLAN_KEY);
-  assert.equal(result.openmeterPlanId, "");
-  assert.equal(result.created, false);
+type FakeSubscription = {
+  id: string;
+  status?: string;
+  planKey?: string | null;
+  planId?: string | null;
+  customerId?: string | null;
+};
+
+const OWNER_ID = "user_owner_1";
+const CUSTOMER_ID = "cust_owner_1";
+const PLAN_ID = "01OWNERSTARTERPLAN0000000001";
+const STARTER_KEY = "pymthouse_owner_starter";
+const PAID_KEY = "pymthouse_owner_paid";
+
+const cancelled: string[] = [];
+const changed: Array<{ subscriptionId: string; planId: string }> = [];
+const freeProfileApplied: string[] = [];
+const created: Array<{ customerId: string; planKey: string | undefined }> = [];
+
+let subscriptionsCreate: () => Promise<{ id?: string } | null> = async () => ({
+  id: "sub_new",
+});
+let subscriptionsCancel: () => Promise<void> = async () => undefined;
+
+const fakeClient = {
+  subscriptions: {
+    create: async (body: { customerId: string; plan?: { key?: string } }) => {
+      created.push({ customerId: body.customerId, planKey: body.plan?.key });
+      return subscriptionsCreate();
+    },
+    cancel: async (id: string) => {
+      cancelled.push(id);
+      return subscriptionsCancel();
+    },
+  },
+};
+
+const stubs = createStubRegistry();
+
+const adminClient = stubs.module("@/lib/openmeter/admin-client", {
+  isHostedAdminClientAvailable: (): boolean => true,
+  getHostedAdminClient: (): unknown => fakeClient,
 });
 
-dbTest("ensureOwnerStarterPlanSynced rejects when OpenMeter is unavailable", async () => {
-  resetOwnerStarterPlanCacheForTests();
+const platformDefault = stubs.module(
+  "@/lib/billing/platform-owner-starter-default",
+  {
+    resolvePlatformOwnerStarterIncludedUsdMicros: async (): Promise<string> =>
+      "5000000",
+    resolvePlatformOwnerStarterPlanName: async (): Promise<string> =>
+      "Owner Sandbox Starter",
+    resolvePlatformOwnerStarterDefault: async (): Promise<{
+      ownerStarterIncludedUsdMicros: string;
+      ownerStarterPlanName: string;
+    }> => ({
+      ownerStarterIncludedUsdMicros: "5000000",
+      ownerStarterPlanName: "Owner Sandbox Starter",
+    }),
+  },
+);
+
+const ownerBillingConfig = stubs.module("@/lib/billing/owner-billing-config", {
+  resolveOwnerStarterIncludedUsdMicros: async (): Promise<string> => "5000000",
+});
+
+stubs.module("@/lib/openmeter/billing-profiles", {
+  applyFreeBillingProfileToCustomer: async (input: {
+    customerId: string;
+  }): Promise<void> => {
+    freeProfileApplied.push(input.customerId);
+  },
+});
+
+const catalog = stubs.module("@/lib/openmeter/konnect-catalog", {
+  ensureKonnectTenantCatalog: async (): Promise<void> => undefined,
+  findKonnectFeatureIdByKey: async (): Promise<string | null> => "feature_1",
+});
+
+const konnectSubscriptions = stubs.module(
+  "@/lib/openmeter/konnect-subscriptions",
+  {
+    changeKonnectSubscription: async (input: {
+      subscriptionId: string;
+      planId: string;
+    }): Promise<void> => {
+      changed.push({ subscriptionId: input.subscriptionId, planId: input.planId });
+    },
+  },
+);
+
+const allowancePlan = stubs.module("@/lib/openmeter/owner-allowance-plan", {
+  findOpenMeterPlanByKey: async (): Promise<{
+    id: string;
+    status?: string;
+  } | null> => null,
+  createOwnerAllowancePlan: async (): Promise<string> => PLAN_ID,
+  publishOpenMeterPlanBestEffort: async (
+    _client: unknown,
+    planId: string,
+  ): Promise<string> => planId,
+  openMeterPlanNeedsPublish: (status: string | undefined): boolean =>
+    status === "draft",
+  forceSyncOwnerAllowancePlan: async (input: {
+    planKey: string;
+    includedUsdMicros: string;
+  }): Promise<{
+    key: string;
+    openmeterPlanId: string;
+    includedUsdMicros: string;
+  }> => ({
+    key: input.planKey,
+    openmeterPlanId: PLAN_ID,
+    includedUsdMicros: input.includedUsdMicros,
+  }),
+});
+
+const customers = stubs.module("@/lib/openmeter/customers", {
+  ensureOwnerCustomer: async (): Promise<{ id: string }> => ({ id: CUSTOMER_ID }),
+});
+
+const subscriptionRead = stubs.module("@/lib/openmeter/subscription-read", {
+  verifyOpenMeterSubscriptionId: async (): Promise<FakeSubscription | null> => null,
+  findOpenMeterSubscriptionByPlanKey:
+    async (): Promise<FakeSubscription | null> => null,
+  listOpenMeterSubscriptionsForCustomer: async (): Promise<FakeSubscription[]> => [],
+});
+
+process.env.OPENMETER_ROUTE_MODE = "hosted";
+process.env.OPENMETER_API_KEY ??= "km_test_owner_starter";
+
+// The stubs above must be registered before the module graph loads, so the
+// subject is imported dynamically once the mocks are in place.
+let sut: typeof import("@/lib/openmeter/owner-starter-plan");
+
+before(async () => {
+  sut = await import("@/lib/openmeter/owner-starter-plan");
+});
+
+beforeEach(() => {
+  stubs.reset();
+  cancelled.length = 0;
+  changed.length = 0;
+  freeProfileApplied.length = 0;
+  created.length = 0;
+  subscriptionsCreate = async () => ({ id: "sub_new" });
+  subscriptionsCancel = async () => undefined;
+  process.env.OPENMETER_ROUTE_MODE = "hosted";
+  sut.resetOwnerStarterPlanCacheForTests();
+  sut.invalidateOwnerStarterPlanCache();
+});
+
+const conflictError = () => new Error("conflict error: subscription already exists");
+const planNotFoundError = () => new Error("plan not found");
+const stripeBillingError = () => new Error("invalid billing setup");
+
+test("ensureOwnerStarterPlanSynced rejects when OpenMeter is unavailable", async () => {
+  adminClient.isHostedAdminClientAvailable = () => false;
   await assert.rejects(
-    () => ensureOwnerStarterPlanSynced("5000000"),
+    () => sut.ensureOwnerStarterPlanSynced("5000000"),
     /OpenMeter is not configured/,
   );
+});
+
+test("ensureOwnerStarterPlanSynced rejects when Konnect routes are off", async () => {
+  process.env.OPENMETER_ROUTE_MODE = "self_hosted";
+  await assert.rejects(
+    () => sut.ensureOwnerStarterPlanSynced("5000000"),
+    /requires Konnect metering routes/,
+  );
+});
+
+test("ensureOwnerStarterPlanSynced rejects when the trial feature is missing", async () => {
+  catalog.findKonnectFeatureIdByKey = async () => null;
+  await assert.rejects(
+    () => sut.ensureOwnerStarterPlanSynced("5000000"),
+    /Konnect feature missing/,
+  );
+});
+
+test("ensureOwnerStarterPlanSynced reuses a published plan without publishing", async () => {
+  let published = 0;
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  allowancePlan.publishOpenMeterPlanBestEffort = async (
+    _client: unknown,
+    planId: string,
+  ) => {
+    published += 1;
+    return planId;
+  };
+
+  const ref = await sut.ensureOwnerStarterPlanSynced("5000000");
+  assert.deepEqual(ref, {
+    key: STARTER_KEY,
+    openmeterPlanId: PLAN_ID,
+    includedUsdMicros: "5000000",
+  });
+  assert.equal(published, 0);
+});
+
+test("ensureOwnerStarterPlanSynced publishes an existing draft plan", async () => {
+  const published: string[] = [];
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "draft",
+  });
+  allowancePlan.publishOpenMeterPlanBestEffort = async (
+    _client: unknown,
+    planId: string,
+  ) => {
+    published.push(planId);
+    return planId;
+  };
+
+  const ref = await sut.ensureOwnerStarterPlanSynced("5000000");
+  assert.equal(ref.openmeterPlanId, PLAN_ID);
+  assert.deepEqual(published, [PLAN_ID]);
+});
+
+test("ensureOwnerStarterPlanSynced creates and publishes an amount-keyed plan", async () => {
+  const createdPlans: Array<{ planKey: string; includedUsdMicros: string }> = [];
+  allowancePlan.createOwnerAllowancePlan = async (input: {
+    planKey: string;
+    includedUsdMicros: string;
+  }) => {
+    createdPlans.push(input);
+    return "plan_created";
+  };
+  allowancePlan.publishOpenMeterPlanBestEffort = async () => "plan_published";
+
+  const ref = await sut.ensureOwnerStarterPlanSynced("9000000");
+  assert.equal(ref.key, `${STARTER_KEY}_9000000`);
+  assert.equal(ref.openmeterPlanId, "plan_published");
+  assert.equal(ref.includedUsdMicros, "9000000");
+  assert.equal(createdPlans[0]?.planKey, `${STARTER_KEY}_9000000`);
+});
+
+test("ensureOwnerStarterPlanSynced falls back to the platform default amount", async () => {
+  platformDefault.resolvePlatformOwnerStarterIncludedUsdMicros = async () =>
+    "7000000";
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+
+  const ref = await sut.ensureOwnerStarterPlanSynced();
+  assert.equal(ref.key, STARTER_KEY);
+  assert.equal(ref.includedUsdMicros, "7000000");
 });
 
 test("forceSyncOwnerStarterPlan rejects when OpenMeter is unavailable", async () => {
-  resetOwnerStarterPlanCacheForTests();
+  allowancePlan.forceSyncOwnerAllowancePlan = async () => {
+    throw new Error("OpenMeter is not configured");
+  };
   await assert.rejects(
-    () => forceSyncOwnerStarterPlan("5000000"),
+    () => sut.forceSyncOwnerStarterPlan("5000000"),
     /OpenMeter is not configured/,
   );
+});
+
+test("forceSyncOwnerStarterPlan rewrites the base key and seeds the cache", async () => {
+  const syncs: Array<{ planKey: string; planName: string }> = [];
+  allowancePlan.forceSyncOwnerAllowancePlan = async (input: {
+    planKey: string;
+    planName: string;
+    includedUsdMicros: string;
+  }) => {
+    syncs.push({ planKey: input.planKey, planName: input.planName });
+    return {
+      key: input.planKey,
+      openmeterPlanId: PLAN_ID,
+      includedUsdMicros: input.includedUsdMicros,
+    };
+  };
+
+  const ref = await sut.forceSyncOwnerStarterPlan(" 5000000 ");
+  assert.deepEqual(ref, {
+    key: STARTER_KEY,
+    openmeterPlanId: PLAN_ID,
+    includedUsdMicros: "5000000",
+  });
+  assert.deepEqual(syncs, [
+    { planKey: STARTER_KEY, planName: "Owner Sandbox Starter" },
+  ]);
+});
+
+test("ensureOwnerStarterSubscription returns empty when OpenMeter is unavailable", async () => {
+  adminClient.isHostedAdminClientAvailable = () => false;
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: null,
+    planKey: STARTER_KEY,
+    openmeterPlanId: "",
+    created: false,
+  });
+});
+
+test("ensureOwnerStarterSubscription keeps a matching Starter on the free profile", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => ({
+    id: "sub_starter",
+    planKey: STARTER_KEY,
+    planId: PLAN_ID,
+  });
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_starter",
+    planKey: STARTER_KEY,
+    openmeterPlanId: PLAN_ID,
+    created: false,
+  });
+  assert.deepEqual(freeProfileApplied, [CUSTOMER_ID]);
+  assert.deepEqual(created, []);
+});
+
+test("ensureOwnerStarterSubscription trusts a verified hint subscription", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  subscriptionRead.verifyOpenMeterSubscriptionId = async () => ({
+    id: "sub_hint",
+    customerId: CUSTOMER_ID,
+    planKey: PAID_KEY,
+    planId: "plan_paid",
+  });
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => {
+    throw new Error("should not query by plan key when the hint verifies");
+  };
+
+  const result = await sut.ensureOwnerStarterSubscription({
+    ownerUserId: OWNER_ID,
+    hintOpenMeterSubscriptionId: "sub_hint",
+  });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_hint",
+    planKey: PAID_KEY,
+    openmeterPlanId: "plan_paid",
+    created: false,
+  });
+  assert.deepEqual(freeProfileApplied, []);
+});
+
+test("ensureOwnerStarterSubscription ignores a hint owned by another customer", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  subscriptionRead.verifyOpenMeterSubscriptionId = async () => ({
+    id: "sub_other",
+    customerId: "cust_someone_else",
+    planKey: STARTER_KEY,
+    planId: PLAN_ID,
+  });
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => ({
+    id: "sub_starter",
+    planKey: STARTER_KEY,
+    planId: PLAN_ID,
+  });
+
+  const result = await sut.ensureOwnerStarterSubscription({
+    ownerUserId: OWNER_ID,
+    hintOpenMeterSubscriptionId: "sub_other",
+  });
+  assert.equal(result.openmeterSubscriptionId, "sub_starter");
+});
+
+test("ensureOwnerStarterSubscription leaves an unknown wallet subscription alone", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_expired", status: "expired", planKey: STARTER_KEY, planId: PLAN_ID },
+    { id: "sub_unknown", status: "pending", planKey: "some_app_plan", planId: "p9" },
+  ];
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_unknown",
+    planKey: "some_app_plan",
+    openmeterPlanId: "p9",
+    created: false,
+  });
+});
+
+test("ensureOwnerStarterSubscription changes an off-amount Starter in place", async () => {
+  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: "plan_amount_keyed",
+    status: "active",
+  });
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
+  ];
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_base",
+    planKey: `${STARTER_KEY}_9000000`,
+    openmeterPlanId: "plan_amount_keyed",
+    created: false,
+  });
+  assert.deepEqual(changed, [
+    { subscriptionId: "sub_base", planId: "plan_amount_keyed" },
+  ]);
+  assert.deepEqual(freeProfileApplied, [CUSTOMER_ID]);
+});
+
+test("ensureOwnerStarterSubscription recreates then cancels when the change fails", async () => {
+  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: "plan_amount_keyed",
+    status: "active",
+  });
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
+  ];
+  konnectSubscriptions.changeKonnectSubscription = async () => {
+    throw new Error("change rejected");
+  };
+  subscriptionsCreate = async () => ({ id: "sub_recreated" });
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_recreated",
+    planKey: `${STARTER_KEY}_9000000`,
+    openmeterPlanId: "plan_amount_keyed",
+    created: true,
+  });
+  assert.deepEqual(cancelled, ["sub_base"]);
+});
+
+test("ensureOwnerStarterSubscription keeps the recreated subscription when cancel fails", async () => {
+  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: "plan_amount_keyed",
+    status: "active",
+  });
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
+  ];
+  konnectSubscriptions.changeKonnectSubscription = async () => {
+    throw new Error("change rejected");
+  };
+  subscriptionsCancel = async () => {
+    throw new Error("cancel rejected");
+  };
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.equal(result.openmeterSubscriptionId, "sub_new");
+  assert.equal(result.created, true);
+});
+
+test("ensureOwnerStarterSubscription surfaces the change error when recreate fails", async () => {
+  ownerBillingConfig.resolveOwnerStarterIncludedUsdMicros = async () => "9000000";
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: "plan_amount_keyed",
+    status: "active",
+  });
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => [
+    { id: "sub_base", status: "active", planKey: STARTER_KEY, planId: PLAN_ID },
+  ];
+  konnectSubscriptions.changeKonnectSubscription = async () => {
+    throw new Error("change rejected");
+  };
+  subscriptionsCreate = async () => {
+    throw new Error("recreate rejected");
+  };
+
+  await assert.rejects(
+    () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
+    /change rejected/,
+  );
+  assert.deepEqual(cancelled, []);
+});
+
+test("ensureOwnerStarterSubscription tolerates a failing subscription list", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  subscriptionRead.listOpenMeterSubscriptionsForCustomer = async () => {
+    throw new Error("list unavailable");
+  };
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_new",
+    planKey: STARTER_KEY,
+    openmeterPlanId: PLAN_ID,
+    created: true,
+  });
+  assert.deepEqual(freeProfileApplied, [CUSTOMER_ID]);
+});
+
+test("ensureOwnerStarterSubscription skips creation when createIfMissing is false", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+
+  const result = await sut.ensureOwnerStarterSubscription({
+    ownerUserId: OWNER_ID,
+    createIfMissing: false,
+  });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: null,
+    planKey: STARTER_KEY,
+    openmeterPlanId: PLAN_ID,
+    created: false,
+  });
+  assert.deepEqual(created, []);
+});
+
+test("ensureOwnerStarterSubscription rejects when create returns no id", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  subscriptionsCreate = async () => null;
+
+  await assert.rejects(
+    () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
+    /Failed to create Owner Starter subscription/,
+  );
+});
+
+test("ensureOwnerStarterSubscription resyncs the plan on a plan-not-found create", async () => {
+  const lookups: string[] = [];
+  allowancePlan.findOpenMeterPlanByKey = async (
+    _client: unknown,
+    planKey: string,
+  ) => {
+    lookups.push(planKey);
+    return { id: PLAN_ID, status: "active" };
+  };
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) {
+      throw planNotFoundError();
+    }
+    return { id: "sub_after_resync" };
+  };
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_after_resync",
+    planKey: STARTER_KEY,
+    openmeterPlanId: PLAN_ID,
+    created: true,
+  });
+  assert.equal(lookups.length, 2);
+});
+
+test("ensureOwnerStarterSubscription adopts the winner of a create race", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  let queried = 0;
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => {
+    queried += 1;
+    return queried === 1 ? null : { id: "sub_raced", planKey: STARTER_KEY };
+  };
+  subscriptionsCreate = async () => {
+    throw conflictError();
+  };
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_raced",
+    planKey: STARTER_KEY,
+    openmeterPlanId: PLAN_ID,
+    created: false,
+  });
+});
+
+test("ensureOwnerStarterSubscription rethrows a conflict with no winning subscription", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  subscriptionsCreate = async () => {
+    throw conflictError();
+  };
+
+  await assert.rejects(
+    () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
+    /already exists/,
+  );
+});
+
+test("ensureOwnerStarterSubscription retries a Stripe billing error on the free profile", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) {
+      throw stripeBillingError();
+    }
+    return { id: "sub_after_profile" };
+  };
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.equal(result.openmeterSubscriptionId, "sub_after_profile");
+  assert.equal(result.created, true);
+  assert.deepEqual(freeProfileApplied, [CUSTOMER_ID, CUSTOMER_ID]);
+});
+
+test("ensureOwnerStarterSubscription rejects when the billing retry returns no id", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) {
+      throw stripeBillingError();
+    }
+    return {};
+  };
+
+  await assert.rejects(
+    () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
+    /after billing profile apply/,
+  );
+});
+
+test("ensureOwnerStarterSubscription rethrows an unrecognized create error", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  subscriptionsCreate = async () => {
+    throw new Error("openmeter exploded");
+  };
+
+  await assert.rejects(
+    () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
+    /openmeter exploded/,
+  );
+});
+
+test("plan-sync recovery rejects when the resynced create returns no id", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) {
+      throw planNotFoundError();
+    }
+    return {};
+  };
+
+  await assert.rejects(
+    () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
+    /after plan sync$/,
+  );
+});
+
+test("plan-sync recovery applies the free profile on a Stripe billing error", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) throw planNotFoundError();
+    if (attempt === 2) throw stripeBillingError();
+    return { id: "sub_recovered" };
+  };
+
+  const result = await sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID });
+  assert.equal(result.openmeterSubscriptionId, "sub_recovered");
+  assert.equal(freeProfileApplied.length, 2);
+});
+
+test("plan-sync recovery rejects when the profile retry returns no id", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) throw planNotFoundError();
+    if (attempt === 2) throw stripeBillingError();
+    return null;
+  };
+
+  await assert.rejects(
+    () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
+    /after plan sync and billing profile apply/,
+  );
+});
+
+test("plan-sync recovery rethrows a non-billing create error", async () => {
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) throw planNotFoundError();
+    throw new Error("second create exploded");
+  };
+
+  await assert.rejects(
+    () => sut.ensureOwnerStarterSubscription({ ownerUserId: OWNER_ID }),
+    /second create exploded/,
+  );
+});
+
+test("ensureOwnerStarterSubscription forwards owned client ids to the customer ensure", async () => {
+  const seen: Array<string[]> = [];
+  allowancePlan.findOpenMeterPlanByKey = async () => ({
+    id: PLAN_ID,
+    status: "active",
+  });
+  customers.ensureOwnerCustomer = async (
+    _client: unknown,
+    _ownerUserId: string,
+    publicClientIds: string[],
+  ) => {
+    seen.push(publicClientIds);
+    return { id: CUSTOMER_ID };
+  };
+
+  await sut.ensureOwnerStarterSubscription({
+    ownerUserId: OWNER_ID,
+    publicClientIds: ["app_one", "app_two"],
+  });
+  assert.deepEqual(seen, [["app_one", "app_two"]]);
 });

--- a/src/lib/openmeter/starter-subscription.test.ts
+++ b/src/lib/openmeter/starter-subscription.test.ts
@@ -109,7 +109,11 @@ const billingIdentity = stubs.module("@/lib/openmeter/billing-identity", {
 });
 
 const ownerStarterPlan = stubs.module("@/lib/openmeter/owner-starter-plan", {
-  ensureOwnerStarterSubscription: async (): Promise<{
+  ensureOwnerStarterSubscription: async (_input: {
+    ownerUserId: string;
+    publicClientIds: string[];
+    hintOpenMeterSubscriptionId?: string | null;
+  }): Promise<{
     openmeterSubscriptionId: string | null;
     planKey: string;
     openmeterPlanId: string;

--- a/src/lib/openmeter/starter-subscription.test.ts
+++ b/src/lib/openmeter/starter-subscription.test.ts
@@ -1,0 +1,606 @@
+import assert from "node:assert/strict";
+import { before, beforeEach } from "node:test";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import { plans } from "@/db/schema";
+import { buildOpenMeterPlanKey } from "@/lib/openmeter/plan-naming";
+import { test as dbTest } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  seedDeveloperAppWithClient,
+  type SeededDeveloperApp,
+} from "@/test-utils/fixtures";
+import { createStubRegistry } from "@/test-utils/module-stubs";
+
+type FakeSubscriptionView = {
+  id: string;
+  status?: string;
+  customerId?: string | null;
+  planKey?: string | null;
+  planId?: string | null;
+};
+
+const CUSTOMER_ID = "cust_app_user";
+
+const created: Array<{ customerId: string; plan: unknown }> = [];
+const freeProfileApplied: string[] = [];
+let subscriptionsCreate: () => Promise<
+  | {
+      id?: string;
+      status?: string;
+      customerId?: string;
+      activeFrom?: Date;
+      activeTo?: Date;
+    }
+  | null
+> = async () => ({
+  id: "sub_created",
+  status: "active",
+  customerId: CUSTOMER_ID,
+  activeFrom: new Date("2026-01-01T00:00:00.000Z"),
+});
+
+const fakeClient = {
+  subscriptions: {
+    create: async (body: { customerId: string; plan: unknown }) => {
+      created.push(body);
+      return subscriptionsCreate();
+    },
+  },
+};
+
+const stubs = createStubRegistry();
+
+const adminClient = stubs.module("@/lib/openmeter/admin-client", {
+  isHostedAdminClientAvailable: (): boolean => true,
+  getHostedAdminClient: (): unknown => fakeClient,
+});
+
+stubs.module("@/lib/openmeter/billing-profiles", {
+  applyFreeBillingProfileToCustomer: async (input: {
+    customerId: string;
+  }): Promise<void> => {
+    freeProfileApplied.push(input.customerId);
+  },
+});
+
+const customers = stubs.module("@/lib/openmeter/customers", {
+  ensureOpenMeterCustomer: async (): Promise<{ id: string }> => ({
+    id: CUSTOMER_ID,
+  }),
+  listOwnedPublicClientIds: async (): Promise<string[]> => [],
+});
+
+const plansSync = stubs.module("@/lib/openmeter/plans-sync", {
+  buildOpenMeterPlanKey,
+  verifyOpenMeterPlanId: async (
+    _client: unknown,
+    planId: string,
+  ): Promise<{ id: string } | null> => ({ id: planId }),
+  syncPlanToOpenMeter: async (): Promise<{ ok: boolean; error?: string }> => ({
+    ok: true,
+  }),
+});
+
+const subscriptionRead = stubs.module("@/lib/openmeter/subscription-read", {
+  verifyOpenMeterSubscriptionId:
+    async (): Promise<FakeSubscriptionView | null> => null,
+  findOpenMeterSubscriptionByPlanKey:
+    async (): Promise<FakeSubscriptionView | null> => null,
+});
+
+const billingIdentity = stubs.module("@/lib/openmeter/billing-identity", {
+  resolveOpenMeterBillingIdentity: async (input: {
+    clientId: string;
+    externalUserId: string;
+  }): Promise<{
+    customerKey: string;
+    isOwner: boolean;
+    ownerUserId?: string;
+    publicClientId: string;
+    developerAppId: string;
+  }> => ({
+    customerKey: `${input.clientId}:${input.externalUserId}`,
+    isOwner: false,
+    publicClientId: input.clientId,
+    developerAppId: input.clientId,
+  }),
+});
+
+const ownerStarterPlan = stubs.module("@/lib/openmeter/owner-starter-plan", {
+  ensureOwnerStarterSubscription: async (): Promise<{
+    openmeterSubscriptionId: string | null;
+    planKey: string;
+    openmeterPlanId: string;
+    created: boolean;
+  }> => ({
+    openmeterSubscriptionId: "sub_owner",
+    planKey: "pymthouse_owner_starter",
+    openmeterPlanId: "plan_owner_starter",
+    created: true,
+  }),
+});
+
+let sut: typeof import("@/lib/openmeter/starter-subscription");
+
+before(async () => {
+  sut = await import("@/lib/openmeter/starter-subscription");
+});
+
+beforeEach(() => {
+  stubs.reset();
+  created.length = 0;
+  freeProfileApplied.length = 0;
+  subscriptionsCreate = async () => ({
+    id: "sub_created",
+    status: "active",
+    customerId: CUSTOMER_ID,
+    activeFrom: new Date("2026-01-01T00:00:00.000Z"),
+  });
+  sut.resetStarterPlanSyncedCacheForTests();
+});
+
+const conflictError = () => new Error("conflict error: subscription already exists");
+const planNotFoundError = () => new Error("plan not found");
+const stripeBillingError = () =>
+  new Error("customers need a default payment method");
+
+async function seedApp(): Promise<{
+  app: SeededDeveloperApp;
+  starter: typeof plans.$inferSelect;
+}> {
+  const app = await seedDeveloperAppWithClient();
+  const rows = await db.select().from(plans).where(eq(plans.clientId, app.clientId));
+  const starter = rows.find((row) => row.isStarterDefault);
+  if (!starter) {
+    throw new Error("seeded app has no Starter plan row");
+  }
+  await db
+    .update(plans)
+    .set({ openmeterPlanId: `plan_${starter.id}` })
+    .where(eq(plans.id, starter.id));
+  return { app, starter: { ...starter, openmeterPlanId: `plan_${starter.id}` } };
+}
+
+dbTest("ensureStarterPlanSynced returns the local row when OpenMeter is off", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  adminClient.isHostedAdminClientAvailable = () => false;
+
+  const synced = await sut.ensureStarterPlanSynced(app.clientId);
+  assert.equal(synced.id, starter.id);
+});
+
+dbTest("ensureStarterPlanSynced keeps a verified OpenMeter plan id", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  let synced = 0;
+  plansSync.syncPlanToOpenMeter = async () => {
+    synced += 1;
+    return { ok: true };
+  };
+
+  const result = await sut.ensureStarterPlanSynced(app.clientId);
+  assert.equal(result.openmeterPlanId, starter.openmeterPlanId);
+  assert.equal(synced, 0);
+});
+
+dbTest("ensureStarterPlanSynced re-syncs an unverifiable plan id", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  plansSync.verifyOpenMeterPlanId = async () => null;
+  plansSync.syncPlanToOpenMeter = async () => {
+    await db
+      .update(plans)
+      .set({ openmeterPlanId: "plan_resynced" })
+      .where(eq(plans.id, starter.id));
+    return { ok: true };
+  };
+
+  const result = await sut.ensureStarterPlanSynced(app.clientId);
+  assert.equal(result.openmeterPlanId, "plan_resynced");
+});
+
+dbTest("ensureStarterPlanSynced surfaces a failed plan sync", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  plansSync.verifyOpenMeterPlanId = async () => null;
+  plansSync.syncPlanToOpenMeter = async () => ({
+    ok: false,
+    error: "konnect rejected the plan body",
+  });
+
+  await assert.rejects(
+    () => sut.ensureStarterPlanSynced(app.clientId),
+    /konnect rejected the plan body/,
+  );
+});
+
+dbTest("ensureStarterPlanSynced rejects when the plan row disappears", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  plansSync.verifyOpenMeterPlanId = async () => null;
+  plansSync.syncPlanToOpenMeter = async () => {
+    await db.delete(plans).where(eq(plans.id, starter.id));
+    return { ok: true };
+  };
+
+  await assert.rejects(
+    () => sut.ensureStarterPlanSynced(app.clientId),
+    /Starter plan row missing after OpenMeter sync/,
+  );
+});
+
+dbTest("ensureStarterSubscriptionForAppUser returns the local plan when OpenMeter is off", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  adminClient.isHostedAdminClientAvailable = () => false;
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+  });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: null,
+    planId: starter.id,
+    created: false,
+  });
+});
+
+dbTest("ensureStarterSubscriptionForAppUser delegates owners to the Owner Starter plan", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  billingIdentity.resolveOpenMeterBillingIdentity = async () => ({
+    customerKey: app.userId,
+    isOwner: true,
+    ownerUserId: app.userId,
+    publicClientId: app.clientId,
+    developerAppId: app.clientId,
+  });
+  customers.listOwnedPublicClientIds = async () => [app.clientId, "app_other"];
+  const seen: Array<string[]> = [];
+  ownerStarterPlan.ensureOwnerStarterSubscription = async (input: {
+    publicClientIds: string[];
+  }) => {
+    seen.push(input.publicClientIds);
+    return {
+      openmeterSubscriptionId: "sub_owner",
+      planKey: "pymthouse_owner_starter",
+      openmeterPlanId: "plan_owner_starter",
+      created: false,
+    };
+  };
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: `owner:${app.userId}`,
+  });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_owner",
+    planId: starter.id,
+    created: false,
+  });
+  assert.deepEqual(seen, [[app.clientId, "app_other"]]);
+});
+
+dbTest("ensureStarterSubscriptionForAppUser rejects an unsynced Starter plan", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  await db
+    .update(plans)
+    .set({ openmeterPlanId: null })
+    .where(eq(plans.id, starter.id));
+  plansSync.syncPlanToOpenMeter = async () => ({ ok: true });
+
+  await assert.rejects(
+    () =>
+      sut.ensureStarterSubscriptionForAppUser({
+        clientId: app.clientId,
+        externalUserId: "external-1",
+      }),
+    /Starter plan is not synced to OpenMeter/,
+  );
+});
+
+dbTest("ensureStarterSubscriptionForAppUser reuses an existing subscription", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => ({
+    id: "sub_existing",
+    status: "active",
+    customerId: CUSTOMER_ID,
+  });
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+  });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_existing",
+    planId: starter.id,
+    created: false,
+  });
+  assert.deepEqual(created, []);
+});
+
+dbTest("ensureStarterSubscriptionForAppUser trusts a verified hint", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  subscriptionRead.verifyOpenMeterSubscriptionId = async () => ({
+    id: "sub_hint",
+    status: "active",
+    customerId: CUSTOMER_ID,
+  });
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => {
+    throw new Error("should not query by plan key when the hint verifies");
+  };
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+    hintOpenMeterSubscriptionId: "sub_hint",
+  });
+  assert.equal(result.openmeterSubscriptionId, "sub_hint");
+});
+
+dbTest("ensureStarterSubscriptionForAppUser ignores a hint for another customer", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  subscriptionRead.verifyOpenMeterSubscriptionId = async () => ({
+    id: "sub_hint",
+    status: "active",
+    customerId: "cust_someone_else",
+  });
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => ({
+    id: "sub_by_key",
+    status: "active",
+    customerId: CUSTOMER_ID,
+  });
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+    hintOpenMeterSubscriptionId: "sub_hint",
+  });
+  assert.equal(result.openmeterSubscriptionId, "sub_by_key");
+});
+
+dbTest("ensureStarterSubscriptionForAppUser creates a subscription by plan id", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+  });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_created",
+    planId: starter.id,
+    created: true,
+  });
+  assert.deepEqual(created, [
+    { customerId: CUSTOMER_ID, plan: { id: starter.openmeterPlanId } },
+  ]);
+  assert.deepEqual(freeProfileApplied, []);
+});
+
+dbTest("ensureStarterSubscriptionForAppUser rejects a create with no id", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  subscriptionsCreate = async () => null;
+
+  await assert.rejects(
+    () =>
+      sut.ensureStarterSubscriptionForAppUser({
+        clientId: app.clientId,
+        externalUserId: "external-1",
+      }),
+    /Failed to create OpenMeter Starter subscription/,
+  );
+});
+
+dbTest("ensureStarterSubscriptionForAppUser adopts the winner of a create conflict", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  let queried = 0;
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => {
+    queried += 1;
+    return queried === 1
+      ? null
+      : { id: "sub_raced", status: "active", customerId: CUSTOMER_ID };
+  };
+  subscriptionsCreate = async () => {
+    throw conflictError();
+  };
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+  });
+  assert.equal(result.openmeterSubscriptionId, "sub_raced");
+  assert.equal(result.created, false);
+});
+
+dbTest("ensureStarterSubscriptionForAppUser rethrows a conflict with no winner", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  subscriptionsCreate = async () => {
+    throw conflictError();
+  };
+
+  await assert.rejects(
+    () =>
+      sut.ensureStarterSubscriptionForAppUser({
+        clientId: app.clientId,
+        externalUserId: "external-1",
+      }),
+    /already exists/,
+  );
+  assert.deepEqual(freeProfileApplied, []);
+});
+
+dbTest("ensureStarterSubscriptionForAppUser retries a Stripe setup error on the free profile", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) {
+      throw stripeBillingError();
+    }
+    return { id: "sub_after_profile", status: "active", customerId: CUSTOMER_ID };
+  };
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+  });
+  assert.equal(result.openmeterSubscriptionId, "sub_after_profile");
+  assert.deepEqual(freeProfileApplied, [CUSTOMER_ID]);
+});
+
+dbTest("ensureStarterSubscriptionForAppUser adopts a conflict raised by the retry", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  let queried = 0;
+  subscriptionRead.findOpenMeterSubscriptionByPlanKey = async () => {
+    queried += 1;
+    return queried === 1
+      ? null
+      : { id: "sub_raced_retry", status: "active", customerId: CUSTOMER_ID };
+  };
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    throw attempt === 1 ? stripeBillingError() : conflictError();
+  };
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+  });
+  assert.equal(result.openmeterSubscriptionId, "sub_raced_retry");
+  assert.equal(result.created, false);
+});
+
+dbTest("ensureStarterSubscriptionForAppUser rethrows a failing retry", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    throw attempt === 1
+      ? stripeBillingError()
+      : new Error("retry create exploded");
+  };
+
+  await assert.rejects(
+    () =>
+      sut.ensureStarterSubscriptionForAppUser({
+        clientId: app.clientId,
+        externalUserId: "external-1",
+      }),
+    /retry create exploded/,
+  );
+});
+
+dbTest("ensureStarterSubscriptionForAppUser re-syncs the plan on a plan-not-found create", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  plansSync.syncPlanToOpenMeter = async () => {
+    await db
+      .update(plans)
+      .set({ openmeterPlanId: "plan_resynced" })
+      .where(eq(plans.id, starter.id));
+    return { ok: true };
+  };
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) {
+      throw planNotFoundError();
+    }
+    return { id: "sub_after_resync", status: "active", customerId: CUSTOMER_ID };
+  };
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+  });
+  assert.deepEqual(result, {
+    openmeterSubscriptionId: "sub_after_resync",
+    planId: starter.id,
+    created: true,
+  });
+  assert.deepEqual(created[1]?.plan, { id: "plan_resynced" });
+});
+
+dbTest("ensureStarterSubscriptionForAppUser surfaces a failed recovery sync", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  plansSync.syncPlanToOpenMeter = async () => ({
+    ok: false,
+    error: "resync rejected",
+  });
+  subscriptionsCreate = async () => {
+    throw planNotFoundError();
+  };
+
+  await assert.rejects(
+    () =>
+      sut.ensureStarterSubscriptionForAppUser({
+        clientId: app.clientId,
+        externalUserId: "external-1",
+      }),
+    /resync rejected/,
+  );
+});
+
+dbTest("ensureStarterSubscriptionForAppUser rethrows an unrelated create error", async (t) => {
+  const { app } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  subscriptionsCreate = async () => {
+    throw new Error("openmeter exploded");
+  };
+
+  await assert.rejects(
+    () =>
+      sut.ensureStarterSubscriptionForAppUser({
+        clientId: app.clientId,
+        externalUserId: "external-1",
+      }),
+    /openmeter exploded/,
+  );
+});
+
+dbTest("ensureStarterSubscriptionForAppUser falls back to the plan key after a blank re-sync", async (t) => {
+  const { app, starter } = await seedApp();
+  t.after(() => cleanupTestApp(app));
+  // A re-sync that reports ok but leaves openmeterPlanId unset is the only way
+  // the create can reach the { key } plan reference.
+  plansSync.syncPlanToOpenMeter = async () => {
+    await db
+      .update(plans)
+      .set({ openmeterPlanId: null })
+      .where(eq(plans.id, starter.id));
+    return { ok: true };
+  };
+  let attempt = 0;
+  subscriptionsCreate = async () => {
+    attempt += 1;
+    if (attempt === 1) {
+      throw planNotFoundError();
+    }
+    return { id: "sub_by_key", status: "active", customerId: CUSTOMER_ID };
+  };
+
+  const result = await sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+  });
+  assert.equal(result.openmeterSubscriptionId, "sub_by_key");
+  assert.deepEqual(created[1]?.plan, {
+    key: buildOpenMeterPlanKey(app.clientId, starter.id),
+  });
+});

--- a/src/lib/openmeter/starter-subscription.test.ts
+++ b/src/lib/openmeter/starter-subscription.test.ts
@@ -150,6 +150,17 @@ const planNotFoundError = () => new Error("plan not found");
 const stripeBillingError = () =>
   new Error("customers need a default payment method");
 
+function ensureForApp(
+  app: SeededDeveloperApp,
+  hintOpenMeterSubscriptionId?: string,
+) {
+  return sut.ensureStarterSubscriptionForAppUser({
+    clientId: app.clientId,
+    externalUserId: "external-1",
+    ...(hintOpenMeterSubscriptionId ? { hintOpenMeterSubscriptionId } : {}),
+  });
+}
+
 async function seedApp(): Promise<{
   app: SeededDeveloperApp;
   starter: typeof plans.$inferSelect;
@@ -241,10 +252,7 @@ dbTest("ensureStarterSubscriptionForAppUser returns the local plan when OpenMete
   t.after(() => cleanupTestApp(app));
   adminClient.isHostedAdminClientAvailable = () => false;
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-  });
+  const result = await ensureForApp(app);
   assert.deepEqual(result, {
     openmeterSubscriptionId: null,
     planId: starter.id,
@@ -299,10 +307,7 @@ dbTest("ensureStarterSubscriptionForAppUser rejects an unsynced Starter plan", a
 
   await assert.rejects(
     () =>
-      sut.ensureStarterSubscriptionForAppUser({
-        clientId: app.clientId,
-        externalUserId: "external-1",
-      }),
+      ensureForApp(app),
     /Starter plan is not synced to OpenMeter/,
   );
 });
@@ -316,10 +321,7 @@ dbTest("ensureStarterSubscriptionForAppUser reuses an existing subscription", as
     customerId: CUSTOMER_ID,
   });
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-  });
+  const result = await ensureForApp(app);
   assert.deepEqual(result, {
     openmeterSubscriptionId: "sub_existing",
     planId: starter.id,
@@ -340,11 +342,7 @@ dbTest("ensureStarterSubscriptionForAppUser trusts a verified hint", async (t) =
     throw new Error("should not query by plan key when the hint verifies");
   };
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-    hintOpenMeterSubscriptionId: "sub_hint",
-  });
+  const result = await ensureForApp(app, "sub_hint");
   assert.equal(result.openmeterSubscriptionId, "sub_hint");
 });
 
@@ -362,11 +360,7 @@ dbTest("ensureStarterSubscriptionForAppUser ignores a hint for another customer"
     customerId: CUSTOMER_ID,
   });
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-    hintOpenMeterSubscriptionId: "sub_hint",
-  });
+  const result = await ensureForApp(app, "sub_hint");
   assert.equal(result.openmeterSubscriptionId, "sub_by_key");
 });
 
@@ -374,10 +368,7 @@ dbTest("ensureStarterSubscriptionForAppUser creates a subscription by plan id", 
   const { app, starter } = await seedApp();
   t.after(() => cleanupTestApp(app));
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-  });
+  const result = await ensureForApp(app);
   assert.deepEqual(result, {
     openmeterSubscriptionId: "sub_created",
     planId: starter.id,
@@ -396,10 +387,7 @@ dbTest("ensureStarterSubscriptionForAppUser rejects a create with no id", async 
 
   await assert.rejects(
     () =>
-      sut.ensureStarterSubscriptionForAppUser({
-        clientId: app.clientId,
-        externalUserId: "external-1",
-      }),
+      ensureForApp(app),
     /Failed to create OpenMeter Starter subscription/,
   );
 });
@@ -418,10 +406,7 @@ dbTest("ensureStarterSubscriptionForAppUser adopts the winner of a create confli
     throw conflictError();
   };
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-  });
+  const result = await ensureForApp(app);
   assert.equal(result.openmeterSubscriptionId, "sub_raced");
   assert.equal(result.created, false);
 });
@@ -435,10 +420,7 @@ dbTest("ensureStarterSubscriptionForAppUser rethrows a conflict with no winner",
 
   await assert.rejects(
     () =>
-      sut.ensureStarterSubscriptionForAppUser({
-        clientId: app.clientId,
-        externalUserId: "external-1",
-      }),
+      ensureForApp(app),
     /already exists/,
   );
   assert.deepEqual(freeProfileApplied, []);
@@ -456,10 +438,7 @@ dbTest("ensureStarterSubscriptionForAppUser retries a Stripe setup error on the 
     return { id: "sub_after_profile", status: "active", customerId: CUSTOMER_ID };
   };
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-  });
+  const result = await ensureForApp(app);
   assert.equal(result.openmeterSubscriptionId, "sub_after_profile");
   assert.deepEqual(freeProfileApplied, [CUSTOMER_ID]);
 });
@@ -480,10 +459,7 @@ dbTest("ensureStarterSubscriptionForAppUser adopts a conflict raised by the retr
     throw attempt === 1 ? stripeBillingError() : conflictError();
   };
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-  });
+  const result = await ensureForApp(app);
   assert.equal(result.openmeterSubscriptionId, "sub_raced_retry");
   assert.equal(result.created, false);
 });
@@ -501,10 +477,7 @@ dbTest("ensureStarterSubscriptionForAppUser rethrows a failing retry", async (t)
 
   await assert.rejects(
     () =>
-      sut.ensureStarterSubscriptionForAppUser({
-        clientId: app.clientId,
-        externalUserId: "external-1",
-      }),
+      ensureForApp(app),
     /retry create exploded/,
   );
 });
@@ -528,10 +501,7 @@ dbTest("ensureStarterSubscriptionForAppUser re-syncs the plan on a plan-not-foun
     return { id: "sub_after_resync", status: "active", customerId: CUSTOMER_ID };
   };
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-  });
+  const result = await ensureForApp(app);
   assert.deepEqual(result, {
     openmeterSubscriptionId: "sub_after_resync",
     planId: starter.id,
@@ -553,10 +523,7 @@ dbTest("ensureStarterSubscriptionForAppUser surfaces a failed recovery sync", as
 
   await assert.rejects(
     () =>
-      sut.ensureStarterSubscriptionForAppUser({
-        clientId: app.clientId,
-        externalUserId: "external-1",
-      }),
+      ensureForApp(app),
     /resync rejected/,
   );
 });
@@ -570,10 +537,7 @@ dbTest("ensureStarterSubscriptionForAppUser rethrows an unrelated create error",
 
   await assert.rejects(
     () =>
-      sut.ensureStarterSubscriptionForAppUser({
-        clientId: app.clientId,
-        externalUserId: "external-1",
-      }),
+      ensureForApp(app),
     /openmeter exploded/,
   );
 });
@@ -599,10 +563,7 @@ dbTest("ensureStarterSubscriptionForAppUser falls back to the plan key after a b
     return { id: "sub_by_key", status: "active", customerId: CUSTOMER_ID };
   };
 
-  const result = await sut.ensureStarterSubscriptionForAppUser({
-    clientId: app.clientId,
-    externalUserId: "external-1",
-  });
+  const result = await ensureForApp(app);
   assert.equal(result.openmeterSubscriptionId, "sub_by_key");
   assert.deepEqual(created[1]?.plan, {
     key: buildOpenMeterPlanKey(app.clientId, starter.id),

--- a/src/lib/openmeter/subscriptions-billing.flows.test.ts
+++ b/src/lib/openmeter/subscriptions-billing.flows.test.ts
@@ -1,0 +1,620 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { before, beforeEach } from "node:test";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import { plans, subscriptions } from "@/db/schema";
+import { buildOpenMeterPlanKey } from "@/lib/openmeter/plan-naming";
+import { test as dbTest } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  seedDeveloperAppWithClient,
+  type SeededDeveloperApp,
+} from "@/test-utils/fixtures";
+import { createStubRegistry } from "@/test-utils/module-stubs";
+
+type BillingConfig = {
+  checkoutSuccessUrl?: string | null;
+  checkoutCancelUrl?: string | null;
+} | null;
+
+const CUSTOMER_ID = "cust_end_user";
+const CUSTOMER_KEY = "app:end-user";
+const ORIGIN = "https://pymthouse.test";
+
+const openMeterCreates: Array<{ customerId: string; planKey?: string }> = [];
+const konnectChanges: Array<{ subscriptionId: string; planId: string; timing: string }> =
+  [];
+
+let subscriptionsCreate: () => Promise<{ id?: string } | null> = async () => ({
+  id: "om_sub_created",
+});
+
+const fakeClient = {
+  subscriptions: {
+    create: async (body: { customerId: string; plan?: { key?: string } }) => {
+      openMeterCreates.push({
+        customerId: body.customerId,
+        planKey: body.plan?.key,
+      });
+      return subscriptionsCreate();
+    },
+  },
+};
+
+const stubs = createStubRegistry();
+
+stubs.module("@/lib/openmeter/admin-client", {
+  isHostedAdminClientAvailable: (): boolean => true,
+  getHostedAdminClient: (): unknown => fakeClient,
+});
+
+stubs.module("@/lib/oidc/issuer-urls", {
+  getPublicOrigin: (): string => ORIGIN,
+});
+
+const billingProfiles = stubs.module("@/lib/openmeter/billing-profiles", {
+  getAppBillingConfig: async (): Promise<BillingConfig> => null,
+  prepareAppCustomerStripeBilling: async (): Promise<void> => undefined,
+  applyTenantBillingProfileToCustomer: async (): Promise<void> => undefined,
+});
+
+stubs.module("@/lib/openmeter/customers", {
+  ensureOpenMeterCustomerForAppUser: async (): Promise<{
+    id: string;
+    key: string;
+  }> => ({ id: CUSTOMER_ID, key: CUSTOMER_KEY }),
+});
+
+const konnectSubscriptions = stubs.module(
+  "@/lib/openmeter/konnect-subscriptions",
+  {
+    changeKonnectSubscription: async (input: {
+      subscriptionId: string;
+      planId: string;
+      timing: string;
+    }): Promise<{ next?: { id?: string }; current?: { id?: string } }> => {
+      konnectChanges.push(input);
+      return { current: { id: input.subscriptionId } };
+    },
+  },
+);
+
+const subscriptionRead = stubs.module("@/lib/openmeter/subscription-read", {
+  getPrimaryOpenMeterSubscriptionForAppUser: async (): Promise<{
+    id: string;
+  } | null> => null,
+  resolveLocalPlanIdFromOpenMeterSubscription: async (): Promise<string | null> =>
+    null,
+});
+
+const checkoutSession = stubs.module("@/lib/openmeter/stripe-checkout-session", {
+  createOpenMeterStripeCheckoutSession: async (): Promise<{
+    checkoutUrl: string;
+    sessionId: string | null;
+  }> => ({
+    checkoutUrl: "https://checkout.stripe.com/c/pay_openmeter",
+    sessionId: "cs_openmeter",
+  }),
+});
+
+const stripeCustomerData = stubs.module("@/lib/openmeter/stripe-customer-data", {
+  getKonnectDefaultPaymentMethodId: async (): Promise<string | null> => null,
+});
+
+const merchantConnect = stubs.module("@/lib/stripe/merchant-connect", {
+  isMerchantConnectPaymentsReady: (): boolean => false,
+  connectPaymentsOnlyEnabled: (): boolean => false,
+  createMerchantConnectCheckoutForUser: async (input: {
+    successUrl: string;
+    cancelUrl: string;
+  }): Promise<{ checkoutUrl: string; sessionId: string | null }> => ({
+    checkoutUrl: `https://checkout.stripe.com/c/connect?ok=${encodeURIComponent(input.successUrl)}`,
+    sessionId: "cs_connect",
+  }),
+});
+
+let sut: typeof import("@/lib/openmeter/subscriptions-billing");
+
+before(async () => {
+  sut = await import("@/lib/openmeter/subscriptions-billing");
+});
+
+beforeEach(() => {
+  stubs.reset();
+  openMeterCreates.length = 0;
+  konnectChanges.length = 0;
+  subscriptionsCreate = async () => ({ id: "om_sub_created" });
+  process.env.OPENMETER_ROUTE_MODE = "hosted";
+});
+
+async function seedPaidPlan(
+  clientId: string,
+  overrides: Partial<typeof plans.$inferInsert> = {},
+): Promise<typeof plans.$inferSelect> {
+  const id = `plan-paid-${randomUUID()}`;
+  await db.insert(plans).values({
+    id,
+    clientId,
+    // plans has a unique (client_id, name) index, so keep every seeded plan
+    // distinct even when a test seeds a current and a target plan.
+    name: `Plan ${id.slice(-12)}`,
+    type: "subscription",
+    priceAmount: "19.99",
+    status: "active",
+    openmeterPlanId: `om_${id}`,
+    ...overrides,
+  });
+  const rows = await db.select().from(plans).where(eq(plans.id, id));
+  return rows[0]!;
+}
+
+async function readCachedSubscription(
+  app: SeededDeveloperApp,
+  externalUserId: string,
+) {
+  const rows = await db
+    .select()
+    .from(subscriptions)
+    .where(
+      and(
+        eq(subscriptions.clientId, app.clientId),
+        eq(subscriptions.externalUserId, externalUserId),
+      ),
+    );
+  return rows[0];
+}
+
+dbTest("createEndUserCheckout rejects a plan from another app", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  const other = await seedDeveloperAppWithClient();
+  t.after(async () => {
+    await cleanupTestApp(app);
+    await cleanupTestApp(other);
+  });
+  const foreign = await seedPaidPlan(other.clientId);
+
+  await assert.rejects(
+    () =>
+      sut.createEndUserCheckout({
+        clientId: app.clientId,
+        externalUserId: "end-user-1",
+        planId: foreign.id,
+      }),
+    /Plan not found/,
+  );
+});
+
+dbTest("createEndUserCheckout rejects a phased-out plan", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId, { status: "phase_out" });
+
+  await assert.rejects(
+    () =>
+      sut.createEndUserCheckout({
+        clientId: app.clientId,
+        externalUserId: "end-user-1",
+        planId: plan.id,
+      }),
+    /being phased out/,
+  );
+});
+
+dbTest("createEndUserCheckout rejects an inactive plan", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId, { status: "draft" });
+
+  await assert.rejects(
+    () =>
+      sut.createEndUserCheckout({
+        clientId: app.clientId,
+        externalUserId: "end-user-1",
+        planId: plan.id,
+      }),
+    /Plan is not active/,
+  );
+});
+
+dbTest("createEndUserCheckout rejects an unsynced plan", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId, { openmeterPlanId: null });
+
+  await assert.rejects(
+    () =>
+      sut.createEndUserCheckout({
+        clientId: app.clientId,
+        externalUserId: "end-user-1",
+        planId: plan.id,
+      }),
+    /not synced to OpenMeter/,
+  );
+});
+
+dbTest("createEndUserCheckout requires merchant onboarding when connect-only", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId);
+  merchantConnect.connectPaymentsOnlyEnabled = () => true;
+
+  await assert.rejects(
+    () =>
+      sut.createEndUserCheckout({
+        clientId: app.clientId,
+        externalUserId: "end-user-1",
+        planId: plan.id,
+      }),
+    /Stripe Connect onboarding is required/,
+  );
+});
+
+dbTest("createEndUserCheckout rejects when OpenMeter returns no subscription", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId);
+  subscriptionsCreate = async () => null;
+
+  await assert.rejects(
+    () =>
+      sut.createEndUserCheckout({
+        clientId: app.clientId,
+        externalUserId: "end-user-1",
+        planId: plan.id,
+      }),
+    /Failed to create OpenMeter subscription/,
+  );
+});
+
+dbTest("createEndUserCheckout caches a pending row for the platform Stripe flow", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId);
+
+  const result = await sut.createEndUserCheckout({
+    clientId: app.clientId,
+    externalUserId: "end-user-1",
+    planId: plan.id,
+  });
+  assert.equal(result.checkoutUrl, "https://checkout.stripe.com/c/pay_openmeter");
+  assert.equal(result.subscriptionId, "om_sub_created");
+  assert.deepEqual(openMeterCreates, [
+    { customerId: CUSTOMER_ID, planKey: buildOpenMeterPlanKey(app.clientId, plan.id) },
+  ]);
+
+  const cached = await readCachedSubscription(app, "end-user-1");
+  assert.equal(cached?.status, "pending");
+  assert.equal(cached?.planId, plan.id);
+  assert.equal(cached?.stripeCheckoutSessionId, "cs_openmeter");
+  assert.equal(cached?.openmeterSubscriptionId, "om_sub_created");
+});
+
+dbTest("createEndUserCheckout routes a merchant-ready app to Connect", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId);
+  merchantConnect.isMerchantConnectPaymentsReady = () => true;
+  billingProfiles.getAppBillingConfig = async () => ({
+    checkoutSuccessUrl: "https://merchant.test/done",
+    checkoutCancelUrl: "https://merchant.test/cancel",
+  });
+
+  const result = await sut.createEndUserCheckout({
+    clientId: app.clientId,
+    externalUserId: "end-user-1",
+    planId: plan.id,
+  });
+  assert.match(result.checkoutUrl, /connect\?ok=/);
+  assert.match(
+    result.checkoutUrl,
+    new RegExp(encodeURIComponent("https://merchant.test/done")),
+  );
+
+  const cached = await readCachedSubscription(app, "end-user-1");
+  assert.equal(cached?.stripeCheckoutSessionId, "cs_connect");
+});
+
+dbTest("createEndUserCheckout falls back to app settings redirect urls", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId);
+  const seen: Array<{ successUrl: string; cancelUrl: string }> = [];
+  checkoutSession.createOpenMeterStripeCheckoutSession = async (input: {
+    successUrl: string;
+    cancelUrl: string;
+  }) => {
+    seen.push({ successUrl: input.successUrl, cancelUrl: input.cancelUrl });
+    return { checkoutUrl: "https://checkout.stripe.com/c/pay_default", sessionId: null };
+  };
+
+  await sut.createEndUserCheckout({
+    clientId: app.clientId,
+    externalUserId: "end-user-1",
+    planId: plan.id,
+  });
+  assert.deepEqual(seen, [
+    {
+      successUrl: `${ORIGIN}/apps/${app.clientId}/payments`,
+      cancelUrl: `${ORIGIN}/apps/${app.clientId}/payments`,
+    },
+  ]);
+});
+
+dbTest("changeAppUserSubscriptionPlan creates a checkout when there is no subscription", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId);
+
+  const result = await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-1",
+    planId: plan.id,
+  });
+  assert.equal(result.subscriptionId, "om_sub_created");
+  assert.equal(result.planId, plan.id);
+  assert.equal(result.timing, "immediate");
+  assert.equal(result.checkoutUrl, "https://checkout.stripe.com/c/pay_openmeter");
+  assert.deepEqual(konnectChanges, []);
+});
+
+dbTest("changeAppUserSubscriptionPlan rejects a no-op plan change", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId);
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () => plan.id;
+
+  await assert.rejects(
+    () =>
+      sut.changeAppUserSubscriptionPlan({
+        clientId: app.clientId,
+        externalUserId: "end-user-1",
+        planId: plan.id,
+      }),
+    /already on this plan/,
+  );
+});
+
+dbTest("changeAppUserSubscriptionPlan requires Konnect routes", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const plan = await seedPaidPlan(app.clientId);
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  process.env.OPENMETER_ROUTE_MODE = "self_hosted";
+
+  await assert.rejects(
+    () =>
+      sut.changeAppUserSubscriptionPlan({
+        clientId: app.clientId,
+        externalUserId: "end-user-1",
+        planId: plan.id,
+      }),
+    /requires Konnect routes/,
+  );
+});
+
+dbTest("changeAppUserSubscriptionPlan downgrades at the next billing cycle", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const current = await seedPaidPlan(app.clientId, { priceAmount: "50" });
+  const target = await seedPaidPlan(app.clientId, {
+    priceAmount: "0",
+    type: "free",
+  });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
+    current.id;
+  konnectSubscriptions.changeKonnectSubscription = async (input) => {
+    konnectChanges.push(input);
+    return { next: { id: "om_sub_next" } };
+  };
+
+  const result = await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-2",
+    planId: target.id,
+  });
+  assert.equal(result.timing, "next_billing_cycle");
+  assert.equal(result.subscriptionId, "om_sub_next");
+  assert.equal(result.checkoutUrl, undefined);
+
+  const cached = await readCachedSubscription(app, "end-user-2");
+  assert.equal(cached?.status, "active");
+  assert.equal(cached?.openmeterSubscriptionId, "om_sub_next");
+});
+
+dbTest("changeAppUserSubscriptionPlan keeps the cached row on a later change", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const first = await seedPaidPlan(app.clientId, { priceAmount: "5" });
+  const second = await seedPaidPlan(app.clientId, {
+    priceAmount: "0",
+    type: "free",
+  });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () => first.id;
+
+  await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-3",
+    planId: second.id,
+  });
+  await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-3",
+    planId: second.id,
+    timing: "immediate",
+  });
+
+  const rows = await db
+    .select()
+    .from(subscriptions)
+    .where(
+      and(
+        eq(subscriptions.clientId, app.clientId),
+        eq(subscriptions.externalUserId, "end-user-3"),
+      ),
+    );
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.openmeterSubscriptionId, "om_sub_current");
+});
+
+dbTest("changeAppUserSubscriptionPlan collects a card when upgrading to a paid plan", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const current = await seedPaidPlan(app.clientId, {
+    priceAmount: "0",
+    type: "free",
+  });
+  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
+    current.id;
+
+  const result = await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-4",
+    planId: target.id,
+    successUrl: "https://app.test/ok",
+    cancelUrl: "https://app.test/no",
+  });
+  assert.equal(result.timing, "immediate");
+  assert.equal(result.checkoutUrl, "https://checkout.stripe.com/c/pay_openmeter");
+
+  const cached = await readCachedSubscription(app, "end-user-4");
+  assert.equal(cached?.status, "pending");
+});
+
+dbTest("changeAppUserSubscriptionPlan skips checkout when a card is on file", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const current = await seedPaidPlan(app.clientId, {
+    priceAmount: "0",
+    type: "free",
+  });
+  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
+    current.id;
+  stripeCustomerData.getKonnectDefaultPaymentMethodId = async () => "pm_existing";
+
+  const result = await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-5",
+    planId: target.id,
+  });
+  assert.equal(result.checkoutUrl, undefined);
+
+  const cached = await readCachedSubscription(app, "end-user-5");
+  assert.equal(cached?.status, "active");
+});
+
+dbTest("changeAppUserSubscriptionPlan uses Connect checkout for a merchant app", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const current = await seedPaidPlan(app.clientId, {
+    priceAmount: "0",
+    type: "free",
+  });
+  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
+    current.id;
+  merchantConnect.isMerchantConnectPaymentsReady = () => true;
+
+  const result = await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-6",
+    planId: target.id,
+  });
+  assert.match(result.checkoutUrl ?? "", /connect\?ok=/);
+
+  const cached = await readCachedSubscription(app, "end-user-6");
+  assert.equal(cached?.stripeCheckoutSessionId, "cs_connect");
+});
+
+dbTest("changeAppUserSubscriptionPlan blocks a paid upgrade for a connect-only app", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const current = await seedPaidPlan(app.clientId, {
+    priceAmount: "0",
+    type: "free",
+  });
+  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
+    current.id;
+  merchantConnect.connectPaymentsOnlyEnabled = () => true;
+
+  await assert.rejects(
+    () =>
+      sut.changeAppUserSubscriptionPlan({
+        clientId: app.clientId,
+        externalUserId: "end-user-7",
+        planId: target.id,
+      }),
+    /Stripe Connect onboarding is required/,
+  );
+});
+
+dbTest("changeAppUserSubscriptionPlan falls back to the current subscription id", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const current = await seedPaidPlan(app.clientId, { priceAmount: "5" });
+  const target = await seedPaidPlan(app.clientId, {
+    priceAmount: "0",
+    type: "free",
+  });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
+    current.id;
+  konnectSubscriptions.changeKonnectSubscription = async (input) => {
+    konnectChanges.push(input);
+    return {};
+  };
+
+  const result = await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-8",
+    planId: target.id,
+  });
+  assert.equal(result.subscriptionId, "om_sub_current");
+  assert.equal(konnectChanges[0]?.planId, target.openmeterPlanId);
+});
+
+dbTest("changeAppUserSubscriptionPlan treats an unmapped current plan as an upgrade", async (t) => {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () => null;
+
+  const result = await sut.changeAppUserSubscriptionPlan({
+    clientId: app.clientId,
+    externalUserId: "end-user-9",
+    planId: target.id,
+  });
+  assert.equal(result.timing, "immediate");
+});

--- a/src/lib/openmeter/subscriptions-billing.flows.test.ts
+++ b/src/lib/openmeter/subscriptions-billing.flows.test.ts
@@ -153,6 +153,36 @@ async function seedPaidPlan(
   return rows[0]!;
 }
 
+/**
+ * Seed an app whose end-user is already on `currentPriceAmount` and wants to
+ * move to `targetPriceAmount`, with the current OpenMeter subscription resolved.
+ */
+async function seedPlanChange(
+  t: { after: (fn: () => Promise<void> | void) => void },
+  amounts: { currentPriceAmount: string; targetPriceAmount: string },
+): Promise<{
+  app: SeededDeveloperApp;
+  current: typeof plans.$inferSelect;
+  target: typeof plans.$inferSelect;
+}> {
+  const app = await seedDeveloperAppWithClient();
+  t.after(() => cleanupTestApp(app));
+  const current = await seedPaidPlan(app.clientId, {
+    priceAmount: amounts.currentPriceAmount,
+    type: amounts.currentPriceAmount === "0" ? "free" : "subscription",
+  });
+  const target = await seedPaidPlan(app.clientId, {
+    priceAmount: amounts.targetPriceAmount,
+    type: amounts.targetPriceAmount === "0" ? "free" : "subscription",
+  });
+  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
+    id: "om_sub_current",
+  });
+  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
+    current.id;
+  return { app, current, target };
+}
+
 async function readCachedSubscription(
   app: SeededDeveloperApp,
   externalUserId: string,
@@ -403,18 +433,10 @@ dbTest("changeAppUserSubscriptionPlan requires Konnect routes", async (t) => {
 });
 
 dbTest("changeAppUserSubscriptionPlan downgrades at the next billing cycle", async (t) => {
-  const app = await seedDeveloperAppWithClient();
-  t.after(() => cleanupTestApp(app));
-  const current = await seedPaidPlan(app.clientId, { priceAmount: "50" });
-  const target = await seedPaidPlan(app.clientId, {
-    priceAmount: "0",
-    type: "free",
+  const { app, target } = await seedPlanChange(t, {
+    currentPriceAmount: "50",
+    targetPriceAmount: "0",
   });
-  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
-    id: "om_sub_current",
-  });
-  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
-    current.id;
   konnectSubscriptions.changeKonnectSubscription = async (input) => {
     konnectChanges.push(input);
     return { next: { id: "om_sub_next" } };
@@ -435,17 +457,10 @@ dbTest("changeAppUserSubscriptionPlan downgrades at the next billing cycle", asy
 });
 
 dbTest("changeAppUserSubscriptionPlan keeps the cached row on a later change", async (t) => {
-  const app = await seedDeveloperAppWithClient();
-  t.after(() => cleanupTestApp(app));
-  const first = await seedPaidPlan(app.clientId, { priceAmount: "5" });
-  const second = await seedPaidPlan(app.clientId, {
-    priceAmount: "0",
-    type: "free",
+  const { app, target: second } = await seedPlanChange(t, {
+    currentPriceAmount: "5",
+    targetPriceAmount: "0",
   });
-  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
-    id: "om_sub_current",
-  });
-  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () => first.id;
 
   await sut.changeAppUserSubscriptionPlan({
     clientId: app.clientId,
@@ -473,18 +488,10 @@ dbTest("changeAppUserSubscriptionPlan keeps the cached row on a later change", a
 });
 
 dbTest("changeAppUserSubscriptionPlan collects a card when upgrading to a paid plan", async (t) => {
-  const app = await seedDeveloperAppWithClient();
-  t.after(() => cleanupTestApp(app));
-  const current = await seedPaidPlan(app.clientId, {
-    priceAmount: "0",
-    type: "free",
+  const { app, target } = await seedPlanChange(t, {
+    currentPriceAmount: "0",
+    targetPriceAmount: "30",
   });
-  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
-  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
-    id: "om_sub_current",
-  });
-  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
-    current.id;
 
   const result = await sut.changeAppUserSubscriptionPlan({
     clientId: app.clientId,
@@ -501,18 +508,10 @@ dbTest("changeAppUserSubscriptionPlan collects a card when upgrading to a paid p
 });
 
 dbTest("changeAppUserSubscriptionPlan skips checkout when a card is on file", async (t) => {
-  const app = await seedDeveloperAppWithClient();
-  t.after(() => cleanupTestApp(app));
-  const current = await seedPaidPlan(app.clientId, {
-    priceAmount: "0",
-    type: "free",
+  const { app, target } = await seedPlanChange(t, {
+    currentPriceAmount: "0",
+    targetPriceAmount: "30",
   });
-  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
-  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
-    id: "om_sub_current",
-  });
-  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
-    current.id;
   stripeCustomerData.getKonnectDefaultPaymentMethodId = async () => "pm_existing";
 
   const result = await sut.changeAppUserSubscriptionPlan({
@@ -527,18 +526,10 @@ dbTest("changeAppUserSubscriptionPlan skips checkout when a card is on file", as
 });
 
 dbTest("changeAppUserSubscriptionPlan uses Connect checkout for a merchant app", async (t) => {
-  const app = await seedDeveloperAppWithClient();
-  t.after(() => cleanupTestApp(app));
-  const current = await seedPaidPlan(app.clientId, {
-    priceAmount: "0",
-    type: "free",
+  const { app, target } = await seedPlanChange(t, {
+    currentPriceAmount: "0",
+    targetPriceAmount: "30",
   });
-  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
-  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
-    id: "om_sub_current",
-  });
-  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
-    current.id;
   merchantConnect.isMerchantConnectPaymentsReady = () => true;
 
   const result = await sut.changeAppUserSubscriptionPlan({
@@ -553,18 +544,10 @@ dbTest("changeAppUserSubscriptionPlan uses Connect checkout for a merchant app",
 });
 
 dbTest("changeAppUserSubscriptionPlan blocks a paid upgrade for a connect-only app", async (t) => {
-  const app = await seedDeveloperAppWithClient();
-  t.after(() => cleanupTestApp(app));
-  const current = await seedPaidPlan(app.clientId, {
-    priceAmount: "0",
-    type: "free",
+  const { app, target } = await seedPlanChange(t, {
+    currentPriceAmount: "0",
+    targetPriceAmount: "30",
   });
-  const target = await seedPaidPlan(app.clientId, { priceAmount: "30" });
-  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
-    id: "om_sub_current",
-  });
-  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
-    current.id;
   merchantConnect.connectPaymentsOnlyEnabled = () => true;
 
   await assert.rejects(
@@ -579,18 +562,10 @@ dbTest("changeAppUserSubscriptionPlan blocks a paid upgrade for a connect-only a
 });
 
 dbTest("changeAppUserSubscriptionPlan falls back to the current subscription id", async (t) => {
-  const app = await seedDeveloperAppWithClient();
-  t.after(() => cleanupTestApp(app));
-  const current = await seedPaidPlan(app.clientId, { priceAmount: "5" });
-  const target = await seedPaidPlan(app.clientId, {
-    priceAmount: "0",
-    type: "free",
+  const { app, target } = await seedPlanChange(t, {
+    currentPriceAmount: "5",
+    targetPriceAmount: "0",
   });
-  subscriptionRead.getPrimaryOpenMeterSubscriptionForAppUser = async () => ({
-    id: "om_sub_current",
-  });
-  subscriptionRead.resolveLocalPlanIdFromOpenMeterSubscription = async () =>
-    current.id;
   konnectSubscriptions.changeKonnectSubscription = async (input) => {
     konnectChanges.push(input);
     return {};

--- a/src/lib/openmeter/subscriptions-billing.flows.test.ts
+++ b/src/lib/openmeter/subscriptions-billing.flows.test.ts
@@ -90,7 +90,10 @@ const subscriptionRead = stubs.module("@/lib/openmeter/subscription-read", {
 });
 
 const checkoutSession = stubs.module("@/lib/openmeter/stripe-checkout-session", {
-  createOpenMeterStripeCheckoutSession: async (): Promise<{
+  createOpenMeterStripeCheckoutSession: async (_input: {
+    successUrl: string;
+    cancelUrl: string;
+  }): Promise<{
     checkoutUrl: string;
     sessionId: string | null;
   }> => ({

--- a/src/lib/sanitize-for-log.test.ts
+++ b/src/lib/sanitize-for-log.test.ts
@@ -15,6 +15,21 @@ test("sanitizeForLog coerces nullish to empty string", () => {
 test("sanitizeForLog stringifies primitives", () => {
   assert.equal(sanitizeForLog(42), "42");
   assert.equal(sanitizeForLog(true), "true");
+  assert.equal(sanitizeForLog(9007199254740993n), "9007199254740993");
+  assert.equal(sanitizeForLog(Symbol("tok\nen")), "Symbol(token)");
+});
+
+test("sanitizeForLog drops values it cannot render", () => {
+  assert.equal(
+    sanitizeForLog(() => "never logged"),
+    "",
+  );
+});
+
+test("sanitizeForLog falls back when JSON.stringify throws", () => {
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  assert.equal(sanitizeForLog(cyclic), "[unserializable]");
 });
 
 test("sanitizeForLog uses Error message", () => {

--- a/src/test-utils/module-stubs.ts
+++ b/src/test-utils/module-stubs.ts
@@ -1,0 +1,39 @@
+import { mock } from "node:test";
+
+/**
+ * Node caches a mocked module after its first import, so a test file can only
+ * install one `mock.module` per specifier. Register the stub once with
+ * placeholder functions that delegate to a mutable record, and each test
+ * reassigns the fields it cares about.
+ */
+type StubRecord = Record<string, (...args: never[]) => unknown>;
+
+export type StubRegistry = {
+  /** Mock `specifier` with delegating exports; returns the mutable record. */
+  module: <T extends StubRecord>(specifier: string, defaults: T) => T;
+  /** Restore every registered record to the defaults it was created with. */
+  reset: () => void;
+};
+
+export function createStubRegistry(): StubRegistry {
+  const restores: Array<() => void> = [];
+
+  return {
+    module<T extends StubRecord>(specifier: string, defaults: T): T {
+      const impl = { ...defaults };
+      const namedExports: Record<string, unknown> = {};
+      for (const key of Object.keys(defaults)) {
+        namedExports[key] = (...args: unknown[]) =>
+          (impl[key] as unknown as (...a: unknown[]) => unknown)(...args);
+      }
+      mock.module(specifier, { namedExports });
+      restores.push(() => Object.assign(impl, defaults));
+      return impl;
+    },
+    reset() {
+      for (const restore of restores) {
+        restore();
+      }
+    },
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[PR #384](https://github.com/pymthouse/pymthouse/pull/384) fails the SonarCloud gate on `new_coverage` (24.8% against a 60% threshold — [component measures](https://sonarcloud.io/component_measures?id=pymthouse_pymthouse&pullRequest=384&metric=new_coverage&view=list)). Nearly all of the shortfall is in four OpenMeter modules the complexity refactor rewrote: `owner-starter-plan.ts` (218 uncovered lines), `billing-consistency.ts` (149), `subscriptions-billing.ts` (61) and `starter-subscription.ts` (59).

This branch targets `fix/sonar-leak-period-issues` so that merging it makes #384's next analysis pass the gate.

Measured against the exact set of lines #384 changes, the new suites take those files from ~7% to ~99%:

| File | new lines covered |
| --- | --- |
| `src/lib/openmeter/owner-starter-plan.ts` | 223 / 223 |
| `src/lib/openmeter/billing-consistency.ts` | 183 / 185 |
| `src/lib/openmeter/subscriptions-billing.ts` | 74 / 74 |
| `src/lib/openmeter/starter-subscription.ts` | 62 / 62 |
| `src/lib/openapi/document.ts` | 24 / 24 |
| `src/lib/sanitize-for-log.ts` | 10 / 10 |
| `src/lib/openmeter/billing-profiles.ts` (lines from #384) | 7 / 7 |

## What changed

- **Enabled Node's experimental test module mocks** (`--experimental-test-module-mocks` on `test` and `test:coverage`). The four modules reach OpenMeter/Konnect through module-level imports rather than injected dependencies, so their recovery branches were unreachable from a unit test without stubbing those modules.
- **`src/test-utils/module-stubs.ts`** — a small registry that installs one `mock.module` per specifier with exports delegating to a mutable record, so a single file can drive many scenarios (Node caches a mocked module after first import) and `reset()` restores defaults between tests.
- **`owner-starter-plan.test.ts`** (32 tests) — plan sync and force-sync, subscription reconciliation (Owner Paid, matching Starter, off-amount change, unknown wallet), change→recreate→cancel recovery, create conflicts, and the plan-not-found and Stripe-setup-409 create recovery paths.
- **`billing-consistency.audit.test.ts`** (25 tests) — drives `auditBillingConsistency` end to end against the CI Postgres with stubbed Konnect reads: owner/client resolution, Starter plan snapshots, customer lookup failures, Stripe app data and sandbox billing profile checks, active-subscription counts, the usage-attribution drill-down, the spendable gate, phase-out subscriber counts and the Owner Paid plan snapshot.
- **`starter-subscription.test.ts`** (22 tests) — `ensureStarterPlanSynced` re-sync/failure paths plus every recovery branch of `ensureStarterSubscriptionForAppUser` (owner delegation, hint verification, conflicts, billing-profile retry, plan re-sync).
- **`subscriptions-billing.flows.test.ts`** (20 tests) — `createEndUserCheckout` and `changeAppUserSubscriptionPlan`: target plan validation, Connect vs platform checkout routing, redirect URL fallbacks, the payment-method gate, and the Neon subscription cache insert/update paths.
- **`sanitize-for-log.test.ts`** — bigint, symbol, unserializable objects and unsupported types.
- **`billing-profiles.test.ts`** — `updateAppBillingProfileSettings`: row creation, threshold clearing, and the progressive-billing push to the OpenMeter profile.

Shared setup in each new file is behind named helpers (`withPublishedPlan`, `withOffAmountStarter`, `createSequence`, `seedPlanChange`, `auditOwnerApp`, `seedPhaseOutPlan`, `ensureForApp`) so the added test code stays under the `new_duplicated_lines_density` gate.

No production code changed apart from the two npm script flags.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (only the pre-existing `AppModeStep.tsx` hook warnings)
- [x] `npm test` against Postgres 16 on Node 22.14 and Node 22.23.2 (the version CI resolves for `node-version: "22"`): 1066 pass, 0 fail, 1 skipped
- [x] `npm run test:coverage` produces the same lcov on both Node versions; per-file line coverage: `owner-starter-plan.ts` 100%, `subscriptions-billing.ts` 99.8%, `starter-subscription.ts` 99.0%, `billing-consistency.ts` 92.1%
- [x] New-line coverage cross-checked by intersecting the branch diff with `coverage/lcov.info` (table above)
- [ ] SonarCloud PR decoration on this PR, then #384's `new_coverage` after merge

Snyk was not run locally — no Snyk CLI or token is available in this environment. The change adds no dependencies and no runtime code paths, so there is no new attack surface to scan.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06cbf0f0-bc87-487b-93e4-b092aeb74883?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06cbf0f0-bc87-487b-93e4-b092aeb74883&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

