### PR TITLE
fix(openmeter): Konnect profile updates fail schema validation (collection backfill 400s)

### DIFF
--- a/scripts/openmeter-backfill-collection-alignment.ts
+++ b/scripts/openmeter-backfill-collection-alignment.ts
@@ -26,18 +26,37 @@ async function main() {
     })
     .from(appBillingConfig);
 
-  const targets = rows.flatMap((row) =>
+  const rowTargets = rows.flatMap((row) =>
     [row.profileId, row.merchantProfileId]
       .map((id) => id?.trim())
       .filter((id): id is string => Boolean(id))
       .map((profileId) => ({ clientId: row.clientId, profileId })),
   );
 
+  // The shared merchant Custom Invoicing profile lives in an env var, not in
+  // app_billing_config, so the row scan alone never reaches it.
+  const envMerchantProfileId =
+    process.env.OPENMETER_MERCHANT_BILLING_PROFILE_ID?.trim();
+  if (envMerchantProfileId) {
+    rowTargets.push({
+      clientId: "(shared merchant profile)",
+      profileId: envMerchantProfileId,
+    });
+  }
+
+  const seen = new Set<string>();
+  const targets = rowTargets.filter((target) => {
+    if (seen.has(target.profileId)) return false;
+    seen.add(target.profileId);
+    return true;
+  });
+
   console.log(
     `${dryRun ? "DRY-RUN" : "APPLY"}: ${targets.length} profile(s) across ${rows.length} app(s)`,
   );
 
   let failures = 0;
+  let skipped = 0;
   for (const target of targets) {
     if (dryRun) {
       console.log(`would anchor ${target.profileId} (${target.clientId})`);
@@ -49,12 +68,20 @@ async function main() {
       });
       console.log(`${target.clientId}: anchored ${target.profileId}`);
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Rows can reference profiles that were since deleted in Konnect;
+      // nothing to anchor there.
+      if (/is deleted/.test(message)) {
+        skipped += 1;
+        console.log(`${target.clientId}: skipped ${target.profileId} (deleted)`);
+        continue;
+      }
       failures += 1;
-      console.error(
-        `${target.clientId}: FAILED ${target.profileId}`,
-        err instanceof Error ? err.message : String(err),
-      );
+      console.error(`${target.clientId}: FAILED ${target.profileId}`, message);
     }
+  }
+  if (skipped > 0) {
+    console.log(`${skipped} deleted profile(s) skipped`);
   }
   if (failures > 0) {
     throw new Error(`collection backfill failed for ${failures} profile(s)`);

--- a/src/lib/billing/billing-state.test.ts
+++ b/src/lib/billing/billing-state.test.ts
@@ -29,7 +29,7 @@ function input(overrides: Partial<BillingStateInput> = {}): BillingStateInput {
     paymentMethod: { hasDefault: true, brand: "visa", last4: "7310" },
     billingAvailable: true,
     cycle: "P1M",
-    collectionInterval: "DAY",
+    collectionInterval: "P1D",
     ...overrides,
   };
 }
@@ -165,7 +165,7 @@ describe("resolveBillingState shape", () => {
   it("publishes the collection timing knobs", () => {
     const state = resolveBillingState(input());
     assert.equal(state.collection.cycle, "P1M");
-    assert.equal(state.collection.collectionInterval, "DAY");
+    assert.equal(state.collection.collectionInterval, "P1D");
     assert.equal(state.collection.leadThreshold.usd, "5.00");
     assert.equal(state.collection.minimumCharge.usd, "0.50");
   });

--- a/src/lib/openmeter/billing-collection.ts
+++ b/src/lib/openmeter/billing-collection.ts
@@ -16,10 +16,12 @@
  */
 
 /**
- * A documented `RecurringPeriodIntervalEnum` member, which avoids OM's
- * heuristic ISO-duration parsing for sub-day values.
+ * ISO-8601 duration, not the `DAY` enum shorthand: Konnect's billing profile
+ * schema validates `recurring_period.interval` with an allOf that rejects the
+ * shorthand (observed live, 400 "workflow [allOf]"), while both Konnect and
+ * the OM SDK accept the canonical duration form.
  */
-export const COLLECTION_INTERVAL = "DAY";
+export const COLLECTION_INTERVAL = "P1D";
 
 /**
  * Anchor on profile creation rather than a shared epoch so tenants collect at

--- a/src/lib/openmeter/billing-profile-settings.test.ts
+++ b/src/lib/openmeter/billing-profile-settings.test.ts
@@ -44,7 +44,7 @@ test("buildKonnectCreateBillingProfileBody anchors daily collection", () => {
     alignment: {
       type: "anchored",
       recurring_period: {
-        interval: "DAY",
+        interval: "P1D",
         anchor: "2026-03-04T05:06:07.000Z",
       },
     },

--- a/src/lib/openmeter/konnect-billing-profiles.test.ts
+++ b/src/lib/openmeter/konnect-billing-profiles.test.ts
@@ -12,6 +12,7 @@ import {
   listKonnectBillingProfiles,
   resolveKonnectStripeAppId,
   selectReadyKonnectStripeApp,
+  updateKonnectBillingProfileCollection,
   updateKonnectBillingProfileProgressiveBilling,
 } from "./konnect-billing-profiles";
 import {
@@ -45,7 +46,7 @@ test("buildKonnectCreateBillingProfileBody uses Konnect snake_case supplier addr
   assert.equal(body.workflow.collection?.alignment.type, "anchored");
   assert.equal(
     body.workflow.collection?.alignment.recurring_period.interval,
-    "DAY",
+    "P1D",
   );
   assert.deepEqual(body.apps, {
     tax: { id: "01G65Z755AFWAKHE12NY0CQ9FH" },
@@ -302,4 +303,70 @@ test("updateKonnectBillingProfileProgressiveBilling patches workflow", async (t)
     progressiveBilling: true,
   });
   assert.equal(calls.length, 2);
+});
+
+test("updateKonnectBillingProfileCollection strips supplier.id and sends P1D", async (t) => {
+  withKonnectEnv(t);
+  let putBody = "";
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    if (method === "GET") {
+      return new Response(
+        JSON.stringify({
+          id: "prof_1",
+          created_at: "t0",
+          updated_at: "t1",
+          apps: { tax: { id: "a" } },
+          // Konnect GET bodies carry response-only supplier.id, which the
+          // update schema rejects with an allOf error when echoed back.
+          supplier: { id: "", name: "Tenant", addresses: {} },
+          workflow: { collection: { alignment: { type: "subscription" } } },
+          name: "Tenant",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    putBody = String(init?.body ?? "");
+    return new Response("{}", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  await updateKonnectBillingProfileCollection({
+    profileId: "prof_1",
+    anchor: new Date("2026-03-04T05:06:07.000Z"),
+  });
+  const body = JSON.parse(putBody);
+  assert.equal("id" in body.supplier, false);
+  assert.equal(body.supplier.name, "Tenant");
+  assert.deepEqual(body.workflow.collection, {
+    alignment: {
+      type: "anchored",
+      recurring_period: {
+        interval: "P1D",
+        anchor: "2026-03-04T05:06:07.000Z",
+      },
+    },
+  });
+});
+
+test("updateKonnectBillingProfileCollection refuses deleted profiles", async (t) => {
+  withKonnectEnv(t);
+  t.mock.method(globalThis, "fetch", async () => {
+    return new Response(
+      JSON.stringify({
+        id: "prof_gone",
+        deleted_at: "2026-06-27T00:00:41.255302Z",
+        workflow: {},
+        name: "Tenant",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  await assert.rejects(
+    updateKonnectBillingProfileCollection({ profileId: "prof_gone" }),
+    /is deleted/,
+  );
 });

--- a/src/lib/openmeter/konnect-billing-profiles.ts
+++ b/src/lib/openmeter/konnect-billing-profiles.ts
@@ -422,6 +422,25 @@ export async function createKonnectBillingProfile(input: {
   return profile.id;
 }
 
+/**
+ * Konnect's GET body carries response-only fields its own update schema
+ * rejects with allOf errors — `supplier.id` is one — so a read-modify-write
+ * must strip them before echoing the body into a PUT.
+ */
+function sanitizeProfileForReplace(
+  replaceable: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = { ...replaceable };
+  if (out.supplier && typeof out.supplier === "object") {
+    const { id: _supplierId, ...supplier } = out.supplier as Record<
+      string,
+      unknown
+    >;
+    out.supplier = supplier;
+  }
+  return out;
+}
+
 /** Read-modify-write of an existing Konnect billing profile's workflow block. */
 async function patchKonnectBillingProfileWorkflow(
   profileId: string,
@@ -432,6 +451,9 @@ async function patchKonnectBillingProfileWorkflow(
   );
   if (!existing || typeof existing !== "object") {
     throw new Error("Konnect billing profile not found");
+  }
+  if (typeof existing.deleted_at === "string" && existing.deleted_at) {
+    throw new Error(`Konnect billing profile ${profileId} is deleted`);
   }
 
   const workflow =
@@ -452,7 +474,7 @@ async function patchKonnectBillingProfileWorkflow(
   await billingFetch(`/profiles/${encodeURIComponent(profileId)}`, {
     method: "PUT",
     body: JSON.stringify({
-      ...replaceable,
+      ...sanitizeProfileForReplace(replaceable),
       workflow,
     }),
   });
@@ -508,7 +530,7 @@ export async function updateKonnectBillingProfileSupplier(input: {
   await billingFetch(`/profiles/${encodeURIComponent(input.profileId)}`, {
     method: "PUT",
     body: JSON.stringify({
-      ...replaceable,
+      ...sanitizeProfileForReplace(replaceable),
       supplier: buildKonnectSupplier(input.name, input.supplier),
     }),
   });


### PR DESCRIPTION
## Summary
The collection-alignment backfill 400ed on **every** profile with `supplier [allOf] / workflow [allOf]` schema errors from Konnect's billing API. Live stepwise bisection against a deleted staging profile isolated two causes:

1. **`supplier.id` echo** — the read-modify-write helpers (`patchKonnectBillingProfileWorkflow`, `updateKonnectBillingProfileSupplier`) echo the GET body into the PUT, and Konnect's GET carries response-only fields its own update schema rejects. Stripping `supplier.id` moved the error from schema rejection to business logic, proving it the supplier offender. Now stripped via `sanitizeProfileForReplace`.
2. **`interval: "DAY"`** — Konnect validates `recurring_period.interval` as an ISO-8601 duration and rejects the enum shorthand; `P1D` passes. `COLLECTION_INTERVAL` is now `P1D` (both the Konnect and OM SDK builders share it, and the SDK accepts durations). Note this also affects **profile creation** (`buildKonnectCreateBillingProfileBody`), which sends the same collection block — new-profile creation would hit the same 400.

Also hardened the backfill script:
- Skips profiles deleted in Konnect but still referenced by `app_billing_config` (found live: rows pointing at soft-deleted profiles) instead of counting them as failures.
- Includes the shared merchant Custom Invoicing profile from `OPENMETER_MERCHANT_BILLING_PROFILE_ID` — it lives in an env var, not in `app_billing_config`, so the row scan alone never anchored it. Targets are deduped.

## Test plan
- [x] `npm test` — 1217 pass, incl. new regression tests: PUT body strips `supplier.id` + sends `P1D`; deleted profiles are refused with a distinct error
- [x] `eslint` + `tsc --noEmit` clean
- [ ] Live: `npm run openmeter:backfill-collection -- --apply` anchors profiles without 400s; deleted ones log `skipped (deleted)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)