### PR TITLE
fix(oidc): grant only consent-visible scopes for DCR clients

### DIFF
--- a/src/app/api/v1/oidc/interaction/[uid]/route.ts
+++ b/src/app/api/v1/oidc/interaction/[uid]/route.ts
@@ -16,7 +16,12 @@ import {
   getIssuer,
   getPublicOrigin,
 } from "@/lib/oidc/issuer-urls";
-import { isDcrClientId } from "@/lib/oidc/dcr-client";
+import { getClient } from "@/lib/oidc/clients";
+import {
+  DCR_ALLOWED_SCOPES,
+  filterScopesToAllowlist,
+  isDcrClientId,
+} from "@/lib/oidc/dcr-client";
 import { bindMcpAppToGrant } from "@/lib/oidc/mcp-app-grant";
 import { resolveOwnedAppChoice } from "@/lib/oidc/owned-apps";
 import {
@@ -47,6 +52,20 @@ function resolveMcpResource(
     return getMcpResourceUrl();
   }
   return null;
+}
+
+/**
+ * Resolve the allowlist used for both consent display and grant issuance.
+ * DCR clients are capped to MCP scopes; registered clients use DB allowedScopes.
+ */
+async function resolveConsentScopeAllowlist(
+  clientId: string,
+): Promise<readonly string[]> {
+  if (isDcrClientId(clientId)) {
+    return DCR_ALLOWED_SCOPES;
+  }
+  const registered = await getClient(clientId);
+  return registered?.allowedScopes ?? [];
 }
 
 /**
@@ -208,13 +227,19 @@ export async function POST(
         grant.clientId = clientId;
         grant.accountId = userId;
 
-        const requestedScopes = details.params.scope as string;
-        if (requestedScopes) {
-          grant.addOIDCScope(requestedScopes);
+        // Grant only scopes the consent UI would show — never the raw request
+        // string, or a malicious client can hide privileged scopes from the user.
+        const scopeAllowlist = await resolveConsentScopeAllowlist(clientId);
+        const grantedScopes = filterScopesToAllowlist(
+          details.params.scope as string | undefined,
+          scopeAllowlist,
+        ).join(" ");
+        if (grantedScopes) {
+          grant.addOIDCScope(grantedScopes);
           if (mcpResource) {
-            grant.addResourceScope(mcpResource, requestedScopes);
+            grant.addResourceScope(mcpResource, grantedScopes);
           } else {
-            grant.addResourceScope(getIssuer(), requestedScopes);
+            grant.addResourceScope(getIssuer(), grantedScopes);
           }
         }
 

--- a/src/app/oidc/consent/page.tsx
+++ b/src/app/oidc/consent/page.tsx
@@ -6,7 +6,7 @@ import { authOptions } from "@/lib/next-auth-options";
 import { db } from "@/db/index";
 import { developerApps, oidcClients } from "@/db/schema";
 import { getClient } from "@/lib/oidc/clients";
-import { isDcrClientId } from "@/lib/oidc/dcr-client";
+import { DCR_ALLOWED_SCOPES, isDcrClientId } from "@/lib/oidc/dcr-client";
 import { listOwnedAppsForUser } from "@/lib/oidc/owned-apps";
 import { getScopeDefinition } from "@/lib/oidc/scopes";
 import { getProvider } from "@/lib/oidc/provider";
@@ -152,13 +152,7 @@ async function resolveConsentClient(
     clientId,
     displayName,
     redirectUris: [],
-    allowedScopes: [
-      "openid",
-      "profile",
-      "email",
-      "offline_access",
-      "sign:job",
-    ],
+    allowedScopes: [...DCR_ALLOWED_SCOPES],
     grantTypes: ["authorization_code", "refresh_token"],
     tokenEndpointAuthMethod: "none",
     clientSecretHash: null,

--- a/src/lib/oidc/dcr-client.test.ts
+++ b/src/lib/oidc/dcr-client.test.ts
@@ -1,11 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { errors } from "oidc-provider";
+import type { KoaContextWithOIDC } from "oidc-provider";
 
 import {
+  applyMcpDcrRegistrationPolicy,
   createDcrClientId,
+  DCR_ALLOWED_SCOPES,
+  filterScopesToAllowlist,
   isAllowedMcpDcrRedirectUri,
   isDcrClientId,
+  mcpDcrRegisteredScope,
+  parseScopeParam,
 } from "@/lib/oidc/dcr-client";
+import { MCP_RESOURCE_SCOPES } from "@/lib/mcp/oauth-resource";
 
 test("DCR client ids use dcr_ prefix", () => {
   const id = createDcrClientId();
@@ -37,5 +45,77 @@ test("only Claude hosted and RFC 8252 loopback redirect URIs are allowed", () =>
   assert.equal(
     isAllowedMcpDcrRedirectUri("https://example.com/oauth/callback"),
     false,
+  );
+});
+
+test("DCR allowlist matches MCP resource scopes (consent display + grant)", () => {
+  assert.deepEqual([...DCR_ALLOWED_SCOPES], [...MCP_RESOURCE_SCOPES]);
+  assert.ok(DCR_ALLOWED_SCOPES.includes("openid"));
+  assert.ok(DCR_ALLOWED_SCOPES.includes("offline_access"));
+  assert.ok(DCR_ALLOWED_SCOPES.includes("sign:job"));
+  assert.equal(DCR_ALLOWED_SCOPES.includes("admin"), false);
+  assert.equal(DCR_ALLOWED_SCOPES.includes("users:write"), false);
+});
+
+test("filterScopesToAllowlist strips privileged scopes hidden from consent UI", () => {
+  const granted = filterScopesToAllowlist(
+    "openid profile email offline_access sign:job admin users:write",
+    DCR_ALLOWED_SCOPES,
+  );
+  assert.deepEqual(granted, [
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "sign:job",
+  ]);
+  assert.equal(granted.includes("admin"), false);
+  assert.equal(granted.includes("users:write"), false);
+});
+
+test("filterScopesToAllowlist preserves request order and ignores unknown tokens", () => {
+  assert.deepEqual(
+    filterScopesToAllowlist("sign:job openid bogus", DCR_ALLOWED_SCOPES),
+    ["sign:job", "openid"],
+  );
+  assert.deepEqual(filterScopesToAllowlist(undefined, DCR_ALLOWED_SCOPES), []);
+  assert.deepEqual(parseScopeParam("openid  openid\temail"), [
+    "openid",
+    "email",
+  ]);
+});
+
+test("DCR registration policy overwrites client-supplied privileged scopes", () => {
+  const properties: Record<string, unknown> = {
+    redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+    scope: "openid admin users:write offline_access",
+  };
+  applyMcpDcrRegistrationPolicy(
+    {} as KoaContextWithOIDC,
+    properties,
+  );
+  assert.equal(properties.scope, mcpDcrRegisteredScope());
+  const scopes = String(properties.scope).split(/\s+/);
+  assert.equal(scopes.includes("admin"), false);
+  assert.equal(scopes.includes("users:write"), false);
+  assert.ok(scopes.includes("openid"));
+  assert.ok(scopes.includes("sign:job"));
+});
+
+test("DCR registration policy skips enforcement for static clients (no ctx)", () => {
+  const properties: Record<string, unknown> = {
+    scope: "admin",
+  };
+  applyMcpDcrRegistrationPolicy(undefined, properties);
+  assert.equal(properties.scope, "admin");
+});
+
+test("DCR registration policy rejects disallowed redirect URIs", () => {
+  assert.throws(
+    () =>
+      applyMcpDcrRegistrationPolicy({} as KoaContextWithOIDC, {
+        redirect_uris: ["http://evil.example/callback"],
+      }),
+    (err: unknown) => err instanceof errors.InvalidClientMetadata,
   );
 });

--- a/src/lib/oidc/dcr-client.ts
+++ b/src/lib/oidc/dcr-client.ts
@@ -4,10 +4,17 @@
 
 import { errors } from "oidc-provider";
 import type { KoaContextWithOIDC } from "oidc-provider";
+import { MCP_RESOURCE_SCOPES } from "@/lib/mcp/oauth-resource";
 import { isAllowedMcpDcrRedirectUri } from "./mcp-dynamic-redirects";
 
 /** Prefix for DCR-issued client_ids so interaction / consent can detect them. */
 export const DCR_CLIENT_ID_PREFIX = "dcr_";
+
+/**
+ * Scopes a DCR (MCP) client may register, request, display on consent, and be
+ * granted. Must stay aligned with consent UI filtering.
+ */
+export const DCR_ALLOWED_SCOPES: readonly string[] = [...MCP_RESOURCE_SCOPES];
 
 export function isDcrClientId(clientId: string): boolean {
   return clientId.startsWith(DCR_CLIENT_ID_PREFIX);
@@ -18,6 +25,40 @@ export function createDcrClientId(): string {
 }
 
 export { isAllowedMcpDcrRedirectUri };
+
+/** Split an OAuth scope string into unique tokens. */
+export function parseScopeParam(scope: string | undefined | null): string[] {
+  if (!scope || typeof scope !== "string") return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const token of scope.split(/[\s,]+/)) {
+    const scopeToken = token.trim();
+    if (!scopeToken || seen.has(scopeToken)) continue;
+    seen.add(scopeToken);
+    out.push(scopeToken);
+  }
+  return out;
+}
+
+/**
+ * Intersect requested scopes with an allowlist (preserves request order).
+ * Used so consent grants only what the UI shows / the client may hold.
+ */
+export function filterScopesToAllowlist(
+  requested: string | string[] | undefined | null,
+  allowlist: readonly string[],
+): string[] {
+  const requestedList = Array.isArray(requested)
+    ? requested.map((s) => s.trim()).filter(Boolean)
+    : parseScopeParam(requested);
+  const allowed = new Set(allowlist);
+  return requestedList.filter((scope) => allowed.has(scope));
+}
+
+/** Fixed scope string written onto every MCP DCR client registration. */
+export function mcpDcrRegisteredScope(): string {
+  return DCR_ALLOWED_SCOPES.join(" ");
+}
 
 /**
  * Applied via `extraClientMetadata.validator` on every DCR request (`ctx` set).
@@ -57,11 +98,7 @@ export function applyMcpDcrRegistrationPolicy(
     properties.client_name = "MCP Connector";
   }
 
-  const existingScope =
-    typeof properties.scope === "string" ? properties.scope.trim() : "";
-  const required = ["openid", "offline_access", "profile", "email"];
-  const scopes = new Set(
-    [...existingScope.split(/\s+/), ...required].filter(Boolean),
-  );
-  properties.scope = [...scopes].join(" ");
+  // Never trust client-supplied scopes: a malicious DCR registrant could
+  // otherwise advertise admin/users:write and receive them at consent time.
+  properties.scope = mcpDcrRegisteredScope();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the HIGH severity security finding on #429: consent granted the full `details.params.scope` string while the DCR consent UI only displayed scopes from a fixed allowlist, so a malicious dynamic client could request privileged scopes (e.g. `admin`, `users:write`) that were not shown but still granted.

## Changes

- **Consent grant path** (`interaction/[uid]/route.ts`): intersect requested scopes with the same allowlist used for display (DCR → `DCR_ALLOWED_SCOPES` / MCP resource scopes; registered clients → DB `allowedScopes`) before `addOIDCScope` / `addResourceScope`.
- **DCR registration** (`dcr-client.ts`): overwrite client-supplied `scope` with the fixed MCP allowlist so privileged scopes cannot be registered on DCR clients.
- **Consent UI**: use shared `DCR_ALLOWED_SCOPES` instead of a duplicated hardcoded list.
- **Tests**: cover allowlist filtering and registration scope overwrite.

## Verification

- `npx tsc --noEmit` — pass
- `node --import ./src/test-env.ts --import tsx --test src/lib/oidc/dcr-client.test.ts` — pass (8/8)
- ESLint on touched files — clean
- Full `npm test` has 5 pre-existing failures unrelated to this change (billing/OpenMeter)
- Sonar/Snyk tokens not available in this environment; CI will run them on the PR

## Related

- Fixes security review finding on https://github.com/pymthouse/pymthouse/pull/429

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-617e3963-fd6d-4ca9-acf4-2809baea68fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-617e3963-fd6d-4ca9-acf4-2809baea68fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

