### PR TITLE
feat(billing): implement admin owner list API with cycle usage filtering

### DIFF
--- a/docs/customer-service-oidc.md
+++ b/docs/customer-service-oidc.md
@@ -81,5 +81,11 @@ scope, plus DB admin role):
 | GET/PATCH | `/api/v1/admin/billing/owners/{userId}` (GET includes `wallet`) |
 | POST | `/api/v1/admin/billing/owners/{userId}/grants` |
 
+`GET /owners` accepts `q` (email, name, user id, **app name**, or app id),
+`status=blocked|overage|attention`, and `page`/`pageSize`. Results are ordered
+by current-cycle usage (local confirmed tickets). Each row includes
+`ownedApps`, `cycleUsage`, `usageStatus`, and `planKind`. Prepaid credits and
+live OpenMeter subscriptions remain on the owner detail `wallet`.
+
 Free Builder `POST …/users/{externalUserId}/allowances` is disabled
 (`403 free_grant_admin_only`).

--- a/src/app/api/v1/admin/billing/owners/route.ts
+++ b/src/app/api/v1/admin/billing/owners/route.ts
@@ -1,116 +1,18 @@
 import { NextResponse } from "next/server";
-import { and, count, eq, ilike, or, sql } from "drizzle-orm";
 
-import { db } from "@/db/index";
-import { ownerBillingConfig, users } from "@/db/schema";
 import { withAdminGuard } from "@/lib/api-guards";
-import { mergeOwnerBilling } from "@/lib/billing/owner-billing-config";
-import { platformDefaultEndUserCap } from "@/lib/billing/platform-billing-defaults";
-import { resolvePlatformOwnerStarterIncludedUsdMicros } from "@/lib/billing/platform-owner-starter-default";
-
-const DEFAULT_PAGE_SIZE = 25;
-const MAX_PAGE_SIZE = 100;
-
-function parsePositiveInt(
-  raw: string | null,
-  fallback: number,
-  max?: number,
-): number {
-  if (!raw) return fallback;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return fallback;
-  if (max != null && n > max) return max;
-  return n;
-}
+import {
+  listAdminBillingOwners,
+  parseOwnerListQuery,
+} from "@/lib/billing/admin-owner-list";
 
 /**
- * GET /api/v1/admin/billing/owners?q=&page=&pageSize=
- * Search developer accounts with resolved cost-rail billing summary.
+ * GET /api/v1/admin/billing/owners?q=&page=&pageSize=&status=
+ * Search developer accounts (email, name, id, or app name) with cycle usage.
+ * Ordered by most used. `status=blocked|overage|attention` filters the list.
  */
 export const GET = withAdminGuard(async (request) => {
-  const q = request.nextUrl.searchParams.get("q")?.trim() ?? "";
-  const page = parsePositiveInt(request.nextUrl.searchParams.get("page"), 1);
-  const pageSize = parsePositiveInt(
-    request.nextUrl.searchParams.get("pageSize"),
-    DEFAULT_PAGE_SIZE,
-    MAX_PAGE_SIZE,
-  );
-  const offset = (page - 1) * pageSize;
-
-  const platformDefault = await resolvePlatformOwnerStarterIncludedUsdMicros();
-  const defaults = {
-    starterIncludedUsdMicros: platformDefault,
-    endUserCap: platformDefaultEndUserCap(),
-  };
-
-  const roleFilter = or(eq(users.role, "developer"), eq(users.role, "admin"));
-  const searchFilter =
-    q.length > 0
-      ? or(
-          ilike(users.email, `%${q}%`),
-          ilike(users.name, `%${q}%`),
-          eq(users.id, q),
-        )
-      : undefined;
-  const whereClause = searchFilter ? and(roleFilter, searchFilter) : roleFilter;
-
-  const [totalRow] = await db
-    .select({ total: count() })
-    .from(users)
-    .where(whereClause);
-  const totalCount = Number(totalRow?.total ?? 0);
-
-  const rows = await db
-    .select({
-      id: users.id,
-      email: users.email,
-      name: users.name,
-      role: users.role,
-      starterIncludedUsdMicros: ownerBillingConfig.starterIncludedUsdMicros,
-      endUserCap: ownerBillingConfig.endUserCap,
-      note: ownerBillingConfig.note,
-    })
-    .from(users)
-    .leftJoin(
-      ownerBillingConfig,
-      eq(ownerBillingConfig.ownerUserId, users.id),
-    )
-    .where(whereClause)
-    .orderBy(sql`${users.email} asc nulls last`)
-    .limit(pageSize)
-    .offset(offset);
-
-  const owners = rows.map((row) => {
-    const hasRow =
-      row.starterIncludedUsdMicros != null ||
-      row.endUserCap != null ||
-      row.note != null;
-    const overrides = hasRow
-      ? {
-          starterIncludedUsdMicros: row.starterIncludedUsdMicros,
-          endUserCap: row.endUserCap,
-          note: row.note,
-        }
-      : null;
-    const resolved = mergeOwnerBilling(overrides, defaults);
-    return {
-      id: row.id,
-      email: row.email,
-      name: row.name,
-      role: row.role,
-      resolved,
-      overrides,
-    };
-  });
-
-  return NextResponse.json({
-    owners,
-    page,
-    pageSize,
-    totalCount,
-    platformDefault: {
-      starterIncludedUsdMicros: platformDefault,
-      endUserCap: defaults.endUserCap,
-    },
-  });
+  const query = parseOwnerListQuery(request.nextUrl.searchParams);
+  const result = await listAdminBillingOwners(query);
+  return NextResponse.json(result);
 });

--- a/src/lib/billing/admin-owner-list.db.test.ts
+++ b/src/lib/billing/admin-owner-list.db.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import { ownerBillingConfig, transactions } from "@/db/schema";
+import { listAdminBillingOwners } from "@/lib/billing/admin-owner-list";
+import { setOwnerBillingOverrides } from "@/lib/billing/owner-billing-config";
+import { test } from "@/test-utils/db-guard";
+import {
+  cleanupTestApp,
+  seedDeveloperAppWithClient,
+  type SeededDeveloperApp,
+} from "@/test-utils/fixtures";
+
+async function insertCycleUsage(appId: string, usedUsdMicros: string): Promise<void> {
+  await db.insert(transactions).values({
+    id: `tx-admin-owner-list-${randomUUID()}`,
+    clientId: appId,
+    appId,
+    type: "usage",
+    status: "confirmed",
+    amountWei: "0",
+    networkFeeUsdMicros: usedUsdMicros,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+test("admin owner list finds owner by app name and sorts by cycle usage", async (t) => {
+  const token = randomUUID().slice(0, 8);
+  const heavyName = `cs-heavy-app-${token}`;
+  const lightName = `cs-light-app-${token}`;
+  let heavy: SeededDeveloperApp | undefined;
+  let light: SeededDeveloperApp | undefined;
+  t.after(async () => {
+    if (heavy) {
+      await db
+        .delete(ownerBillingConfig)
+        .where(eq(ownerBillingConfig.ownerUserId, heavy.userId));
+      await cleanupTestApp(heavy);
+    }
+    if (light) await cleanupTestApp(light);
+  });
+
+  heavy = await seedDeveloperAppWithClient({ name: heavyName });
+  light = await seedDeveloperAppWithClient({ name: lightName });
+  await setOwnerBillingOverrides({
+    ownerUserId: heavy.userId,
+    starterIncludedUsdMicros: "5000000",
+    updatedBy: heavy.userId,
+  });
+  await insertCycleUsage(heavy.clientId, "8000000");
+  await insertCycleUsage(light.clientId, "1000000");
+
+  const byApp = await listAdminBillingOwners({
+    q: heavyName,
+    page: 1,
+    pageSize: 25,
+    status: "all",
+  });
+  assert.equal(byApp.owners.length, 1);
+  assert.equal(byApp.owners[0]?.id, heavy.userId);
+  assert.equal(byApp.owners[0]?.ownedApps[0]?.name, heavyName);
+  assert.equal(byApp.owners[0]?.cycleUsage.usedUsdMicros, "8000000");
+  assert.equal(byApp.owners[0]?.usageStatus, "blocked");
+
+  const attention = await listAdminBillingOwners({
+    q: token,
+    page: 1,
+    pageSize: 25,
+    status: "attention",
+  });
+  const attentionIds = attention.owners.map((owner) => owner.id);
+  assert.ok(attentionIds.includes(heavy.userId));
+  assert.equal(attentionIds[0], heavy.userId, "highest usage is first");
+});

--- a/src/lib/billing/admin-owner-list.test.ts
+++ b/src/lib/billing/admin-owner-list.test.ts
@@ -6,7 +6,6 @@ import {
   compareOwnersByUsageDesc,
   ownerMatchesStatusFilter,
   parseOwnerListQuery,
-  parsePositiveInt,
 } from "@/lib/billing/admin-owner-list";
 
 test("parseOwnerListQuery defaults and clamps page size", () => {
@@ -35,10 +34,15 @@ test("parseOwnerListQuery ignores unknown status and oversize pageSize", () => {
   assert.equal(parsed.pageSize, 100);
 });
 
-test("parsePositiveInt rejects zero and non-numeric", () => {
-  assert.equal(parsePositiveInt("0", 7), 7);
-  assert.equal(parsePositiveInt("abc", 7), 7);
-  assert.equal(parsePositiveInt(null, 7), 7);
+test("parseOwnerListQuery rejects fractional page values and clamps huge pages", () => {
+  const junk = parseOwnerListQuery(
+    new URLSearchParams("page=2.9&pageSize=25junk"),
+  );
+  assert.equal(junk.page, 1);
+  assert.equal(junk.pageSize, 25);
+
+  const huge = parseOwnerListQuery(new URLSearchParams("page=99999"));
+  assert.equal(huge.page, 10_000);
 });
 
 test("starter at or over included is blocked", () => {

--- a/src/lib/billing/admin-owner-list.test.ts
+++ b/src/lib/billing/admin-owner-list.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyOwnerListUsage,
+  compareOwnersByUsageDesc,
+  ownerMatchesStatusFilter,
+  parseOwnerListQuery,
+  parsePositiveInt,
+} from "@/lib/billing/admin-owner-list";
+
+test("parseOwnerListQuery defaults and clamps page size", () => {
+  const parsed = parseOwnerListQuery(new URLSearchParams());
+  assert.equal(parsed.q, "");
+  assert.equal(parsed.page, 1);
+  assert.equal(parsed.pageSize, 25);
+  assert.equal(parsed.status, "all");
+});
+
+test("parseOwnerListQuery reads q, paging, and status", () => {
+  const parsed = parseOwnerListQuery(
+    new URLSearchParams("q=Daydream&page=2&pageSize=50&status=attention"),
+  );
+  assert.equal(parsed.q, "Daydream");
+  assert.equal(parsed.page, 2);
+  assert.equal(parsed.pageSize, 50);
+  assert.equal(parsed.status, "attention");
+});
+
+test("parseOwnerListQuery ignores unknown status and oversize pageSize", () => {
+  const parsed = parseOwnerListQuery(
+    new URLSearchParams("status=nope&pageSize=999"),
+  );
+  assert.equal(parsed.status, "all");
+  assert.equal(parsed.pageSize, 100);
+});
+
+test("parsePositiveInt rejects zero and non-numeric", () => {
+  assert.equal(parsePositiveInt("0", 7), 7);
+  assert.equal(parsePositiveInt("abc", 7), 7);
+  assert.equal(parsePositiveInt(null, 7), 7);
+});
+
+test("starter at or over included is blocked", () => {
+  assert.equal(
+    classifyOwnerListUsage({
+      usedUsdMicros: 5_000_000n,
+      includedUsdMicros: 5_000_000n,
+      planKind: "starter",
+    }).status,
+    "blocked",
+  );
+  assert.equal(
+    classifyOwnerListUsage({
+      usedUsdMicros: 8_000_000n,
+      includedUsdMicros: 5_000_000n,
+      planKind: "starter",
+    }).status,
+    "blocked",
+  );
+});
+
+test("starter under included is ok", () => {
+  const result = classifyOwnerListUsage({
+    usedUsdMicros: 1_000_000n,
+    includedUsdMicros: 5_000_000n,
+    planKind: "starter",
+  });
+  assert.equal(result.status, "ok");
+  assert.equal(result.remainingUsdMicros, 4_000_000n);
+  assert.equal(result.overageUsdMicros, 0n);
+});
+
+test("paid over included is overage, not blocked", () => {
+  const result = classifyOwnerListUsage({
+    usedUsdMicros: 25_000_000n,
+    includedUsdMicros: 20_000_000n,
+    planKind: "paid",
+  });
+  assert.equal(result.status, "overage");
+  assert.equal(result.overageUsdMicros, 5_000_000n);
+  assert.equal(result.remainingUsdMicros, 0n);
+});
+
+test("paid exactly at included is still ok", () => {
+  assert.equal(
+    classifyOwnerListUsage({
+      usedUsdMicros: 20_000_000n,
+      includedUsdMicros: 20_000_000n,
+      planKind: "paid",
+    }).status,
+    "ok",
+  );
+});
+
+test("zero used and zero included is ok rather than flagging everyone", () => {
+  assert.equal(
+    classifyOwnerListUsage({
+      usedUsdMicros: 0n,
+      includedUsdMicros: 0n,
+      planKind: "starter",
+    }).status,
+    "ok",
+  );
+});
+
+test("ownerMatchesStatusFilter attention is blocked or overage", () => {
+  assert.equal(ownerMatchesStatusFilter("ok", "all"), true);
+  assert.equal(ownerMatchesStatusFilter("ok", "attention"), false);
+  assert.equal(ownerMatchesStatusFilter("blocked", "attention"), true);
+  assert.equal(ownerMatchesStatusFilter("overage", "attention"), true);
+  assert.equal(ownerMatchesStatusFilter("blocked", "blocked"), true);
+  assert.equal(ownerMatchesStatusFilter("overage", "blocked"), false);
+});
+
+test("compareOwnersByUsageDesc puts highest spend first", () => {
+  const low = {
+    id: "a",
+    email: "a@example.test",
+    cycleUsage: { usedUsdMicros: "100", includedUsdMicros: "1", remainingUsdMicros: "0", overageUsdMicros: "0", requestCount: 1 },
+  };
+  const high = {
+    id: "b",
+    email: "b@example.test",
+    cycleUsage: { usedUsdMicros: "900", includedUsdMicros: "1", remainingUsdMicros: "0", overageUsdMicros: "0", requestCount: 1 },
+  };
+  assert.ok(compareOwnersByUsageDesc(high, low) < 0);
+  assert.ok(compareOwnersByUsageDesc(low, high) > 0);
+});

--- a/src/lib/billing/admin-owner-list.ts
+++ b/src/lib/billing/admin-owner-list.ts
@@ -13,6 +13,7 @@ import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
 import { mergeOwnerBilling } from "@/lib/billing/owner-billing-config";
 import { platformDefaultEndUserCap } from "@/lib/billing/platform-billing-defaults";
 import { resolvePlatformOwnerStarterIncludedUsdMicros } from "@/lib/billing/platform-owner-starter-default";
+import { clampPageParam } from "@/lib/billing/wallet-http";
 import { parseUsdMicrosString } from "@/lib/format-usd-micros";
 
 export const ADMIN_OWNER_LIST_DEFAULT_PAGE_SIZE = 25;
@@ -90,25 +91,13 @@ function parseStatusFilterParam(raw: string): OwnerListStatusFilter {
   }
 }
 
-export function parsePositiveInt(
-  raw: string | null,
-  fallback: number,
-  max?: number,
-): number {
-  if (!raw) return fallback;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return fallback;
-  if (max != null && n > max) return max;
-  return n;
-}
-
 export function parseOwnerListQuery(
   searchParams: URLSearchParams,
 ): AdminOwnerListQuery {
   return {
     q: searchParams.get("q")?.trim() ?? "",
-    page: parsePositiveInt(searchParams.get("page"), 1),
-    pageSize: parsePositiveInt(
+    page: clampPageParam(searchParams.get("page"), 1, 10_000),
+    pageSize: clampPageParam(
       searchParams.get("pageSize"),
       ADMIN_OWNER_LIST_DEFAULT_PAGE_SIZE,
       ADMIN_OWNER_LIST_MAX_PAGE_SIZE,

--- a/src/lib/billing/admin-owner-list.ts
+++ b/src/lib/billing/admin-owner-list.ts
@@ -1,0 +1,466 @@
+import { and, eq, exists, gte, ilike, inArray, lte, or, sql } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import {
+  developerApps,
+  ownerBillingConfig,
+  ownerPaidUpgradeOperations,
+  ownerSubscriptionTiers,
+  transactions,
+  users,
+} from "@/db/schema";
+import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
+import { mergeOwnerBilling } from "@/lib/billing/owner-billing-config";
+import { platformDefaultEndUserCap } from "@/lib/billing/platform-billing-defaults";
+import { resolvePlatformOwnerStarterIncludedUsdMicros } from "@/lib/billing/platform-owner-starter-default";
+import { parseUsdMicrosString } from "@/lib/format-usd-micros";
+
+export const ADMIN_OWNER_LIST_DEFAULT_PAGE_SIZE = 25;
+export const ADMIN_OWNER_LIST_MAX_PAGE_SIZE = 100;
+
+export type OwnerListStatusFilter = "all" | "blocked" | "overage" | "attention";
+export type OwnerListUsageStatus = "ok" | "blocked" | "overage";
+export type OwnerListPlanKind = "starter" | "paid";
+
+export type AdminOwnerListQuery = {
+  q: string;
+  page: number;
+  pageSize: number;
+  status: OwnerListStatusFilter;
+};
+
+export type AdminOwnerListApp = {
+  id: string;
+  name: string;
+};
+
+export type AdminOwnerCycleUsage = {
+  usedUsdMicros: string;
+  includedUsdMicros: string;
+  remainingUsdMicros: string;
+  overageUsdMicros: string;
+  requestCount: number;
+};
+
+export type AdminOwnerListItem = {
+  id: string;
+  email: string | null;
+  name: string | null;
+  role: string;
+  resolved: ReturnType<typeof mergeOwnerBilling>;
+  overrides: {
+    starterIncludedUsdMicros: string | null;
+    endUserCap: number | null;
+    note: string | null;
+  } | null;
+  ownedApps: AdminOwnerListApp[];
+  cycleUsage: AdminOwnerCycleUsage;
+  usageStatus: OwnerListUsageStatus;
+  planKind: OwnerListPlanKind;
+};
+
+export type AdminOwnerListResult = {
+  owners: AdminOwnerListItem[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  cycle: { start: string; end: string };
+  statusCounts: {
+    all: number;
+    ok: number;
+    blocked: number;
+    overage: number;
+    attention: number;
+  };
+  platformDefault: {
+    starterIncludedUsdMicros: string;
+    endUserCap: number;
+  };
+};
+
+function parseStatusFilterParam(raw: string): OwnerListStatusFilter {
+  switch (raw) {
+    case "blocked":
+    case "overage":
+    case "attention":
+    case "all":
+      return raw;
+    default:
+      return "all";
+  }
+}
+
+export function parsePositiveInt(
+  raw: string | null,
+  fallback: number,
+  max?: number,
+): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  if (max != null && n > max) return max;
+  return n;
+}
+
+export function parseOwnerListQuery(
+  searchParams: URLSearchParams,
+): AdminOwnerListQuery {
+  return {
+    q: searchParams.get("q")?.trim() ?? "",
+    page: parsePositiveInt(searchParams.get("page"), 1),
+    pageSize: parsePositiveInt(
+      searchParams.get("pageSize"),
+      ADMIN_OWNER_LIST_DEFAULT_PAGE_SIZE,
+      ADMIN_OWNER_LIST_MAX_PAGE_SIZE,
+    ),
+    status: parseStatusFilterParam(
+      searchParams.get("status")?.trim().toLowerCase() ?? "",
+    ),
+  };
+}
+
+function microsOrZero(raw: string | null | undefined): bigint {
+  return parseUsdMicrosString(raw) ?? 0n;
+}
+
+/**
+ * List-view posture from cycle usage vs plan included.
+ *
+ * Starter is a hard gate (blocked at/over included). Paid can invoice overage.
+ * Prepaid credits and live OpenMeter subscriptions are confirmed on owner detail.
+ */
+export function classifyOwnerListUsage(input: {
+  usedUsdMicros: bigint;
+  includedUsdMicros: bigint;
+  planKind: OwnerListPlanKind;
+}): {
+  status: OwnerListUsageStatus;
+  remainingUsdMicros: bigint;
+  overageUsdMicros: bigint;
+} {
+  const used = input.usedUsdMicros > 0n ? input.usedUsdMicros : 0n;
+  const included = input.includedUsdMicros > 0n ? input.includedUsdMicros : 0n;
+  const remaining = included > used ? included - used : 0n;
+  const overage = used > included ? used - included : 0n;
+
+  if (used === 0n && included === 0n) {
+    return { status: "ok", remainingUsdMicros: 0n, overageUsdMicros: 0n };
+  }
+  if (input.planKind === "paid") {
+    return {
+      status: overage > 0n ? "overage" : "ok",
+      remainingUsdMicros: remaining,
+      overageUsdMicros: overage,
+    };
+  }
+  return {
+    status: used >= included ? "blocked" : "ok",
+    remainingUsdMicros: remaining,
+    overageUsdMicros: overage,
+  };
+}
+
+export function ownerMatchesStatusFilter(
+  status: OwnerListUsageStatus,
+  filter: OwnerListStatusFilter,
+): boolean {
+  if (filter === "all") return true;
+  if (filter === "attention") return status === "blocked" || status === "overage";
+  return status === filter;
+}
+
+export function compareOwnersByUsageDesc(
+  a: Pick<AdminOwnerListItem, "cycleUsage" | "email" | "id">,
+  b: Pick<AdminOwnerListItem, "cycleUsage" | "email" | "id">,
+): number {
+  const usedA = microsOrZero(a.cycleUsage.usedUsdMicros);
+  const usedB = microsOrZero(b.cycleUsage.usedUsdMicros);
+  if (usedA !== usedB) return usedB > usedA ? 1 : -1;
+  const emailA = (a.email ?? "").toLowerCase();
+  const emailB = (b.email ?? "").toLowerCase();
+  if (emailA !== emailB) return emailA.localeCompare(emailB);
+  return a.id.localeCompare(b.id);
+}
+
+function ownerSearchFilter(q: string) {
+  if (!q) return undefined;
+  const pattern = `%${q}%`;
+  return or(
+    ilike(users.email, pattern),
+    ilike(users.name, pattern),
+    eq(users.id, q),
+    exists(
+      db
+        .select({ id: developerApps.id })
+        .from(developerApps)
+        .where(
+          and(
+            eq(developerApps.ownerId, users.id),
+            or(ilike(developerApps.name, pattern), eq(developerApps.id, q)),
+          ),
+        ),
+    ),
+  );
+}
+
+type OwnerRow = {
+  id: string;
+  email: string | null;
+  name: string | null;
+  role: string;
+  starterIncludedUsdMicros: string | null;
+  endUserCap: number | null;
+  note: string | null;
+};
+
+async function loadMatchingOwners(q: string): Promise<OwnerRow[]> {
+  const roleFilter = or(eq(users.role, "developer"), eq(users.role, "admin"));
+  const searchFilter = ownerSearchFilter(q);
+  const whereClause = searchFilter ? and(roleFilter, searchFilter) : roleFilter;
+  return db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      role: users.role,
+      starterIncludedUsdMicros: ownerBillingConfig.starterIncludedUsdMicros,
+      endUserCap: ownerBillingConfig.endUserCap,
+      note: ownerBillingConfig.note,
+    })
+    .from(users)
+    .leftJoin(ownerBillingConfig, eq(ownerBillingConfig.ownerUserId, users.id))
+    .where(whereClause);
+}
+
+async function loadOwnedAppsByOwner(
+  ownerIds: string[],
+): Promise<Map<string, AdminOwnerListApp[]>> {
+  const byOwner = new Map<string, AdminOwnerListApp[]>();
+  if (ownerIds.length === 0) return byOwner;
+  const rows = await db
+    .select({
+      ownerId: developerApps.ownerId,
+      id: developerApps.id,
+      name: developerApps.name,
+    })
+    .from(developerApps)
+    .where(inArray(developerApps.ownerId, ownerIds));
+  for (const row of rows) {
+    const list = byOwner.get(row.ownerId) ?? [];
+    list.push({ id: row.id, name: row.name });
+    byOwner.set(row.ownerId, list);
+  }
+  for (const list of byOwner.values()) {
+    list.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  return byOwner;
+}
+
+async function loadCycleUsageByOwner(cycle: {
+  start: string;
+  end: string;
+}): Promise<Map<string, { usedUsdMicros: string; requestCount: number }>> {
+  const rows = await db
+    .select({
+      ownerId: developerApps.ownerId,
+      usedUsdMicros: sql<string>`coalesce(sum(case when ${transactions.networkFeeUsdMicros} ~ '^[0-9]+$' then ${transactions.networkFeeUsdMicros}::bigint else 0 end), 0)::text`,
+      requestCount: sql<number>`count(*)::int`,
+    })
+    .from(transactions)
+    .innerJoin(
+      developerApps,
+      sql`${developerApps.id} = coalesce(${transactions.clientId}, ${transactions.appId})`,
+    )
+    .where(
+      and(
+        eq(transactions.type, "usage"),
+        eq(transactions.status, "confirmed"),
+        gte(transactions.createdAt, cycle.start),
+        lte(transactions.createdAt, cycle.end),
+      ),
+    )
+    .groupBy(developerApps.ownerId);
+
+  const byOwner = new Map<string, { usedUsdMicros: string; requestCount: number }>();
+  for (const row of rows) {
+    const requestCount = Number(row.requestCount);
+    byOwner.set(row.ownerId, {
+      usedUsdMicros: row.usedUsdMicros,
+      requestCount: Number.isFinite(requestCount) ? requestCount : 0,
+    });
+  }
+  return byOwner;
+}
+
+async function loadPaidPlanByOwner(
+  ownerIds: string[],
+): Promise<Map<string, { planKey: string; includedUsdMicros: string | null }>> {
+  const byOwner = new Map<string, { planKey: string; includedUsdMicros: string | null }>();
+  if (ownerIds.length === 0) return byOwner;
+
+  const [ops, tiers] = await Promise.all([
+    db
+      .select({
+        ownerUserId: ownerPaidUpgradeOperations.ownerUserId,
+        planKey: ownerPaidUpgradeOperations.planKey,
+        updatedAt: ownerPaidUpgradeOperations.updatedAt,
+      })
+      .from(ownerPaidUpgradeOperations)
+      .where(
+        and(
+          inArray(ownerPaidUpgradeOperations.ownerUserId, ownerIds),
+          eq(ownerPaidUpgradeOperations.status, "completed"),
+        ),
+      ),
+    db
+      .select({
+        key: ownerSubscriptionTiers.key,
+        includedUsdMicros: ownerSubscriptionTiers.includedUsdMicros,
+      })
+      .from(ownerSubscriptionTiers),
+  ]);
+
+  const includedByKey = new Map(
+    tiers.map((tier) => [tier.key, tier.includedUsdMicros]),
+  );
+  const latest = new Map<
+    string,
+    { planKey: string; includedUsdMicros: string | null; updatedAt: string }
+  >();
+  for (const op of ops) {
+    const existing = latest.get(op.ownerUserId);
+    if (existing && op.updatedAt <= existing.updatedAt) continue;
+    latest.set(op.ownerUserId, {
+      planKey: op.planKey,
+      includedUsdMicros: includedByKey.get(op.planKey) ?? null,
+      updatedAt: op.updatedAt,
+    });
+  }
+  for (const [ownerId, value] of latest) {
+    byOwner.set(ownerId, {
+      planKey: value.planKey,
+      includedUsdMicros: value.includedUsdMicros,
+    });
+  }
+  return byOwner;
+}
+
+/**
+ * GET /api/v1/admin/billing/owners list payload: search by email/name/id/app,
+ * current-cycle usage, blocked/overage filters, most-used first.
+ */
+export async function listAdminBillingOwners(
+  query: AdminOwnerListQuery,
+): Promise<AdminOwnerListResult> {
+  const cycleBounds = calendarMonthBoundsUtc(new Date());
+  const cycle = { start: cycleBounds.start, end: cycleBounds.end };
+  const platformDefault = await resolvePlatformOwnerStarterIncludedUsdMicros();
+  const defaults = {
+    starterIncludedUsdMicros: platformDefault,
+    endUserCap: platformDefaultEndUserCap(),
+  };
+
+  const rows = await loadMatchingOwners(query.q);
+  const ownerIds = rows.map((row) => row.id);
+  if (ownerIds.length === 0) {
+    return {
+      owners: [],
+      page: query.page,
+      pageSize: query.pageSize,
+      totalCount: 0,
+      cycle,
+      statusCounts: { all: 0, ok: 0, blocked: 0, overage: 0, attention: 0 },
+      platformDefault: {
+        starterIncludedUsdMicros: platformDefault,
+        endUserCap: defaults.endUserCap,
+      },
+    };
+  }
+  const [appsByOwner, usageByOwner, paidByOwner] = await Promise.all([
+    loadOwnedAppsByOwner(ownerIds),
+    loadCycleUsageByOwner(cycle),
+    loadPaidPlanByOwner(ownerIds),
+  ]);
+
+  const items: AdminOwnerListItem[] = rows.map((row) => {
+    const hasRow =
+      row.starterIncludedUsdMicros != null ||
+      row.endUserCap != null ||
+      row.note != null;
+    const overrides = hasRow
+      ? {
+          starterIncludedUsdMicros: row.starterIncludedUsdMicros,
+          endUserCap: row.endUserCap,
+          note: row.note,
+        }
+      : null;
+    const resolved = mergeOwnerBilling(overrides, defaults);
+    const paid = paidByOwner.get(row.id);
+    const planKind: OwnerListPlanKind = paid ? "paid" : "starter";
+    const includedUsdMicros =
+      paid?.includedUsdMicros && /^\d+$/.test(paid.includedUsdMicros)
+        ? paid.includedUsdMicros
+        : resolved.starterIncludedUsdMicros;
+    const usage = usageByOwner.get(row.id);
+    const usedUsdMicros = usage?.usedUsdMicros ?? "0";
+    const classified = classifyOwnerListUsage({
+      usedUsdMicros: microsOrZero(usedUsdMicros),
+      includedUsdMicros: microsOrZero(includedUsdMicros),
+      planKind,
+    });
+    return {
+      id: row.id,
+      email: row.email,
+      name: row.name,
+      role: row.role,
+      resolved,
+      overrides,
+      ownedApps: appsByOwner.get(row.id) ?? [],
+      cycleUsage: {
+        usedUsdMicros,
+        includedUsdMicros,
+        remainingUsdMicros: classified.remainingUsdMicros.toString(),
+        overageUsdMicros: classified.overageUsdMicros.toString(),
+        requestCount: usage?.requestCount ?? 0,
+      },
+      usageStatus: classified.status,
+      planKind,
+    };
+  });
+
+  const statusCounts = {
+    all: items.length,
+    ok: 0,
+    blocked: 0,
+    overage: 0,
+    attention: 0,
+  };
+  for (const item of items) {
+    statusCounts[item.usageStatus] += 1;
+    if (item.usageStatus === "blocked" || item.usageStatus === "overage") {
+      statusCounts.attention += 1;
+    }
+  }
+
+  const filtered = items.filter((item) =>
+    ownerMatchesStatusFilter(item.usageStatus, query.status),
+  );
+  filtered.sort(compareOwnersByUsageDesc);
+
+  const totalCount = filtered.length;
+  const offset = (query.page - 1) * query.pageSize;
+  const owners = filtered.slice(offset, offset + query.pageSize);
+
+  return {
+    owners,
+    page: query.page,
+    pageSize: query.pageSize,
+    totalCount,
+    cycle,
+    statusCounts,
+    platformDefault: {
+      starterIncludedUsdMicros: platformDefault,
+      endUserCap: defaults.endUserCap,
+    },
+  };
+}


### PR DESCRIPTION
Add a new API endpoint `/api/v1/admin/billing/owners` to retrieve a list of developer accounts, allowing filtering by query parameters such as `q`, `status`, `page`, and `pageSize`. The results are ordered by cycle usage, and each entry includes details on owned apps, cycle usage, and usage status. Update documentation to reflect these changes and introduce tests for the new functionality.