### PR TITLE
Remove dead PPU spend guide field from plans tab

### DIFF
--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -22,7 +22,6 @@ import {
   parseMarkupPercentInput,
 } from "@/lib/plan-pricing";
 import { validateCapabilityFeatureKeys } from "@/lib/openmeter/capability-features";
-import { resolvedPayPerUseBehavior } from "@/lib/billing/pay-per-use-threshold";
 import { OPENMETER_DOCS } from "@/lib/openmeter/constants";
 import {
   CUSTOM_PLAN_NAME_MAX_LENGTH,
@@ -55,7 +54,6 @@ interface PlanRow {
   overageRateUsd: string | null;
   includedUsdMicros: string | null;
   billingCycle: string;
-  chargeThresholdUsdMicros?: string | null;
   resolvedBehavior?: string;
   discoveryProfileId?: string | null;
   isNetworkDefault?: boolean;
@@ -105,8 +103,6 @@ interface PlanDraft {
   priceAmount: string;
   priceCurrency: string;
   billingCycle: PlanBillingCycle;
-  /** Pay-Per-Use only: invoice/charge threshold in dollars, e.g. "10.00". */
-  chargeThresholdUsdDisplay: string;
   includedUsdDisplay: string;
   defaultMarkupPct: string;
   capabilityKeys: string[];
@@ -325,7 +321,6 @@ function planToDraft(plan: PlanRow): PlanDraft {
     priceAmount: normalizeUsdCentsDisplay(plan.priceAmount || "0"),
     priceCurrency: plan.priceCurrency,
     billingCycle: normalizePlanBillingCycle(plan.billingCycle),
-    chargeThresholdUsdDisplay: usdMicrosToDisplay(plan.chargeThresholdUsdMicros),
     includedUsdDisplay: usdMicrosToDisplay(plan.includedUsdMicros),
     defaultMarkupPct: retailRateUsdToMarkupPercent(plan.overageRateUsd),
     capabilityKeys,
@@ -342,7 +337,6 @@ function emptyDraft(): PlanDraft {
     priceAmount: "0.00",
     priceCurrency: "USD",
     billingCycle: "monthly",
-    chargeThresholdUsdDisplay: "",
     includedUsdDisplay: "",
     defaultMarkupPct: "0",
     capabilityKeys: [],
@@ -769,39 +763,6 @@ function PlanDraftForm({
         </div>
       )}
 
-      {draft.type === "usage" && (
-        <div>
-          <label
-            htmlFor={`${idPrefix}-charge-threshold`}
-            className="mb-1 flex items-center gap-1.5 text-xs text-zinc-500"
-          >
-            Pay-as-you-go spend guide (USD)
-            <InfoTooltip
-              wide
-              label={
-                "Display only — shown to users as the typical amount of a\n" +
-                "pay-as-you-go invoice once their credits run out. It does not\n" +
-                "trigger collection: overage invoice timing is app-wide, set by\n" +
-                "the overage limit on the Payments tab."
-              }
-            />
-          </label>
-          <DollarCentsInput
-            id={`${idPrefix}-charge-threshold`}
-            value={draft.chargeThresholdUsdDisplay}
-            onChange={(chargeThresholdUsdDisplay) =>
-              onChange({ ...draft, chargeThresholdUsdDisplay })
-            }
-            placeholder="10.00"
-            disabled={!canEdit}
-            aria-label="Pay-as-you-go spend guide in dollars"
-          />
-          <p className="text-xs text-zinc-500 mt-1">
-            {resolvedPayPerUseBehavior()}
-          </p>
-        </div>
-      )}
-
       {(draft.type === "subscription" || draft.type === "usage") && (
         <div>
           <label htmlFor={`${idPrefix}-default-markup`} className="block text-xs text-zinc-500 mb-1">
@@ -1021,12 +982,6 @@ function buildPlanPayload(
         : "0",
     priceCurrency: draft.priceCurrency,
     billingCycle: draft.billingCycle,
-    // Pay-Per-Use is threshold-only (#398): send the threshold; clear it on
-    // other types so switching a plan away from usage drops it server-side.
-    chargeThresholdUsd:
-      draft.type === "usage" && draft.chargeThresholdUsdDisplay.trim()
-        ? draft.chargeThresholdUsdDisplay.trim()
-        : null,
     ...(planId ? {} : { status: "active" }),
     capabilities,
     includedUsdMicros,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the `Pay-as-you-go spend guide (USD)` input block from the Pay-Per-Use plan editor UI
- remove `chargeThresholdUsdDisplay` from `PlanDraft` state and draft conversion helpers
- stop sending `chargeThresholdUsd` from `buildPlanPayload` when creating/updating plans from the Plans tab

## Testing
- `npm run lint -- src/components/apps/PlansTab.tsx` ✅ (passes; repo has existing unrelated warnings)
- `npx tsc --noEmit` ✅
- `PYMTHOUSE_TEST_DATABASE_URL_UNSET=1 npm run test:coverage` ⚠️ fails due existing unrelated baseline test failures
- `npx sonar-scanner` ⚠️ fails locally (no Sonar server at localhost)
- `npx sonar-scanner -Dsonar.host.url=https://sonarcloud.io` ⚠️ fails locally (missing `SONAR_TOKEN` / unauthorized)
- `npx snyk code test --severity-threshold=high` ⚠️ fails locally (missing Snyk auth)
- `npx snyk test --all-projects --severity-threshold=high` ⚠️ fails locally (missing Snyk auth)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6367983-d0c0-4142-85eb-877fce96bfc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6367983-d0c0-4142-85eb-877fce96bfc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

