### PR TITLE
chore(release): bump version to 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymthouse",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pymthouse",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^9.1.0",
         "@braintree/sanitize-url": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymthouse",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "engines": {
     "node": ">=20.19.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump `pymthouse` package version from `0.3.6` to `0.3.7`
- update lockfile root metadata version fields to keep release metadata consistent

## Validation
- ✅ `npx tsc --noEmit`
- ⚠️ `npx sonar-scanner -Dsonar.host.url=https://sonarcloud.io -Dsonar.token="${SONAR_TOKEN:-}"` failed locally due missing/unauthorized `SONAR_TOKEN`
- ⚠️ `npx snyk code test --severity-threshold=high` / `npx snyk test --all-projects --severity-threshold=high` failed locally due missing/unauthorized `SNYK_TOKEN`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e9f9506-4e08-4257-9208-2234c3198681?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e9f9506-4e08-4257-9208-2234c3198681&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

