### PR TITLE
fix(payments): dark selects, billing-mode radios, drop supplier tax ID field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -133,6 +133,7 @@ async function rejectIfSupplierIncomplete(
     country: config?.supplierCountry,
     name: config?.supplierName,
     taxId: pendingTaxId,
+    taxIdOnFileAtStripe: config?.supplierTaxIdOnFileAtStripe,
   };
   if (supplierIsComplete(supplierInput)) {
     return null;
@@ -142,7 +143,7 @@ async function rejectIfSupplierIncomplete(
     response: NextResponse.json(
       {
         error:
-          "Switching to merchant mode requires a complete invoice supplier (country, legal name, and tax id where required). Complete Connect onboarding and set supplierTaxId if needed.",
+          "Switching to merchant mode requires a complete invoice supplier (country and legal name from Connect; tax id on file at Stripe where required). Finish Connect onboarding and retry.",
         supplierGaps: supplierGaps(supplierInput),
       },
       { status: 400 },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,29 @@
   --animate-apps-marquee: apps-marquee 45s linear infinite;
 }
 
+/*
+ * App is dark-only. Native <select> popups ignore most Tailwind on <option>,
+ * so without color-scheme they render a light OS menu with inherited light
+ * text — unreadable. Force dark form chrome + option colors.
+ */
+html {
+  color-scheme: dark;
+}
+
+select {
+  color-scheme: dark;
+}
+
+select option,
+select optgroup {
+  background-color: var(--color-zinc-900);
+  color: var(--color-zinc-100);
+}
+
+select option:disabled {
+  color: var(--color-zinc-500);
+}
+
 @keyframes apps-marquee {
   from {
     transform: translateX(0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export default async function RootLayout({
   const session = await getServerSession(authOptions);
 
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className="dark scheme-dark">
       <body className="antialiased bg-zinc-950 text-zinc-100">
         <Providers session={session}>{children}</Providers>
       </body>

--- a/src/components/apps/PaymentsTab.tsx
+++ b/src/components/apps/PaymentsTab.tsx
@@ -42,9 +42,6 @@ type StripeStatus = {
   activation?: ActivationInfo | null;
   supplierCountry?: string | null;
   supplierName?: string | null;
-  supplierTaxId?: string | null;
-  supplierTaxIdRequired?: boolean;
-  supplierTaxIdOnFileAtStripe?: boolean;
   supplierGaps?: string[];
   supplierComplete?: boolean;
 };
@@ -89,8 +86,8 @@ function redirectToStripeConnectUrl(url: string): void {
 const BUTTON_CLASS =
   "inline-flex items-center rounded-md bg-emerald-500/15 px-3 py-2 text-sm font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/30 transition-colors hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-emerald-500/15";
 
-const FIELD_CLASS =
-  "mt-1 w-full max-w-xs rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30";
+const BILLING_MODE_OPTION_CLASS =
+  "flex w-full max-w-md items-start gap-3 rounded-lg border px-3 py-2.5 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-bright/30 disabled:cursor-not-allowed disabled:opacity-40";
 
 function CapabilityValue({ allowed }: Readonly<{ allowed: boolean }>) {
   return (
@@ -172,7 +169,6 @@ function applyStatusToForm(
     progressiveBilling: (v: boolean) => void;
     billingMode: (v: "owner_rollup" | "merchant") => void;
     thresholdDisplay: (v: string) => void;
-    supplierTaxId: (v: string) => void;
   },
 ): void {
   set.progressiveBilling(nextStatus.progressiveBilling ?? true);
@@ -182,7 +178,6 @@ function applyStatusToForm(
       ? usdMicrosToCentsDisplay(nextStatus.softNegativeUsdMicros)
       : "",
   );
-  set.supplierTaxId(nextStatus.supplierTaxId?.trim() || "");
 }
 
 function parseThresholdMicros(display: string): string | null {
@@ -300,7 +295,6 @@ async function requestSaveBillingSettings(input: {
   progressiveBilling: boolean;
   thresholdDisplay: string;
   billingMode: "owner_rollup" | "merchant";
-  supplierTaxId: string;
   setters: BusySetters & {
     setSettingsSaved: (v: string | null) => void;
     setStatus: Dispatch<SetStateAction<StripeStatus | null>>;
@@ -317,11 +311,6 @@ async function requestSaveBillingSettings(input: {
       softNegativeUsdMicros,
       billingMode: input.billingMode,
     };
-    // Always send when Connect is linked so merchant switch can satisfy tax_id
-    // gaps in the same PATCH as billingMode.
-    if (input.supplierTaxId.trim() || input.billingMode === "merchant") {
-      payload.supplierTaxId = input.supplierTaxId.trim() || null;
-    }
     const res = await fetch(`/api/v1/apps/${input.appId}/billing/stripe`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -380,7 +369,6 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
   const [billingMode, setBillingMode] = useState<"owner_rollup" | "merchant">(
     "owner_rollup",
   );
-  const [supplierTaxId, setSupplierTaxId] = useState("");
   const [settingsSaved, setSettingsSaved] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -400,7 +388,6 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
         progressiveBilling: setProgressiveBilling,
         billingMode: setBillingMode,
         thresholdDisplay: setThresholdDisplay,
-        supplierTaxId: setSupplierTaxId,
       });
       if (invoicesRes.ok) {
         const body = await invoicesRes.json();
@@ -445,14 +432,12 @@ export default function PaymentsTab({ appId, canManageBilling }: Readonly<Props>
       progressiveBilling={progressiveBilling}
       thresholdDisplay={thresholdDisplay}
       billingMode={billingMode}
-      supplierTaxId={supplierTaxId}
       settingsSaved={settingsSaved}
       setBusy={setBusy}
       setError={setError}
       setStatus={setStatus}
       setSettingsSaved={setSettingsSaved}
       setBillingMode={setBillingMode}
-      setSupplierTaxId={setSupplierTaxId}
       setProgressiveBilling={setProgressiveBilling}
       setThresholdDisplay={setThresholdDisplay}
       reload={load}
@@ -526,66 +511,90 @@ function PaymentsBillingModeForm(props: Readonly<{
   busy: boolean;
   billingMode: "owner_rollup" | "merchant";
   connectReadyForMerchant: boolean;
-  supplierTaxId: string;
-  supplierTaxIdRequired: boolean;
   settingsSaved: string | null;
   setBillingMode: (v: "owner_rollup" | "merchant") => void;
-  setSupplierTaxId: (v: string) => void;
   onSave: () => void;
 }>) {
   const {
     busy,
     billingMode,
     connectReadyForMerchant,
-    supplierTaxId,
-    supplierTaxIdRequired,
     settingsSaved,
     setBillingMode,
-    setSupplierTaxId,
     onSave,
   } = props;
-  const showTaxId =
-    connectReadyForMerchant &&
-    (supplierTaxIdRequired || billingMode === "merchant");
   return (
     <div className="pt-2 border-t border-white/[0.06] space-y-3">
-      <label className="block text-sm">
-        <span className="text-zinc-500">Billing mode</span>
-        <select
-          className={FIELD_CLASS}
-          value={billingMode}
-          onChange={(e) =>
-            setBillingMode(e.target.value === "merchant" ? "merchant" : "owner_rollup")
-          }
-          disabled={busy}
+      <fieldset className="block text-sm" disabled={busy}>
+        <legend className="text-zinc-500">Billing mode</legend>
+        <div
+          role="radiogroup"
+          aria-label="Billing mode"
+          className="mt-1.5 flex flex-col gap-2"
         >
-          <option value="owner_rollup">Owner roll-up (default)</option>
-          <option value="merchant" disabled={!connectReadyForMerchant}>
-            Merchant (requires Connect ready)
-          </option>
-        </select>
-      </label>
-      {showTaxId ? (
-        <label className="block text-sm">
-          <span className="text-zinc-500">
-            Supplier tax ID
-            {supplierTaxIdRequired ? " (required for invoices)" : " (optional)"}
-          </span>
-          <input
-            type="text"
-            className={`${FIELD_CLASS} font-mono`}
-            value={supplierTaxId}
-            onChange={(e) => setSupplierTaxId(e.target.value)}
-            disabled={busy}
-            placeholder="e.g. VAT / EIN"
-            autoComplete="off"
-          />
-          <span className="mt-1 block text-xs text-zinc-500">
-            Stripe does not share the verified tax ID — enter the value that should
-            appear on customer invoices.
-          </span>
-        </label>
-      ) : null}
+          {(
+            [
+              {
+                value: "owner_rollup" as const,
+                title: "Owner roll-up",
+                detail: "Platform bills end-users; default for most apps",
+                disabled: false,
+              },
+              {
+                value: "merchant" as const,
+                title: "Merchant",
+                detail: connectReadyForMerchant
+                  ? "Charges on your Connected Account"
+                  : "Requires Stripe Connect to be ready",
+                disabled: !connectReadyForMerchant,
+              },
+            ] as const
+          ).map((option) => {
+            const selected = billingMode === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                disabled={busy || option.disabled}
+                onClick={() => setBillingMode(option.value)}
+                className={`${BILLING_MODE_OPTION_CLASS} ${
+                  selected
+                    ? "border-emerald-500/40 bg-emerald-500/10 text-zinc-100"
+                    : "border-white/10 bg-zinc-950/60 text-zinc-300 hover:border-white/20 hover:bg-zinc-900/80"
+                }`}
+              >
+                <span
+                  className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+                    selected
+                      ? "border-emerald-400 bg-emerald-500/20"
+                      : "border-zinc-600 bg-transparent"
+                  }`}
+                  aria-hidden
+                >
+                  {selected ? (
+                    <span className="h-2 w-2 rounded-full bg-emerald-400" />
+                  ) : null}
+                </span>
+                <span className="min-w-0">
+                  <span className="block font-medium text-zinc-100">
+                    {option.title}
+                    {option.value === "owner_rollup" ? (
+                      <span className="ml-1.5 text-xs font-normal text-zinc-500">
+                        default
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="mt-0.5 block text-xs text-zinc-500">
+                    {option.detail}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
       <div className="flex items-center gap-3">
         <button
           type="button"
@@ -779,14 +788,12 @@ function PaymentsTabLoaded(props: Readonly<{
   progressiveBilling: boolean;
   thresholdDisplay: string;
   billingMode: "owner_rollup" | "merchant";
-  supplierTaxId: string;
   settingsSaved: string | null;
   setBusy: (v: boolean) => void;
   setError: (v: string | null) => void;
   setStatus: Dispatch<SetStateAction<StripeStatus | null>>;
   setSettingsSaved: (v: string | null) => void;
   setBillingMode: (v: "owner_rollup" | "merchant") => void;
-  setSupplierTaxId: (v: string) => void;
   setProgressiveBilling: (v: boolean) => void;
   setThresholdDisplay: (v: string) => void;
   reload: () => Promise<void>;
@@ -801,14 +808,12 @@ function PaymentsTabLoaded(props: Readonly<{
     progressiveBilling,
     thresholdDisplay,
     billingMode,
-    supplierTaxId,
     settingsSaved,
     setBusy,
     setError,
     setStatus,
     setSettingsSaved,
     setBillingMode,
-    setSupplierTaxId,
     setProgressiveBilling,
     setThresholdDisplay,
     reload,
@@ -823,7 +828,6 @@ function PaymentsTabLoaded(props: Readonly<{
       progressiveBilling,
       thresholdDisplay,
       billingMode,
-      supplierTaxId,
       setters: { setBusy, setError, setSettingsSaved, setStatus },
     });
   const showDetails =
@@ -870,11 +874,8 @@ function PaymentsTabLoaded(props: Readonly<{
             busy={busy}
             billingMode={billingMode}
             connectReadyForMerchant={connectReadyForMerchant}
-            supplierTaxId={supplierTaxId}
-            supplierTaxIdRequired={Boolean(status?.supplierTaxIdRequired)}
             settingsSaved={settingsSaved}
             setBillingMode={setBillingMode}
-            setSupplierTaxId={setSupplierTaxId}
             onSave={save}
           />
         )}

--- a/src/lib/openmeter/billing-supplier.ts
+++ b/src/lib/openmeter/billing-supplier.ts
@@ -64,8 +64,9 @@ export function buildKonnectSupplierAddress(s?: BillingProfileSupplierInput) {
 }
 
 /**
- * Jurisdictions requiring the seller's tax number on a B2B invoice.
- * Stripe will not share the verified value, so the developer must supply it.
+ * Jurisdictions that expect a seller tax number on B2B invoices.
+ * Stripe Connect only exposes `tax_id_provided` (boolean) — never the value —
+ * so {@link supplierGaps} treats on-file-at-Stripe as satisfying the gap.
  *
  * First-pass list — have tax counsel review before gating production onboarding.
  */
@@ -120,11 +121,15 @@ export function supplierGaps(input: {
   country?: string | null;
   name?: string | null;
   taxId?: string | null;
+  /** Stripe Connect `company.tax_id_provided` / `vat_id_provided`. */
+  taxIdOnFileAtStripe?: boolean | null;
 }): SupplierGap[] {
   const gaps: SupplierGap[] = [];
   if (!present(input.country)) gaps.push("country");
   if (!present(input.name)) gaps.push("name");
-  if (requiresSupplierTaxId(input.country) && !present(input.taxId)) {
+  const hasTaxId =
+    present(input.taxId) || Boolean(input.taxIdOnFileAtStripe);
+  if (requiresSupplierTaxId(input.country) && !hasTaxId) {
     gaps.push("tax_id");
   }
   return gaps;

--- a/src/lib/openmeter/supplier-sync.test.ts
+++ b/src/lib/openmeter/supplier-sync.test.ts
@@ -36,6 +36,15 @@ test("supplierGaps: DE company needs tax id", () => {
     supplierGaps({ country: "DE", name: "GmbH", taxId: "DE123" }),
     [],
   );
+  assert.deepEqual(
+    supplierGaps({
+      country: "DE",
+      name: "GmbH",
+      taxId: null,
+      taxIdOnFileAtStripe: true,
+    }),
+    [],
+  );
 });
 
 test("supplierGaps: missing country and name", () => {
@@ -137,6 +146,15 @@ test("resolveMerchantChargeModel gates direct on supplier completeness", () => {
       supplierTaxId: null,
     }),
     "destination",
+  );
+  assert.equal(
+    resolveMerchantChargeModel({
+      supplierCountry: "DE",
+      supplierName: "GmbH",
+      supplierTaxId: null,
+      supplierTaxIdOnFileAtStripe: true,
+    }),
+    "direct",
   );
 });
 

--- a/src/lib/openmeter/supplier-sync.ts
+++ b/src/lib/openmeter/supplier-sync.ts
@@ -67,6 +67,7 @@ export async function appSupplierGaps(
     country: config.supplierCountry,
     name: config.supplierName,
     taxId: config.supplierTaxId,
+    taxIdOnFileAtStripe: config.supplierTaxIdOnFileAtStripe,
   });
 }
 
@@ -162,6 +163,7 @@ export async function syncTenantSupplierFromConnect(input: {
         country: config.supplierCountry,
         name: config.supplierName,
         taxId: config.supplierTaxId,
+        taxIdOnFileAtStripe: config.supplierTaxIdOnFileAtStripe,
       }),
     };
   }
@@ -199,6 +201,8 @@ export async function syncTenantSupplierFromConnect(input: {
     country: refreshed?.supplierCountry ?? country,
     name: refreshed?.supplierName ?? supplierName,
     taxId: refreshed?.supplierTaxId,
+    taxIdOnFileAtStripe:
+      refreshed?.supplierTaxIdOnFileAtStripe ?? identity.taxIdProvided,
   });
 
   const profileId = preferredMerchantProfileId(refreshed ?? config);
@@ -236,6 +240,7 @@ export async function setAppSupplierTaxId(input: {
     country: config.supplierCountry,
     name: config.supplierName,
     taxId: config.supplierTaxId,
+    taxIdOnFileAtStripe: config.supplierTaxIdOnFileAtStripe,
   });
 
   const profileId = preferredMerchantProfileId(config);
@@ -258,12 +263,14 @@ export function resolveMerchantChargeModel(config: {
   supplierCountry?: string | null;
   supplierName?: string | null;
   supplierTaxId?: string | null;
+  supplierTaxIdOnFileAtStripe?: boolean | null;
 }): "direct" | "destination" {
   if (
     supplierIsComplete({
       country: config.supplierCountry,
       name: config.supplierName,
       taxId: config.supplierTaxId,
+      taxIdOnFileAtStripe: config.supplierTaxIdOnFileAtStripe,
     })
   ) {
     return "direct";
@@ -283,6 +290,7 @@ export function supplierStatusPayload(config: {
     country: config.supplierCountry,
     name: config.supplierName,
     taxId: config.supplierTaxId,
+    taxIdOnFileAtStripe: config.supplierTaxIdOnFileAtStripe,
   });
   return {
     supplierCountry: config.supplierCountry ?? null,


### PR DESCRIPTION
## Summary
- Fix unreadable native `<select>` menus in dark mode (`color-scheme: dark` + option colors).
- Replace Payments **Billing mode** `<select>` with accessible radio cards.
- Remove the unused **Supplier tax ID** UI field; treat Stripe Connect `tax_id_provided` as satisfying merchant supplier tax gaps.
- Keep API/`supplierTaxId` storage for programmatic use; merchant switch no longer asks builders to paste a tax ID Stripe will not share.

## Test plan
- [ ] Payments tab: Billing mode radios select Owner roll-up / Merchant; Save still works
- [ ] Supplier tax ID input is gone
- [ ] Native selects elsewhere (Plans / App settings) open with readable dark menus
- [ ] Merchant mode switch succeeds when Connect is ready and Stripe has tax ID on file (EU) without a manual tax ID
- [ ] `npx tsx --test src/lib/openmeter/supplier-sync.test.ts` passes