### PR TITLE
Potential fix for code scanning alert no. 125: Unused variable, import, function or class

### DIFF
--- a/src/lib/openmeter/owner-paid-plan.test.ts
+++ b/src/lib/openmeter/owner-paid-plan.test.ts
@@ -2,10 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  OWNER_PAID_PLAN_KEY,
-  isOwnerPaidPlanKey,
-} from "@/lib/openmeter/owner-paid-key";
-import {
   ensureOwnerPaidPlanSynced,
   isKonnectScheduledChangeForbidden,
   listScheduledOwnerWalletSubscriptionIds,


### PR DESCRIPTION
Potential fix for [https://github.com/pymthouse/pymthouse/security/code-scanning/125](https://github.com/pymthouse/pymthouse/security/code-scanning/125)

Remove the unused import of `OWNER_PAID_PLAN_KEY` and `isOwnerPaidPlanKey` from `src/lib/openmeter/owner-paid-plan.test.ts`.

Best fix (without changing functionality):
- Delete the entire import block on lines 4–7:
  - `import { OWNER_PAID_PLAN_KEY, isOwnerPaidPlanKey } from "@/lib/openmeter/owner-paid-key";`
- Keep all other imports and test logic unchanged.

This change is minimal, preserves behavior, and resolves the static analysis warning by eliminating unused program elements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
