### PR TITLE
Add merchant Stripe Connect e2e against staging

### DIFF
--- a/scripts/e2e/merchant-payments.ts
+++ b/scripts/e2e/merchant-payments.ts
@@ -200,7 +200,7 @@ async function stripe<T = Record<string, unknown>>(
   });
   const body = (await response.json()) as T & { error?: { message?: string } };
   if (!response.ok) {
-    fail(`Stripe ${init.method ?? "GET"} ${path} → ${response.status}: ${body.error?.message}`);
+    fail(`Stripe ${init.method ?? "GET"} request failed (status ${response.status})`);
   }
   return body;
 }


### PR DESCRIPTION
## Summary
- Add `scripts/e2e/merchant-payments.ts` and `.github/workflows/e2e-merchant-payments.yml` to prove the merchant Stripe Connect rail on the deployed staging stack (Plane B webhooks, metering, collect, Connect charge).
- Isolation is by data: dedicated fixture app, Stripe sandbox, and a fresh namespaced end-user per run. Preflight refuses a production base URL or a live (`sk_live_`) key.
- Enable with repository variable `E2E_MERCHANT_PAYMENTS=true` plus `e2e / staging` secrets. See `docs/e2e-merchant-payments.md`.

Split out of #436 so the customer-service billing move can land independently.

## Test plan
- [ ] Workflow is `workflow_dispatch` + optional nightly; it does not run on every PR
- [ ] `npm run e2e:merchant-payments -- preflight` fails against a production URL or `sk_live_` key
- [ ] Do not enable the nightly schedule until the fixture app, sandbox Connect account, and `e2e / staging` secrets are provisioned