### PR TITLE
fix(billing): pin merchant Starter users to Custom Invoicing

### DIFF
--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -420,9 +420,16 @@ async function persistBillingPatch(
   }
 
   if (billingMode !== undefined || endUserCap !== undefined) {
+    const merchantProfileId =
+      billingMode === "merchant"
+        ? process.env.OPENMETER_MERCHANT_BILLING_PROFILE_ID?.trim() || null
+        : null;
     await upsertAppBillingConfig(appId, {
       ...(billingMode !== undefined ? { billingMode } : {}),
       ...(endUserCap !== undefined ? { endUserCap } : {}),
+      ...(merchantProfileId
+        ? { openmeterMerchantBillingProfileId: merchantProfileId }
+        : {}),
     });
   }
   return updated;

--- a/src/lib/openmeter/billing-profiles.test.ts
+++ b/src/lib/openmeter/billing-profiles.test.ts
@@ -174,3 +174,41 @@ test("assignMerchantCustomInvoicingProfile pins via the Konnect billing route", 
     billing_profile: { id: "prof_merchant" },
   });
 });
+
+test("persistMerchantBillingProfileIdIfMissing writes only when unset", async () => {
+  const { persistMerchantBillingProfileIdIfMissing } = await import(
+    "./billing-profiles"
+  );
+  const writes: Array<{ clientId: string; profileId: string }> = [];
+  const upsert = async (
+    clientId: string,
+    values: { openmeterMerchantBillingProfileId?: string | null },
+  ) => {
+    writes.push({
+      clientId,
+      profileId: values.openmeterMerchantBillingProfileId ?? "",
+    });
+  };
+
+  assert.equal(
+    await persistMerchantBillingProfileIdIfMissing(
+      "app_1",
+      "already_set",
+      "prof_env",
+      upsert as never,
+    ),
+    false,
+  );
+  assert.deepEqual(writes, []);
+
+  assert.equal(
+    await persistMerchantBillingProfileIdIfMissing(
+      "app_1",
+      "  ",
+      "prof_env",
+      upsert as never,
+    ),
+    true,
+  );
+  assert.deepEqual(writes, [{ clientId: "app_1", profileId: "prof_env" }]);
+});

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -374,11 +374,18 @@ export async function prepareAppCustomerStripeBilling(input: {
     null;
 
   // Merchant plane: pin to Custom Invoicing profile (no platform Stripe charge).
+  // Credits-first Starter users stay on this profile too — Sandbox is wrong
+  // because it fake-pays invoices and bypasses settlement / Connect.
   if (config?.billingMode === "merchant") {
     if (!merchantProfileId) {
       throw new Error(
         "OPENMETER_MERCHANT_BILLING_PROFILE_ID (or app openmeterMerchantBillingProfileId) is required when billingMode=merchant",
       );
+    }
+    if (!config.openmeterMerchantBillingProfileId?.trim()) {
+      await upsertAppBillingConfig(input.clientId, {
+        openmeterMerchantBillingProfileId: merchantProfileId,
+      });
     }
     await assignMerchantCustomInvoicingProfile({
       client: input.client,

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -382,11 +382,11 @@ export async function prepareAppCustomerStripeBilling(input: {
         "OPENMETER_MERCHANT_BILLING_PROFILE_ID (or app openmeterMerchantBillingProfileId) is required when billingMode=merchant",
       );
     }
-    if (!config.openmeterMerchantBillingProfileId?.trim()) {
-      await upsertAppBillingConfig(input.clientId, {
-        openmeterMerchantBillingProfileId: merchantProfileId,
-      });
-    }
+    await persistMerchantBillingProfileIdIfMissing(
+      input.clientId,
+      config.openmeterMerchantBillingProfileId,
+      merchantProfileId,
+    );
     await assignMerchantCustomInvoicingProfile({
       client: input.client,
       customerId: input.customerId,
@@ -718,6 +718,26 @@ export function resetOwnersBillingProfileCacheForTests(): void {
 
 export function resetFreeBillingProfileCacheForTests(): void {
   cachedFreeBillingProfileId = null;
+}
+
+/**
+ * Persist the merchant Custom Invoicing profile id on the app row when it was
+ * only available via env (so later pins do not depend on process env alone).
+ * @internal Exported for unit tests.
+ */
+export async function persistMerchantBillingProfileIdIfMissing(
+  clientId: string,
+  existingProfileId: string | null | undefined,
+  merchantProfileId: string,
+  upsert: typeof upsertAppBillingConfig = upsertAppBillingConfig,
+): Promise<boolean> {
+  if (existingProfileId?.trim()) {
+    return false;
+  }
+  await upsert(clientId, {
+    openmeterMerchantBillingProfileId: merchantProfileId,
+  });
+  return true;
 }
 
 export async function upsertAppBillingConfig(

--- a/src/lib/openmeter/starter-subscription.test.ts
+++ b/src/lib/openmeter/starter-subscription.test.ts
@@ -218,3 +218,109 @@ test("recoverStarterBillingProfile uses sandbox free profile otherwise", async (
   assert.deepEqual(prepareCalls, []);
   assert.deepEqual(freeCalls, ["cust_f"]);
 });
+
+test("pinMerchantCustomInvoicingIfNeeded pins only merchant apps", async () => {
+  const { pinMerchantCustomInvoicingIfNeeded } = await import(
+    "@/lib/openmeter/starter-subscription"
+  );
+  type PrepareCall = { clientId: string; customerId: string };
+  const prepareCalls: PrepareCall[] = [];
+  const recordPrepare = async (input: {
+    clientId: string;
+    customerId: string;
+  }) => {
+    prepareCalls.push({
+      clientId: input.clientId,
+      customerId: input.customerId,
+    });
+  };
+
+  assert.equal(
+    await pinMerchantCustomInvoicingIfNeeded(
+      {
+        client: {} as never,
+        clientId: "app_owner",
+        customerId: "cust_o",
+        customerKey: "key_o",
+      },
+      {
+        getConfig: async () =>
+          ({ billingMode: "owner_rollup" }) as never,
+        prepareMerchant: recordPrepare,
+      },
+    ),
+    false,
+  );
+  assert.equal(prepareCalls.length, 0);
+
+  assert.equal(
+    await pinMerchantCustomInvoicingIfNeeded(
+      {
+        client: {} as never,
+        clientId: "app_m",
+        customerId: "cust_m",
+        customerKey: "key_m",
+      },
+      {
+        getConfig: async () =>
+          ({ billingMode: "merchant" }) as never,
+        prepareMerchant: recordPrepare,
+      },
+    ),
+    true,
+  );
+  assert.deepEqual(prepareCalls, [{ clientId: "app_m", customerId: "cust_m" }]);
+});
+test("stripe billing 409 recovers via recoverProfile then creates", async () => {
+  resetPlanKeyCacheForTests();
+  const stripeErr = new Error(
+    "conflict error: invalid billing setup: failed to get stripe customer data: " +
+      "customer has no data for stripe app",
+  );
+  (stripeErr as unknown as { status: number }).status = 409;
+
+  let creates = 0;
+  const recoverCalls: Array<string | undefined> = [];
+  const client = {
+    customers: {
+      listSubscriptions: async () => ({ items: [] }),
+    },
+    plans: {
+      get: async () => ({ key: STARTER_PLAN_KEY }),
+    },
+    subscriptions: {
+      create: async () => {
+        creates += 1;
+        if (creates === 1) {
+          throw stripeErr;
+        }
+        return {
+          id: "sub_after_recover",
+          status: "active",
+          customerId: "cust_stripe",
+        };
+      },
+    },
+  };
+
+  const provisioned = await createStarterSubscriptionWithBillingRecovery(
+    {
+      client: client as never,
+      customerId: "cust_stripe",
+      starter: { openmeterPlanId: "plan_om" } as never,
+      planKey: STARTER_PLAN_KEY,
+      clientId: "app_m",
+    },
+    {
+      recoverProfile: async (input) => {
+        recoverCalls.push(input.clientId);
+        return "merchant";
+      },
+    },
+  );
+
+  assert.equal(provisioned.created, true);
+  assert.equal(provisioned.subscription.id, "sub_after_recover");
+  assert.equal(creates, 2);
+  assert.deepEqual(recoverCalls, ["app_m"]);
+});

--- a/src/lib/openmeter/starter-subscription.test.ts
+++ b/src/lib/openmeter/starter-subscription.test.ts
@@ -162,3 +162,59 @@ test("a conflict with no occupying row rethrows naming customer and plan", async
     },
   );
 });
+
+test("recoverStarterBillingProfile pins Custom Invoicing for merchant apps", async () => {
+  const { recoverStarterBillingProfile } = await import(
+    "@/lib/openmeter/starter-subscription"
+  );
+  const prepareCalls: string[] = [];
+  const freeCalls: string[] = [];
+  const mode = await recoverStarterBillingProfile(
+    {
+      client: {} as never,
+      customerId: "cust_m",
+      clientId: "app_m",
+    },
+    {
+      getConfig: async () =>
+        ({ billingMode: "merchant" }) as never,
+      prepareMerchant: async (input) => {
+        prepareCalls.push(input.customerId);
+      },
+      applyFree: async (input) => {
+        freeCalls.push(input.customerId);
+      },
+    },
+  );
+  assert.equal(mode, "merchant");
+  assert.deepEqual(prepareCalls, ["cust_m"]);
+  assert.deepEqual(freeCalls, []);
+});
+
+test("recoverStarterBillingProfile uses sandbox free profile otherwise", async () => {
+  const { recoverStarterBillingProfile } = await import(
+    "@/lib/openmeter/starter-subscription"
+  );
+  const prepareCalls: string[] = [];
+  const freeCalls: string[] = [];
+  const mode = await recoverStarterBillingProfile(
+    {
+      client: {} as never,
+      customerId: "cust_f",
+      clientId: "app_f",
+    },
+    {
+      getConfig: async () =>
+        ({ billingMode: "owner_rollup" }) as never,
+      prepareMerchant: async (input) => {
+        prepareCalls.push(input.customerId);
+      },
+      applyFree: async (input) => {
+        freeCalls.push(input.customerId);
+      },
+    },
+  );
+  assert.equal(mode, "free");
+  assert.deepEqual(prepareCalls, []);
+  assert.deepEqual(freeCalls, ["cust_f"]);
+});

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -4,7 +4,11 @@ import { db } from "@/db/index";
 import { plans } from "@/db/schema";
 import { createAsyncTtlCache, resolveCacheTtlSeconds } from "@/lib/async-ttl-cache";
 import { getOrCreateStarterPlan } from "@/lib/starter-default-plan";
-import { applyFreeBillingProfileToCustomer } from "./billing-profiles";
+import {
+  applyFreeBillingProfileToCustomer,
+  getAppBillingConfig,
+  prepareAppCustomerStripeBilling,
+} from "./billing-profiles";
 import { getHostedAdminClient, isHostedAdminClientAvailable } from "./admin-client";
 import { ensureOpenMeterCustomer } from "./customers";
 import {
@@ -167,11 +171,51 @@ function subscriptionViewFromCreateResult(
 }
 
 /**
+ * Recover from Konnect's Stripe-setup 409 when creating Starter.
+ * Merchant apps pin Custom Invoicing (credits-first still settles via
+ * settlement). Owner-rollup / unset apps use the sandbox free profile.
+ * @internal Exported for unit tests.
+ */
+export async function recoverStarterBillingProfile(
+  input: {
+    client: OpenMeter;
+    customerId: string;
+    clientId?: string;
+  },
+  deps?: {
+    getConfig?: typeof getAppBillingConfig;
+    prepareMerchant?: typeof prepareAppCustomerStripeBilling;
+    applyFree?: typeof applyFreeBillingProfileToCustomer;
+  },
+): Promise<"merchant" | "free"> {
+  const getConfig = deps?.getConfig ?? getAppBillingConfig;
+  const prepareMerchant =
+    deps?.prepareMerchant ?? prepareAppCustomerStripeBilling;
+  const applyFree = deps?.applyFree ?? applyFreeBillingProfileToCustomer;
+
+  if (input.clientId) {
+    const config = await getConfig(input.clientId);
+    if (config?.billingMode === "merchant") {
+      await prepareMerchant({
+        client: input.client,
+        clientId: input.clientId,
+        customerId: input.customerId,
+      });
+      return "merchant";
+    }
+  }
+  await applyFree({
+    client: input.client,
+    customerId: input.customerId,
+  });
+  return "free";
+}
+
+/**
  * Create a Starter subscription. On the Konnect Stripe-setup 409
- * ({@link isOpenMeterStripeBillingError}), apply the sandbox free billing
- * profile once and retry. On a plain conflict with an existing sub, return
- * that sub. Does not eagerly apply the profile — it only exists to recover
- * from that specific error.
+ * ({@link isOpenMeterStripeBillingError}), recover the billing profile once
+ * and retry. Merchant apps pin Custom Invoicing; others use the sandbox free
+ * profile. On a plain conflict with an existing sub, return that sub.
  * @internal Exported for unit tests.
  */
 export async function createStarterSubscriptionWithBillingRecovery(input: {
@@ -179,6 +223,8 @@ export async function createStarterSubscriptionWithBillingRecovery(input: {
   customerId: string;
   starter: typeof plans.$inferSelect;
   planKey: string;
+  /** When set, merchant-mode apps recover onto Custom Invoicing instead of Sandbox. */
+  clientId?: string;
 }): Promise<{
   subscription: OpenMeterSubscriptionView;
   created: boolean;
@@ -228,9 +274,10 @@ export async function createStarterSubscriptionWithBillingRecovery(input: {
       throw err;
     }
 
-    await applyFreeBillingProfileToCustomer({
+    await recoverStarterBillingProfile({
       client: input.client,
       customerId: input.customerId,
+      clientId: input.clientId,
     });
     try {
       const createdSub = await createStarterOpenMeterSubscription(input);
@@ -282,6 +329,7 @@ async function createStarterSubscriptionWithRecovery(input: {
       customerId: input.customerId,
       starter: activeStarter,
       planKey: input.planKey,
+      clientId: input.clientId,
     });
     return {
       subscription: provisioned.subscription,
@@ -307,6 +355,7 @@ async function createStarterSubscriptionWithRecovery(input: {
       customerId: input.customerId,
       starter: activeStarter,
       planKey: input.planKey,
+      clientId: input.clientId,
     });
     return {
       subscription: provisioned.subscription,
@@ -379,10 +428,20 @@ export async function ensureStarterSubscriptionForAppUser(input: {
 
   const client = getHostedAdminClient();
   const customer = await ensureOpenMeterCustomer(client, identity.customerKey);
-  // Starter needs no Stripe setup: end users only get a Stripe customer and a
-  // payment method when they check out into a paid plan. Pinning them to the
-  // app's Stripe billing profile here makes Konnect reject the subscription
-  // with "customers need a default payment method".
+  // Merchant apps: pin Custom Invoicing (+ settlement metadata) at Starter
+  // create so credits-first usage still invoices through settlement once a
+  // card is on file. Do not use Sandbox — it fake-pays and skips Connect.
+  // Owner-rollup Starters stay unpinned until paid checkout (Konnect rejects
+  // Stripe-profile customers without a default payment method).
+  const billingConfig = await getAppBillingConfig(identity.developerAppId);
+  if (billingConfig?.billingMode === "merchant") {
+    await prepareAppCustomerStripeBilling({
+      client,
+      clientId: identity.developerAppId,
+      customerId: customer.id,
+      customerKey: identity.customerKey,
+    });
+  }
 
   const planKey = buildOpenMeterPlanKey(identity.developerAppId, starter.id);
 
@@ -401,9 +460,9 @@ export async function ensureStarterSubscriptionForAppUser(input: {
   let created = false;
   let activeStarter = starter;
   if (!omSubscription) {
-    // Free billing-profile override is applied only inside
-    // createStarterSubscriptionWithBillingRecovery when Konnect returns the
-    // Stripe-setup 409 (isOpenMeterStripeBillingError) — not eagerly.
+    // Profile recovery on Stripe-setup 409 lives in
+    // createStarterSubscriptionWithBillingRecovery (Custom Invoicing for
+    // merchant apps; sandbox free profile otherwise).
     const provisioned = await createStarterSubscriptionWithRecovery({
       client,
       customerId: customer.id,

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -212,23 +212,62 @@ export async function recoverStarterBillingProfile(
 }
 
 /**
+ * Eager Custom Invoicing pin for merchant Starter users (before create).
+ * @internal Exported for unit tests.
+ */
+export async function pinMerchantCustomInvoicingIfNeeded(
+  input: {
+    client: OpenMeter;
+    clientId: string;
+    customerId: string;
+    customerKey?: string;
+  },
+  deps?: {
+    getConfig?: typeof getAppBillingConfig;
+    prepareMerchant?: typeof prepareAppCustomerStripeBilling;
+  },
+): Promise<boolean> {
+  const getConfig = deps?.getConfig ?? getAppBillingConfig;
+  const prepareMerchant =
+    deps?.prepareMerchant ?? prepareAppCustomerStripeBilling;
+  const billingConfig = await getConfig(input.clientId);
+  if (billingConfig?.billingMode !== "merchant") {
+    return false;
+  }
+  await prepareMerchant({
+    client: input.client,
+    clientId: input.clientId,
+    customerId: input.customerId,
+    customerKey: input.customerKey,
+  });
+  return true;
+}
+
+/**
  * Create a Starter subscription. On the Konnect Stripe-setup 409
  * ({@link isOpenMeterStripeBillingError}), recover the billing profile once
  * and retry. Merchant apps pin Custom Invoicing; others use the sandbox free
  * profile. On a plain conflict with an existing sub, return that sub.
  * @internal Exported for unit tests.
  */
-export async function createStarterSubscriptionWithBillingRecovery(input: {
-  client: OpenMeter;
-  customerId: string;
-  starter: typeof plans.$inferSelect;
-  planKey: string;
-  /** When set, merchant-mode apps recover onto Custom Invoicing instead of Sandbox. */
-  clientId?: string;
-}): Promise<{
+export async function createStarterSubscriptionWithBillingRecovery(
+  input: {
+    client: OpenMeter;
+    customerId: string;
+    starter: typeof plans.$inferSelect;
+    planKey: string;
+    /** When set, merchant-mode apps recover onto Custom Invoicing instead of Sandbox. */
+    clientId?: string;
+  },
+  deps?: {
+    recoverProfile?: typeof recoverStarterBillingProfile;
+  },
+): Promise<{
   subscription: OpenMeterSubscriptionView;
   created: boolean;
 }> {
+  const recoverProfile =
+    deps?.recoverProfile ?? recoverStarterBillingProfile;
   try {
     const createdSub = await createStarterOpenMeterSubscription(input);
     if (!createdSub?.id) {
@@ -274,7 +313,7 @@ export async function createStarterSubscriptionWithBillingRecovery(input: {
       throw err;
     }
 
-    await recoverStarterBillingProfile({
+    await recoverProfile({
       client: input.client,
       customerId: input.customerId,
       clientId: input.clientId,
@@ -433,15 +472,12 @@ export async function ensureStarterSubscriptionForAppUser(input: {
   // card is on file. Do not use Sandbox — it fake-pays and skips Connect.
   // Owner-rollup Starters stay unpinned until paid checkout (Konnect rejects
   // Stripe-profile customers without a default payment method).
-  const billingConfig = await getAppBillingConfig(identity.developerAppId);
-  if (billingConfig?.billingMode === "merchant") {
-    await prepareAppCustomerStripeBilling({
-      client,
-      clientId: identity.developerAppId,
-      customerId: customer.id,
-      customerKey: identity.customerKey,
-    });
-  }
+  await pinMerchantCustomInvoicingIfNeeded({
+    client,
+    clientId: identity.developerAppId,
+    customerId: customer.id,
+    customerKey: identity.customerKey,
+  });
 
   const planKey = buildOpenMeterPlanKey(identity.developerAppId, starter.id);
 

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -234,6 +234,10 @@ async function persistConnectedAccountFlags(input: {
 }): Promise<void> {
   const ready = input.chargesEnabled && input.detailsSubmitted;
   const existing = await getAppBillingConfig(input.clientId);
+  const merchantProfileId =
+    existing?.openmeterMerchantBillingProfileId?.trim() ||
+    process.env.OPENMETER_MERCHANT_BILLING_PROFILE_ID?.trim() ||
+    null;
   // Do not write stripeConnectStatus here — that column is Plane A (OM Stripe
   // app install). Merchant readiness is stripeChargesEnabled + detailsSubmitted.
   await upsertAppBillingConfig(input.clientId, {
@@ -244,6 +248,9 @@ async function persistConnectedAccountFlags(input: {
     connectedAt: ready
       ? (existing?.connectedAt ?? new Date().toISOString())
       : (existing?.connectedAt ?? null),
+    ...(existing?.billingMode === "merchant" && merchantProfileId
+      ? { openmeterMerchantBillingProfileId: merchantProfileId }
+      : {}),
   });
 }
 


### PR DESCRIPTION
## Summary
- Pin merchant-mode end users to the Custom Invoicing billing profile at Starter provision (and on Stripe-setup 409 recovery), so credits-first usage settles via Connect instead of Sandbox fake-pay.
- Persist `openmeterMerchantBillingProfileId` on merchant mode switch, Connect refresh, and first pin so the profile id is not env-only.
- Add unit coverage for merchant vs sandbox recovery paths.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node --import tsx --test src/lib/openmeter/starter-subscription.test.ts` (7 pass)
- [x] Snyk Code/SCA on changed area (no new high+ issues in this diff)
- [ ] CI green
- [ ] After merge: new merchant Starter user lands on Custom Invoicing (not Sandbox); force-collect invoice routes through settlement