### PR TITLE
Align MCP DCR redirect policy with authorization redirect gate

### DIFF
--- a/src/app/api/v1/oidc/[...oidc]/utils.ts
+++ b/src/app/api/v1/oidc/[...oidc]/utils.ts
@@ -1,10 +1,9 @@
 import { PROVIDER_ENDPOINT_PATHS } from "@/lib/oidc/routes";
 import { OIDC_MOUNT_PATH, getPublicOrigin } from "@/lib/oidc/issuer-urls";
-
-const CLAUDE_HOSTED_REDIRECT_ORIGINS = new Set([
-  "https://claude.ai",
-  "https://claude.com",
-]);
+import {
+  isLoopbackMcpRedirectUrl,
+  isPermittedMcpDynamicRedirect,
+} from "@/lib/oidc/mcp-dynamic-redirects";
 
 export function deriveExternalOriginFromHeaders(headers: Headers): string {
   const publicFallback = getPublicOrigin();
@@ -50,17 +49,7 @@ export async function getTrustedOidcOrigins(): Promise<Set<string>> {
 
 /** RFC 8252 loopback — Claude Code / native MCP clients. */
 export function isLoopbackHttpRedirect(url: URL): boolean {
-  if (url.protocol !== "http:") return false;
-  const host = url.hostname.toLowerCase();
-  if (host !== "localhost" && host !== "127.0.0.1" && host !== "[::1]") {
-    return false;
-  }
-  return url.pathname === "/callback" || url.pathname.endsWith("/callback");
-}
-
-function isPermittedDynamicRedirect(url: URL): boolean {
-  if (isLoopbackHttpRedirect(url)) return true;
-  return CLAUDE_HOSTED_REDIRECT_ORIGINS.has(url.origin);
+  return isLoopbackMcpRedirectUrl(url);
 }
 
 export function resolveRedirectLocation(
@@ -73,7 +62,7 @@ export function resolveRedirectLocation(
     if (
       allowedOrigins &&
       !allowedOrigins.has(redirectUrl.origin) &&
-      !isPermittedDynamicRedirect(redirectUrl)
+      !isPermittedMcpDynamicRedirect(redirectUrl)
     ) {
       throw new Error(
         `[OIDC] Redirect to unregistered origin blocked: ${redirectUrl.origin}`,

--- a/src/lib/oidc/dcr-client.test.ts
+++ b/src/lib/oidc/dcr-client.test.ts
@@ -13,7 +13,7 @@ test("DCR client ids use dcr_ prefix", () => {
   assert.equal(isDcrClientId("app_abc"), false);
 });
 
-test("Claude redirect URIs are allowed", () => {
+test("only Claude hosted and RFC 8252 loopback redirect URIs are allowed", () => {
   assert.equal(
     isAllowedMcpDcrRedirectUri("https://claude.ai/api/mcp/auth_callback"),
     true,
@@ -36,6 +36,6 @@ test("Claude redirect URIs are allowed", () => {
   );
   assert.equal(
     isAllowedMcpDcrRedirectUri("https://example.com/oauth/callback"),
-    true,
+    false,
   );
 });

--- a/src/lib/oidc/dcr-client.ts
+++ b/src/lib/oidc/dcr-client.ts
@@ -4,6 +4,7 @@
 
 import { errors } from "oidc-provider";
 import type { KoaContextWithOIDC } from "oidc-provider";
+import { isAllowedMcpDcrRedirectUri } from "./mcp-dynamic-redirects";
 
 /** Prefix for DCR-issued client_ids so interaction / consent can detect them. */
 export const DCR_CLIENT_ID_PREFIX = "dcr_";
@@ -16,31 +17,7 @@ export function createDcrClientId(): string {
   return `${DCR_CLIENT_ID_PREFIX}${crypto.randomUUID().replaceAll("-", "")}`;
 }
 
-const CLAUDE_REDIRECT_URIS = new Set([
-  "https://claude.ai/api/mcp/auth_callback",
-  "https://claude.com/api/mcp/auth_callback",
-]);
-
-/**
- * Allow Claude hosted callbacks and RFC 8252 loopback redirects (Claude Code).
- * Other https redirect URIs are accepted for non-Claude MCP clients.
- */
-export function isAllowedMcpDcrRedirectUri(uri: string): boolean {
-  if (CLAUDE_REDIRECT_URIS.has(uri)) return true;
-  try {
-    const u = new URL(uri);
-    if (u.protocol === "http:") {
-      const host = u.hostname.toLowerCase();
-      if (host === "localhost" || host === "127.0.0.1" || host === "[::1]") {
-        return u.pathname === "/callback" || u.pathname.endsWith("/callback");
-      }
-      return false;
-    }
-    return u.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
+export { isAllowedMcpDcrRedirectUri };
 
 /**
  * Applied via `extraClientMetadata.validator` on every DCR request (`ctx` set).

--- a/src/lib/oidc/mcp-dynamic-redirects.ts
+++ b/src/lib/oidc/mcp-dynamic-redirects.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared redirect policy for MCP dynamic clients (DCR + final redirect).
+ *
+ * Keeping this logic centralized avoids drift between registration-time
+ * metadata checks and authorization-time redirect enforcement.
+ */
+
+const CLAUDE_MCP_REDIRECT_ORIGINS = new Set([
+  "https://claude.ai",
+  "https://claude.com",
+]);
+
+const CLAUDE_MCP_CALLBACK_PATH = "/api/mcp/auth_callback";
+
+/**
+ * RFC 8252 loopback redirects used by Claude Code and other native MCP clients.
+ */
+export function isLoopbackMcpRedirectUrl(url: URL): boolean {
+  if (url.protocol !== "http:") return false;
+  const host = url.hostname.toLowerCase();
+  if (host !== "localhost" && host !== "127.0.0.1" && host !== "[::1]") {
+    return false;
+  }
+  return url.pathname === "/callback" || url.pathname.endsWith("/callback");
+}
+
+/**
+ * Hosted Claude callback redirects.
+ */
+export function isClaudeHostedMcpRedirectUrl(url: URL): boolean {
+  return (
+    url.protocol === "https:" &&
+    CLAUDE_MCP_REDIRECT_ORIGINS.has(url.origin) &&
+    url.pathname === CLAUDE_MCP_CALLBACK_PATH
+  );
+}
+
+/**
+ * Redirect targets explicitly permitted for open MCP dynamic clients.
+ */
+export function isPermittedMcpDynamicRedirect(url: URL): boolean {
+  return isLoopbackMcpRedirectUrl(url) || isClaudeHostedMcpRedirectUrl(url);
+}
+
+/**
+ * Registration-time validator for `redirect_uris` metadata in DCR payloads.
+ */
+export function isAllowedMcpDcrRedirectUri(uri: string): boolean {
+  try {
+    return isPermittedMcpDynamicRedirect(new URL(uri));
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- centralize MCP dynamic redirect policy in `src/lib/oidc/mcp-dynamic-redirects.ts`
- reuse that shared policy in both DCR metadata validation and authorization redirect resolution
- tighten DCR redirect acceptance to only Claude hosted callbacks and RFC 8252 loopback callbacks
- update DCR redirect tests to assert arbitrary HTTPS callback URIs are rejected early

## Why
DCR registration previously accepted any `https:` redirect URI while the final redirect gate only allowed registered OIDC origins plus Claude/loopback exceptions. This let non-Claude HTTPS callbacks pass registration and fail later during redirect. This change makes policy consistent and fail-fast at registration.

## Validation
- `node --import ./src/test-env.ts --import tsx --test --test-force-exit src/lib/oidc/dcr-client.test.ts`
- `node --import ./src/test-env.ts --import tsx --test --test-force-exit "src/app/api/v1/oidc/*/route.test.ts"`
- `npx eslint src/lib/oidc/mcp-dynamic-redirects.ts src/lib/oidc/dcr-client.ts src/lib/oidc/dcr-client.test.ts "src/app/api/v1/oidc/*/utils.ts"`
- `npx tsc --noEmit`

## Security tooling checks
- SonarQube local invocation attempted via `npx sonarqube-scanner -Dsonar.projectBaseDir=/workspace` but could not run analysis without `SONAR_TOKEN` in this environment.
- Snyk local invocation attempted via `npx snyk test --all-projects --severity-threshold=high` but failed authentication because `SNYK_TOKEN` is unavailable in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c23a8287-59fc-414a-b886-720330987540?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c23a8287-59fc-414a-b886-720330987540&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

