### PR TITLE
feat(billing): add unbilledInvoiceDebtFromItems function and related tests

### DIFF
--- a/src/lib/billing/app-user-ledger.ts
+++ b/src/lib/billing/app-user-ledger.ts
@@ -127,6 +127,7 @@ function merchantHistoryToLedgerInvoices(
     periodStart?: string;
     periodEnd?: string;
     invoiceType: string;
+    paymentMethodBrand?: string | null;
   }>,
 ): { grants: LedgerGrantInput[]; invoices: LedgerInvoiceInput[] } {
   const grants: LedgerGrantInput[] = [];
@@ -161,6 +162,7 @@ function merchantHistoryToLedgerInvoices(
       periodStart: item.periodStart,
       periodEnd: item.periodEnd,
       invoiceType: "standard",
+      paymentMethodBrand: item.paymentMethodBrand ?? null,
     });
   }
 

--- a/src/lib/billing/invoice-trigger.test.ts
+++ b/src/lib/billing/invoice-trigger.test.ts
@@ -106,6 +106,29 @@ test("shouldTriggerInvoice at the $2 minimum ceiling raises at $1", () => {
   );
 });
 
+test("shouldAttemptPendingLines: force always tries OM even when debt reads $0", () => {
+  // Konnect gathering list can under-report debt; force collect must not skip
+  // before invoicePendingLines when the helper returns 0.
+  assert.equal(
+    __testInvoiceTrigger.shouldAttemptPendingLines({
+      force: true,
+      unbilledDebtUsdMicros: 0n,
+      softNegativeUsdMicros: 2_000_000n,
+      leadUsdMicros: 1_000_000n,
+    }),
+    true,
+  );
+  assert.equal(
+    __testInvoiceTrigger.shouldAttemptPendingLines({
+      force: false,
+      unbilledDebtUsdMicros: 0n,
+      softNegativeUsdMicros: 2_000_000n,
+      leadUsdMicros: 1_000_000n,
+    }),
+    false,
+  );
+});
+
 test("invoiceGatheringForIdentity returns unavailable without OpenMeter", async (t) => {
   __resetInvoiceTriggerCacheForTests();
   const prevUrl = process.env.OPENMETER_URL;

--- a/src/lib/billing/invoice-trigger.ts
+++ b/src/lib/billing/invoice-trigger.ts
@@ -196,7 +196,8 @@ export async function invoiceGatheringForIdentity(input: {
 /**
  * Push a freshly raised invoice toward collection. With auto_advance + P0D
  * `advance` is often a no-op; Custom Invoicing may pause at draft.sync and
- * settlement drives the rest.
+ * settlement drives the rest. Force collect also snapshots + approves so
+ * waiting_for_collection / waiting_auto_approval do not park the raise.
  */
 async function advanceInvoice(
   client: ReturnType<typeof getHostedAdminClient>,
@@ -220,6 +221,18 @@ async function advanceInvoice(
       sanitizeForLog(invoiceId),
       sanitizeForLog(err instanceof Error ? err.message : String(err)),
     );
+  }
+  if (force) {
+    try {
+      // Skip draft.waiting_auto_approval so settlement can issue immediately.
+      await client.billing.invoices.approve(invoiceId);
+    } catch (err) {
+      console.warn(
+        "[invoice-trigger] approve skipped",
+        sanitizeForLog(invoiceId),
+        sanitizeForLog(err instanceof Error ? err.message : String(err)),
+      );
+    }
   }
 }
 

--- a/src/lib/billing/invoice-trigger.ts
+++ b/src/lib/billing/invoice-trigger.ts
@@ -51,8 +51,7 @@ function shouldTriggerInvoice(input: {
   leadUsdMicros: bigint;
 }): boolean {
   // Below Stripe's minimum charge the invoice cannot be collected, so raising
-  // it would only park a draft that no collector can clear. Anything left under
-  // the floor is swept up by OM's anchored collection alignment or cycle close.
+  // it would only park a draft. OM's daily collection alignment picks these up instead.
   if (input.unbilledDebtUsdMicros < MIN_INVOICE_USD_MICROS) {
     return false;
   }
@@ -65,6 +64,22 @@ function shouldTriggerInvoice(input: {
     softNegativeUsdMicros: input.softNegativeUsdMicros,
     leadUsdMicros: input.leadUsdMicros,
   });
+}
+
+/**
+ * Whether to call OpenMeter `invoicePendingLines`.
+ * Force collect always attempts; automatic mid-cycle uses debt + lead window.
+ */
+function shouldAttemptPendingLines(input: {
+  force: boolean;
+  unbilledDebtUsdMicros: bigint;
+  softNegativeUsdMicros: bigint;
+  leadUsdMicros: bigint;
+}): boolean {
+  if (input.force) {
+    return true;
+  }
+  return shouldTriggerInvoice(input);
 }
 
 export type InvoiceTriggerOutcome =
@@ -82,9 +97,11 @@ export type InvoiceTriggerResult = {
 /**
  * Create invoices from gathering lines and advance each toward collection.
  *
- * `force` skips the lead-window check for an explicit "collect now" request.
- * The Stripe minimum-charge floor always applies: raising an invoice below it
- * only parks a draft no collector can clear.
+ * `force` (test-usage / explicit collect-now) always asks OpenMeter for pending
+ * lines — it must not gate on {@link getUnbilledDebtUsdMicros}, which can read
+ * $0 when Konnect's invoice list misses gathering totals. Empty pending lines
+ * still return `skipped`. Non-force mid-cycle triggers keep the lead-window and
+ * Stripe minimum-charge floors via {@link shouldTriggerInvoice}.
  */
 export async function invoiceGatheringForIdentity(input: {
   clientId: string;
@@ -112,33 +129,34 @@ export async function invoiceGatheringForIdentity(input: {
   }
 
   try {
-    const identity = await resolveOpenMeterBillingIdentity({
-      clientId,
-      externalUserId,
-    });
-    const app = await getProviderApp(clientId);
-    const appId = app?.id?.trim() || identity.developerAppId;
-    const billingConfig = await getAppBillingConfig(appId);
-    const softNegativeUsdMicros = effectiveSoftNegativeUsdMicros(
-      billingConfig?.softNegativeUsdMicros,
-    );
-    const unbilledDebtUsdMicros = await getUnbilledDebtUsdMicros({
-      clientId,
-      externalUserId,
-    });
-    const collectable = unbilledDebtUsdMicros >= MIN_INVOICE_USD_MICROS;
-    const shouldRaise = input.force
-      ? collectable
-      : shouldTriggerInvoice({
-          unbilledDebtUsdMicros,
+    const force = input.force === true;
+    if (!force) {
+      const identity = await resolveOpenMeterBillingIdentity({
+        clientId,
+        externalUserId,
+      });
+      const app = await getProviderApp(clientId);
+      const appId = app?.id?.trim() || identity.developerAppId;
+      const billingConfig = await getAppBillingConfig(appId);
+      const softNegativeUsdMicros = effectiveSoftNegativeUsdMicros(
+        billingConfig?.softNegativeUsdMicros,
+      );
+      const unbilledDebtUsdMicros = await getUnbilledDebtUsdMicros({
+        clientId,
+        externalUserId,
+      });
+      const shouldRaise = shouldAttemptPendingLines({
+        force: false,
+        unbilledDebtUsdMicros,
+        softNegativeUsdMicros,
+        leadUsdMicros: effectiveInvoiceLeadUsdMicros({
+          storedUsdMicros: billingConfig?.invoiceLeadUsdMicros,
           softNegativeUsdMicros,
-          leadUsdMicros: effectiveInvoiceLeadUsdMicros({
-            storedUsdMicros: billingConfig?.invoiceLeadUsdMicros,
-            softNegativeUsdMicros,
-          }),
-        });
-    if (!shouldRaise) {
-      return { outcome: "skipped", invoiceIds: [] };
+        }),
+      });
+      if (!shouldRaise) {
+        return { outcome: "skipped", invoiceIds: [] };
+      }
     }
 
     const customerId = await resolveBillingCustomerId({
@@ -163,7 +181,7 @@ export async function invoiceGatheringForIdentity(input: {
       const invoiceId = invoice.id?.trim();
       if (!invoiceId) continue;
       invoiceIds.push(invoiceId);
-      await advanceInvoice(client, invoiceId, input.force === true);
+      await advanceInvoice(client, invoiceId, force);
     }
     return { outcome: "invoiced", invoiceIds };
   } catch (err) {
@@ -221,4 +239,5 @@ export function scheduleInvoiceTrigger(input: {
 /** @internal Exported for unit tests. */
 export const __testInvoiceTrigger = {
   shouldTriggerInvoice,
+  shouldAttemptPendingLines,
 };

--- a/src/lib/billing/transactions-ledger.test.ts
+++ b/src/lib/billing/transactions-ledger.test.ts
@@ -83,6 +83,7 @@ test("ledger records credit burn only for usage past the allowance", () => {
   assert.equal(byId.get("usage:2026-07-01")?.creditDeltaUsdMicros, "0");
   assert.equal(byId.get("usage:2026-07-01")?.description, "Usage — covered by plan");
   assert.equal(byId.get("usage:2026-07-20")?.creditDeltaUsdMicros, "-2000000");
+  assert.equal(byId.get("usage:2026-07-20")?.description, "Usage (metered)");
   // Gross amount stays the full day's spend even when partly plan-covered.
   assert.equal(byId.get("usage:2026-07-20")?.amountUsdMicros, "6000000");
 });
@@ -192,7 +193,38 @@ test("ledger falls back to invoice header when lines are missing", () => {
 
   assert.equal(entries.length, 1);
   assert.equal(entries[0].id, "invoice:inv_header");
-  assert.equal(entries[0].description, "Invoice · Jul 2026");
+  assert.equal(entries[0].description, "Invoice · Jul 2026 · Paid");
+});
+
+test("ledger labels paid invoices with payment method brand", () => {
+  const entries = buildLedgerEntries({
+    grants: [],
+    dailyUsage: [],
+    invoices: [
+      {
+        id: "inv_link",
+        status: "paid",
+        totalAmountUsdMicros: "12000000",
+        issuedAt: "2026-08-11T00:00:00Z",
+        periodStart: "2026-08-01T00:00:00Z",
+        paymentMethodBrand: "LINK",
+      },
+    ],
+    endingCreditBalanceUsdMicros: "0",
+  });
+  assert.equal(entries[0].description, "Invoice · Aug 2026 · Paid via LINK");
+});
+
+test("ledger usage beyond allowance is labeled as metered activity", () => {
+  const entries = buildLedgerEntries({
+    grants: [],
+    dailyUsage: [{ date: "2026-08-11", usedUsdMicros: "51990000" }],
+    invoices: [],
+    planIncludedUsdMicros: "0",
+    endingCreditBalanceUsdMicros: "0",
+  });
+  assert.equal(entries[0].type, "usage");
+  assert.equal(entries[0].description, "Usage (metered)");
 });
 
 test("ledger maps credit_note invoice type to refund", () => {

--- a/src/lib/billing/transactions-ledger.ts
+++ b/src/lib/billing/transactions-ledger.ts
@@ -84,6 +84,8 @@ export type LedgerInvoiceInput = {
   hostedInvoiceUrl?: string | null;
   /** OpenMeter `standard` | `credit_note`. */
   invoiceType?: string | null;
+  /** Card brand / LINK when the invoice was paid (Connect settlement). */
+  paymentMethodBrand?: string | null;
   lines?: LedgerInvoiceLineInput[] | null;
 };
 
@@ -129,9 +131,22 @@ export function splitDailyUsageAgainstAllowance(
     });
 }
 
-function invoiceDescription(invoice: LedgerInvoiceInput): string {
+/** Ledger label for a settlement invoice, including paid-via brand when known. */
+export function invoiceDescription(invoice: LedgerInvoiceInput): string {
   const period = formatInvoicePeriodLabel(invoice.periodStart, invoice.periodEnd);
-  return period ? `Invoice · ${period}` : "Invoice";
+  const base = period ? `Invoice · ${period}` : "Invoice";
+  const status = (invoice.status ?? "").trim().toLowerCase();
+  if (status !== "paid") {
+    if (status === "open" || status === "draft") {
+      return `${base} · ${status}`;
+    }
+    return base;
+  }
+  const brand = invoice.paymentMethodBrand?.trim();
+  if (brand) {
+    return `${base} · Paid via ${brand}`;
+  }
+  return `${base} · Paid`;
 }
 
 function toLineSummary(line: LedgerInvoiceLineInput): InvoiceLineSummary {
@@ -266,8 +281,10 @@ export function buildLedgerEntries(input: {
       // Sort usage after same-day grants so credits are available to burn.
       date: `${day.date}T23:59:59.999Z`,
       type: "usage",
+      // Metered spend is activity, not an open receivable — Connect invoices
+      // (and prepaid drawdowns via creditDelta) are what settled the bill.
       description:
-        burn > 0n ? "Usage — beyond plan allowance" : "Usage — covered by plan",
+        burn > 0n ? "Usage (metered)" : "Usage — covered by plan",
       amountUsdMicros: day.usedUsdMicros.toString(),
       creditDeltaUsdMicros: (-burn).toString(),
       creditDelta: -burn,

--- a/src/lib/billing/unbilled-debt.test.ts
+++ b/src/lib/billing/unbilled-debt.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   gatheringTotalUsdMicros,
   netBillableMeterDebtUsdMicros,
+  unbilledInvoiceDebtFromItems,
 } from "@/lib/billing/unbilled-debt";
 
 test("gatheringTotalUsdMicros parses dollars, micros strings, and rejects garbage", () => {
@@ -49,5 +50,88 @@ test("netBillableMeterDebtUsdMicros subtracts remaining included usage", () => {
       remainingIncludedUsdMicros: 0n,
     }),
     1_000_000n,
+  );
+});
+
+test("unbilledInvoiceDebtFromItems returns 0 for empty successful list", () => {
+  assert.equal(unbilledInvoiceDebtFromItems([], "cus_1"), 0n);
+});
+
+test("unbilledInvoiceDebtFromItems ignores paid invoices (no meter fallthrough)", () => {
+  assert.equal(
+    unbilledInvoiceDebtFromItems(
+      [
+        {
+          status: "paid",
+          customer: { id: "cus_1" },
+          totals: { total: "12.00" },
+        },
+        {
+          status: "paid",
+          customerId: "cus_1",
+          totals: { total: "10.00" },
+        },
+      ],
+      "cus_1",
+    ),
+    0n,
+  );
+});
+
+test("unbilledInvoiceDebtFromItems uses max gathering plus unpaid open", () => {
+  assert.equal(
+    unbilledInvoiceDebtFromItems(
+      [
+        {
+          status: "gathering",
+          customer: { id: "cus_1" },
+          totals: { total: "5.00" },
+        },
+        {
+          status: "gathering",
+          customer: { id: "cus_1" },
+          totals: { total: "8.00" },
+        },
+        {
+          status: "draft.syncing",
+          customer: { id: "cus_1" },
+          totals: { total: "12.00" },
+        },
+        {
+          status: "paid",
+          customer: { id: "cus_1" },
+          totals: { total: "99.00" },
+        },
+        {
+          status: "issuing.sync",
+          customer: { id: "cus_other" },
+          totals: { total: "50.00" },
+        },
+      ],
+      "cus_1",
+    ),
+    // max gathering 8 + unpaid draft 12
+    20_000_000n,
+  );
+});
+
+test("unbilledInvoiceDebtFromItems counts unpaid open without gathering", () => {
+  assert.equal(
+    unbilledInvoiceDebtFromItems(
+      [
+        {
+          status: "payment_processing.pending",
+          customer: { id: "cus_1" },
+          totals: { total: "3.50" },
+        },
+        {
+          status: "overdue",
+          customer: { id: "cus_1" },
+          totals: { total: "1.25" },
+        },
+      ],
+      "cus_1",
+    ),
+    4_750_000n,
   );
 });

--- a/src/lib/billing/unbilled-debt.ts
+++ b/src/lib/billing/unbilled-debt.ts
@@ -1,7 +1,7 @@
 /**
  * Resolve unbilled debt (USD micros) for soft-negative gating / invoice trigger.
- * Prefer gathering invoice totals; fall back to calendar-month meter usage net of
- * remaining included usage (OM-billable amount).
+ * Prefer OpenMeter invoice totals (gathering + unpaid open); fall back to
+ * calendar-month meter usage only when the invoice list fails.
  */
 import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
 import {
@@ -63,7 +63,7 @@ export function netBillableMeterDebtUsdMicros(input: {
     : 0n;
 }
 
-type GatheringInvoiceRow = {
+type InvoiceDebtRow = {
   status?: string | null;
   customer?: { id?: string | null } | null;
   customerId?: string | null;
@@ -71,7 +71,7 @@ type GatheringInvoiceRow = {
   totals?: { total?: unknown } | null;
 };
 
-function invoiceCustomerId(inv: GatheringInvoiceRow): string | null {
+function invoiceCustomerId(inv: InvoiceDebtRow): string | null {
   return (
     inv.customer?.id?.trim() ||
     (typeof inv.customerId === "string" ? inv.customerId.trim() : null) ||
@@ -80,78 +80,139 @@ function invoiceCustomerId(inv: GatheringInvoiceRow): string | null {
   );
 }
 
-function maxGatheringFromItems(
-  items: GatheringInvoiceRow[],
+function statusRoot(status: string): string {
+  const lower = status.toLowerCase();
+  const dot = lower.indexOf(".");
+  return dot >= 0 ? lower.slice(0, dot) : lower;
+}
+
+function isPaidOrClosedStatus(status: string): boolean {
+  const root = statusRoot(status);
+  return (
+    root === "paid" ||
+    root === "void" ||
+    root === "uncollectible" ||
+    root === "deleted"
+  );
+}
+
+function isUnpaidOpenStatus(status: string): boolean {
+  const root = statusRoot(status);
+  return (
+    root === "draft" ||
+    root === "issuing" ||
+    root === "issued" ||
+    root === "payment_processing" ||
+    root === "overdue"
+  );
+}
+
+function invoiceDebtContribution(
+  inv: InvoiceDebtRow,
   customerId: string,
-): bigint | null {
-  let max = 0n;
-  let found = false;
-  for (const inv of items) {
-    if (String(inv.status ?? "").toLowerCase() !== "gathering") {
-      continue;
-    }
-    const invCustomer = invoiceCustomerId(inv);
-    if (invCustomer && invCustomer !== customerId) {
-      continue;
-    }
-    const micros = gatheringTotalUsdMicros(inv.totals?.total);
-    if (micros == null) continue;
-    found = true;
-    if (micros > max) max = micros;
+): { kind: "gathering" | "unpaid"; micros: bigint } | null {
+  const invCustomer = invoiceCustomerId(inv);
+  if (invCustomer && invCustomer !== customerId) {
+    return null;
   }
-  return found ? max : null;
+  const status = String(inv.status ?? "").trim();
+  if (!status) return null;
+  const micros = gatheringTotalUsdMicros(inv.totals?.total);
+  if (micros == null) return null;
+
+  const root = statusRoot(status);
+  if (root === "gathering") {
+    return { kind: "gathering", micros };
+  }
+  if (isPaidOrClosedStatus(status) || !isUnpaidOpenStatus(status)) {
+    return null;
+  }
+  return { kind: "unpaid", micros };
+}
+
+/**
+ * Debt from a successful invoice list: max gathering total + sum of unpaid
+ * open invoices (draft/issued/overdue/…). Paid/void are excluded. Empty list
+ * is 0 — do not fall through to meter.
+ */
+export function unbilledInvoiceDebtFromItems(
+  items: InvoiceDebtRow[],
+  customerId: string,
+): bigint {
+  let gatheringMax = 0n;
+  let hasGathering = false;
+  let unpaidOpenSum = 0n;
+
+  for (const inv of items) {
+    const contrib = invoiceDebtContribution(inv, customerId);
+    if (!contrib) continue;
+    if (contrib.kind === "gathering") {
+      hasGathering = true;
+      if (contrib.micros > gatheringMax) gatheringMax = contrib.micros;
+      continue;
+    }
+    unpaidOpenSum += contrib.micros;
+  }
+
+  return (hasGathering ? gatheringMax : 0n) + unpaidOpenSum;
 }
 
 /**
  * Konnect `customers` list filter is often ignored on `/v3/openmeter`. Prefer
  * `/metering/v1` with an explicit customer filter, then client-side match.
  */
-async function maxGatheringDebtViaMeteringV1(
+async function listInvoicesViaMeteringV1(
   customerId: string,
-): Promise<bigint | null> {
+): Promise<InvoiceDebtRow[] | null> {
   try {
     const params = new URLSearchParams();
     params.set("filter[customer.id][eq]", customerId);
-    params.set("filter[status][eq]", "gathering");
-    params.set("page[size]", "20");
+    params.set("page[size]", "50");
     params.set("page[number]", "1");
     const listed = await konnectMeteringV1Fetch<{
-      items?: GatheringInvoiceRow[];
-    }>(`/billing/invoices?${params.toString()}`, { method: "GET" }, "gathering-invoices");
-    return maxGatheringFromItems(listed?.items ?? [], customerId);
+      items?: InvoiceDebtRow[];
+      data?: InvoiceDebtRow[];
+    }>(`/billing/invoices?${params.toString()}`, { method: "GET" }, "unbilled-invoices");
+    return listed?.items ?? listed?.data ?? [];
   } catch {
-    // Fall through to alternate filter shapes / SDK list.
     try {
       const params = new URLSearchParams();
       params.set("filter[customer_id][eq]", customerId);
-      params.set("statuses", "gathering");
-      params.set("page[size]", "20");
+      params.set("page[size]", "50");
       const listed = await konnectMeteringV1Fetch<{
-        items?: GatheringInvoiceRow[];
+        items?: InvoiceDebtRow[];
+        data?: InvoiceDebtRow[];
       }>(
         `/billing/invoices?${params.toString()}`,
         { method: "GET" },
-        "gathering-invoices",
+        "unbilled-invoices",
       );
-      return maxGatheringFromItems(listed?.items ?? [], customerId);
+      return listed?.items ?? listed?.data ?? [];
     } catch {
       return null;
     }
   }
 }
 
-async function maxGatheringDebtUsdMicros(
+type InvoiceDebtLookup =
+  | { ok: true; usdMicros: bigint }
+  | { ok: false };
+
+async function lookupUnbilledInvoiceDebt(
   customerId: string,
-): Promise<bigint | null> {
+): Promise<InvoiceDebtLookup> {
   if (!isHostedAdminClientAvailable()) {
-    return null;
+    return { ok: false };
   }
 
   const openmeterUrl = getHostedOpenMeterUrl();
   if (isKonnectMeteringUrl(openmeterUrl)) {
-    const viaMetering = await maxGatheringDebtViaMeteringV1(customerId);
+    const viaMetering = await listInvoicesViaMeteringV1(customerId);
     if (viaMetering != null) {
-      return viaMetering;
+      return {
+        ok: true,
+        usdMicros: unbilledInvoiceDebtFromItems(viaMetering, customerId),
+      };
     }
   }
 
@@ -160,13 +221,16 @@ async function maxGatheringDebtUsdMicros(
     const listed = await client.billing.invoices.list({
       customers: [customerId],
       page: 1,
-      pageSize: 20,
+      pageSize: 50,
       order: "DESC",
       orderBy: "createdAt",
     });
-    return maxGatheringFromItems(listed?.items ?? [], customerId);
+    return {
+      ok: true,
+      usdMicros: unbilledInvoiceDebtFromItems(listed?.items ?? [], customerId),
+    };
   } catch {
-    return null;
+    return { ok: false };
   }
 }
 
@@ -273,8 +337,9 @@ export type UnbilledDebtSource =
   | "unavailable";
 
 /**
- * Unbilled debt for soft-negative gating. Gathering total when present,
- * else period network-fee meter sum net of remaining included usage.
+ * Unbilled debt for soft-negative gating. Invoice totals when the list
+ * succeeds (including 0 when gathering is empty / only paid remain); else
+ * period network-fee meter sum net of remaining included usage.
  */
 export async function getUnbilledDebtDetails(input: {
   clientId: string;
@@ -295,9 +360,9 @@ export async function getUnbilledDebtDetails(input: {
   });
 
   if (customerId) {
-    const gathering = await maxGatheringDebtUsdMicros(customerId);
-    if (gathering != null) {
-      return { usdMicros: gathering, source: "gathering_invoice" };
+    const looked = await lookupUnbilledInvoiceDebt(customerId);
+    if (looked.ok) {
+      return { usdMicros: looked.usdMicros, source: "gathering_invoice" };
     }
   }
 

--- a/src/lib/openmeter/konnect-routes.test.ts
+++ b/src/lib/openmeter/konnect-routes.test.ts
@@ -12,6 +12,7 @@ import {
   isKonnectMeterQueryGet,
   mapKonnectMeterGranularity,
   normalizeKonnectMeterQueryResponse,
+  normalizeKonnectCustomerRecord,
   normalizeKonnectListResponse,
   normalizeKonnectSubscriptionRecord,
   rewriteKonnectInvoiceActionToMeteringV1,
@@ -292,6 +293,59 @@ test("rewriteKonnectRequestBody maps customer usageAttribution to snake_case", (
       subject_keys: ["owner:uuid-1", "app_1:uuid-1"],
     },
   });
+});
+
+test("rewriteKonnectRequestBody maps customer metadata to labels", () => {
+  const rewritten = rewriteKonnectRequestBody(
+    "/v3/openmeter/api/v1/customers/cust_1",
+    "PUT",
+    {
+      name: "eu_1",
+      usageAttribution: { subjectKeys: ["app_1:eu_1"] },
+      metadata: {
+        stripe_charge_model: "direct",
+        stripe_connect_account_id: "acct_1",
+        pymthouse_stripe_customer_id: "cus_1",
+      },
+    },
+  );
+  assert.deepEqual(rewritten, {
+    name: "eu_1",
+    usage_attribution: {
+      subject_keys: ["app_1:eu_1"],
+    },
+    labels: {
+      stripe_charge_model: "direct",
+      stripe_connect_account_id: "acct_1",
+      pymthouse_stripe_customer_id: "cus_1",
+    },
+  });
+  assert.equal(
+    (rewritten as { metadata?: unknown }).metadata,
+    undefined,
+  );
+});
+
+test("normalizeKonnectCustomerRecord merges labels into metadata", () => {
+  const normalized = normalizeKonnectCustomerRecord({
+    id: "01KZQQCY1ZVYN66HBR3V7FJ590",
+    key: "app_1:eu_1",
+    labels: {
+      stripe_charge_model: "direct",
+      stripe_connect_account_id: "acct_1",
+    },
+    metadata: null,
+    usage_attribution: { subject_keys: ["app_1:eu_1"] },
+  }) as {
+    metadata?: Record<string, string>;
+    usageAttribution?: { subjectKeys: string[] };
+  };
+
+  assert.deepEqual(normalized.metadata, {
+    stripe_charge_model: "direct",
+    stripe_connect_account_id: "acct_1",
+  });
+  assert.deepEqual(normalized.usageAttribution?.subjectKeys, ["app_1:eu_1"]);
 });
 
 test("rewriteKonnectRequestBody maps customerId to nested customer for subscription create", () => {

--- a/src/lib/openmeter/konnect-routes.ts
+++ b/src/lib/openmeter/konnect-routes.ts
@@ -427,7 +427,26 @@ function isKonnectCustomerMutation(pathname: string, method: string): boolean {
   return /\/customers(?:\/[^/]+)?$/.test(normalizedPath);
 }
 
-function normalizeKonnectCustomerRecord(record: unknown): unknown {
+/** String map from Konnect `labels` / SDK `metadata` bags (drop non-strings). */
+function stringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof nested === "string") {
+      out[key] = nested;
+    }
+  }
+  return out;
+}
+
+/**
+ * Konnect stores customer KV under `labels` and silently discards `metadata`.
+ * The OpenMeter SDK reads/writes `metadata`, so merge labels into metadata on
+ * the way in and map metadata → labels on the way out.
+ */
+export function normalizeKonnectCustomerRecord(record: unknown): unknown {
   if (!record || typeof record !== "object") {
     return record;
   }
@@ -444,7 +463,36 @@ function normalizeKonnectCustomerRecord(record: unknown): unknown {
     };
     delete item.usage_attribution;
   }
+
+  const fromLabels = stringRecord(item.labels);
+  const fromMetadata = stringRecord(item.metadata);
+  const merged = { ...fromLabels, ...fromMetadata };
+  if (Object.keys(merged).length > 0) {
+    item.metadata = merged;
+  } else if ("metadata" in item && item.metadata == null) {
+    item.metadata = {};
+  }
+
   return item;
+}
+
+/** Map SDK customer `metadata` onto Konnect `labels` (full-replace PUT). */
+function rewriteKonnectCustomerRequestBody(body: unknown): unknown {
+  const snake = deepCamelToSnake(body);
+  if (!snake || typeof snake !== "object" || Array.isArray(snake)) {
+    return snake;
+  }
+  const record = { ...(snake as Record<string, unknown>) };
+  const fromLabels = stringRecord(record.labels);
+  const fromMetadata = stringRecord(record.metadata);
+  const merged = { ...fromLabels, ...fromMetadata };
+  delete record.metadata;
+  if (Object.keys(merged).length > 0) {
+    record.labels = merged;
+  } else {
+    delete record.labels;
+  }
+  return record;
 }
 
 /** Normalize SDK JSON bodies to Konnect v3 request shapes. */
@@ -461,7 +509,7 @@ export function rewriteKonnectRequestBody(
   }
 
   if (isKonnectCustomerMutation(pathname, method)) {
-    return deepCamelToSnake(body);
+    return rewriteKonnectCustomerRequestBody(body);
   }
 
   if (verb === "POST" && normalizedPath.endsWith("/subscriptions")) {
@@ -521,7 +569,11 @@ export function normalizeKonnectResponseBody(body: unknown): unknown {
     listed &&
     typeof listed === "object" &&
     "id" in listed &&
-    ("key" in listed || "usage_attribution" in listed || "usageAttribution" in listed)
+    ("key" in listed ||
+      "usage_attribution" in listed ||
+      "usageAttribution" in listed ||
+      "labels" in listed ||
+      "metadata" in listed)
   ) {
     return normalizeKonnectCustomerRecord(listed);
   }

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -784,6 +784,45 @@ test("ensureOpenMeterCustomer repairs missing usageAttribution subjectKeys", asy
   assert.deepEqual(updatedSubjectKeys, ["app_1:user-1"]);
 });
 
+test("ensureOpenMeterCustomer preserves settlement metadata on subject-key repair", async () => {
+  let updatedMetadata: Record<string, string> | undefined;
+  const settlement = {
+    stripe_charge_model: "direct",
+    stripe_connect_account_id: "acct_1U1ELc06T9MFDxzI",
+  };
+  const customerRecord = {
+    id: "om-cust-1",
+    key: "app_1:user-1",
+    name: "app_1:user-1",
+    usageAttribution: { subjectKeys: [] as string[] },
+    // After Konnect normalize, labels land here as metadata.
+    metadata: { ...settlement },
+  };
+  const client = {
+    customers: {
+      get: async () => customerRecord,
+      list: async () => ({ items: [customerRecord] }),
+      listSubscriptions: async () => ({ items: [] }),
+      update: async (
+        _id: string,
+        input: {
+          usageAttribution?: { subjectKeys: string[] };
+          metadata?: Record<string, string>;
+        },
+      ) => {
+        updatedMetadata = input.metadata;
+        return customerRecord;
+      },
+      create: async () => {
+        throw new Error("should not create");
+      },
+    },
+  };
+
+  await ensureOpenMeterCustomer(openMeterTestClient(client), "app_1:user-1");
+  assert.deepEqual(updatedMetadata, settlement);
+});
+
 test("ensureOpenMeterCustomer creates customer when missing", async () => {
   const client = {
     customers: {

--- a/src/lib/stripe/connect-accounts.test.ts
+++ b/src/lib/stripe/connect-accounts.test.ts
@@ -77,6 +77,7 @@ test("merchant invoice mapper preserves Stripe invoice fields for app-user billi
       periodEnd: "2025-01-03T00:00:00.000Z",
       externalInvoicingId: "in_connected",
       invoiceType: "stripe_connect",
+      paymentMethodBrand: null,
     },
   );
 });

--- a/src/lib/stripe/merchant-connect.test.ts
+++ b/src/lib/stripe/merchant-connect.test.ts
@@ -77,7 +77,7 @@ test("stripePaymentMethodBrandLabel maps LINK and card brands", () => {
     stripePaymentMethodBrandLabel({
       id: "pm_2",
       type: "card",
-      card: { brand: "visa", last4: "4242" },
+      card: { brand: "visa" },
     }),
     "VISA",
   );

--- a/src/lib/stripe/merchant-connect.test.ts
+++ b/src/lib/stripe/merchant-connect.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   connectPaymentsOnlyEnabled,
   isMerchantConnectPaymentsReady,
+  stripePaymentMethodBrandLabel,
 } from "./merchant-connect";
 
 test("isMerchantConnectPaymentsReady requires account, charges, and details", () => {
@@ -62,5 +63,22 @@ test("connectPaymentsOnlyEnabled honors env override and config flag", (t) => {
   assert.equal(
     connectPaymentsOnlyEnabled({ connectPaymentsOnly: false } as never),
     true,
+  );
+});
+
+test("stripePaymentMethodBrandLabel maps LINK and card brands", () => {
+  assert.equal(stripePaymentMethodBrandLabel(null), null);
+  assert.equal(stripePaymentMethodBrandLabel("pm_123"), null);
+  assert.equal(
+    stripePaymentMethodBrandLabel({ id: "pm_1", type: "link" }),
+    "LINK",
+  );
+  assert.equal(
+    stripePaymentMethodBrandLabel({
+      id: "pm_2",
+      type: "card",
+      card: { brand: "visa", last4: "4242" },
+    }),
+    "VISA",
   );
 });

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -44,6 +44,13 @@ type StripeConnectInvoice = {
   invoice_pdf?: string | null;
 };
 
+type StripeConnectPaymentMethod = {
+  id?: string;
+  type?: string | null;
+  card?: { brand?: string | null } | null;
+  link?: { email?: string | null } | null;
+};
+
 type StripeConnectPaymentIntent = {
   id?: string;
   amount?: number | null;
@@ -54,6 +61,7 @@ type StripeConnectPaymentIntent = {
   /** Set when this PI paid a Stripe Invoice — history should keep the invoice only. */
   invoice?: string | { id?: string | null } | null;
   metadata?: Record<string, unknown> | null;
+  payment_method?: string | StripeConnectPaymentMethod | null;
   latest_charge?:
     | string
     | {
@@ -76,7 +84,30 @@ export type MerchantBillingHistoryItem = {
   periodEnd?: string;
   externalInvoicingId?: string;
   invoiceType: "stripe_connect" | "auto_topup" | "payment";
+  /** Card brand / LINK when this invoice was paid off-session. */
+  paymentMethodBrand?: string | null;
 };
+
+/** Human label for a Connect payment method (LINK, VISA, …). */
+export function stripePaymentMethodBrandLabel(
+  paymentMethod: StripeConnectPaymentMethod | string | null | undefined,
+): string | null {
+  if (!paymentMethod || typeof paymentMethod === "string") {
+    return null;
+  }
+  const type = paymentMethod.type?.trim().toLowerCase() || "";
+  if (type === "link" || paymentMethod.link) {
+    return "LINK";
+  }
+  const cardBrand = paymentMethod.card?.brand?.trim();
+  if (cardBrand) {
+    return cardBrand.toUpperCase();
+  }
+  if (type) {
+    return type.replaceAll("_", " ").toUpperCase();
+  }
+  return null;
+}
 
 function stripeSecretKey(): string {
   const key =
@@ -121,6 +152,7 @@ async function stripeConnectInvoiceRequest<T>(
 
 function mapMerchantInvoice(
   invoice: StripeConnectInvoice,
+  paymentMethodBrand?: string | null,
 ): MerchantBillingHistoryItem | null {
   const id = invoice.id?.trim();
   if (!id) return null;
@@ -136,6 +168,7 @@ function mapMerchantInvoice(
     periodEnd: invoiceDate(invoice.period_end),
     externalInvoicingId: id,
     invoiceType: "stripe_connect",
+    paymentMethodBrand: paymentMethodBrand?.trim() || null,
   };
 }
 
@@ -220,6 +253,8 @@ export const __testMerchantConnectInvoices = {
   mapLegacyAutoTopUpPaymentIntent,
   mapMerchantPaymentIntent,
   paymentIntentInvoiceId,
+  paymentBrandByInvoiceId,
+  stripePaymentMethodBrandLabel,
   stripeConnectInvoiceRequest,
 };
 /** @internal Exported for unit tests. */
@@ -587,6 +622,7 @@ async function listAllMerchantConnectPaymentIntents(
     const params = new URLSearchParams({
       customer: stripeCustomerId,
       limit: String(STRIPE_INVOICE_PAGE_LIMIT),
+      "expand[]": "data.payment_method",
     });
     if (startingAfter) {
       params.set("starting_after", startingAfter);
@@ -607,6 +643,23 @@ async function listAllMerchantConnectPaymentIntents(
     startingAfter = lastId;
   }
   return intents;
+}
+
+/** invoice id → brand from the PI that settled it (LINK, VISA, …). */
+function paymentBrandByInvoiceId(
+  paymentIntents: StripeConnectPaymentIntent[],
+): Map<string, string> {
+  const brands = new Map<string, string>();
+  for (const pi of paymentIntents) {
+    if ((pi.status?.trim() || "") !== "succeeded") continue;
+    const invoiceId = paymentIntentInvoiceId(pi);
+    if (!invoiceId || brands.has(invoiceId)) continue;
+    const brand = stripePaymentMethodBrandLabel(pi.payment_method);
+    if (brand) {
+      brands.set(invoiceId, brand);
+    }
+  }
+  return brands;
 }
 
 function billingHistorySortKey(item: MerchantBillingHistoryItem): number {
@@ -651,8 +704,15 @@ export async function listMerchantConnectInvoicesForAppUser(input: {
     listAllMerchantConnectInvoices(accountId, customer.stripeCustomerId),
     listAllMerchantConnectPaymentIntents(accountId, customer.stripeCustomerId),
   ]);
+  const paidBrands = paymentBrandByInvoiceId(paymentIntentRows);
   const invoices = invoiceRows
-    .map((invoice) => mapMerchantInvoice(invoice))
+    .map((invoice) => {
+      const id = invoice.id?.trim();
+      return mapMerchantInvoice(
+        invoice,
+        id ? paidBrands.get(id) ?? null : null,
+      );
+    })
     .filter((invoice): invoice is MerchantBillingHistoryItem => invoice !== null);
   const topUps = paymentIntentRows
     .map((pi) => mapMerchantPaymentIntent(pi))


### PR DESCRIPTION
Implement the unbilledInvoiceDebtFromItems function to calculate unbilled debt from invoice items, considering gathering and unpaid open invoices. Add comprehensive tests to validate its behavior, including scenarios for empty lists, ignoring paid invoices, and counting unpaid open invoices. Update related types and utility functions for better clarity and functionality.