### PR TITLE
chore(openmeter): bump compose image to v1.0.0-beta.232

### DIFF
--- a/docker-compose.openmeter.yml
+++ b/docker-compose.openmeter.yml
@@ -3,7 +3,7 @@
 # API: http://127.0.0.1:48888
 # Local secrets: set OPENMETER_POSTGRES_SECRET and OPENMETER_CLICKHOUSE_SECRET in .env (see .env.example).
 
-x-openmeter-image: &openmeter-image ghcr.io/openmeterio/openmeter:v1.0.0-beta.231
+x-openmeter-image: &openmeter-image ghcr.io/openmeterio/openmeter:v1.0.0-beta.232
 
 services:
   openmeter-postgres:


### PR DESCRIPTION
## Summary
- Bump `docker-compose.openmeter.yml` OpenMeter image from `v1.0.0-beta.231` to `v1.0.0-beta.232` so local/self-hosted stacks match `@openmeter/sdk` after #408.

## Test plan
- [x] Confirm `ghcr.io/openmeterio/openmeter:v1.0.0-beta.232` exists
- [x] `docker compose -f docker-compose.openmeter.yml pull`
- [x] `docker compose -f docker-compose.openmeter.yml up -d` and hit `http://127.0.0.1:48888`