### PR TITLE
fix(billing): include Connect charges in history and save cards on payment Checkout

### DIFF
--- a/src/lib/stripe/connect-accounts.test.ts
+++ b/src/lib/stripe/connect-accounts.test.ts
@@ -179,6 +179,38 @@ test("mapMerchantPaymentIntent includes ad-hoc succeeded Connect charges", () =>
   );
 });
 
+test("mapMerchantPaymentIntent skips invoice-backed PaymentIntents", () => {
+  assert.equal(
+    __testMerchantConnectInvoices.mapMerchantPaymentIntent({
+      id: "pi_invoice_paid",
+      amount: 250,
+      currency: "usd",
+      status: "succeeded",
+      customer: "cus_connected",
+      created: 1_735_689_600,
+      invoice: "in_1ABC",
+      metadata: {},
+    }),
+    null,
+  );
+  assert.equal(
+    __testMerchantConnectInvoices.mapMerchantPaymentIntent({
+      id: "pi_invoice_expanded",
+      amount: 250,
+      status: "succeeded",
+      invoice: { id: "in_1DEF" },
+      metadata: { pymthouse_auto_topup: "1" },
+    }),
+    null,
+  );
+  assert.equal(
+    __testMerchantConnectInvoices.paymentIntentInvoiceId({
+      invoice: "in_1ABC",
+    }),
+    "in_1ABC",
+  );
+});
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,

--- a/src/lib/stripe/connect-accounts.test.ts
+++ b/src/lib/stripe/connect-accounts.test.ts
@@ -133,6 +133,52 @@ test("mapLegacyAutoTopUpPaymentIntent maps succeeded auto top-ups only", () => {
   );
 });
 
+test("mapMerchantPaymentIntent includes ad-hoc succeeded Connect charges", () => {
+  assert.deepEqual(
+    __testMerchantConnectInvoices.mapMerchantPaymentIntent({
+      id: "pi_charge_1",
+      amount: 200,
+      currency: "usd",
+      status: "succeeded",
+      customer: "cus_connected",
+      created: 1_735_689_600,
+      metadata: {},
+    }),
+    {
+      id: "pi_charge_1",
+      number: "Payment",
+      status: "succeeded",
+      currency: "USD",
+      totalAmount: "2.00",
+      customerId: "cus_connected",
+      issuedAt: "2025-01-01T00:00:00.000Z",
+      externalInvoicingId: "pi_charge_1",
+      invoiceType: "payment",
+    },
+  );
+  assert.deepEqual(
+    __testMerchantConnectInvoices.mapMerchantPaymentIntent({
+      id: "pi_topup_2",
+      amount: 500,
+      currency: "usd",
+      status: "succeeded",
+      customer: "cus_connected",
+      created: 1_735_689_600,
+      metadata: { pymthouse_auto_topup: "1" },
+    })?.number,
+    "Auto top-up",
+  );
+  assert.equal(
+    __testMerchantConnectInvoices.mapMerchantPaymentIntent({
+      id: "pi_zero",
+      amount: 0,
+      status: "succeeded",
+      metadata: {},
+    }),
+    null,
+  );
+});
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -426,6 +472,10 @@ test("createConnectedCheckoutSession setup and payment modes", async (t) => {
   assert.equal(payment.url, "https://checkout.stripe.com/c/pay/cs_test_1");
   assert.match(bodies[1]!, /mode=payment/);
   assert.match(bodies[1]!, /payment_intent_data.*application_fee_amount.*250/);
+  assert.match(
+    bodies[1]!,
+    /payment_intent_data%5Bsetup_future_usage%5D=off_session/,
+  );
 });
 
 test("createConnectedCheckoutSession fails without session url", async (t) => {

--- a/src/lib/stripe/connect-accounts.ts
+++ b/src/lib/stripe/connect-accounts.ts
@@ -455,6 +455,8 @@ function addPaymentCheckoutFields(
   if (fee > 0) {
     body.set("payment_intent_data[application_fee_amount]", String(fee));
   }
+  // Save the card on the Connect customer for later subscription / usage debit.
+  body.set("payment_intent_data[setup_future_usage]", "off_session");
 }
 
 export async function createConnectedCheckoutSession(input: {

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -51,6 +51,8 @@ type StripeConnectPaymentIntent = {
   status?: string | null;
   customer?: string | null;
   created?: number | null;
+  /** Set when this PI paid a Stripe Invoice — history should keep the invoice only. */
+  invoice?: string | { id?: string | null } | null;
   metadata?: Record<string, unknown> | null;
   latest_charge?:
     | string
@@ -164,10 +166,16 @@ function mapLegacyAutoTopUpPaymentIntent(
  * PaymentIntent on the Connect customer (legacy auto top-ups and ad-hoc
  * charges). One-time Dashboard/Checkout charges without invoice rows would
  * otherwise never appear.
+ *
+ * Invoice-backed PaymentIntents are omitted — the invoice row is the
+ * canonical history entry (avoids duplicate billed amounts).
  */
 function mapMerchantPaymentIntent(
   pi: StripeConnectPaymentIntent,
 ): MerchantBillingHistoryItem | null {
+  if (paymentIntentInvoiceId(pi)) {
+    return null;
+  }
   const legacy = mapLegacyAutoTopUpPaymentIntent(pi);
   if (legacy) return legacy;
   const id = pi.id?.trim();
@@ -190,11 +198,28 @@ function mapMerchantPaymentIntent(
 }
 
 /** @internal Exported for unit tests. */
+function paymentIntentInvoiceId(
+  pi: StripeConnectPaymentIntent,
+): string | null {
+  const raw = pi.invoice;
+  if (typeof raw === "string") {
+    const id = raw.trim();
+    return id.startsWith("in_") ? id : null;
+  }
+  if (raw && typeof raw === "object") {
+    const id = raw.id?.trim();
+    return id?.startsWith("in_") ? id : null;
+  }
+  return null;
+}
+
+/** @internal Exported for unit tests. */
 export const __testMerchantConnectInvoices = {
   invoiceDate,
   mapMerchantInvoice,
   mapLegacyAutoTopUpPaymentIntent,
   mapMerchantPaymentIntent,
+  paymentIntentInvoiceId,
   stripeConnectInvoiceRequest,
 };
 /** @internal Exported for unit tests. */
@@ -585,8 +610,9 @@ function billingHistorySortKey(item: MerchantBillingHistoryItem): number {
 }
 
 /**
- * List invoices + succeeded auto top-up PaymentIntents from the merchant's
- * Connected Account for one app user (newest first).
+ * List invoices + standalone succeeded PaymentIntents from the merchant's
+ * Connected Account for one app user (newest first). Invoice-backed intents
+ * are omitted so the same charge is not listed twice.
  * Merchant billing never reads OpenMeter owner-rollup invoices.
  */
 export async function listMerchantConnectInvoicesForAppUser(input: {

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -73,7 +73,7 @@ export type MerchantBillingHistoryItem = {
   periodStart?: string;
   periodEnd?: string;
   externalInvoicingId?: string;
-  invoiceType: "stripe_connect" | "auto_topup";
+  invoiceType: "stripe_connect" | "auto_topup" | "payment";
 };
 
 function stripeSecretKey(): string {
@@ -159,11 +159,42 @@ function mapLegacyAutoTopUpPaymentIntent(
   };
 }
 
+/**
+ * Merchant billing history includes Stripe invoices plus any succeeded
+ * PaymentIntent on the Connect customer (legacy auto top-ups and ad-hoc
+ * charges). One-time Dashboard/Checkout charges without invoice rows would
+ * otherwise never appear.
+ */
+function mapMerchantPaymentIntent(
+  pi: StripeConnectPaymentIntent,
+): MerchantBillingHistoryItem | null {
+  const legacy = mapLegacyAutoTopUpPaymentIntent(pi);
+  if (legacy) return legacy;
+  const id = pi.id?.trim();
+  if (!id?.startsWith("pi_")) return null;
+  const status = pi.status?.trim() || "unknown";
+  if (status !== "succeeded") return null;
+  const amount = pi.amount ?? 0;
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  return {
+    id,
+    number: "Payment",
+    status,
+    currency: pi.currency?.toUpperCase() || "USD",
+    totalAmount: (amount / 100).toFixed(2),
+    customerId: pi.customer?.trim() || undefined,
+    issuedAt: invoiceDate(pi.created),
+    externalInvoicingId: id,
+    invoiceType: "payment",
+  };
+}
+
 /** @internal Exported for unit tests. */
 export const __testMerchantConnectInvoices = {
   invoiceDate,
   mapMerchantInvoice,
   mapLegacyAutoTopUpPaymentIntent,
+  mapMerchantPaymentIntent,
   stripeConnectInvoiceRequest,
 };
 /** @internal Exported for unit tests. */
@@ -591,7 +622,7 @@ export async function listMerchantConnectInvoicesForAppUser(input: {
     .map((invoice) => mapMerchantInvoice(invoice))
     .filter((invoice): invoice is MerchantBillingHistoryItem => invoice !== null);
   const topUps = paymentIntentRows
-    .map((pi) => mapLegacyAutoTopUpPaymentIntent(pi))
+    .map((pi) => mapMerchantPaymentIntent(pi))
     .filter((row): row is MerchantBillingHistoryItem => row !== null);
   const merged = [...invoices, ...topUps].sort(
     (a, b) => billingHistorySortKey(b) - billingHistorySortKey(a),


### PR DESCRIPTION
## Summary
- Surface succeeded Connect PaymentIntents (ad-hoc charges and auto top-ups) in merchant billing history as `invoiceType: "payment"`.
- Skip invoice-backed PaymentIntents so the same charge is not listed twice next to its Stripe invoice.
- Set `payment_intent_data[setup_future_usage]=off_session` on Connect payment Checkout so cards are saved for later subscription / usage debit.

## Test plan
- [x] Unit tests for `mapMerchantPaymentIntent` (ad-hoc charges + invoice-backed skip)
- [x] Unit test asserts Connect payment Checkout includes `setup_future_usage`
- [ ] Merchant app with Connect: confirm billing history shows a one-off Connect charge without duplicating invoice-paid rows
- [ ] Connect payment Checkout: confirm the card is attached on the connected customer after success