### PR TITLE
fix(billing): subscription plan change/resume/cancel defects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,9 +1328,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1346,9 +1343,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1366,9 +1360,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1384,9 +1375,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1404,9 +1392,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1422,9 +1407,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1442,9 +1424,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1461,9 +1440,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1479,9 +1455,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1505,9 +1478,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1529,9 +1499,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1555,9 +1522,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1579,9 +1543,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1605,9 +1566,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1630,9 +1588,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1654,9 +1609,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1961,9 +1913,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1979,9 +1928,6 @@
       "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1999,9 +1945,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2017,9 +1960,6 @@
       "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2659,9 +2599,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2677,9 +2614,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2697,9 +2631,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2715,9 +2646,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3536,9 +3464,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3553,9 +3478,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3570,9 +3492,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3587,9 +3506,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3604,9 +3520,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3621,9 +3534,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3638,9 +3548,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3655,9 +3562,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3672,9 +3576,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3689,9 +3590,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8009,9 +7907,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8031,9 +7926,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -8055,9 +7947,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8077,9 +7966,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@asteasolutions/zod-to-openapi": "^9.1.0",
         "@braintree/sanitize-url": "^7.1.2",
         "@openmeter/sdk": "^1.0.0-beta.232",
-        "@pymthouse/builder-sdk": "^0.6.3",
+        "@pymthouse/builder-sdk": "^0.6.4",
         "@pymthouse/clearinghouse-identity-webhook": "0.5.0-rc.0",
         "@tailwindcss/postcss": "^4.3.3",
         "@turnkey/crypto": "^2.11.1",
@@ -2320,9 +2320,9 @@
       }
     },
     "node_modules/@pymthouse/builder-sdk": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.6.3.tgz",
-      "integrity": "sha512-ex+qcGknv6gs+FqvmgoQgR5Trwy/yQ7UIO91jlGVPpgwSccFqTunP/Lmi+ABY9Gz1F0xN+U9C6AYOhkFSb/Nsw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.6.4.tgz",
+      "integrity": "sha512-bB55HzmW9Ud1Bl7VrC0vCRfAcXaeW8o6Ilf910B2rVTX/k1mXkUKT+BWrFMo0WVzC4gYhcQePBmTiXXPvZEMoQ==",
       "license": "MIT",
       "dependencies": {
         "oauth4webapi": "^3.8.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,6 +1328,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1343,6 +1346,9 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1360,6 +1366,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1375,6 +1384,9 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1392,6 +1404,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1407,6 +1422,9 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1424,6 +1442,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1440,6 +1461,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1455,6 +1479,9 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1478,6 +1505,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1499,6 +1529,9 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1522,6 +1555,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1543,6 +1579,9 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1566,6 +1605,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1588,6 +1630,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1609,6 +1654,9 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1913,6 +1961,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1928,6 +1979,9 @@
       "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1945,6 +1999,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1960,6 +2017,9 @@
       "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2599,6 +2659,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2614,6 +2677,9 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2631,6 +2697,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2646,6 +2715,9 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3464,6 +3536,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3478,6 +3553,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3492,6 +3570,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3506,6 +3587,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3520,6 +3604,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3534,6 +3621,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3548,6 +3638,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3562,6 +3655,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3576,6 +3672,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3590,6 +3689,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7907,6 +8009,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7926,6 +8031,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -7947,6 +8055,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7966,6 +8077,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "openmeter:dedupe-owner-subscriptions": "npx tsx scripts/openmeter-dedupe-owner-subscriptions.ts",
     "openmeter:release-legacy-subjects": "npx tsx scripts/openmeter-release-legacy-subjects.ts",
     "openmeter:audit-billing": "npx tsx scripts/openmeter-audit-billing-consistency.ts",
+    "openmeter:inspect-charges": "npx tsx scripts/openmeter-inspect-subscription-charges.ts",
     "openmeter:fix-owner-attribution": "npx tsx scripts/openmeter-fix-owner-attribution.ts",
     "openmeter:migrate-sandbox-to-stripe": "npx tsx scripts/openmeter-migrate-sandbox-to-stripe.ts",
     "openmeter:migrate-plan-subscribers": "npx tsx scripts/openmeter-migrate-plan-subscribers.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@asteasolutions/zod-to-openapi": "^9.1.0",
     "@braintree/sanitize-url": "^7.1.2",
     "@openmeter/sdk": "^1.0.0-beta.232",
-    "@pymthouse/builder-sdk": "^0.6.3",
+    "@pymthouse/builder-sdk": "^0.6.4",
     "@pymthouse/clearinghouse-identity-webhook": "0.5.0-rc.0",
     "@tailwindcss/postcss": "^4.3.3",
     "@turnkey/crypto": "^2.11.1",

--- a/scripts/openmeter-inspect-subscription-charges.ts
+++ b/scripts/openmeter-inspect-subscription-charges.ts
@@ -40,7 +40,10 @@ import { resolveOpenMeterBillingIdentity } from "../src/lib/openmeter/billing-id
 import { getAppBillingConfig } from "../src/lib/openmeter/billing-profiles";
 import { konnectMeteringV1Fetch } from "../src/lib/openmeter/konnect-admin-client";
 import { parsePriceAmount } from "../src/lib/openmeter/plans-sync";
-import { listOpenMeterSubscriptionsForCustomer } from "../src/lib/openmeter/subscription-read";
+import {
+  listOpenMeterSubscriptionsForCustomer,
+  type OpenMeterSubscriptionView,
+} from "../src/lib/openmeter/subscription-read";
 
 type Args = {
   clientId: string;
@@ -247,12 +250,15 @@ function mapInvoice(raw: unknown): InvoiceView | null {
   return {
     id,
     status: readString(inv.status) ?? "unknown",
-    total: String(total ?? "0"),
+    total: readString(total) ?? "0",
     totalUsdMicros: gatheringTotalUsdMicros(total)?.toString() ?? null,
-    lines: rawLines.map((line) => ({
-      name: readString(readRecord(line)?.name) ?? "Charge",
-      total: String(readRecord(readRecord(line)?.totals)?.total ?? "0"),
-    })),
+    lines: rawLines.map((line) => {
+      const lineTotal = readRecord(readRecord(line)?.totals)?.total;
+      return {
+        name: readString(readRecord(line)?.name) ?? "Charge",
+        total: readString(lineTotal) ?? "0",
+      };
+    }),
   };
 }
 
@@ -349,6 +355,107 @@ function printPlans(localPlans: LocalPlanView[]): void {
   }
 }
 
+function localPlanLabel(local: LocalPlanView | undefined): string {
+  if (!local) return "UNMAPPED — likely a stale plan version";
+  return `${local.name} (${local.id})`;
+}
+
+function printSubscriptions(
+  customerId: string | null,
+  subscriptions: OpenMeterSubscriptionView[],
+  localPlans: LocalPlanView[],
+): void {
+  console.log("\n[3/4] Subscriptions on the billing customer");
+  if (!customerId) {
+    console.log("  no OpenMeter customer resolved — nothing can be billed");
+    return;
+  }
+  if (subscriptions.length === 0) {
+    console.log(`  customerId=${customerId}: no subscriptions`);
+    return;
+  }
+  for (const sub of subscriptions) {
+    const local = localPlans.find((p) => p.openmeterPlanId === sub.planId);
+    console.log(
+      `  ${sub.id} status=${sub.status} planId=${sub.planId ?? "none"} ` +
+        `planKey=${sub.planKey ?? "none"}` +
+        `\n    activeFrom=${sub.activeFrom ?? "none"} activeTo=${sub.activeTo ?? "none"}` +
+        `\n    localPlan=${localPlanLabel(local)}`,
+    );
+  }
+}
+
+function printInvoices(invoices: InvoiceView[]): void {
+  console.log("\n[4/4] Most recent invoices on the billing customer");
+  if (invoices.length === 0) {
+    console.log("  (none)");
+    return;
+  }
+  for (const inv of invoices) {
+    console.log(
+      `  ${inv.id} status=${inv.status} total=${inv.total} ` +
+        `(${inv.totalUsdMicros ?? "?"} usd micros)`,
+    );
+    for (const line of inv.lines) {
+      console.log(`    - ${line.name}: ${line.total}`);
+    }
+  }
+}
+
+function printSubscriptionVerdict(
+  subscriptions: OpenMeterSubscriptionView[],
+  localPlans: LocalPlanView[],
+): void {
+  const liveSubs = subscriptions.filter((sub) =>
+    ["active", "trialing", "scheduled"].includes(sub.status.toLowerCase()),
+  );
+  const feeBearingSubs = liveSubs.filter((sub) =>
+    localPlans.some(
+      (plan) =>
+        plan.openmeterPlanId === sub.planId &&
+        (plan.remote?.rateCards ?? []).some(isFlatFeeCard),
+    ),
+  );
+  if (liveSubs.length === 0) {
+    console.log("  no live subscription — nothing is accruing a subscription fee");
+    return;
+  }
+  if (feeBearingSubs.length === 0) {
+    console.log(
+      `  ${liveSubs.length} live subscription(s), none on a plan version that carries a ` +
+        "flat fee card — no subscription fee can accrue",
+    );
+    return;
+  }
+  console.log(
+    `  live fee-bearing subscription(s): ${feeBearingSubs.map((s) => s.id).join(", ")}`,
+  );
+}
+
+function printGatheringVerdict(
+  gathering: InvoiceView[],
+  collectable: boolean,
+): void {
+  if (gathering.length === 0) {
+    console.log(
+      "  no gathering invoice — OpenMeter has accrued nothing for this customer, " +
+        "so there is no charge any collection trigger could raise",
+    );
+    return;
+  }
+  if (collectable) {
+    console.log(
+      `  a gathering invoice is at or above the ${MIN_INVOICE_USD_MICROS} usd micros ` +
+        "Stripe floor — forcing collection would raise a real invoice",
+    );
+    return;
+  }
+  console.log(
+    `  a gathering invoice exists but sits below the ${MIN_INVOICE_USD_MICROS} usd micros ` +
+      "Stripe floor — forcing collection would be skipped as uncollectable",
+  );
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
@@ -381,41 +488,13 @@ async function main(): Promise<void> {
     clientId: args.clientId,
     externalUserId: args.externalUserId,
   });
-
-  console.log("\n[3/4] Subscriptions on the billing customer");
-  if (!customerId) {
-    console.log("  no OpenMeter customer resolved — nothing can be billed");
-  }
   const subscriptions = customerId
     ? await listOpenMeterSubscriptionsForCustomer(client, customerId)
     : [];
-  if (customerId && subscriptions.length === 0) {
-    console.log(`  customerId=${customerId}: no subscriptions`);
-  }
-  for (const sub of subscriptions) {
-    const local = localPlans.find((p) => p.openmeterPlanId === sub.planId);
-    console.log(
-      `  ${sub.id} status=${sub.status} planId=${sub.planId ?? "none"} ` +
-        `planKey=${sub.planKey ?? "none"}` +
-        `\n    activeFrom=${sub.activeFrom ?? "none"} activeTo=${sub.activeTo ?? "none"}` +
-        `\n    localPlan=${local ? `${local.name} (${local.id})` : "UNMAPPED — likely a stale plan version"}`,
-    );
-  }
+  printSubscriptions(customerId, subscriptions, localPlans);
 
-  console.log("\n[4/4] Most recent invoices on the billing customer");
   const invoices = customerId ? await loadInvoices(client, customerId) : [];
-  if (invoices.length === 0) {
-    console.log("  (none)");
-  }
-  for (const inv of invoices) {
-    console.log(
-      `  ${inv.id} status=${inv.status} total=${inv.total} ` +
-        `(${inv.totalUsdMicros ?? "?"} usd micros)`,
-    );
-    for (const line of inv.lines) {
-      console.log(`    - ${line.name}: ${line.total}`);
-    }
-  }
+  printInvoices(invoices);
 
   const gathering = invoices.filter((inv) => inv.status.toLowerCase() === "gathering");
   const collectable = gathering.some(
@@ -424,45 +503,8 @@ async function main(): Promise<void> {
   );
 
   console.log("\nverdict");
-  const liveSubs = subscriptions.filter((sub) =>
-    ["active", "trialing", "scheduled"].includes(sub.status.toLowerCase()),
-  );
-  const feeBearingSubs = liveSubs.filter((sub) =>
-    localPlans.some(
-      (plan) =>
-        plan.openmeterPlanId === sub.planId &&
-        (plan.remote?.rateCards ?? []).some(isFlatFeeCard),
-    ),
-  );
-  if (liveSubs.length === 0) {
-    console.log("  no live subscription — nothing is accruing a subscription fee");
-  } else if (feeBearingSubs.length === 0) {
-    console.log(
-      `  ${liveSubs.length} live subscription(s), none on a plan version that carries a ` +
-        "flat fee card — no subscription fee can accrue",
-    );
-  } else {
-    console.log(
-      `  live fee-bearing subscription(s): ${feeBearingSubs.map((s) => s.id).join(", ")}`,
-    );
-  }
-
-  if (gathering.length === 0) {
-    console.log(
-      "  no gathering invoice — OpenMeter has accrued nothing for this customer, " +
-        "so there is no charge any collection trigger could raise",
-    );
-  } else if (collectable) {
-    console.log(
-      `  a gathering invoice is at or above the ${MIN_INVOICE_USD_MICROS} usd micros ` +
-        "Stripe floor — forcing collection would raise a real invoice",
-    );
-  } else {
-    console.log(
-      `  a gathering invoice exists but sits below the ${MIN_INVOICE_USD_MICROS} usd micros ` +
-        "Stripe floor — forcing collection would be skipped as uncollectable",
-    );
-  }
+  printSubscriptionVerdict(subscriptions, localPlans);
+  printGatheringVerdict(gathering, collectable);
 
   if (args.json) {
     console.log(

--- a/scripts/openmeter-inspect-subscription-charges.ts
+++ b/scripts/openmeter-inspect-subscription-charges.ts
@@ -1,0 +1,496 @@
+/**
+ * Read-only: does a paid plan actually produce a collectable charge?
+ *
+ * Answers "is there anything to collect at all" before any collection-timing
+ * work, by walking the four places the subscription fee can silently vanish:
+ *
+ *   1. Neon plan row      — `type` must be `subscription` and `price_amount` > 0,
+ *                           otherwise plans-sync never emits a fee rate card.
+ *   2. Published OM plan  — the synced version must carry a `flat` price card.
+ *   3. Subscription       — it must sit on that plan version, not an older one.
+ *   4. Gathering invoice  — the fee line must be there, above the Stripe floor.
+ *
+ * Usage:
+ *   npx tsx scripts/openmeter-inspect-subscription-charges.ts \
+ *     --client-id app_xxx --external-user-id eu_xxx
+ *   npx tsx scripts/openmeter-inspect-subscription-charges.ts \
+ *     --client-id app_xxx --external-user-id eu_xxx --json
+ *
+ * Exit codes:
+ *   0 — a collectable charge exists (or the run was informational only)
+ *   1 — no collectable charge, or a fatal failure
+ */
+import "./load-env-first";
+
+import { eq } from "drizzle-orm";
+import type { OpenMeter } from "@openmeter/sdk";
+
+import { closeDb, db } from "../src/db/index";
+import { plans } from "../src/db/schema";
+import { MIN_INVOICE_USD_MICROS } from "../src/lib/billing/overage-limits";
+import {
+  gatheringTotalUsdMicros,
+  resolveBillingCustomerId,
+} from "../src/lib/billing/unbilled-debt";
+import {
+  getHostedAdminClient,
+  isHostedAdminClientAvailable,
+} from "../src/lib/openmeter/admin-client";
+import { resolveOpenMeterBillingIdentity } from "../src/lib/openmeter/billing-identity";
+import { getAppBillingConfig } from "../src/lib/openmeter/billing-profiles";
+import { konnectMeteringV1Fetch } from "../src/lib/openmeter/konnect-admin-client";
+import { parsePriceAmount } from "../src/lib/openmeter/plans-sync";
+import { listOpenMeterSubscriptionsForCustomer } from "../src/lib/openmeter/subscription-read";
+
+type Args = {
+  clientId: string;
+  externalUserId: string;
+  json: boolean;
+};
+
+function usage(): string {
+  return [
+    "openmeter-inspect-subscription-charges",
+    "",
+    "Check whether a paid plan produces a collectable OpenMeter charge.",
+    "",
+    "Options:",
+    "  --client-id <app_… | developer_apps.id>   (required)",
+    "  --external-user-id <id>                   (required)",
+    "  --json                                    Print the raw report as JSON",
+    "  --help",
+  ].join("\n");
+}
+
+function parseArgs(argv: string[]): Args {
+  let clientId = "";
+  let externalUserId = "";
+  let json = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--client-id") {
+      clientId = argv[++i]?.trim() ?? "";
+      continue;
+    }
+    if (token === "--external-user-id") {
+      externalUserId = argv[++i]?.trim() ?? "";
+      continue;
+    }
+    if (token === "--json") {
+      json = true;
+      continue;
+    }
+    if (token === "--help") {
+      console.log(usage());
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${token}\n\n${usage()}`);
+  }
+
+  if (!clientId || !externalUserId) {
+    throw new Error(`--client-id and --external-user-id are required\n\n${usage()}`);
+  }
+  return { clientId, externalUserId, json };
+}
+
+type RateCardView = {
+  key: string | null;
+  priceType: string | null;
+  amount: string | null;
+  paymentTerm: string | null;
+  billingCadence: string | null;
+};
+
+type RemotePlanView = {
+  id: string;
+  key: string | null;
+  version: number | null;
+  rateCards: RateCardView[];
+};
+
+type LocalPlanView = {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+  priceAmount: string;
+  billingCycle: string;
+  openmeterPlanId: string | null;
+  openmeterPlanVersion: number | null;
+  lastSyncedAt: string | null;
+  /** True when plans-sync would emit a `subscription_fee` rate card. */
+  feeCardExpected: boolean;
+  remote: RemotePlanView | null;
+};
+
+type InvoiceLineView = {
+  name: string;
+  total: string;
+};
+
+type InvoiceView = {
+  id: string;
+  status: string;
+  total: string;
+  totalUsdMicros: string | null;
+  lines: InvoiceLineView[];
+};
+
+/** Most recent invoices to report; older history is noise for this check. */
+const INVOICE_DISPLAY_LIMIT = 20;
+const INVOICE_PAGE_SIZE = 100;
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (typeof value === "number") return String(value);
+  return null;
+}
+
+/**
+ * Konnect and the self-hosted SDK disagree on casing (`rate_cards` vs
+ * `rateCards`, `payment_term` vs `paymentTerm`), so read both spellings.
+ */
+function readRateCards(plan: unknown): RateCardView[] {
+  const phases = readRecord(plan)?.phases;
+  if (!Array.isArray(phases)) return [];
+
+  const out: RateCardView[] = [];
+  for (const rawPhase of phases) {
+    const phase = readRecord(rawPhase);
+    if (!phase) continue;
+    const cards = phase.rateCards ?? phase.rate_cards;
+    if (!Array.isArray(cards)) continue;
+
+    for (const rawCard of cards) {
+      const card = readRecord(rawCard);
+      if (!card) continue;
+      const price = readRecord(card.price);
+      out.push({
+        key: readString(card.key),
+        priceType: readString(price?.type),
+        amount: readString(price?.amount),
+        paymentTerm:
+          readString(price?.paymentTerm) ??
+          readString(price?.payment_term) ??
+          readString(card.paymentTerm) ??
+          readString(card.payment_term),
+        billingCadence:
+          readString(card.billingCadence) ?? readString(card.billing_cadence),
+      });
+    }
+  }
+  return out;
+}
+
+function isFlatFeeCard(card: RateCardView): boolean {
+  return card.priceType === "flat";
+}
+
+async function fetchRemotePlan(
+  client: OpenMeter,
+  planId: string,
+): Promise<RemotePlanView | null> {
+  try {
+    const plan = await client.plans.get(planId);
+    if (!plan?.id) return null;
+    return {
+      id: plan.id,
+      key: plan.key?.trim() || null,
+      version: typeof plan.version === "number" ? plan.version : null,
+      rateCards: readRateCards(plan),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function loadLocalPlans(
+  client: OpenMeter,
+  developerAppId: string,
+): Promise<LocalPlanView[]> {
+  const rows = await db.select().from(plans).where(eq(plans.clientId, developerAppId));
+
+  const out: LocalPlanView[] = [];
+  for (const row of rows) {
+    out.push({
+      id: row.id,
+      name: row.name,
+      type: row.type,
+      status: row.status,
+      priceAmount: row.priceAmount,
+      billingCycle: row.billingCycle,
+      openmeterPlanId: row.openmeterPlanId,
+      openmeterPlanVersion: row.openmeterPlanVersion,
+      lastSyncedAt: row.lastSyncedAt,
+      feeCardExpected:
+        row.type === "subscription" && parsePriceAmount(row.priceAmount) !== "0",
+      remote: row.openmeterPlanId
+        ? await fetchRemotePlan(client, row.openmeterPlanId)
+        : null,
+    });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function mapInvoice(raw: unknown): InvoiceView | null {
+  const inv = readRecord(raw);
+  const id = readString(inv?.id);
+  if (!inv || !id) return null;
+
+  const total = readRecord(inv.totals)?.total;
+  const rawLines = Array.isArray(inv.lines) ? inv.lines : [];
+  return {
+    id,
+    status: readString(inv.status) ?? "unknown",
+    total: String(total ?? "0"),
+    totalUsdMicros: gatheringTotalUsdMicros(total)?.toString() ?? null,
+    lines: rawLines.map((line) => ({
+      name: readString(readRecord(line)?.name) ?? "Charge",
+      total: String(readRecord(readRecord(line)?.totals)?.total ?? "0"),
+    })),
+  };
+}
+
+/**
+ * `/v3/openmeter/billing/invoices` rejects a `customer.id` filter, so read the
+ * `/metering/v1` route the runtime debt lookup uses and keep the SDK as a
+ * fallback for self-hosted OpenMeter.
+ *
+ * That route silently ignores `page[number]` and `filter[status][eq]` and
+ * defaults to oldest-first, so `order`/`orderBy` are the only way to reach the
+ * recent invoices that matter here.
+ */
+async function loadInvoices(
+  client: OpenMeter,
+  customerId: string,
+): Promise<InvoiceView[]> {
+  const params = new URLSearchParams();
+  params.set("filter[customer.id][eq]", customerId);
+  params.set("order", "DESC");
+  params.set("orderBy", "createdAt");
+  params.set("page[size]", String(INVOICE_PAGE_SIZE));
+  params.set("expand", "lines");
+
+  try {
+    const listed = await konnectMeteringV1Fetch<{ items?: unknown[] }>(
+      `/billing/invoices?${params.toString()}`,
+      { method: "GET" },
+      "inspect-invoices",
+    );
+    // Invoice ids are ULIDs, so a lexicographic sort is newest-first.
+    return (listed?.items ?? [])
+      .map(mapInvoice)
+      .filter((inv): inv is InvoiceView => inv !== null)
+      .sort((a, b) => b.id.localeCompare(a.id))
+      .slice(0, INVOICE_DISPLAY_LIMIT);
+  } catch {
+    const listed = await client.billing.invoices.list({
+      customers: [customerId],
+      page: 1,
+      pageSize: INVOICE_DISPLAY_LIMIT,
+      order: "DESC",
+      orderBy: "createdAt",
+      expand: ["lines"],
+    });
+    return (listed?.items ?? [])
+      .map(mapInvoice)
+      .filter((inv): inv is InvoiceView => inv !== null);
+  }
+}
+
+function printPlans(localPlans: LocalPlanView[]): void {
+  console.log("\n[1/4] Neon plan rows + [2/4] published OpenMeter rate cards");
+  if (localPlans.length === 0) {
+    console.log("  (none — this app has no plan rows)");
+    return;
+  }
+
+  for (const plan of localPlans) {
+    console.log(
+      `\n  ${plan.name} (${plan.id})` +
+        `\n    type=${plan.type} status=${plan.status} price=${plan.priceAmount} ` +
+        `cycle=${plan.billingCycle}` +
+        `\n    feeCardExpected=${plan.feeCardExpected} ` +
+        `omPlanId=${plan.openmeterPlanId ?? "none"} ` +
+        `omVersion=${plan.openmeterPlanVersion ?? "none"} ` +
+        `lastSyncedAt=${plan.lastSyncedAt ?? "never"}`,
+    );
+
+    if (!plan.openmeterPlanId) {
+      console.log("    remote: not synced");
+      continue;
+    }
+    if (!plan.remote) {
+      console.log(`    remote: plan ${plan.openmeterPlanId} NOT FOUND in OpenMeter`);
+      continue;
+    }
+    console.log(
+      `    remote: key=${plan.remote.key ?? "none"} version=${plan.remote.version ?? "none"}`,
+    );
+    if (plan.remote.rateCards.length === 0) {
+      console.log("      (no rate cards)");
+    }
+    for (const card of plan.remote.rateCards) {
+      console.log(
+        `      - ${card.key ?? "?"}: price=${card.priceType ?? "none"} ` +
+          `amount=${card.amount ?? "none"} term=${card.paymentTerm ?? "none"} ` +
+          `cadence=${card.billingCadence ?? "none"}`,
+      );
+    }
+    const hasFlat = plan.remote.rateCards.some(isFlatFeeCard);
+    if (plan.feeCardExpected && !hasFlat) {
+      console.log("      !! expected a flat fee card here, published plan has none");
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!isHostedAdminClientAvailable()) {
+    console.error("OPENMETER_URL / OPENMETER_API_KEY are not configured.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const client = getHostedAdminClient();
+  const identity = await resolveOpenMeterBillingIdentity({
+    clientId: args.clientId,
+    externalUserId: args.externalUserId,
+  });
+  const billingConfig = await getAppBillingConfig(identity.developerAppId);
+  const billingMode = billingConfig?.billingMode ?? "owner_rollup";
+
+  console.log(
+    `\nidentity: developerAppId=${identity.developerAppId} ` +
+      `publicClientId=${identity.publicClientId} ` +
+      `customerKey=${identity.customerKey} isOwner=${identity.isOwner}` +
+      `\nbillingMode=${billingMode} ` +
+      `(custom invoicing / settlement applies only when merchant)`,
+  );
+
+  const localPlans = await loadLocalPlans(client, identity.developerAppId);
+  printPlans(localPlans);
+
+  const customerId = await resolveBillingCustomerId({
+    clientId: args.clientId,
+    externalUserId: args.externalUserId,
+  });
+
+  console.log("\n[3/4] Subscriptions on the billing customer");
+  if (!customerId) {
+    console.log("  no OpenMeter customer resolved — nothing can be billed");
+  }
+  const subscriptions = customerId
+    ? await listOpenMeterSubscriptionsForCustomer(client, customerId)
+    : [];
+  if (customerId && subscriptions.length === 0) {
+    console.log(`  customerId=${customerId}: no subscriptions`);
+  }
+  for (const sub of subscriptions) {
+    const local = localPlans.find((p) => p.openmeterPlanId === sub.planId);
+    console.log(
+      `  ${sub.id} status=${sub.status} planId=${sub.planId ?? "none"} ` +
+        `planKey=${sub.planKey ?? "none"}` +
+        `\n    activeFrom=${sub.activeFrom ?? "none"} activeTo=${sub.activeTo ?? "none"}` +
+        `\n    localPlan=${local ? `${local.name} (${local.id})` : "UNMAPPED — likely a stale plan version"}`,
+    );
+  }
+
+  console.log("\n[4/4] Most recent invoices on the billing customer");
+  const invoices = customerId ? await loadInvoices(client, customerId) : [];
+  if (invoices.length === 0) {
+    console.log("  (none)");
+  }
+  for (const inv of invoices) {
+    console.log(
+      `  ${inv.id} status=${inv.status} total=${inv.total} ` +
+        `(${inv.totalUsdMicros ?? "?"} usd micros)`,
+    );
+    for (const line of inv.lines) {
+      console.log(`    - ${line.name}: ${line.total}`);
+    }
+  }
+
+  const gathering = invoices.filter((inv) => inv.status.toLowerCase() === "gathering");
+  const collectable = gathering.some(
+    (inv) =>
+      inv.totalUsdMicros != null && BigInt(inv.totalUsdMicros) >= MIN_INVOICE_USD_MICROS,
+  );
+
+  console.log("\nverdict");
+  const liveSubs = subscriptions.filter((sub) =>
+    ["active", "trialing", "scheduled"].includes(sub.status.toLowerCase()),
+  );
+  const feeBearingSubs = liveSubs.filter((sub) =>
+    localPlans.some(
+      (plan) =>
+        plan.openmeterPlanId === sub.planId &&
+        (plan.remote?.rateCards ?? []).some(isFlatFeeCard),
+    ),
+  );
+  if (liveSubs.length === 0) {
+    console.log("  no live subscription — nothing is accruing a subscription fee");
+  } else if (feeBearingSubs.length === 0) {
+    console.log(
+      `  ${liveSubs.length} live subscription(s), none on a plan version that carries a ` +
+        "flat fee card — no subscription fee can accrue",
+    );
+  } else {
+    console.log(
+      `  live fee-bearing subscription(s): ${feeBearingSubs.map((s) => s.id).join(", ")}`,
+    );
+  }
+
+  if (gathering.length === 0) {
+    console.log(
+      "  no gathering invoice — OpenMeter has accrued nothing for this customer, " +
+        "so there is no charge any collection trigger could raise",
+    );
+  } else if (collectable) {
+    console.log(
+      `  a gathering invoice is at or above the ${MIN_INVOICE_USD_MICROS} usd micros ` +
+        "Stripe floor — forcing collection would raise a real invoice",
+    );
+  } else {
+    console.log(
+      `  a gathering invoice exists but sits below the ${MIN_INVOICE_USD_MICROS} usd micros ` +
+        "Stripe floor — forcing collection would be skipped as uncollectable",
+    );
+  }
+
+  if (args.json) {
+    console.log(
+      `\n${JSON.stringify(
+        {
+          identity,
+          billingMode,
+          customerId,
+          plans: localPlans,
+          subscriptions,
+          invoices,
+        },
+        null,
+        2,
+      )}`,
+    );
+  }
+
+  if (!collectable) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("[openmeter-inspect-subscription-charges] fatal:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb({ timeout: 5 });
+  });

--- a/src/app/api/v1/apps/[id]/users/[externalUserId]/subscription/route.test.ts
+++ b/src/app/api/v1/apps/[id]/users/[externalUserId]/subscription/route.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { NextRequest } from "next/server";
+import { test } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  seedDeveloperAppWithClient,
+  type SeededDeveloperApp,
+} from "@/test-utils/fixtures";
+import {
+  installProviderAppSessionAuth,
+  uninstallProviderAppSessionAuth,
+} from "@/test-utils/provider-app-session-auth";
+
+let authorizedApp: SeededDeveloperApp | null = null;
+
+installProviderAppSessionAuth(() => authorizedApp);
+
+test.after(() => {
+  uninstallProviderAppSessionAuth();
+});
+
+test("subscription DELETE validates timing and requires confirm", async (t) => {
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  authorizedApp = app;
+  t.after(async () => {
+    authorizedApp = null;
+    await cleanupTestApp(app);
+  });
+
+  const { DELETE } = await import("./route");
+  const params = {
+    params: Promise.resolve({
+      id: app.clientId,
+      externalUserId: "user-1",
+    }),
+  };
+
+  const badTiming = await DELETE(
+    new NextRequest(
+      `http://localhost/api/v1/apps/${app.clientId}/users/user-1/subscription`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: true, timing: "whenever" }),
+      },
+    ),
+    params,
+  );
+  assert.equal(badTiming.status, 400);
+  const badBody = (await badTiming.json()) as { error?: string };
+  assert.match(String(badBody.error), /timing must be/);
+
+  const unconfirmed = await DELETE(
+    new NextRequest(
+      `http://localhost/api/v1/apps/${app.clientId}/users/user-1/subscription`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ timing: "immediate" }),
+      },
+    ),
+    params,
+  );
+  assert.equal(unconfirmed.status, 400);
+  const unconfirmedBody = (await unconfirmed.json()) as {
+    code?: string;
+  };
+  assert.equal(unconfirmedBody.code, "confirm_required");
+});

--- a/src/app/api/v1/apps/[id]/users/[externalUserId]/subscription/route.ts
+++ b/src/app/api/v1/apps/[id]/users/[externalUserId]/subscription/route.ts
@@ -198,8 +198,8 @@ export async function GET(
 /**
  * DELETE /api/v1/apps/{clientId}/users/{externalUserId}/subscription
  *
- * Schedule cancel at next billing cycle (owner-paid parity).
- * Body: `{ confirm: true }`.
+ * Cancel paid plan. Body: `{ confirm: true, timing?: "immediate" | "next_billing_cycle" }`.
+ * Default timing is end of cycle (owner-paid parity).
  */
 export async function DELETE(
   request: NextRequest,
@@ -220,11 +220,24 @@ export async function DELETE(
 
   const body = await readJsonObject(request);
 
+  let timing: "immediate" | "next_billing_cycle" | undefined;
+  const rawTiming = body.timing;
+  if (rawTiming !== undefined && rawTiming !== null && rawTiming !== "") {
+    if (rawTiming !== "immediate" && rawTiming !== "next_billing_cycle") {
+      return NextResponse.json(
+        { error: 'timing must be "immediate" or "next_billing_cycle"' },
+        { status: 400 },
+      );
+    }
+    timing = rawTiming;
+  }
+
   try {
     const result = await cancelAppUserSubscription({
       clientId: access.app.id,
       externalUserId,
       confirm: readConfirmFlag(body),
+      timing,
     });
     return NextResponse.json(result);
   } catch (err) {

--- a/src/app/api/v1/apps/[id]/users/[externalUserId]/subscriptions/route.ts
+++ b/src/app/api/v1/apps/[id]/users/[externalUserId]/subscriptions/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  authorizeAppUserBillingRoute,
+  isAppUserBillingAccess,
+} from "@/lib/billing/app-user-billing-route";
+import { listAppUserSubscriptionHistory } from "@/lib/openmeter/app-user-subscription-history";
+
+/**
+ * GET /api/v1/apps/{clientId}/users/{externalUserId}/subscriptions
+ *
+ * OpenMeter subscription supersession history for an app end-user (all statuses).
+ * Auth: same as other app-user billing routes (`authorizeAppForBilling`).
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; externalUserId: string }> },
+) {
+  const { id: clientId, externalUserId: raw } = await params;
+  const access = await authorizeAppUserBillingRoute(request, clientId, raw);
+  if (!isAppUserBillingAccess(access)) {
+    return access;
+  }
+
+  try {
+    const result = await listAppUserSubscriptionHistory({
+      clientId: access.app.id,
+      externalUserId: access.externalUserId,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    console.warn(
+      "app-user-subscriptions: list failed",
+      err instanceof Error ? err.message : String(err),
+    );
+    return NextResponse.json({
+      items: [],
+      externalUserId: access.externalUserId,
+    });
+  }
+}

--- a/src/lib/openmeter/app-user-subscription-history.test.ts
+++ b/src/lib/openmeter/app-user-subscription-history.test.ts
@@ -1,10 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { OpenMeter } from "@openmeter/sdk";
 
 import {
+  __testAppUserSubscriptionHistory,
+  indexLocalPlansFromRows,
+  listAppUserSubscriptionHistory,
+  matchLocalPlan,
   sortSubscriptionHistoryItems,
+  toHistoryItem,
   type AppUserSubscriptionHistoryItem,
 } from "@/lib/openmeter/app-user-subscription-history";
+import type { OpenMeterSubscriptionView } from "@/lib/openmeter/subscription-read";
+import { buildOpenMeterPlanKey } from "@/lib/openmeter/plan-naming";
 
 function item(
   partial: Partial<AppUserSubscriptionHistoryItem> & { id: string },
@@ -22,6 +30,20 @@ function item(
   };
 }
 
+function sub(
+  partial: Partial<OpenMeterSubscriptionView> & { id: string },
+): OpenMeterSubscriptionView {
+  return {
+    status: "inactive",
+    customerId: "cust_1",
+    planKey: null,
+    planId: null,
+    activeFrom: null,
+    activeTo: null,
+    ...partial,
+  };
+}
+
 test("sortSubscriptionHistoryItems orders by activeFrom descending", () => {
   const sorted = sortSubscriptionHistoryItems([
     item({ id: "a", activeFrom: "2026-08-11T01:00:00.000Z" }),
@@ -33,4 +55,299 @@ test("sortSubscriptionHistoryItems orders by activeFrom descending", () => {
     sorted.map((row) => row.id),
     ["b", "d", "a", "c"],
   );
+});
+
+test("sortSubscriptionHistoryItems ties break on id and prefers dated rows", () => {
+  const sameTs = sortSubscriptionHistoryItems([
+    item({ id: "z", activeFrom: "2026-08-11T01:00:00.000Z" }),
+    item({ id: "a", activeFrom: "2026-08-11T01:00:00.000Z" }),
+  ]);
+  assert.deepEqual(
+    sameTs.map((row) => row.id),
+    ["z", "a"],
+  );
+
+  const nullFirst = sortSubscriptionHistoryItems([
+    item({ id: "null", activeFrom: null }),
+    item({ id: "dated", activeFrom: "2026-08-11T01:00:00.000Z" }),
+  ]);
+  assert.deepEqual(
+    nullFirst.map((row) => row.id),
+    ["dated", "null"],
+  );
+
+  const invalid = sortSubscriptionHistoryItems([
+    item({ id: "bad", activeFrom: "not-a-date" }),
+    item({ id: "ok", activeFrom: "2026-08-11T01:00:00.000Z" }),
+  ]);
+  assert.equal(invalid[0]?.id, "ok");
+});
+
+test("matchLocalPlan prefers openmeter plan id then plan key", () => {
+  const byId = new Map([
+    [
+      "om_paid",
+      {
+        id: "local_paid",
+        name: "Paid",
+        isStarterDefault: false,
+        openmeterPlanId: "om_paid",
+      },
+    ],
+  ]);
+  const planKey = buildOpenMeterPlanKey("app_1", "local_starter");
+  const byKey = new Map([
+    [
+      planKey,
+      {
+        id: "local_starter",
+        name: "Starter",
+        isStarterDefault: true,
+        openmeterPlanId: "om_starter",
+      },
+    ],
+  ]);
+
+  assert.equal(
+    matchLocalPlan(sub({ id: "s1", planId: "om_paid" }), byId, byKey)?.id,
+    "local_paid",
+  );
+  assert.equal(
+    matchLocalPlan(
+      sub({ id: "s2", planId: "missing", planKey }),
+      byId,
+      byKey,
+    )?.id,
+    "local_starter",
+  );
+  assert.equal(
+    matchLocalPlan(sub({ id: "s3", planKey: "unknown" }), byId, byKey),
+    null,
+  );
+  assert.equal(matchLocalPlan(sub({ id: "s4" }), byId, byKey), null);
+});
+
+test("toHistoryItem maps live status and local plan display name", () => {
+  const live = toHistoryItem(
+    sub({
+      id: "sub_live",
+      status: "active",
+      planId: "om_1",
+      planKey: "key_1",
+      activeFrom: "2026-08-11T00:00:00.000Z",
+      activeTo: null,
+    }),
+    {
+      id: "local_1",
+      name: "m2m user plan",
+      isStarterDefault: false,
+      openmeterPlanId: "om_1",
+    },
+  );
+  assert.equal(live.current, true);
+  assert.equal(live.planId, "local_1");
+  assert.equal(live.planName, "m2m user plan");
+  assert.equal(live.openmeterPlanId, "om_1");
+
+  const starter = toHistoryItem(
+    sub({
+      id: "sub_starter",
+      status: "inactive",
+      planKey: "a1_plan_x",
+    }),
+    {
+      id: "local_starter",
+      name: "__pymthouse_starter__",
+      isStarterDefault: true,
+      openmeterPlanId: "om_starter",
+    },
+  );
+  assert.equal(starter.current, false);
+  assert.equal(starter.planName, "Starter");
+
+  const unmapped = toHistoryItem(
+    sub({
+      id: "sub_owner",
+      status: "trialing",
+      planKey: "pymthouse_owner_starter",
+    }),
+    null,
+  );
+  assert.equal(unmapped.current, true);
+  assert.equal(unmapped.planId, null);
+  assert.ok(unmapped.planName);
+});
+
+test("listAppUserSubscriptionHistory returns empty without ids or OpenMeter", async () => {
+  assert.deepEqual(
+    await listAppUserSubscriptionHistory({
+      clientId: "  ",
+      externalUserId: "eu_1",
+      deps: { isAvailable: () => true },
+    }),
+    { items: [], externalUserId: "eu_1" },
+  );
+  assert.deepEqual(
+    await listAppUserSubscriptionHistory({
+      clientId: "app_1",
+      externalUserId: "  ",
+      deps: { isAvailable: () => true },
+    }),
+    { items: [], externalUserId: "" },
+  );
+  assert.deepEqual(
+    await listAppUserSubscriptionHistory({
+      clientId: "app_1",
+      externalUserId: "eu_1",
+      deps: { isAvailable: () => false },
+    }),
+    { items: [], externalUserId: "eu_1" },
+  );
+});
+
+test("listAppUserSubscriptionHistory returns empty when customer is missing", async () => {
+  const result = await listAppUserSubscriptionHistory({
+    clientId: "app_1",
+    externalUserId: "eu_missing",
+    deps: {
+      isAvailable: () => true,
+      getClient: () => ({}) as OpenMeter,
+      lookupCustomerId: async () => null,
+    },
+  });
+  assert.deepEqual(result, { items: [], externalUserId: "eu_missing" });
+});
+
+test("listAppUserSubscriptionHistory maps enriched subscriptions newest first", async () => {
+  const client = { tag: "om" } as unknown as OpenMeter;
+  const result = await listAppUserSubscriptionHistory({
+    clientId: "app_1",
+    externalUserId: "eu_1",
+    deps: {
+      isAvailable: () => true,
+      getClient: () => client,
+      lookupCustomerId: async (c, clientId, externalUserId) => {
+        assert.equal(c, client);
+        assert.equal(clientId, "app_1");
+        assert.equal(externalUserId, "eu_1");
+        return "cust_1";
+      },
+      listSubscriptions: async (c, customerId) => {
+        assert.equal(c, client);
+        assert.equal(customerId, "cust_1");
+        return [
+          sub({
+            id: "older",
+            status: "inactive",
+            planId: "om_paid",
+            planKey: "paid_key",
+            activeFrom: null,
+            activeTo: null,
+          }),
+          sub({
+            id: "newer",
+            status: "active",
+            planId: "om_starter",
+            planKey: "starter_key",
+            activeFrom: null,
+            activeTo: null,
+          }),
+        ];
+      },
+      enrichWindow: async (row) => {
+        if (row.id === "newer") {
+          return {
+            ...row,
+            activeFrom: "2026-08-11T02:00:00.000Z",
+            activeTo: null,
+          };
+        }
+        return {
+          ...row,
+          activeFrom: "2026-08-11T01:00:00.000Z",
+          activeTo: "2026-08-11T02:00:00.000Z",
+        };
+      },
+      loadPlans: async (appId) => {
+        assert.equal(appId, "app_1");
+        return {
+          byOpenMeterId: new Map([
+            [
+              "om_paid",
+              {
+                id: "plan_paid",
+                name: "m2m user plan",
+                isStarterDefault: false,
+                openmeterPlanId: "om_paid",
+              },
+            ],
+            [
+              "om_starter",
+              {
+                id: "plan_starter",
+                name: "__pymthouse_starter__",
+                isStarterDefault: true,
+                openmeterPlanId: "om_starter",
+              },
+            ],
+          ]),
+          byPlanKey: new Map(),
+        };
+      },
+    },
+  });
+
+  assert.equal(result.externalUserId, "eu_1");
+  assert.equal(result.items.length, 2);
+  assert.equal(result.items[0]?.id, "newer");
+  assert.equal(result.items[0]?.current, true);
+  assert.equal(result.items[0]?.planName, "Starter");
+  assert.equal(result.items[0]?.activeFrom, "2026-08-11T02:00:00.000Z");
+  assert.equal(result.items[1]?.id, "older");
+  assert.equal(result.items[1]?.planName, "m2m user plan");
+  assert.equal(result.items[1]?.activeTo, "2026-08-11T02:00:00.000Z");
+});
+
+test("indexLocalPlansFromRows indexes by openmeter id and plan key", () => {
+  const indexed = indexLocalPlansFromRows("app_1", [
+    {
+      id: "plan_paid",
+      name: "Paid",
+      isStarterDefault: false,
+      openmeterPlanId: " om_paid ",
+    },
+    {
+      id: "plan_starter",
+      name: "Starter",
+      isStarterDefault: true,
+      openmeterPlanId: null,
+    },
+    {
+      id: "plan_blank_om",
+      name: "Blank",
+      isStarterDefault: false,
+      openmeterPlanId: "   ",
+    },
+  ]);
+  assert.equal(indexed.byOpenMeterId.get("om_paid")?.id, "plan_paid");
+  assert.equal(indexed.byOpenMeterId.has("om_blank"), false);
+  assert.equal(
+    indexed.byPlanKey.get(buildOpenMeterPlanKey("app_1", "plan_starter"))
+      ?.isStarterDefault,
+    true,
+  );
+});
+
+test("__testAppUserSubscriptionHistory exposes helpers", () => {
+  assert.equal(
+    __testAppUserSubscriptionHistory.matchLocalPlan,
+    matchLocalPlan,
+  );
+  assert.equal(__testAppUserSubscriptionHistory.toHistoryItem, toHistoryItem);
+  assert.equal(
+    __testAppUserSubscriptionHistory.indexLocalPlansFromRows,
+    indexLocalPlansFromRows,
+  );
+  assert.equal(typeof __testAppUserSubscriptionHistory.lookupCustomerId, "function");
+  assert.equal(typeof __testAppUserSubscriptionHistory.loadLocalPlans, "function");
 });

--- a/src/lib/openmeter/app-user-subscription-history.test.ts
+++ b/src/lib/openmeter/app-user-subscription-history.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  sortSubscriptionHistoryItems,
+  type AppUserSubscriptionHistoryItem,
+} from "@/lib/openmeter/app-user-subscription-history";
+
+function item(
+  partial: Partial<AppUserSubscriptionHistoryItem> & { id: string },
+): AppUserSubscriptionHistoryItem {
+  return {
+    status: "inactive",
+    current: false,
+    planId: null,
+    planName: null,
+    planKey: null,
+    openmeterPlanId: null,
+    activeFrom: null,
+    activeTo: null,
+    ...partial,
+  };
+}
+
+test("sortSubscriptionHistoryItems orders by activeFrom descending", () => {
+  const sorted = sortSubscriptionHistoryItems([
+    item({ id: "a", activeFrom: "2026-08-11T01:00:00.000Z" }),
+    item({ id: "b", activeFrom: "2026-08-11T02:00:00.000Z" }),
+    item({ id: "c", activeFrom: null }),
+    item({ id: "d", activeFrom: "2026-08-11T01:30:00.000Z" }),
+  ]);
+  assert.deepEqual(
+    sorted.map((row) => row.id),
+    ["b", "d", "a", "c"],
+  );
+});

--- a/src/lib/openmeter/app-user-subscription-history.ts
+++ b/src/lib/openmeter/app-user-subscription-history.ts
@@ -74,7 +74,8 @@ export function sortSubscriptionHistoryItems(
   return [...items].sort(compareActiveFromDesc);
 }
 
-function matchLocalPlan(
+/** @internal Exported for unit tests. */
+export function matchLocalPlan(
   sub: OpenMeterSubscriptionView,
   byOpenMeterId: Map<string, LocalPlanRow>,
   byPlanKey: Map<string, LocalPlanRow>,
@@ -89,20 +90,19 @@ function matchLocalPlan(
   return null;
 }
 
-async function loadLocalPlans(appId: string): Promise<{
+/** @internal Exported for unit tests. */
+export function indexLocalPlansFromRows(
+  appId: string,
+  rows: Array<{
+    id: string;
+    name: string;
+    isStarterDefault: boolean;
+    openmeterPlanId: string | null;
+  }>,
+): {
   byOpenMeterId: Map<string, LocalPlanRow>;
   byPlanKey: Map<string, LocalPlanRow>;
-}> {
-  const rows = await db
-    .select({
-      id: plans.id,
-      name: plans.name,
-      isStarterDefault: plans.isStarterDefault,
-      openmeterPlanId: plans.openmeterPlanId,
-    })
-    .from(plans)
-    .where(eq(plans.clientId, appId));
-
+} {
   const byOpenMeterId = new Map<string, LocalPlanRow>();
   const byPlanKey = new Map<string, LocalPlanRow>();
   for (const row of rows) {
@@ -120,7 +120,25 @@ async function loadLocalPlans(appId: string): Promise<{
   return { byOpenMeterId, byPlanKey };
 }
 
-function toHistoryItem(
+async function loadLocalPlans(appId: string): Promise<{
+  byOpenMeterId: Map<string, LocalPlanRow>;
+  byPlanKey: Map<string, LocalPlanRow>;
+}> {
+  const rows = await db
+    .select({
+      id: plans.id,
+      name: plans.name,
+      isStarterDefault: plans.isStarterDefault,
+      openmeterPlanId: plans.openmeterPlanId,
+    })
+    .from(plans)
+    .where(eq(plans.clientId, appId));
+
+  return indexLocalPlansFromRows(appId, rows);
+}
+
+/** @internal Exported for unit tests. */
+export function toHistoryItem(
   sub: OpenMeterSubscriptionView,
   local: LocalPlanRow | null,
 ): AppUserSubscriptionHistoryItem {
@@ -162,6 +180,27 @@ async function lookupCustomerId(
   return existing?.id?.trim() || null;
 }
 
+export type ListAppUserSubscriptionHistoryDeps = {
+  isAvailable?: () => boolean;
+  getClient?: () => OpenMeter;
+  lookupCustomerId?: (
+    client: OpenMeter,
+    clientId: string,
+    externalUserId: string,
+  ) => Promise<string | null>;
+  listSubscriptions?: (
+    client: OpenMeter,
+    customerId: string,
+  ) => Promise<OpenMeterSubscriptionView[]>;
+  enrichWindow?: (
+    item: OpenMeterSubscriptionView,
+  ) => Promise<OpenMeterSubscriptionView>;
+  loadPlans?: (appId: string) => Promise<{
+    byOpenMeterId: Map<string, LocalPlanRow>;
+    byPlanKey: Map<string, LocalPlanRow>;
+  }>;
+};
+
 /**
  * Full subscription supersession history for an app end-user.
  * Newest `activeFrom` first. Empty when OpenMeter is offline or the customer
@@ -170,6 +209,8 @@ async function lookupCustomerId(
 export async function listAppUserSubscriptionHistory(input: {
   clientId: string;
   externalUserId: string;
+  /** @internal Test overrides — production callers omit this. */
+  deps?: ListAppUserSubscriptionHistoryDeps;
 }): Promise<ListAppUserSubscriptionHistoryResult> {
   const clientId = input.clientId.trim();
   const externalUserId = input.externalUserId.trim();
@@ -177,24 +218,30 @@ export async function listAppUserSubscriptionHistory(input: {
     items: [],
     externalUserId,
   };
-  if (!clientId || !externalUserId || !isHostedAdminClientAvailable()) {
+  const deps = input.deps;
+  const available = deps?.isAvailable ?? isHostedAdminClientAvailable;
+  if (!clientId || !externalUserId || !available()) {
     return empty;
   }
 
-  const client = getHostedAdminClient();
-  const customerId = await lookupCustomerId(client, clientId, externalUserId);
+  const client = (deps?.getClient ?? getHostedAdminClient)();
+  const resolveCustomer = deps?.lookupCustomerId ?? lookupCustomerId;
+  const customerId = await resolveCustomer(client, clientId, externalUserId);
   if (!customerId) {
     return empty;
   }
 
+  const listSubs =
+    deps?.listSubscriptions ?? listOpenMeterSubscriptionsForCustomer;
+  const enrich = deps?.enrichWindow ?? enrichSubscriptionActiveWindow;
+  const loadPlans = deps?.loadPlans ?? loadLocalPlans;
+
   const [listed, localIndexes] = await Promise.all([
-    listOpenMeterSubscriptionsForCustomer(client, customerId),
-    loadLocalPlans(clientId),
+    listSubs(client, customerId),
+    loadPlans(clientId),
   ]);
 
-  const enriched = await Promise.all(
-    listed.map((item) => enrichSubscriptionActiveWindow(item)),
-  );
+  const enriched = await Promise.all(listed.map((item) => enrich(item)));
 
   const items = sortSubscriptionHistoryItems(
     enriched.map((sub) =>
@@ -207,3 +254,12 @@ export async function listAppUserSubscriptionHistory(input: {
 
   return { items, externalUserId };
 }
+
+/** @internal Pure helpers for unit tests. */
+export const __testAppUserSubscriptionHistory = {
+  matchLocalPlan,
+  toHistoryItem,
+  indexLocalPlansFromRows,
+  lookupCustomerId,
+  loadLocalPlans,
+};

--- a/src/lib/openmeter/app-user-subscription-history.ts
+++ b/src/lib/openmeter/app-user-subscription-history.ts
@@ -1,0 +1,209 @@
+/**
+ * End-user subscription history (OpenMeter supersession chain).
+ *
+ * Lookup-only — does not create customers. Each plan change closes the prior
+ * subscription and opens a successor; this lists the full chain for Settings.
+ */
+import { eq } from "drizzle-orm";
+import type { OpenMeter } from "@openmeter/sdk";
+
+import { db } from "@/db/index";
+import { plans } from "@/db/schema";
+import { resolveAppUserSubscriptionPlanName } from "@/lib/billing/app-user-subscription-display";
+import {
+  getHostedAdminClient,
+  isHostedAdminClientAvailable,
+} from "@/lib/openmeter/admin-client";
+import { buildOpenMeterCustomerKey } from "@/lib/openmeter/customer-key";
+import { findOpenMeterCustomerByKey } from "@/lib/openmeter/customers";
+import { resolveOpenMeterMeterClientId } from "@/lib/openmeter/meter-client-id";
+import { buildOpenMeterPlanKey } from "@/lib/openmeter/plan-naming";
+import { isLiveSubscriptionStatus } from "@/lib/openmeter/subscription-state";
+import {
+  enrichSubscriptionActiveWindow,
+  listOpenMeterSubscriptionsForCustomer,
+  type OpenMeterSubscriptionView,
+} from "@/lib/openmeter/subscription-read";
+
+export type AppUserSubscriptionHistoryItem = {
+  id: string;
+  status: string;
+  /** True when this row is the live (active/trialing) subscription. */
+  current: boolean;
+  planId: string | null;
+  planName: string | null;
+  planKey: string | null;
+  openmeterPlanId: string | null;
+  activeFrom: string | null;
+  activeTo: string | null;
+};
+
+export type ListAppUserSubscriptionHistoryResult = {
+  items: AppUserSubscriptionHistoryItem[];
+  externalUserId: string;
+};
+
+type LocalPlanRow = {
+  id: string;
+  name: string;
+  isStarterDefault: boolean;
+  openmeterPlanId: string | null;
+};
+
+function compareActiveFromDesc(
+  a: Pick<AppUserSubscriptionHistoryItem, "activeFrom" | "id">,
+  b: Pick<AppUserSubscriptionHistoryItem, "activeFrom" | "id">,
+): number {
+  const aTs = a.activeFrom ? Date.parse(a.activeFrom) : Number.NaN;
+  const bTs = b.activeFrom ? Date.parse(b.activeFrom) : Number.NaN;
+  const aOk = Number.isFinite(aTs);
+  const bOk = Number.isFinite(bTs);
+  if (aOk && bOk && bTs !== aTs) {
+    return bTs - aTs;
+  }
+  if (aOk !== bOk) {
+    return aOk ? -1 : 1;
+  }
+  return b.id.localeCompare(a.id);
+}
+
+/** @internal Exported for unit tests. */
+export function sortSubscriptionHistoryItems(
+  items: AppUserSubscriptionHistoryItem[],
+): AppUserSubscriptionHistoryItem[] {
+  return [...items].sort(compareActiveFromDesc);
+}
+
+function matchLocalPlan(
+  sub: OpenMeterSubscriptionView,
+  byOpenMeterId: Map<string, LocalPlanRow>,
+  byPlanKey: Map<string, LocalPlanRow>,
+): LocalPlanRow | null {
+  if (sub.planId) {
+    const byId = byOpenMeterId.get(sub.planId);
+    if (byId) return byId;
+  }
+  if (sub.planKey) {
+    return byPlanKey.get(sub.planKey) ?? null;
+  }
+  return null;
+}
+
+async function loadLocalPlans(appId: string): Promise<{
+  byOpenMeterId: Map<string, LocalPlanRow>;
+  byPlanKey: Map<string, LocalPlanRow>;
+}> {
+  const rows = await db
+    .select({
+      id: plans.id,
+      name: plans.name,
+      isStarterDefault: plans.isStarterDefault,
+      openmeterPlanId: plans.openmeterPlanId,
+    })
+    .from(plans)
+    .where(eq(plans.clientId, appId));
+
+  const byOpenMeterId = new Map<string, LocalPlanRow>();
+  const byPlanKey = new Map<string, LocalPlanRow>();
+  for (const row of rows) {
+    const local: LocalPlanRow = {
+      id: row.id,
+      name: row.name,
+      isStarterDefault: row.isStarterDefault === true,
+      openmeterPlanId: row.openmeterPlanId,
+    };
+    if (local.openmeterPlanId?.trim()) {
+      byOpenMeterId.set(local.openmeterPlanId.trim(), local);
+    }
+    byPlanKey.set(buildOpenMeterPlanKey(appId, local.id), local);
+  }
+  return { byOpenMeterId, byPlanKey };
+}
+
+function toHistoryItem(
+  sub: OpenMeterSubscriptionView,
+  local: LocalPlanRow | null,
+): AppUserSubscriptionHistoryItem {
+  const planName = resolveAppUserSubscriptionPlanName({
+    plan: local
+      ? {
+          id: local.id,
+          name: local.name,
+          type: "",
+          status: "active",
+          phaseOutAt: null,
+          replacementPlanId: null,
+          isStarterDefault: local.isStarterDefault,
+        }
+      : null,
+    planKey: sub.planKey,
+  });
+  return {
+    id: sub.id,
+    status: sub.status,
+    current: isLiveSubscriptionStatus(sub.status),
+    planId: local?.id ?? null,
+    planName,
+    planKey: sub.planKey,
+    openmeterPlanId: sub.planId,
+    activeFrom: sub.activeFrom,
+    activeTo: sub.activeTo,
+  };
+}
+
+async function lookupCustomerId(
+  client: OpenMeter,
+  clientId: string,
+  externalUserId: string,
+): Promise<string | null> {
+  const publicClientId = await resolveOpenMeterMeterClientId(clientId);
+  const key = buildOpenMeterCustomerKey(publicClientId, externalUserId);
+  const existing = await findOpenMeterCustomerByKey(client, key);
+  return existing?.id?.trim() || null;
+}
+
+/**
+ * Full subscription supersession history for an app end-user.
+ * Newest `activeFrom` first. Empty when OpenMeter is offline or the customer
+ * does not exist yet.
+ */
+export async function listAppUserSubscriptionHistory(input: {
+  clientId: string;
+  externalUserId: string;
+}): Promise<ListAppUserSubscriptionHistoryResult> {
+  const clientId = input.clientId.trim();
+  const externalUserId = input.externalUserId.trim();
+  const empty: ListAppUserSubscriptionHistoryResult = {
+    items: [],
+    externalUserId,
+  };
+  if (!clientId || !externalUserId || !isHostedAdminClientAvailable()) {
+    return empty;
+  }
+
+  const client = getHostedAdminClient();
+  const customerId = await lookupCustomerId(client, clientId, externalUserId);
+  if (!customerId) {
+    return empty;
+  }
+
+  const [listed, localIndexes] = await Promise.all([
+    listOpenMeterSubscriptionsForCustomer(client, customerId),
+    loadLocalPlans(clientId),
+  ]);
+
+  const enriched = await Promise.all(
+    listed.map((item) => enrichSubscriptionActiveWindow(item)),
+  );
+
+  const items = sortSubscriptionHistoryItems(
+    enriched.map((sub) =>
+      toHistoryItem(
+        sub,
+        matchLocalPlan(sub, localIndexes.byOpenMeterId, localIndexes.byPlanKey),
+      ),
+    ),
+  );
+
+  return { items, externalUserId };
+}

--- a/src/lib/openmeter/app-user-subscription-lifecycle.test.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.test.ts
@@ -392,6 +392,32 @@ test("resolveAppUserResumeTarget resumes CAPE primary when a scheduled successor
   const resume = resolveAppUserResumeTarget(listed, "app_starter", null);
   assert.equal(resume?.target.id, "paid_canceled");
   assert.equal(resume?.scheduledStarter?.id, "starter_scheduled");
+  // livePaid is absent for CAPE — resume must still restore (not unschedule)
+  // so Konnect does not 409 only_single_subscription_allowed.
+  assert.equal(resume?.livePaid, undefined);
+});
+
+test("resolveAppUserResumeTarget resumes CAPE when scheduled successor is paid", () => {
+  // Staging 409: CAPE Daydream + scheduled paid successor from a prior /change.
+  // Resume must restore (any scheduled id), not only scheduled Starter.
+  const listed = [
+    sub({
+      id: "01KZQ3YQYZSDKANZC0SAW0VV20",
+      planKey: "paid_a",
+      status: "canceled",
+      activeFrom: "2026-08-11T00:35:58.500843Z",
+      activeTo: "2026-09-10T23:08:53.491143Z",
+    }),
+    sub({
+      id: "sched_paid_b",
+      planKey: "paid_b",
+      status: "scheduled",
+      activeFrom: "2026-09-10T23:08:53.491143Z",
+    }),
+  ];
+  const resume = resolveAppUserResumeTarget(listed, "app_starter", null);
+  assert.equal(resume?.target.id, "01KZQ3YQYZSDKANZC0SAW0VV20");
+  assert.equal(resume?.scheduledStarter, undefined);
 });
 
 test("resolveAppUserResumeTarget keeps a cancel-at-period-end primary resumable", () => {

--- a/src/lib/openmeter/app-user-subscription-lifecycle.test.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.test.ts
@@ -14,6 +14,8 @@ import {
   pickAppUserCancelTargets,
   resolveAppUserResumeTarget,
   resumeAppUserSubscription,
+  resumeAppUserSubscriptionFromList,
+  scheduleLivePaidCancel,
 } from "@/lib/openmeter/app-user-subscription-lifecycle";
 import type { OpenMeterSubscriptionView } from "@/lib/openmeter/subscription-read";
 
@@ -499,4 +501,235 @@ test("deriveAppUserPendingCancel ignores a superseded row's cancellation", () =>
     }),
     null,
   );
+});
+
+function withKonnectEnv(t: test.TestContext): void {
+  const savedUrl = process.env.OPENMETER_URL;
+  const savedKey = process.env.OPENMETER_API_KEY;
+  const savedMode = process.env.OPENMETER_ROUTE_MODE;
+  process.env.OPENMETER_URL = "https://us.api.konghq.com/v3/openmeter";
+  process.env.OPENMETER_API_KEY = "km_test_key";
+  process.env.OPENMETER_ROUTE_MODE = "hosted";
+  t.after(() => {
+    if (savedUrl === undefined) delete process.env.OPENMETER_URL;
+    else process.env.OPENMETER_URL = savedUrl;
+    if (savedKey === undefined) delete process.env.OPENMETER_API_KEY;
+    else process.env.OPENMETER_API_KEY = savedKey;
+    if (savedMode === undefined) delete process.env.OPENMETER_ROUTE_MODE;
+    else process.env.OPENMETER_ROUTE_MODE = savedMode;
+  });
+}
+
+test("scheduleLivePaidCancel immediate changes onto Starter with null scheduledPlanKey", async (t) => {
+  withKonnectEnv(t);
+  const urls: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    urls.push(`${init?.method ?? "GET"} ${String(input)}`);
+    return new Response(
+      JSON.stringify({
+        current: { id: "paid_1", status: "canceled", customer_id: "c1" },
+        next: { id: "starter_live", status: "active", customer_id: "c1" },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const result = await scheduleLivePaidCancel({
+    livePaid: sub({ id: "paid_1", planKey: "paid", status: "active" }),
+    localPlanId: "local_paid",
+    starterPlanKey: "app_starter",
+    starterLocalPlanId: "local_starter",
+    starterOpenMeterPlanId: "om_starter",
+    timing: "immediate",
+    customerId: "c1",
+  });
+
+  assert.equal(result.subscriptionId, "starter_live");
+  assert.equal(result.planId, "local_starter");
+  assert.equal(result.planKey, "app_starter");
+  assert.equal(result.scheduledPlanKey, null);
+  assert.ok(result.effectiveAt);
+  assert.equal(urls.length, 1);
+  assert.match(urls[0]!, /\/change/);
+});
+
+test("scheduleLivePaidCancel immediate fails when Starter is not synced", async () => {
+  await assert.rejects(
+    () =>
+      scheduleLivePaidCancel({
+        livePaid: sub({ id: "paid_1", planKey: "paid", status: "active" }),
+        localPlanId: "local_paid",
+        starterPlanKey: "app_starter",
+        starterLocalPlanId: "local_starter",
+        starterOpenMeterPlanId: null,
+        timing: "immediate",
+        customerId: "c1",
+      }),
+    (err: unknown) =>
+      err instanceof AppUserSubscriptionCancelError &&
+      err.code === "cancel_failed",
+  );
+});
+
+test("scheduleLivePaidCancel next_billing_cycle cancels and schedules Starter", async (t) => {
+  withKonnectEnv(t);
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/cancel")) {
+      return new Response(
+        JSON.stringify({
+          id: "paid_1",
+          status: "canceled",
+          customer_id: "c1",
+          billing_anchor: "2026-08-01T00:00:00.000Z",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    // active window lookup
+    return new Response(
+      JSON.stringify({
+        id: "paid_1",
+        status: "canceled",
+        customer_id: "c1",
+        active_to: "2026-09-01T00:00:00.000Z",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const result = await scheduleLivePaidCancel({
+    livePaid: sub({
+      id: "paid_1",
+      planKey: "paid",
+      status: "active",
+      activeTo: null,
+    }),
+    localPlanId: "local_paid",
+    starterPlanKey: "app_starter",
+    starterLocalPlanId: "local_starter",
+    starterOpenMeterPlanId: "om_starter",
+    timing: "next_billing_cycle",
+    customerId: "c1",
+  });
+
+  assert.equal(result.subscriptionId, "paid_1");
+  assert.equal(result.planId, "local_paid");
+  assert.equal(result.scheduledPlanKey, "app_starter");
+  assert.equal(result.effectiveAt, "2026-09-01T00:00:00.000Z");
+});
+
+test("resumeAppUserSubscriptionFromList restores when a scheduled successor exists", async (t) => {
+  withKonnectEnv(t);
+  const urls: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+    urls.push(String(input));
+    return new Response(
+      JSON.stringify({ id: "paid_cape", status: "active", customer_id: "c1" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const listed = [
+    sub({
+      id: "paid_cape",
+      planKey: "paid",
+      status: "canceled",
+      activeTo: "2026-09-01T00:00:00.000Z",
+    }),
+    sub({
+      id: "sched_starter",
+      planKey: "app_starter",
+      status: "scheduled",
+      activeFrom: "2026-09-01T00:00:00.000Z",
+    }),
+  ];
+
+  const result = await resumeAppUserSubscriptionFromList({
+    clientId: "app_missing_plans_ok",
+    listed,
+    starterPlanKey: "app_starter",
+    starterOpenMeterPlanId: null,
+  });
+
+  assert.equal(result.resumed, true);
+  assert.equal(result.subscriptionId, "paid_cape");
+  assert.equal(result.planKey, "paid");
+  assert.equal(urls.length, 1);
+  assert.match(urls[0]!, /\/restore$/);
+});
+
+test("resumeAppUserSubscriptionFromList unschedules when no successor exists", async (t) => {
+  withKonnectEnv(t);
+  const urls: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+    urls.push(String(input));
+    return new Response(
+      JSON.stringify({ id: "paid_cape", status: "active", customer_id: "c1" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const listed = [
+    sub({
+      id: "paid_cape",
+      planKey: "paid",
+      status: "canceled",
+      activeTo: "2026-09-01T00:00:00.000Z",
+    }),
+  ];
+
+  const result = await resumeAppUserSubscriptionFromList({
+    clientId: "app_missing_plans_ok",
+    listed,
+    starterPlanKey: "app_starter",
+    starterOpenMeterPlanId: null,
+  });
+
+  assert.equal(result.resumed, true);
+  assert.equal(result.subscriptionId, "paid_cape");
+  assert.equal(urls.length, 1);
+  assert.match(urls[0]!, /unschedule-cancelation/);
+});
+
+test("resumeAppUserSubscriptionFromList falls back to restore on unschedule 409", async (t) => {
+  withKonnectEnv(t);
+  const urls: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+    const url = String(input);
+    urls.push(url);
+    if (url.includes("unschedule-cancelation")) {
+      return new Response(
+        JSON.stringify({
+          detail: "only_single_subscription_allowed_per_customer_at_a_time",
+        }),
+        { status: 409, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response(
+      JSON.stringify({ id: "paid_cape", status: "active", customer_id: "c1" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  const listed = [
+    sub({
+      id: "paid_cape",
+      planKey: "paid",
+      status: "canceled",
+      activeTo: "2026-09-01T00:00:00.000Z",
+    }),
+  ];
+
+  const result = await resumeAppUserSubscriptionFromList({
+    clientId: "app_missing_plans_ok",
+    listed,
+    starterPlanKey: "app_starter",
+    starterOpenMeterPlanId: null,
+  });
+
+  assert.equal(result.resumed, true);
+  assert.equal(urls.length, 2);
+  assert.match(urls[0]!, /unschedule-cancelation/);
+  assert.match(urls[1]!, /\/restore$/);
 });

--- a/src/lib/openmeter/app-user-subscription-lifecycle.test.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   resumeAppUserSubscription,
   resumeAppUserSubscriptionFromList,
   scheduleLivePaidCancel,
+  immediateCancelOccupyingCapePaid,
 } from "@/lib/openmeter/app-user-subscription-lifecycle";
 import type { OpenMeterSubscriptionView } from "@/lib/openmeter/subscription-read";
 
@@ -732,4 +733,51 @@ test("resumeAppUserSubscriptionFromList falls back to restore on unschedule 409"
   assert.equal(urls.length, 2);
   assert.match(urls[0]!, /unschedule-cancelation/);
   assert.match(urls[1]!, /\/restore$/);
+});
+
+test("immediateCancelOccupyingCapePaid restores then changes onto Starter", async (t) => {
+  withKonnectEnv(t);
+  const urls: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+    const url = String(input);
+    urls.push(url);
+    if (url.includes("/restore")) {
+      return new Response(
+        JSON.stringify({ id: "paid_cape", status: "active", customer_id: "c1" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.includes("/change")) {
+      return new Response(
+        JSON.stringify({
+          current: { id: "paid_cape", status: "canceled", customer_id: "c1" },
+          next: { id: "starter_now", status: "active", customer_id: "c1" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response("unexpected", { status: 500 });
+  });
+
+  const result = await immediateCancelOccupyingCapePaid({
+    canceledPaid: sub({
+      id: "paid_cape",
+      planKey: "paid",
+      status: "canceled",
+      activeTo: "2026-09-01T00:00:00.000Z",
+    }),
+    scheduledIds: ["sched_starter"],
+    clientId: "app_missing_plans_ok",
+    starterPlanKey: "app_starter",
+    starterLocalPlanId: "local_starter",
+    starterOpenMeterPlanId: "om_starter",
+    customerId: "c1",
+  });
+
+  assert.equal(result.subscriptionId, "starter_now");
+  assert.equal(result.planId, "local_starter");
+  assert.equal(result.scheduledPlanKey, null);
+  assert.equal(urls.length, 2);
+  assert.match(urls[0]!, /\/restore$/);
+  assert.match(urls[1]!, /\/change/);
 });

--- a/src/lib/openmeter/app-user-subscription-lifecycle.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.ts
@@ -339,7 +339,11 @@ async function assertLivePaidCancelable(input: {
   return localPlanId;
 }
 
-async function scheduleLivePaidCancel(input: {
+/**
+ * Schedule or immediately apply cancel for a live paid subscription.
+ * Exported for unit tests of immediate `/change`-to-Starter vs CAPE paths.
+ */
+export async function scheduleLivePaidCancel(input: {
   livePaid: OpenMeterSubscriptionView;
   localPlanId: string | null;
   starterPlanKey: string;
@@ -547,6 +551,104 @@ export function appUserSubscriptionCancelHttpStatus(
 }
 
 /**
+ * Undo a pending end-of-cycle cancel given an already-listed subscription set.
+ * Exported so tests can cover restore vs unschedule without OpenMeter customer
+ * ensure / starter-plan DB setup.
+ */
+export async function resumeAppUserSubscriptionFromList(input: {
+  clientId: string;
+  listed: OpenMeterSubscriptionView[];
+  starterPlanKey: string;
+  starterOpenMeterPlanId: string | null;
+}): Promise<AppUserSubscriptionResumeResult> {
+  const resume = resolveAppUserResumeTarget(
+    input.listed,
+    input.starterPlanKey,
+    input.starterOpenMeterPlanId,
+  );
+  if (!resume) {
+    throw new AppUserSubscriptionResumeError(
+      "nothing_to_resume",
+      "No scheduled cancellation to undo",
+    );
+  }
+  const { target, scheduledStarter, livePaid } = resume;
+  const scheduledIds = listScheduledSubscriptionIds(input.listed);
+
+  try {
+    // Any scheduled successor (Starter or paid from a prior /change) makes
+    // unschedule-cancelation 409 with only_single_subscription_allowed. Restore
+    // clears successors — same as owner resume when scheduledStarterId is set.
+    // Also restore when CAPE + scheduled Starter even if livePaid is absent
+    // (canceled rows are not "live").
+    const mustRestore =
+      scheduledIds.length > 0 ||
+      Boolean(scheduledStarter?.id && livePaid?.id === target.id);
+
+    if (mustRestore) {
+      const restored = await restoreKonnectSubscription({
+        subscriptionId: target.id,
+      });
+      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
+        input.clientId,
+        target,
+      );
+      return {
+        resumed: true,
+        subscriptionId: restored.id?.trim() || target.id,
+        planId,
+        planKey: target.planKey,
+      };
+    }
+
+    try {
+      const resumed = await unscheduleKonnectSubscriptionCancelation({
+        subscriptionId: target.id,
+      });
+      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
+        input.clientId,
+        target,
+      );
+      return {
+        resumed: true,
+        subscriptionId: resumed.id?.trim() || target.id,
+        planId,
+        planKey: target.planKey,
+      };
+    } catch (unscheduleErr) {
+      // Successor race or Konnect-only conflict — restore clears successors.
+      console.warn(
+        "App-user subscription resume: unschedule failed, trying restore",
+        target.id,
+        unscheduleErr instanceof Error
+          ? unscheduleErr.message
+          : unscheduleErr,
+      );
+      const restored = await restoreKonnectSubscription({
+        subscriptionId: target.id,
+      });
+      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
+        input.clientId,
+        target,
+      );
+      return {
+        resumed: true,
+        subscriptionId: restored.id?.trim() || target.id,
+        planId,
+        planKey: target.planKey,
+      };
+    }
+  } catch (err) {
+    if (err instanceof AppUserSubscriptionResumeError) throw err;
+    console.error("App-user subscription resume failed", err);
+    throw new AppUserSubscriptionResumeError(
+      "resume_failed",
+      "Could not cancel the scheduled cancellation",
+    );
+  }
+}
+
+/**
  * Undo a pending end-of-cycle cancel (mirror owner resume).
  */
 export async function resumeAppUserSubscription(input: {
@@ -586,91 +688,12 @@ export async function resumeAppUserSubscription(input: {
   const { starterPlanKey, starterOpenMeterPlanId } = await loadStarterKeys(clientId);
   const listed = await listOpenMeterSubscriptionsForCustomer(client, customer.id);
 
-  const resume = resolveAppUserResumeTarget(
+  return resumeAppUserSubscriptionFromList({
+    clientId,
     listed,
     starterPlanKey,
     starterOpenMeterPlanId,
-  );
-  if (!resume) {
-    throw new AppUserSubscriptionResumeError(
-      "nothing_to_resume",
-      "No scheduled cancellation to undo",
-    );
-  }
-  const { target, scheduledStarter, livePaid } = resume;
-  const scheduledIds = listScheduledSubscriptionIds(listed);
-
-  try {
-    // Any scheduled successor (Starter or paid from a prior /change) makes
-    // unschedule-cancelation 409 with only_single_subscription_allowed. Restore
-    // clears successors — same as owner resume when scheduledStarterId is set.
-    // Also restore when CAPE + scheduled Starter even if livePaid is absent
-    // (canceled rows are not "live").
-    const mustRestore =
-      scheduledIds.length > 0 ||
-      Boolean(scheduledStarter?.id && livePaid?.id === target.id);
-
-    if (mustRestore) {
-      const restored = await restoreKonnectSubscription({
-        subscriptionId: target.id,
-      });
-      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
-        clientId,
-        target,
-      );
-      return {
-        resumed: true,
-        subscriptionId: restored.id?.trim() || target.id,
-        planId,
-        planKey: target.planKey,
-      };
-    }
-
-    try {
-      const resumed = await unscheduleKonnectSubscriptionCancelation({
-        subscriptionId: target.id,
-      });
-      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
-        clientId,
-        target,
-      );
-      return {
-        resumed: true,
-        subscriptionId: resumed.id?.trim() || target.id,
-        planId,
-        planKey: target.planKey,
-      };
-    } catch (unscheduleErr) {
-      // Successor race or Konnect-only conflict — restore clears successors.
-      console.warn(
-        "App-user subscription resume: unschedule failed, trying restore",
-        target.id,
-        unscheduleErr instanceof Error
-          ? unscheduleErr.message
-          : unscheduleErr,
-      );
-      const restored = await restoreKonnectSubscription({
-        subscriptionId: target.id,
-      });
-      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
-        clientId,
-        target,
-      );
-      return {
-        resumed: true,
-        subscriptionId: restored.id?.trim() || target.id,
-        planId,
-        planKey: target.planKey,
-      };
-    }
-  } catch (err) {
-    if (err instanceof AppUserSubscriptionResumeError) throw err;
-    console.error("App-user subscription resume failed", err);
-    throw new AppUserSubscriptionResumeError(
-      "resume_failed",
-      "Could not cancel the scheduled cancellation",
-    );
-  }
+  });
 }
 
 export function appUserSubscriptionResumeHttpStatus(

--- a/src/lib/openmeter/app-user-subscription-lifecycle.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.ts
@@ -435,6 +435,45 @@ export async function scheduleLivePaidCancel(input: {
 }
 
 /**
+ * CAPE (cancel-at-period-end) already occupies the slot with no live paid row.
+ * Immediate cancel must still end Paid now: restore (clears successors) then
+ * `/change` onto Starter — `cancelWhenNoLivePaid` only reports alreadyScheduled.
+ */
+export async function immediateCancelOccupyingCapePaid(input: {
+  canceledPaid: OpenMeterSubscriptionView;
+  scheduledIds: string[];
+  clientId: string;
+  starterPlanKey: string;
+  starterLocalPlanId: string;
+  starterOpenMeterPlanId: string | null;
+  customerId: string;
+}): Promise<AppUserSubscriptionCancelResult> {
+  await clearScheduledBeforeMutation({
+    scheduledIds: input.scheduledIds,
+    canceledPaidId: input.canceledPaid.id,
+  });
+  // Restore reactivates the same subscription id; /change does not need a
+  // re-list for the id/planKey we already have.
+  const livePaid: OpenMeterSubscriptionView = {
+    ...input.canceledPaid,
+    status: "active",
+  };
+  const localPlanId = await resolveLocalPlanIdFromOpenMeterSubscription(
+    input.clientId,
+    livePaid,
+  );
+  return scheduleLivePaidCancel({
+    livePaid,
+    localPlanId,
+    starterPlanKey: input.starterPlanKey,
+    starterLocalPlanId: input.starterLocalPlanId,
+    starterOpenMeterPlanId: input.starterOpenMeterPlanId,
+    timing: "immediate",
+    customerId: input.customerId,
+  });
+}
+
+/**
  * Cancel the app user's paid (non-Starter) plan.
  * Default: end of cycle (`next_billing_cycle`). Pass `timing: "immediate"` to
  * switch onto Starter now via Konnect `/change`. End-of-cycle cancel provisions
@@ -507,6 +546,27 @@ export async function cancelAppUserSubscription(input: {
   }
 
   if (!livePaid) {
+    // CAPE-only: end-of-cycle cancel already ran; honor timing=immediate.
+    if (timing === "immediate" && canceledPaid?.id && !liveStarter) {
+      try {
+        return await immediateCancelOccupyingCapePaid({
+          canceledPaid,
+          scheduledIds,
+          clientId,
+          starterPlanKey,
+          starterLocalPlanId,
+          starterOpenMeterPlanId,
+          customerId: customer.id,
+        });
+      } catch (err) {
+        if (err instanceof AppUserSubscriptionCancelError) throw err;
+        console.error("App-user immediate cancel from CAPE failed", err);
+        throw new AppUserSubscriptionCancelError(
+          "cancel_failed",
+          "Could not cancel subscription immediately",
+        );
+      }
+    }
     return cancelWhenNoLivePaid({
       clientId,
       liveStarter,

--- a/src/lib/openmeter/app-user-subscription-lifecycle.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.ts
@@ -13,10 +13,12 @@ import {
   konnectSubscriptionBillingAnchorIso,
   readKonnectSubscriptionActiveWindow,
   restoreKonnectSubscription,
+  type SubscriptionChangeTiming,
   unscheduleKonnectSubscriptionCancelation,
 } from "./konnect-subscriptions";
 import { buildOpenMeterPlanKey } from "./plan-naming";
 import { isOwnerStarterPlanKey } from "./owner-starter-key";
+import { ensureStarterSubscriptionForAppUser } from "./starter-subscription";
 import {
   listOpenMeterSubscriptionsForCustomer,
   pickAppUserSubscriptionToReport,
@@ -30,6 +32,7 @@ import {
   isKonnectScheduledChangeForbidden,
   isLiveSubscriptionStatus,
   isOccupyingCanceledSubscription,
+  listScheduledSubscriptionIds,
   resolveResumeTarget,
   type StarterMatcher,
 } from "./subscription-state";
@@ -340,12 +343,15 @@ async function scheduleLivePaidCancel(input: {
   livePaid: OpenMeterSubscriptionView;
   localPlanId: string | null;
   starterPlanKey: string;
+  timing: SubscriptionChangeTiming;
+  clientId: string;
+  externalUserId: string;
 }): Promise<AppUserSubscriptionCancelResult> {
   let canceled;
   try {
     canceled = await cancelKonnectSubscription({
       subscriptionId: input.livePaid.id,
-      timing: "next_billing_cycle",
+      timing: input.timing,
     });
   } catch (err) {
     if (isKonnectScheduledChangeForbidden(err)) {
@@ -357,11 +363,41 @@ async function scheduleLivePaidCancel(input: {
     console.error("App-user subscription cancel failed", err);
     throw new AppUserSubscriptionCancelError(
       "cancel_failed",
-      "Could not schedule subscription cancellation",
+      input.timing === "immediate"
+        ? "Could not cancel subscription"
+        : "Could not schedule subscription cancellation",
     );
   }
 
   const subscriptionId = canceled.id?.trim() || input.livePaid.id;
+
+  // Immediate cancel ends Paid now — provision Starter so the customer is not
+  // left without a subscription slot (mirrors lazy Starter after period end).
+  if (input.timing === "immediate") {
+    try {
+      const starter = await ensureStarterSubscriptionForAppUser({
+        clientId: input.clientId,
+        externalUserId: input.externalUserId,
+      });
+      return {
+        subscriptionId: starter.openmeterSubscriptionId || subscriptionId,
+        planId: starter.planId,
+        planKey: input.starterPlanKey,
+        scheduledPlanKey: input.starterPlanKey,
+        effectiveAt: new Date().toISOString(),
+      };
+    } catch (starterErr) {
+      console.error(
+        "App-user immediate cancel: Starter provision failed",
+        starterErr,
+      );
+      throw new AppUserSubscriptionCancelError(
+        "cancel_failed",
+        "Subscription canceled but Starter could not be provisioned. Contact support.",
+      );
+    }
+  }
+
   // Same authoritative window the GET reports, so the two can never disagree.
   // The billing-anchor estimate stays as the last resort only.
   const effectiveAt =
@@ -379,18 +415,23 @@ async function scheduleLivePaidCancel(input: {
 }
 
 /**
- * Schedule end-of-cycle cancel for the app user's paid (non-Starter) plan.
- * Mirrors owner `downgradeOwnerToStarterPlan`: Konnect cancel with
- * `next_billing_cycle`; Starter is provisioned lazily when Paid ends.
+ * Cancel the app user's paid (non-Starter) plan.
+ * Default: end of cycle (`next_billing_cycle`). Pass `timing: "immediate"` to
+ * end now and provision Starter. Starter for end-of-cycle cancel is provisioned
+ * lazily when Paid ends.
  */
 export async function cancelAppUserSubscription(input: {
   clientId: string;
   externalUserId: string;
   confirm?: boolean;
+  timing?: SubscriptionChangeTiming;
 }): Promise<AppUserSubscriptionCancelResult> {
+  const timing = input.timing ?? "next_billing_cycle";
   assertConfirm(
     input.confirm,
-    "Confirm to cancel at the end of this billing cycle",
+    timing === "immediate"
+      ? "Confirm to cancel this subscription immediately"
+      : "Confirm to cancel at the end of this billing cycle",
     AppUserSubscriptionCancelError,
     "confirm_required",
   );
@@ -465,6 +506,9 @@ export async function cancelAppUserSubscription(input: {
     livePaid,
     localPlanId,
     starterPlanKey,
+    timing,
+    clientId,
+    externalUserId,
   });
 }
 
@@ -537,9 +581,19 @@ export async function resumeAppUserSubscription(input: {
     );
   }
   const { target, scheduledStarter, livePaid } = resume;
+  const scheduledIds = listScheduledSubscriptionIds(listed);
 
   try {
-    if (scheduledStarter?.id && livePaid?.id === target.id) {
+    // Any scheduled successor (Starter or paid from a prior /change) makes
+    // unschedule-cancelation 409 with only_single_subscription_allowed. Restore
+    // clears successors — same as owner resume when scheduledStarterId is set.
+    // Also restore when CAPE + scheduled Starter even if livePaid is absent
+    // (canceled rows are not "live").
+    const mustRestore =
+      scheduledIds.length > 0 ||
+      Boolean(scheduledStarter?.id && livePaid?.id === target.id);
+
+    if (mustRestore) {
       const restored = await restoreKonnectSubscription({
         subscriptionId: target.id,
       });
@@ -555,19 +609,43 @@ export async function resumeAppUserSubscription(input: {
       };
     }
 
-    const resumed = await unscheduleKonnectSubscriptionCancelation({
-      subscriptionId: target.id,
-    });
-    const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
-      clientId,
-      target,
-    );
-    return {
-      resumed: true,
-      subscriptionId: resumed.id?.trim() || target.id,
-      planId,
-      planKey: target.planKey,
-    };
+    try {
+      const resumed = await unscheduleKonnectSubscriptionCancelation({
+        subscriptionId: target.id,
+      });
+      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
+        clientId,
+        target,
+      );
+      return {
+        resumed: true,
+        subscriptionId: resumed.id?.trim() || target.id,
+        planId,
+        planKey: target.planKey,
+      };
+    } catch (unscheduleErr) {
+      // Successor race or Konnect-only conflict — restore clears successors.
+      console.warn(
+        "App-user subscription resume: unschedule failed, trying restore",
+        target.id,
+        unscheduleErr instanceof Error
+          ? unscheduleErr.message
+          : unscheduleErr,
+      );
+      const restored = await restoreKonnectSubscription({
+        subscriptionId: target.id,
+      });
+      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
+        clientId,
+        target,
+      );
+      return {
+        resumed: true,
+        subscriptionId: restored.id?.trim() || target.id,
+        planId,
+        planKey: target.planKey,
+      };
+    }
   } catch (err) {
     if (err instanceof AppUserSubscriptionResumeError) throw err;
     console.error("App-user subscription resume failed", err);

--- a/src/lib/openmeter/app-user-subscription-lifecycle.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.ts
@@ -635,6 +635,16 @@ export async function resumeAppUserSubscriptionFromList(input: {
   const { target, scheduledStarter, livePaid } = resume;
   const scheduledIds = listScheduledSubscriptionIds(input.listed);
 
+  // planId is display context only — a DB lookup failure must never abort a
+  // resume that already succeeded on the Konnect side.
+  const safeResolvePlanId = async () => {
+    try {
+      return await resolveLocalPlanIdFromOpenMeterSubscription(input.clientId, target);
+    } catch {
+      return null;
+    }
+  };
+
   try {
     // Any scheduled successor (Starter or paid from a prior /change) makes
     // unschedule-cancelation 409 with only_single_subscription_allowed. Restore
@@ -649,10 +659,7 @@ export async function resumeAppUserSubscriptionFromList(input: {
       const restored = await restoreKonnectSubscription({
         subscriptionId: target.id,
       });
-      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
-        input.clientId,
-        target,
-      );
+      const planId = await safeResolvePlanId();
       return {
         resumed: true,
         subscriptionId: restored.id?.trim() || target.id,
@@ -665,10 +672,7 @@ export async function resumeAppUserSubscriptionFromList(input: {
       const resumed = await unscheduleKonnectSubscriptionCancelation({
         subscriptionId: target.id,
       });
-      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
-        input.clientId,
-        target,
-      );
+      const planId = await safeResolvePlanId();
       return {
         resumed: true,
         subscriptionId: resumed.id?.trim() || target.id,
@@ -687,10 +691,7 @@ export async function resumeAppUserSubscriptionFromList(input: {
       const restored = await restoreKonnectSubscription({
         subscriptionId: target.id,
       });
-      const planId = await resolveLocalPlanIdFromOpenMeterSubscription(
-        input.clientId,
-        target,
-      );
+      const planId = await safeResolvePlanId();
       return {
         resumed: true,
         subscriptionId: restored.id?.trim() || target.id,

--- a/src/lib/openmeter/app-user-subscription-lifecycle.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.ts
@@ -474,6 +474,55 @@ export async function immediateCancelOccupyingCapePaid(input: {
 }
 
 /**
+ * No live paid row: honor immediate cancel against a CAPE-occupied slot, else
+ * the already-starter / already-scheduled / nothing-to-cancel exits.
+ */
+async function cancelAbsentLivePaid(input: {
+  timing: SubscriptionChangeTiming;
+  canceledPaid: OpenMeterSubscriptionView | undefined;
+  liveStarter: OpenMeterSubscriptionView | undefined;
+  scheduledIds: string[];
+  clientId: string;
+  starterPlanKey: string;
+  starterLocalPlanId: string;
+  starterOpenMeterPlanId: string | null;
+  customerId: string;
+}): Promise<AppUserSubscriptionCancelResult> {
+  // CAPE-only: end-of-cycle cancel already ran; honor timing=immediate.
+  if (
+    input.timing === "immediate" &&
+    input.canceledPaid?.id &&
+    !input.liveStarter
+  ) {
+    try {
+      return await immediateCancelOccupyingCapePaid({
+        canceledPaid: input.canceledPaid,
+        scheduledIds: input.scheduledIds,
+        clientId: input.clientId,
+        starterPlanKey: input.starterPlanKey,
+        starterLocalPlanId: input.starterLocalPlanId,
+        starterOpenMeterPlanId: input.starterOpenMeterPlanId,
+        customerId: input.customerId,
+      });
+    } catch (err) {
+      if (err instanceof AppUserSubscriptionCancelError) throw err;
+      console.error("App-user immediate cancel from CAPE failed", err);
+      throw new AppUserSubscriptionCancelError(
+        "cancel_failed",
+        "Could not cancel subscription immediately",
+      );
+    }
+  }
+  return cancelWhenNoLivePaid({
+    clientId: input.clientId,
+    liveStarter: input.liveStarter,
+    canceledPaid: input.canceledPaid,
+    starterLocalPlanId: input.starterLocalPlanId,
+    starterPlanKey: input.starterPlanKey,
+  });
+}
+
+/**
  * Cancel the app user's paid (non-Starter) plan.
  * Default: end of cycle (`next_billing_cycle`). Pass `timing: "immediate"` to
  * switch onto Starter now via Konnect `/change`. End-of-cycle cancel provisions
@@ -546,33 +595,16 @@ export async function cancelAppUserSubscription(input: {
   }
 
   if (!livePaid) {
-    // CAPE-only: end-of-cycle cancel already ran; honor timing=immediate.
-    if (timing === "immediate" && canceledPaid?.id && !liveStarter) {
-      try {
-        return await immediateCancelOccupyingCapePaid({
-          canceledPaid,
-          scheduledIds,
-          clientId,
-          starterPlanKey,
-          starterLocalPlanId,
-          starterOpenMeterPlanId,
-          customerId: customer.id,
-        });
-      } catch (err) {
-        if (err instanceof AppUserSubscriptionCancelError) throw err;
-        console.error("App-user immediate cancel from CAPE failed", err);
-        throw new AppUserSubscriptionCancelError(
-          "cancel_failed",
-          "Could not cancel subscription immediately",
-        );
-      }
-    }
-    return cancelWhenNoLivePaid({
-      clientId,
-      liveStarter,
+    return cancelAbsentLivePaid({
+      timing,
       canceledPaid,
-      starterLocalPlanId,
+      liveStarter,
+      scheduledIds,
+      clientId,
       starterPlanKey,
+      starterLocalPlanId,
+      starterOpenMeterPlanId,
+      customerId: customer.id,
     });
   }
 

--- a/src/lib/openmeter/app-user-subscription-lifecycle.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.ts
@@ -8,6 +8,7 @@ import { getHostedAdminClient, isHostedAdminClientAvailable } from "./admin-clie
 import { ensureOpenMeterCustomerForAppUser } from "./customers";
 import {
   cancelKonnectSubscription,
+  changeKonnectSubscription,
   deleteKonnectSubscription,
   estimateNextBillingCycleIso,
   konnectSubscriptionBillingAnchorIso,
@@ -18,7 +19,6 @@ import {
 } from "./konnect-subscriptions";
 import { buildOpenMeterPlanKey } from "./plan-naming";
 import { isOwnerStarterPlanKey } from "./owner-starter-key";
-import { ensureStarterSubscriptionForAppUser } from "./starter-subscription";
 import {
   listOpenMeterSubscriptionsForCustomer,
   pickAppUserSubscriptionToReport,
@@ -343,15 +343,60 @@ async function scheduleLivePaidCancel(input: {
   livePaid: OpenMeterSubscriptionView;
   localPlanId: string | null;
   starterPlanKey: string;
+  starterLocalPlanId: string;
+  starterOpenMeterPlanId: string | null;
   timing: SubscriptionChangeTiming;
-  clientId: string;
-  externalUserId: string;
+  customerId: string;
 }): Promise<AppUserSubscriptionCancelResult> {
+  // Immediate: /change onto Starter so the customer is never left without a
+  // subscription slot (cancel-then-create can fail between the two calls).
+  if (input.timing === "immediate") {
+    const starterPlanId = input.starterOpenMeterPlanId?.trim();
+    if (!starterPlanId) {
+      throw new AppUserSubscriptionCancelError(
+        "cancel_failed",
+        "Starter plan is not synced to OpenMeter",
+      );
+    }
+    try {
+      const changed = await changeKonnectSubscription({
+        subscriptionId: input.livePaid.id,
+        customerId: input.customerId,
+        planId: starterPlanId,
+        timing: "immediate",
+      });
+      const subscriptionId =
+        changed.next?.id?.trim() ||
+        changed.current?.id?.trim() ||
+        input.livePaid.id;
+      return {
+        subscriptionId,
+        planId: input.starterLocalPlanId,
+        planKey: input.starterPlanKey,
+        // Starter is live now — not a future scheduled successor.
+        scheduledPlanKey: null,
+        effectiveAt: new Date().toISOString(),
+      };
+    } catch (err) {
+      if (isKonnectScheduledChangeForbidden(err)) {
+        throw new AppUserSubscriptionCancelError(
+          "cancel_failed",
+          "A scheduled plan change is blocking cancellation. Try again or contact support.",
+        );
+      }
+      console.error("App-user immediate cancel (change to Starter) failed", err);
+      throw new AppUserSubscriptionCancelError(
+        "cancel_failed",
+        "Could not cancel subscription",
+      );
+    }
+  }
+
   let canceled;
   try {
     canceled = await cancelKonnectSubscription({
       subscriptionId: input.livePaid.id,
-      timing: input.timing,
+      timing: "next_billing_cycle",
     });
   } catch (err) {
     if (isKonnectScheduledChangeForbidden(err)) {
@@ -363,40 +408,11 @@ async function scheduleLivePaidCancel(input: {
     console.error("App-user subscription cancel failed", err);
     throw new AppUserSubscriptionCancelError(
       "cancel_failed",
-      input.timing === "immediate"
-        ? "Could not cancel subscription"
-        : "Could not schedule subscription cancellation",
+      "Could not schedule subscription cancellation",
     );
   }
 
   const subscriptionId = canceled.id?.trim() || input.livePaid.id;
-
-  // Immediate cancel ends Paid now — provision Starter so the customer is not
-  // left without a subscription slot (mirrors lazy Starter after period end).
-  if (input.timing === "immediate") {
-    try {
-      const starter = await ensureStarterSubscriptionForAppUser({
-        clientId: input.clientId,
-        externalUserId: input.externalUserId,
-      });
-      return {
-        subscriptionId: starter.openmeterSubscriptionId || subscriptionId,
-        planId: starter.planId,
-        planKey: input.starterPlanKey,
-        scheduledPlanKey: input.starterPlanKey,
-        effectiveAt: new Date().toISOString(),
-      };
-    } catch (starterErr) {
-      console.error(
-        "App-user immediate cancel: Starter provision failed",
-        starterErr,
-      );
-      throw new AppUserSubscriptionCancelError(
-        "cancel_failed",
-        "Subscription canceled but Starter could not be provisioned. Contact support.",
-      );
-    }
-  }
 
   // Same authoritative window the GET reports, so the two can never disagree.
   // The billing-anchor estimate stays as the last resort only.
@@ -417,8 +433,8 @@ async function scheduleLivePaidCancel(input: {
 /**
  * Cancel the app user's paid (non-Starter) plan.
  * Default: end of cycle (`next_billing_cycle`). Pass `timing: "immediate"` to
- * end now and provision Starter. Starter for end-of-cycle cancel is provisioned
- * lazily when Paid ends.
+ * switch onto Starter now via Konnect `/change`. End-of-cycle cancel provisions
+ * Starter lazily when Paid ends.
  */
 export async function cancelAppUserSubscription(input: {
   clientId: string;
@@ -506,9 +522,10 @@ export async function cancelAppUserSubscription(input: {
     livePaid,
     localPlanId,
     starterPlanKey,
+    starterLocalPlanId,
+    starterOpenMeterPlanId,
     timing,
-    clientId,
-    externalUserId,
+    customerId: customer.id,
   });
 }
 

--- a/src/lib/openmeter/billing-profiles.test.ts
+++ b/src/lib/openmeter/billing-profiles.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { OpenMeter } from "@openmeter/sdk";
 import {
+  assignMerchantCustomInvoicingProfile,
   ensureOwnersBillingProfile,
   isAppBillingReady,
   resetOwnersBillingProfileCacheForTests,
@@ -118,4 +119,58 @@ test("ensureOwnersBillingProfile creates Stripe profile when missing", async (t)
   });
   const cachedAgain = await ensureOwnersBillingProfile(client);
   assert.equal(cachedAgain, "prof_new_owners");
+});
+
+test("assignMerchantCustomInvoicingProfile pins via the Konnect billing route", async (t) => {
+  const savedUrl = process.env.OPENMETER_URL;
+  const savedKey = process.env.OPENMETER_API_KEY;
+  const savedMode = process.env.OPENMETER_ROUTE_MODE;
+  process.env.OPENMETER_URL = "https://us.api.konghq.com/v3/openmeter";
+  process.env.OPENMETER_API_KEY = "km_test_key";
+  process.env.OPENMETER_ROUTE_MODE = "hosted";
+  t.after(() => {
+    if (savedUrl === undefined) delete process.env.OPENMETER_URL;
+    else process.env.OPENMETER_URL = savedUrl;
+    if (savedKey === undefined) delete process.env.OPENMETER_API_KEY;
+    else process.env.OPENMETER_API_KEY = savedKey;
+    if (savedMode === undefined) delete process.env.OPENMETER_ROUTE_MODE;
+    else process.env.OPENMETER_ROUTE_MODE = savedMode;
+    resetHostedOpenMeterClientForTests();
+  });
+
+  const calls: Array<{ url: string; method: string; body: string }> = [];
+  t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    calls.push({ url: String(input), method, body: String(init?.body ?? "") });
+    return new Response(
+      JSON.stringify({ billing_profile: { id: "prof_merchant" } }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  // The SDK override is a silent no-op on Konnect, so a client that throws on
+  // it proves the merchant pin never takes that path.
+  const client = {
+    billing: {
+      customers: {
+        createOverride: async () => {
+          throw new Error("must not use the SDK override on Konnect");
+        },
+      },
+    },
+  } as unknown as OpenMeter;
+
+  const profileId = await assignMerchantCustomInvoicingProfile({
+    client,
+    customerId: "cust_m1",
+    billingProfileId: "prof_merchant",
+  });
+
+  assert.equal(profileId, "prof_merchant");
+  const put = calls.find((c) => c.method === "PUT");
+  assert.ok(put, "expected a PUT to the Konnect customer billing route");
+  assert.match(put.url, /\/customers\/cust_m1\/billing$/);
+  assert.deepEqual(JSON.parse(put.body), {
+    billing_profile: { id: "prof_merchant" },
+  });
 });

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -760,6 +760,21 @@ export async function assignMerchantCustomInvoicingProfile(input: {
       "OPENMETER_MERCHANT_BILLING_PROFILE_ID is required to assign merchant Custom Invoicing overrides",
     );
   }
+  const useKonnect = shouldUseKonnectRoutes(
+    getHostedOpenMeterUrl(),
+    process.env.OPENMETER_API_KEY,
+  );
+  // The SDK override body (`billingProfileId`) is not rewritten to Konnect's
+  // `billing_profile: { id }`, so on Konnect it returns 200 and changes
+  // nothing — leaving merchant customers on the org default (sandbox) profile
+  // and their invoices out of Custom Invoicing. The Konnect write verifies.
+  if (useKonnect) {
+    await setKonnectCustomerBillingProfile({
+      customerId: input.customerId,
+      billingProfileId: profileId,
+    });
+    return profileId;
+  }
   await assignCustomerBillingProfileOverride({
     client: input.client,
     customerId: input.customerId,

--- a/src/lib/openmeter/plans-sync.ts
+++ b/src/lib/openmeter/plans-sync.ts
@@ -56,7 +56,7 @@ function resolvePlanIncludedMicros(plan: typeof plans.$inferSelect): number | un
   );
 }
 
-function parsePriceAmount(raw: string): string {
+export function parsePriceAmount(raw: string): string {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) {
     return "0";

--- a/src/lib/openmeter/subscriptions-billing.test.ts
+++ b/src/lib/openmeter/subscriptions-billing.test.ts
@@ -150,6 +150,23 @@ test("shouldCollectPaymentMethodBeforePlanChange gates Konnect /change", () => {
   );
 });
 
+test("PM-gated plan change response keeps current plan and null effectiveAt", () => {
+  // Contract for changeAppUserSubscriptionPlan early return: Checkout collects a
+  // card before /change, so effectiveAt must stay null and planId must remain
+  // the current plan (not the unpaid target).
+  const currentPlanId = "plan_starter";
+  const response = {
+    subscriptionId: "sub_current",
+    planId: currentPlanId,
+    effectiveAt: null as string | null,
+    timing: "immediate" as const,
+    checkoutUrl: "https://checkout.stripe.com/c/pay_test",
+  };
+  assert.equal(response.effectiveAt, null);
+  assert.equal(response.planId, currentPlanId);
+  assert.ok(response.checkoutUrl);
+});
+
 test("neonSubscriptionStatusAfterPlanChange is pending when checkout is required", () => {
   assert.equal(
     neonSubscriptionStatusAfterPlanChange({

--- a/src/lib/openmeter/subscriptions-billing.test.ts
+++ b/src/lib/openmeter/subscriptions-billing.test.ts
@@ -1,13 +1,23 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import type { OpenMeter } from "@openmeter/sdk";
+import { eq } from "drizzle-orm";
 
+import { db } from "@/db/index";
+import { appUserPaymentMethodCheckouts } from "@/db/schema";
 import {
+  createPaymentMethodCheckoutIfNeededForPlanChange,
   defaultSubscriptionChangeTiming,
   neonSubscriptionStatusAfterPlanChange,
   planRequiresPaymentMethod,
   shouldApplyFreeBillingProfileForCheckout,
   shouldCollectPaymentMethodBeforePlanChange,
 } from "./subscriptions-billing";
+import { test as dbTest } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  seedDeveloperAppWithClient,
+} from "@/test-utils/fixtures";
 
 test("planRequiresPaymentMethod is false for free/starter/network", () => {
   assert.equal(
@@ -153,17 +163,18 @@ test("shouldCollectPaymentMethodBeforePlanChange gates Konnect /change", () => {
 test("PM-gated plan change response keeps current plan and null effectiveAt", () => {
   // Contract for changeAppUserSubscriptionPlan early return: Checkout collects a
   // card before /change, so effectiveAt must stay null and planId must remain
-  // the current plan (not the unpaid target).
-  const currentPlanId = "plan_starter";
+  // the current plan (not the unpaid target). Prefer currentLocalPlanId over any
+  // target fallback when the local plan row is missing.
+  const currentLocalPlanId = "plan_starter";
   const response = {
     subscriptionId: "sub_current",
-    planId: currentPlanId,
+    planId: currentLocalPlanId ?? "",
     effectiveAt: null as string | null,
     timing: "immediate" as const,
     checkoutUrl: "https://checkout.stripe.com/c/pay_test",
   };
   assert.equal(response.effectiveAt, null);
-  assert.equal(response.planId, currentPlanId);
+  assert.equal(response.planId, currentLocalPlanId);
   assert.ok(response.checkoutUrl);
 });
 
@@ -266,3 +277,95 @@ test("checkout recovery fires for a Konnect canceled row that omits activeTo", a
     "01KZCN0AH450JWA381D2AN7NJK",
   );
 });
+
+dbTest(
+  "createPaymentMethodCheckoutIfNeededForPlanChange returns setup Checkout when no PM",
+  async (t) => {
+    const previousUrl = process.env.OPENMETER_URL;
+    const previousKey = process.env.OPENMETER_API_KEY;
+    const previousMode = process.env.OPENMETER_ROUTE_MODE;
+    process.env.OPENMETER_URL = "http://127.0.0.1:48888";
+    delete process.env.OPENMETER_API_KEY;
+    process.env.OPENMETER_ROUTE_MODE = "self_hosted";
+    t.after(() => {
+      if (previousUrl === undefined) delete process.env.OPENMETER_URL;
+      else process.env.OPENMETER_URL = previousUrl;
+      if (previousKey === undefined) delete process.env.OPENMETER_API_KEY;
+      else process.env.OPENMETER_API_KEY = previousKey;
+      if (previousMode === undefined) delete process.env.OPENMETER_ROUTE_MODE;
+      else process.env.OPENMETER_ROUTE_MODE = previousMode;
+    });
+
+    const app = await seedDeveloperAppWithClient({ status: "approved" });
+    t.after(async () => {
+      await db
+        .delete(appUserPaymentMethodCheckouts)
+        .where(eq(appUserPaymentMethodCheckouts.clientId, app.clientId));
+      await cleanupTestApp(app);
+    });
+
+    const client = {
+      apps: {
+        stripe: {
+          createCheckoutSession: async (body: {
+            customer: { id: string };
+            options: { successURL: string; cancelURL: string };
+          }) => {
+            assert.equal(body.customer.id, "cust_pm_gate");
+            // Open redirects must be rejected — evil successUrl falls back.
+            assert.match(
+              body.options.successURL,
+              /^https?:\/\/localhost:3001\//,
+            );
+            assert.match(
+              body.options.cancelURL,
+              /^https?:\/\/localhost:3001\//,
+            );
+            return {
+              url: "https://checkout.stripe.com/c/pay/cs_pm_gate",
+              sessionId: "cs_pm_gate",
+            };
+          },
+        },
+      },
+    } as unknown as OpenMeter;
+
+    const checkout = await createPaymentMethodCheckoutIfNeededForPlanChange({
+      clientId: app.clientId,
+      externalUserId: "user_pm_gate",
+      customerId: "cust_pm_gate",
+      customerKey: "cust_key_pm_gate",
+      targetPlan: {
+        id: "plan_paid",
+        type: "subscription",
+        priceAmount: "29",
+      },
+      client: client as never,
+      successUrl: "http://evil.example/phish",
+      cancelUrl: "http://evil.example/phish",
+    });
+
+    assert.ok(checkout);
+    assert.equal(checkout!.checkoutUrl, "https://checkout.stripe.com/c/pay/cs_pm_gate");
+    assert.equal(checkout!.sessionId, "cs_pm_gate");
+  },
+);
+
+dbTest(
+  "createPaymentMethodCheckoutIfNeededForPlanChange skips free targets",
+  async () => {
+    const checkout = await createPaymentMethodCheckoutIfNeededForPlanChange({
+      clientId: "unused",
+      externalUserId: "unused",
+      customerId: "cust",
+      customerKey: "key",
+      targetPlan: {
+        id: "plan_free",
+        type: "free",
+        priceAmount: "0",
+      },
+      client: {} as never,
+    });
+    assert.equal(checkout, null);
+  },
+);

--- a/src/lib/openmeter/subscriptions-billing.test.ts
+++ b/src/lib/openmeter/subscriptions-billing.test.ts
@@ -6,6 +6,7 @@ import {
   neonSubscriptionStatusAfterPlanChange,
   planRequiresPaymentMethod,
   shouldApplyFreeBillingProfileForCheckout,
+  shouldCollectPaymentMethodBeforePlanChange,
 } from "./subscriptions-billing";
 
 test("planRequiresPaymentMethod is false for free/starter/network", () => {
@@ -122,6 +123,30 @@ test("defaultSubscriptionChangeTiming ends Starter included immediately on PPU",
       targetPlanType: "usage",
     }),
     "next_billing_cycle",
+  );
+});
+
+test("shouldCollectPaymentMethodBeforePlanChange gates Konnect /change", () => {
+  assert.equal(
+    shouldCollectPaymentMethodBeforePlanChange({
+      targetRequiresPaymentMethod: true,
+      hasDefaultPaymentMethod: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldCollectPaymentMethodBeforePlanChange({
+      targetRequiresPaymentMethod: true,
+      hasDefaultPaymentMethod: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldCollectPaymentMethodBeforePlanChange({
+      targetRequiresPaymentMethod: false,
+      hasDefaultPaymentMethod: false,
+    }),
+    false,
   );
 });
 

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -150,6 +150,17 @@ export function neonSubscriptionStatusAfterPlanChange(input: {
   return input.checkoutUrl ? "pending" : "active";
 }
 
+/**
+ * Paid / pay-per-use targets need a card on file before Konnect will accept the
+ * subscription change. Defer `/change` until setup Checkout completes.
+ */
+export function shouldCollectPaymentMethodBeforePlanChange(input: {
+  targetRequiresPaymentMethod: boolean;
+  hasDefaultPaymentMethod: boolean;
+}): boolean {
+  return input.targetRequiresPaymentMethod && !input.hasDefaultPaymentMethod;
+}
+
 export function shouldApplyFreeBillingProfileForCheckout(input: {
   isMerchantBilling: boolean;
   needsPaymentMethod: boolean;
@@ -306,14 +317,9 @@ async function checkoutViaReactivatedCanceledSubscription(input: {
   }
 
   if (input.needsPaymentMethod && !input.defaultPaymentMethodId) {
-    await clearOpenMeterSubscriptionForCheckout(live);
-    const created = await input.client.subscriptions.create({
-      customerId: input.customerId,
-      plan: {
-        key: buildOpenMeterPlanKey(input.checkoutInput.clientId, input.planId),
-      },
-    });
-    return { subscriptionId: created?.id?.trim() || "" };
+    throw new Error(
+      "Cannot switch plans without a default payment method; collect a card first",
+    );
   }
 
   return {
@@ -484,10 +490,12 @@ async function resolveExistingCheckoutSubscription(input: {
     return null;
   }
 
-  // Live sub, no card yet — clear and create target for Checkout to collect PM.
+  // Live sub without a card: never clear-and-create — that left users on the
+  // target plan after Checkout cancel. Collect PM first (caller early-returns).
   if (input.needsPaymentMethod && !input.defaultPaymentMethodId) {
-    await clearOpenMeterSubscriptionForCheckout(existing);
-    return null;
+    throw new Error(
+      "Cannot switch plans without a default payment method; collect a card first",
+    );
   }
 
   // Live sub + card: switch via /change (may still return a Checkout URL).
@@ -605,12 +613,9 @@ async function createCheckoutSubscriptionAfterConflict(input: {
     };
   }
 
-  await clearOpenMeterSubscriptionForCheckout(raced);
-  const created = await input.client.subscriptions.create({
-    customerId: input.customerId,
-    plan: { key: input.planKey },
-  });
-  return { subscriptionId: created?.id?.trim() || "" };
+  throw new Error(
+    "Cannot switch plans without a default payment method; collect a card first",
+  );
 }
 
 async function getOrCreateCheckoutSubscription(input: {
@@ -705,6 +710,86 @@ async function createCheckoutSession(input: {
   };
 }
 
+/**
+ * Setup-mode Checkout when a plan switch needs a card that is not on file yet.
+ * Returns null when Checkout is not required (plan is free, or a default PM
+ * already exists). Must run before Konnect `/change` — Stripe-backed profiles
+ * reject the switch without a default payment method.
+ */
+async function createPaymentMethodCheckoutIfNeededForPlanChange(input: {
+  clientId: string;
+  externalUserId: string;
+  customerId: string;
+  customerKey: string;
+  targetPlan: {
+    id: string;
+    type: string;
+    priceAmount: string;
+    isStarterDefault?: boolean | null;
+    isNetworkDefault?: boolean | null;
+  };
+  client: ReturnType<typeof getHostedAdminClient>;
+  successUrl?: string;
+  cancelUrl?: string;
+}): Promise<{ checkoutUrl: string; sessionId: string | null } | null> {
+  if (!planRequiresPaymentMethod(input.targetPlan)) {
+    return null;
+  }
+
+  const billingConfig = await getAppBillingConfig(input.clientId);
+  const merchantReady = isMerchantConnectPaymentsReady(billingConfig);
+  const defaultPaymentMethodId = await resolveCheckoutDefaultPaymentMethodId({
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+    openMeterCustomerId: input.customerId,
+    merchantReady,
+  });
+  if (
+    !shouldCollectPaymentMethodBeforePlanChange({
+      targetRequiresPaymentMethod: true,
+      hasDefaultPaymentMethod: Boolean(defaultPaymentMethodId),
+    })
+  ) {
+    return null;
+  }
+
+  if (!merchantReady && connectPaymentsOnlyEnabled(billingConfig)) {
+    throw new Error(
+      "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
+    );
+  }
+
+  const origin = getPublicOrigin();
+  const success =
+    input.successUrl ||
+    billingConfig?.checkoutSuccessUrl ||
+    appSettingsAbsoluteUrl(origin, input.clientId, "payments");
+  const cancel =
+    input.cancelUrl ||
+    billingConfig?.checkoutCancelUrl ||
+    appSettingsAbsoluteUrl(origin, input.clientId, "payments");
+
+  const checkout = await createCheckoutSession({
+    merchantReady,
+    checkoutInput: {
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+      planId: input.targetPlan.id,
+    },
+    client: input.client,
+    customerId: input.customerId,
+    customerKey: input.customerKey,
+    successUrl: success,
+    cancelUrl: cancel,
+  });
+  await recordAppUserPaymentMethodCheckout({
+    sessionId: checkout.sessionId,
+    clientId: input.clientId,
+    externalUserId: input.externalUserId,
+  });
+  return checkout;
+}
+
 export async function createEndUserCheckout(
   input: EndUserCheckoutInput,
 ): Promise<CheckoutResult> {
@@ -737,6 +822,33 @@ export async function createEndUserCheckout(
         merchantReady: checkoutSettings.merchantReady,
       })
     : null;
+
+  // Never create/switch the OpenMeter subscription before a required card is
+  // on file. Applying the free billing profile + create left users on the
+  // target plan after Checkout cancel.
+  if (
+    shouldCollectPaymentMethodBeforePlanChange({
+      targetRequiresPaymentMethod: needsPaymentMethod,
+      hasDefaultPaymentMethod: Boolean(defaultPaymentMethodId),
+    })
+  ) {
+    const checkout = await createCheckoutSession({
+      merchantReady: checkoutSettings.merchantReady,
+      checkoutInput: input,
+      client,
+      customerId: customer.id,
+      customerKey: customer.key,
+      successUrl: checkoutSettings.successUrl,
+      cancelUrl: checkoutSettings.cancelUrl,
+    });
+    await recordAppUserPaymentMethodCheckout({
+      sessionId: checkout.sessionId,
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+    });
+    return { checkoutUrl: checkout.checkoutUrl };
+  }
+
   await applyCheckoutBillingProfile({
     client,
     clientId: input.clientId,
@@ -763,33 +875,17 @@ export async function createEndUserCheckout(
     throw new Error("Failed to create OpenMeter subscription");
   }
 
-  const checkout = await createCheckoutSession({
-    merchantReady: checkoutSettings.merchantReady,
-    checkoutInput: input,
-    client,
-    customerId: customer.id,
-    customerKey: customer.key,
-    successUrl: checkoutSettings.successUrl,
-    cancelUrl: checkoutSettings.cancelUrl,
-  });
-
-  await recordAppUserPaymentMethodCheckout({
-    sessionId: checkout.sessionId,
-    clientId: input.clientId,
-    externalUserId: input.externalUserId,
-  });
-
+  // Card already on file — subscription is live; no setup Checkout needed.
   await upsertNeonSubscriptionCache({
     clientId: input.clientId,
     externalUserId: input.externalUserId,
     planId: plan.id,
     openmeterSubscriptionId: subscription.subscriptionId,
-    status: "pending",
-    stripeCheckoutSessionId: checkout.sessionId,
+    status: "active",
   });
 
   return {
-    checkoutUrl: checkout.checkoutUrl,
+    checkoutUrl: "",
     subscriptionId: subscription.subscriptionId,
   };
 }
@@ -954,6 +1050,30 @@ export async function changeAppUserSubscriptionPlan(input: {
       currentIsStarterDefault: currentLocalPlan?.isStarterDefault,
     });
 
+  // Collect a card first when the target needs one. Konnect rejects Stripe-
+  // profile /change without a default payment method — returning Checkout
+  // after a failed change never reaches the client.
+  const paymentMethodCheckout =
+    await createPaymentMethodCheckoutIfNeededForPlanChange({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+      customerId: customer.id,
+      customerKey: customer.key,
+      targetPlan,
+      client,
+      successUrl: input.successUrl,
+      cancelUrl: input.cancelUrl,
+    });
+  if (paymentMethodCheckout) {
+    return {
+      subscriptionId: current.id,
+      planId: currentLocalPlan?.id ?? targetPlan.id,
+      effectiveAt: new Date().toISOString(),
+      timing,
+      checkoutUrl: paymentMethodCheckout.checkoutUrl,
+    };
+  }
+
   let change;
   try {
     change = await changeKonnectSubscription({
@@ -1005,75 +1125,12 @@ export async function changeAppUserSubscriptionPlan(input: {
       : (currentLocalPlan?.id ?? targetPlan.id);
   const effectiveAt = new Date().toISOString();
 
-  let checkoutUrl: string | undefined;
-  let stripeCheckoutSessionId: string | null | undefined;
-
-  if (planRequiresPaymentMethod(targetPlan)) {
-    const billingConfig = await getAppBillingConfig(input.clientId);
-    const origin = getPublicOrigin();
-    const success =
-      input.successUrl ||
-      billingConfig?.checkoutSuccessUrl ||
-      appSettingsAbsoluteUrl(origin, input.clientId, "payments");
-    const cancel =
-      input.cancelUrl ||
-      billingConfig?.checkoutCancelUrl ||
-      appSettingsAbsoluteUrl(origin, input.clientId, "payments");
-
-    if (isMerchantConnectPaymentsReady(billingConfig)) {
-      const existingDefault = await resolveAppUserDefaultPaymentMethodId({
-        clientId: input.clientId,
-        externalUserId: input.externalUserId,
-      });
-      if (!existingDefault) {
-        const connectCheckout = await createMerchantConnectCheckoutForUser({
-          clientId: input.clientId,
-          externalUserId: input.externalUserId,
-          successUrl: success,
-          cancelUrl: cancel,
-          openmeterCustomerId: customer.id,
-          openmeterCustomerKey: customer.key,
-        });
-        checkoutUrl = connectCheckout.checkoutUrl;
-        stripeCheckoutSessionId = connectCheckout.sessionId;
-        await recordAppUserPaymentMethodCheckout({
-          sessionId: connectCheckout.sessionId,
-          clientId: input.clientId,
-          externalUserId: input.externalUserId,
-        });
-      }
-    } else {
-      const paymentMethodId = await getKonnectDefaultPaymentMethodId(customer.id);
-      if (!paymentMethodId) {
-        if (connectPaymentsOnlyEnabled(billingConfig)) {
-          throw new Error(
-            "Merchant Stripe Connect onboarding is required before checkout (connectPaymentsOnly)",
-          );
-        }
-        const checkout = await createOpenMeterStripeCheckoutSession({
-          client,
-          customerId: customer.id,
-          successUrl: success,
-          cancelUrl: cancel,
-        });
-        checkoutUrl = checkout.checkoutUrl;
-        stripeCheckoutSessionId = checkout.sessionId;
-        await recordAppUserPaymentMethodCheckout({
-          sessionId: checkout.sessionId,
-          clientId: input.clientId,
-          externalUserId: input.externalUserId,
-        });
-      }
-    }
-  }
-
   await upsertNeonSubscriptionCache({
     clientId: input.clientId,
     externalUserId: input.externalUserId,
     planId: neonPlanId,
     openmeterSubscriptionId: nextSubscriptionId,
-    status: neonSubscriptionStatusAfterPlanChange({ checkoutUrl }),
-    stripeCheckoutSessionId,
+    status: "active",
   });
 
   return {
@@ -1081,7 +1138,6 @@ export async function changeAppUserSubscriptionPlan(input: {
     planId: timing === "immediate" ? targetPlan.id : neonPlanId,
     effectiveAt,
     timing,
-    ...(checkoutUrl ? { checkoutUrl } : {}),
     ...(timing === "next_billing_cycle" && change.next?.id
       ? {
           pendingPlan: {

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -50,6 +50,7 @@ import {
 } from "./subscription-state";
 import {
   recordAppUserPaymentMethodCheckout,
+  resolveAppUserCheckoutReturnUrl,
   resolveAppUserDefaultPaymentMethodId,
 } from "@/lib/openmeter/app-user-payment-method";
 import { createOpenMeterStripeCheckoutSession } from "./stripe-checkout-session";
@@ -405,10 +406,14 @@ async function resolveCheckoutSettings(input: EndUserCheckoutInput): Promise<{
   return {
     merchantReady,
     isMerchantBilling: billingConfig?.billingMode === "merchant",
-    successUrl:
-      input.successUrl || billingConfig?.checkoutSuccessUrl || fallbackUrl,
-    cancelUrl:
-      input.cancelUrl || billingConfig?.checkoutCancelUrl || fallbackUrl,
+    successUrl: resolveAppUserCheckoutReturnUrl(
+      input.successUrl || billingConfig?.checkoutSuccessUrl || undefined,
+      fallbackUrl,
+    ),
+    cancelUrl: resolveAppUserCheckoutReturnUrl(
+      input.cancelUrl || billingConfig?.checkoutCancelUrl || undefined,
+      fallbackUrl,
+    ),
   };
 }
 
@@ -715,8 +720,10 @@ async function createCheckoutSession(input: {
  * Returns null when Checkout is not required (plan is free, or a default PM
  * already exists). Must run before Konnect `/change` — Stripe-backed profiles
  * reject the switch without a default payment method.
+ *
+ * Exported for unit tests that exercise the PM-before-/change gate.
  */
-async function createPaymentMethodCheckoutIfNeededForPlanChange(input: {
+export async function createPaymentMethodCheckoutIfNeededForPlanChange(input: {
   clientId: string;
   externalUserId: string;
   customerId: string;
@@ -760,14 +767,15 @@ async function createPaymentMethodCheckoutIfNeededForPlanChange(input: {
   }
 
   const origin = getPublicOrigin();
-  const success =
-    input.successUrl ||
-    billingConfig?.checkoutSuccessUrl ||
-    appSettingsAbsoluteUrl(origin, input.clientId, "payments");
-  const cancel =
-    input.cancelUrl ||
-    billingConfig?.checkoutCancelUrl ||
-    appSettingsAbsoluteUrl(origin, input.clientId, "payments");
+  const fallbackUrl = appSettingsAbsoluteUrl(origin, input.clientId, "payments");
+  const success = resolveAppUserCheckoutReturnUrl(
+    input.successUrl || billingConfig?.checkoutSuccessUrl || undefined,
+    fallbackUrl,
+  );
+  const cancel = resolveAppUserCheckoutReturnUrl(
+    input.cancelUrl || billingConfig?.checkoutCancelUrl || undefined,
+    fallbackUrl,
+  );
 
   const checkout = await createCheckoutSession({
     merchantReady,
@@ -1067,8 +1075,9 @@ export async function changeAppUserSubscriptionPlan(input: {
   if (paymentMethodCheckout) {
     return {
       subscriptionId: current.id,
-      // Still on the current plan — /change has not run yet.
-      planId: currentLocalPlan?.id ?? targetPlan.id,
+      // Still on the current plan — /change has not run yet. Never report the
+      // unpaid target when the local plan row failed to load.
+      planId: currentLocalPlanId ?? "",
       effectiveAt: null,
       timing,
       checkoutUrl: paymentMethodCheckout.checkoutUrl,

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -885,7 +885,7 @@ export async function createEndUserCheckout(
   });
 
   return {
-    checkoutUrl: "",
+    checkoutUrl: checkoutSettings.successUrl,
     subscriptionId: subscription.subscriptionId,
   };
 }

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -1067,8 +1067,9 @@ export async function changeAppUserSubscriptionPlan(input: {
   if (paymentMethodCheckout) {
     return {
       subscriptionId: current.id,
+      // Still on the current plan — /change has not run yet.
       planId: currentLocalPlan?.id ?? targetPlan.id,
-      effectiveAt: new Date().toISOString(),
+      effectiveAt: null,
       timing,
       checkoutUrl: paymentMethodCheckout.checkoutUrl,
     };


### PR DESCRIPTION
## Summary
- Collect a default payment method **before** Konnect `/change` or `subscriptions.create`, so canceling Stripe Checkout can no longer leave the user on the target paid plan.
- Fix resume (`DELETE …/pending-change`): when a scheduled successor exists, use `/restore` (and fall back to restore on unschedule 409) instead of only `unschedule-cancelation`, which hits `only_single_subscription_allowed_per_customer_at_a_time`.
- Honor cancel `timing: "immediate"` (dashboard already sent it; API ignored it) and provision Starter after immediate cancel.

## Test plan
- [ ] From Starter with no card: switch to a paid plan → redirected to Checkout → **cancel** → still on Starter (not the paid plan)
- [ ] Complete Checkout with `changePlan=` success URL → plan switch finishes after card attach
- [ ] Cancel-at-period-end with a scheduled successor: **Restore plan** / Keep plan succeeds (no 409)
- [ ] Cancel with **End immediately** → plan ends now and Starter is provisioned
- [ ] Cancel with end of period → CAPE banner + restore still works