### PR TITLE
feat: migrate app settings to nested left side nav panel

### DIFF
--- a/src/app/apps/[id]/auth/page.tsx
+++ b/src/app/apps/[id]/auth/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
 /** Auth settings live under App profile. */
-export default function AppAuthPage() {
-  return <AppSettingsPageClient tab="profile" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/credentials/page.tsx
+++ b/src/app/apps/[id]/credentials/page.tsx
@@ -1,7 +1,3 @@
-"use client";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
-
-export default function AppCredentialsPage() {
-  return <AppSettingsPageClient tab="credentials" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/discovery-profiles/page.tsx
+++ b/src/app/apps/[id]/discovery-profiles/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
 /** Discovery profiles live under Billing Plans. */
-export default function AppDiscoveryProfilesPage() {
-  return <AppSettingsPageClient tab="plans" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/identities/[externalUserId]/page.tsx
+++ b/src/app/apps/[id]/identities/[externalUserId]/page.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import AppSectionBreadcrumb from "@/components/apps/AppSectionBreadcrumb";
-import DashboardLayout from "@/components/DashboardLayout";
 import IdentityLifecycleActions from "@/components/identities/IdentityLifecycleActions";
 import IdentityRequestLog from "@/components/identities/IdentityRequestLog";
 import UsageBreakdownChart from "@/components/UsageBreakdownChart";
@@ -146,7 +145,7 @@ export default async function AppIdentityDetailPage({
   }
 
   return (
-    <DashboardLayout>
+    <>
       <AppSectionBreadcrumb
         appId={id}
         appName={app.name}
@@ -235,6 +234,6 @@ export default async function AppIdentityDetailPage({
       </section>
 
       <IdentityRequestLog appId={id} externalUserId={externalUserId} />
-    </DashboardLayout>
+    </>
   );
 }

--- a/src/app/apps/[id]/identities/page.tsx
+++ b/src/app/apps/[id]/identities/page.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import AppSectionBreadcrumb from "@/components/apps/AppSectionBreadcrumb";
-import DashboardLayout from "@/components/DashboardLayout";
 import IdentitiesTable from "@/components/identities/IdentitiesTable";
 import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
@@ -50,7 +49,7 @@ export default async function AppIdentitiesPage({
     : [];
 
   return (
-    <DashboardLayout>
+    <>
       <AppSectionBreadcrumb appId={id} appName={app.name} section="Identities" />
 
       <div className="mb-6 flex flex-col gap-3 sm:mb-8 sm:flex-row sm:items-start sm:justify-between">
@@ -77,6 +76,6 @@ export default async function AppIdentitiesPage({
           Usage metering is not configured, so per-identity usage is unavailable.
         </div>
       )}
-    </DashboardLayout>
+    </>
   );
 }

--- a/src/app/apps/[id]/layout.tsx
+++ b/src/app/apps/[id]/layout.tsx
@@ -1,0 +1,10 @@
+import AppSettingsRouteShell from "@/components/apps/AppSettingsRouteShell";
+
+/** Keep the settings client mounted while switching left-nav tabs. */
+export default function AppDetailLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <AppSettingsRouteShell>{children}</AppSettingsRouteShell>;
+}

--- a/src/app/apps/[id]/page.tsx
+++ b/src/app/apps/[id]/page.tsx
@@ -1,7 +1,3 @@
-"use client";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
-
-export default function AppDetailPage() {
-  return <AppSettingsPageClient tab="profile" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/payments/page.tsx
+++ b/src/app/apps/[id]/payments/page.tsx
@@ -1,7 +1,3 @@
-"use client";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
-
-export default function AppPaymentsPage() {
-  return <AppSettingsPageClient tab="payments" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/plans/page.tsx
+++ b/src/app/apps/[id]/plans/page.tsx
@@ -1,7 +1,3 @@
-"use client";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
-
-export default function AppPlansPage() {
-  return <AppSettingsPageClient tab="plans" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/profile/page.tsx
+++ b/src/app/apps/[id]/profile/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
 /** Alias of App profile (`/apps/[id]`). */
-export default function AppProfilePage() {
-  return <AppSettingsPageClient tab="profile" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/settings/page.tsx
+++ b/src/app/apps/[id]/settings/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
 /** Alias of App profile (`/apps/[id]`). */
-export default function AppSettingsPage() {
-  return <AppSettingsPageClient tab="profile" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/usage/page.tsx
+++ b/src/app/apps/[id]/usage/page.tsx
@@ -8,5 +8,5 @@ export default async function AppUsagePage({
   params: Promise<{ id: string }>;
 }>) {
   const { id } = await params;
-  return <BillingUsageDashboard filterAppId={id} />;
+  return <BillingUsageDashboard filterAppId={id} wrapLayout={false} />;
 }

--- a/src/app/apps/layout.tsx
+++ b/src/app/apps/layout.tsx
@@ -1,0 +1,10 @@
+import DashboardLayout from "@/components/DashboardLayout";
+
+/** Persist the dashboard chrome across My Apps, create, and app detail tabs. */
+export default function AppsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <DashboardLayout>{children}</DashboardLayout>;
+}

--- a/src/app/apps/new/page.tsx
+++ b/src/app/apps/new/page.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import DashboardLayout from "@/components/DashboardLayout";
 import AppWizard from "@/components/apps/AppWizard";
 
 export default function NewAppPage() {
-  return (
-    <DashboardLayout>
-      <AppWizard />
-    </DashboardLayout>
-  );
+  return <AppWizard />;
 }

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -6,7 +6,6 @@ import { redirect } from "next/navigation";
 import { db } from "@/db/index";
 import { signerConfig } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import DashboardLayout from "@/components/DashboardLayout";
 import AppsListSection from "@/components/apps/AppsListSection";
 import AdminAppsHome from "@/components/apps/AdminAppsHome";
 import MyAppsShortcutTiles from "@/components/apps/MyAppsShortcutTiles";
@@ -39,11 +38,7 @@ export default async function AppsPage({
   const params = await searchParams;
 
   if (role === "admin" || role === "operator") {
-    return (
-      <DashboardLayout>
-        <AdminMyApps userId={userId} />
-      </DashboardLayout>
-    );
+    return <AdminMyApps userId={userId} />;
   }
 
   if (userId && (await developerNeedsOnboarding(userId))) {
@@ -51,12 +46,10 @@ export default async function AppsPage({
   }
 
   return (
-    <DashboardLayout>
-      <DeveloperMyApps
-        userId={userId}
-        showSetupBanner={params.setup === "1"}
-      />
-    </DashboardLayout>
+    <DeveloperMyApps
+      userId={userId}
+      showSetupBanner={params.setup === "1"}
+    />
   );
 }
 

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -701,10 +701,13 @@ function BillingUsageBody({
 export default function BillingUsageDashboard({
   filterAppId,
   fundPanel,
+  appName,
 }: Readonly<{
   filterAppId?: string | null;
   /** Optional MoonPay / prepaid top-up panel (app owners on pay-per-use). */
   fundPanel?: ReactNode;
+  /** When filtering by app, the app name to show in the sidebar sub-nav. */
+  appName?: string | null;
 }>) {
   const { data: session, status: authStatus } = useSession();
   const pathname = usePathname();
@@ -781,7 +784,7 @@ export default function BillingUsageDashboard({
   }, [filterAppId, activeTab, retryToken, showTabs]);
 
   return (
-    <DashboardLayout>
+    <DashboardLayout appName={filterAppId ? (appName ?? null) : undefined}>
       {fundPanel}
       {state.status === "loading" ? (
         <>

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -701,10 +701,13 @@ function BillingUsageBody({
 export default function BillingUsageDashboard({
   filterAppId,
   fundPanel,
+  wrapLayout = true,
 }: Readonly<{
   filterAppId?: string | null;
   /** Optional MoonPay / prepaid top-up panel (app owners on pay-per-use). */
   fundPanel?: ReactNode;
+  /** When false, the parent route already provides DashboardLayout. */
+  wrapLayout?: boolean;
 }>) {
   const { data: session, status: authStatus } = useSession();
   const pathname = usePathname();
@@ -780,8 +783,8 @@ export default function BillingUsageDashboard({
     };
   }, [filterAppId, activeTab, retryToken, showTabs]);
 
-  return (
-    <DashboardLayout>
+  const body = (
+    <>
       {fundPanel}
       {state.status === "loading" ? (
         <>
@@ -829,6 +832,12 @@ export default function BillingUsageDashboard({
           activeTab={activeTab}
         />
       ) : null}
-    </DashboardLayout>
+    </>
   );
+
+  if (!wrapLayout) {
+    return body;
+  }
+
+  return <DashboardLayout>{body}</DashboardLayout>;
 }

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -701,13 +701,10 @@ function BillingUsageBody({
 export default function BillingUsageDashboard({
   filterAppId,
   fundPanel,
-  appName,
 }: Readonly<{
   filterAppId?: string | null;
   /** Optional MoonPay / prepaid top-up panel (app owners on pay-per-use). */
   fundPanel?: ReactNode;
-  /** When filtering by app, the app name to show in the sidebar sub-nav. */
-  appName?: string | null;
 }>) {
   const { data: session, status: authStatus } = useSession();
   const pathname = usePathname();
@@ -784,7 +781,7 @@ export default function BillingUsageDashboard({
   }, [filterAppId, activeTab, retryToken, showTabs]);
 
   return (
-    <DashboardLayout appName={filterAppId ? (appName ?? null) : undefined}>
+    <DashboardLayout>
       {fundPanel}
       {state.status === "loading" ? (
         <>

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -111,11 +111,8 @@ const SKELETON_CARD_KEYS = ["card-a", "card-b", "card-c"] as const;
 
 export default function DashboardLayout({
   children,
-  appName,
 }: Readonly<{
   children: React.ReactNode;
-  /** When provided, shows an expanded nested sub-nav under "My Apps" for the active app. */
-  appName?: string | null;
 }>) {
   const pathname = usePathname();
   const router = useRouter();
@@ -329,58 +326,26 @@ export default function DashboardLayout({
                   : (pathSuffix.split("/")[1] ?? "profile");
 
               return (
-                <div className="mt-0.5">
-                  {/* App name / back-to-list header */}
-                  <div className="flex items-center gap-1.5 px-3 pt-1 pb-1">
-                    <Link
-                      href="/apps"
-                      onClick={() => setMobileNavOpen(false)}
-                      className="flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
-                    >
-                      <svg
-                        className="w-3 h-3 shrink-0"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
+                <div className="mt-0.5 ml-3 border-l border-zinc-800 pl-2 space-y-0.5">
+                  {APP_SUB_NAV_ITEMS.map((sub) => {
+                    const href = `/apps/${activeAppId}${sub.href}`;
+                    const isActive = activeSubId === sub.id;
+                    return (
+                      <Link
+                        key={sub.id}
+                        href={href}
+                        onClick={() => setMobileNavOpen(false)}
+                        aria-current={isActive ? "page" : undefined}
+                        className={`flex items-center gap-2 px-2.5 py-1.5 rounded-md text-sm transition-all duration-150 ${
+                          isActive
+                            ? "bg-emerald-500/10 text-emerald-400 font-medium shadow-[inset_0_0_0_1px_rgba(52,211,153,0.12)]"
+                            : "text-zinc-500 hover:text-zinc-200 hover:bg-white/[0.04] font-normal"
+                        }`}
                       >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M15 19l-7-7 7-7"
-                        />
-                      </svg>
-                      My Apps
-                    </Link>
-                  </div>
-                  {appName && (
-                    <p className="px-3 pb-1.5 text-xs font-semibold text-zinc-300 truncate">
-                      {appName}
-                    </p>
-                  )}
-                  {/* Sub-nav items */}
-                  <div className="ml-3 border-l border-zinc-800 pl-2 space-y-0.5">
-                    {APP_SUB_NAV_ITEMS.map((sub) => {
-                      const href = `/apps/${activeAppId}${sub.href}`;
-                      const isActive = activeSubId === sub.id;
-                      return (
-                        <Link
-                          key={sub.id}
-                          href={href}
-                          onClick={() => setMobileNavOpen(false)}
-                          aria-current={isActive ? "page" : undefined}
-                          className={`flex items-center gap-2 px-2.5 py-1.5 rounded-md text-sm transition-all duration-150 ${
-                            isActive
-                              ? "bg-emerald-500/10 text-emerald-400 font-medium shadow-[inset_0_0_0_1px_rgba(52,211,153,0.12)]"
-                              : "text-zinc-500 hover:text-zinc-200 hover:bg-white/[0.04] font-normal"
-                          }`}
-                        >
-                          {sub.label}
-                        </Link>
-                      );
-                    })}
-                  </div>
+                        {sub.label}
+                      </Link>
+                    );
+                  })}
                 </div>
               );
             };
@@ -394,27 +359,9 @@ export default function DashboardLayout({
                     : pathname.startsWith(item.href);
 
                   if (isAppsItem && activeAppId) {
-                    // Render "My Apps" as an expanded section header instead of a link
                     return (
                       <div key={item.href}>
-                        <div
-                          className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium bg-emerald-500/10 text-emerald-400 shadow-[inset_0_0_0_1px_rgba(52,211,153,0.12)]`}
-                        >
-                          <svg
-                            className="w-5 h-5 shrink-0"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={1.5}
-                              d={item.icon}
-                            />
-                          </svg>
-                          {item.label}
-                        </div>
+                        {renderNavLink(item, true)}
                         {renderAppSubNav()}
                       </div>
                     );

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -15,6 +15,20 @@ interface NavItem {
   external?: boolean; // if set, opens in a new tab
 }
 
+interface AppSubNavItem {
+  id: string;
+  label: string;
+  href: string;
+}
+
+const APP_SUB_NAV_ITEMS: AppSubNavItem[] = [
+  { id: "profile", label: "App Profile", href: "" },
+  { id: "credentials", label: "Credentials & URLs", href: "/credentials" },
+  { id: "plans", label: "Billing Plans", href: "/plans" },
+  { id: "payments", label: "Payments", href: "/payments" },
+  { id: "usage", label: "Usage", href: "/usage" },
+];
+
 const API_REFERENCE_URL = "/api/v1/docs";
 const DOCS_URL = "https://docs.pymthouse.com";
 
@@ -97,8 +111,11 @@ const SKELETON_CARD_KEYS = ["card-a", "card-b", "card-c"] as const;
 
 export default function DashboardLayout({
   children,
+  appName,
 }: Readonly<{
   children: React.ReactNode;
+  /** When provided, shows an expanded nested sub-nav under "My Apps" for the active app. */
+  appName?: string | null;
 }>) {
   const pathname = usePathname();
   const router = useRouter();
@@ -236,6 +253,10 @@ export default function DashboardLayout({
             const resourceItems = navItems.filter((i) => i.group === "Resources");
             const otherItems = navItems.filter((i) => !i.group);
 
+            // Detect if we're inside an app detail page: /apps/<appId>/...
+            const appDetailMatch = pathname.match(/^\/apps\/(app_[^/]+)/);
+            const activeAppId = appDetailMatch?.[1] ?? null;
+
             const renderNavLink = (item: NavItem, isActive: boolean) => {
               const linkClass = `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-150 ${
                 isActive
@@ -298,10 +319,107 @@ export default function DashboardLayout({
               );
             };
 
+            const renderAppSubNav = () => {
+              if (!activeAppId) return null;
+              // Determine the active sub-nav item from the current pathname
+              const pathSuffix = pathname.slice(`/apps/${activeAppId}`.length);
+              const activeSubId =
+                pathSuffix === "" || pathSuffix === "/"
+                  ? "profile"
+                  : (pathSuffix.split("/")[1] ?? "profile");
+
+              return (
+                <div className="mt-0.5">
+                  {/* App name / back-to-list header */}
+                  <div className="flex items-center gap-1.5 px-3 pt-1 pb-1">
+                    <Link
+                      href="/apps"
+                      onClick={() => setMobileNavOpen(false)}
+                      className="flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+                    >
+                      <svg
+                        className="w-3 h-3 shrink-0"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 19l-7-7 7-7"
+                        />
+                      </svg>
+                      My Apps
+                    </Link>
+                  </div>
+                  {appName && (
+                    <p className="px-3 pb-1.5 text-xs font-semibold text-zinc-300 truncate">
+                      {appName}
+                    </p>
+                  )}
+                  {/* Sub-nav items */}
+                  <div className="ml-3 border-l border-zinc-800 pl-2 space-y-0.5">
+                    {APP_SUB_NAV_ITEMS.map((sub) => {
+                      const href = `/apps/${activeAppId}${sub.href}`;
+                      const isActive = activeSubId === sub.id;
+                      return (
+                        <Link
+                          key={sub.id}
+                          href={href}
+                          onClick={() => setMobileNavOpen(false)}
+                          aria-current={isActive ? "page" : undefined}
+                          className={`flex items-center gap-2 px-2.5 py-1.5 rounded-md text-sm transition-all duration-150 ${
+                            isActive
+                              ? "bg-emerald-500/10 text-emerald-400 font-medium shadow-[inset_0_0_0_1px_rgba(52,211,153,0.12)]"
+                              : "text-zinc-500 hover:text-zinc-200 hover:bg-white/[0.04] font-normal"
+                          }`}
+                        >
+                          {sub.label}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            };
+
             return (
               <>
                 {otherItems.map((item) => {
-                  const isActive = pathname.startsWith(item.href);
+                  const isAppsItem = item.href === "/apps";
+                  const isActive = activeAppId
+                    ? isAppsItem
+                    : pathname.startsWith(item.href);
+
+                  if (isAppsItem && activeAppId) {
+                    // Render "My Apps" as an expanded section header instead of a link
+                    return (
+                      <div key={item.href}>
+                        <div
+                          className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium bg-emerald-500/10 text-emerald-400 shadow-[inset_0_0_0_1px_rgba(52,211,153,0.12)]`}
+                        >
+                          <svg
+                            className="w-5 h-5 shrink-0"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.5}
+                              d={item.icon}
+                            />
+                          </svg>
+                          {item.label}
+                        </div>
+                        {renderAppSubNav()}
+                      </div>
+                    );
+                  }
+
                   return renderNavLink(item, isActive);
                 })}
                 {adminItems.length > 0 && (

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -152,6 +152,16 @@ export default function DashboardLayout({
     }
   }, [status, router]);
 
+  const appDetailMatch = pathname.match(/^\/apps\/(app_[^/]+)/);
+  const activeAppId = appDetailMatch?.[1] ?? null;
+
+  useEffect(() => {
+    if (!activeAppId) return;
+    for (const sub of APP_SUB_NAV_ITEMS) {
+      router.prefetch(`/apps/${activeAppId}${sub.href}`);
+    }
+  }, [activeAppId, router]);
+
   if (status === "loading") {
     return (
       <div className="flex h-screen w-full bg-zinc-950">
@@ -249,10 +259,6 @@ export default function DashboardLayout({
             const adminItems = navItems.filter((i) => i.group === "Admin");
             const resourceItems = navItems.filter((i) => i.group === "Resources");
             const otherItems = navItems.filter((i) => !i.group);
-
-            // Detect if we're inside an app detail page: /apps/<appId>/...
-            const appDetailMatch = pathname.match(/^\/apps\/(app_[^/]+)/);
-            const activeAppId = appDetailMatch?.[1] ?? null;
 
             const renderNavLink = (item: NavItem, isActive: boolean) => {
               const linkClass = `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-150 ${

--- a/src/components/apps/AppSettingsPageClient.tsx
+++ b/src/components/apps/AppSettingsPageClient.tsx
@@ -96,9 +96,11 @@ export default function AppSettingsPageClient({
       .finally(() => setLoading(false));
   }, [id]);
 
+  const resolvedAppName = appData?.formData.name || null;
+
   if (loading) {
     return (
-      <DashboardLayout>
+      <DashboardLayout appName={null}>
         <div className="text-zinc-500 text-center py-12 animate-pulse">
           Loading app…
         </div>
@@ -108,7 +110,7 @@ export default function AppSettingsPageClient({
 
   if (!appData) {
     return (
-      <DashboardLayout>
+      <DashboardLayout appName={null}>
         <div className="text-center py-12">
           <h2 className="text-lg font-medium text-zinc-300">App not found</h2>
         </div>
@@ -117,7 +119,7 @@ export default function AppSettingsPageClient({
   }
 
   return (
-    <DashboardLayout>
+    <DashboardLayout appName={resolvedAppName}>
       <div className="mb-8">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="text-2xl font-bold text-zinc-100">
@@ -125,9 +127,6 @@ export default function AppSettingsPageClient({
           </h1>
           <AppStatusBadge status={appData.state.status} />
         </div>
-        <p className="text-sm text-zinc-500 mt-1">
-          Edit integration settings, credentials, network discovery, and pricing.
-        </p>
       </div>
 
       <AppSettingsScreen

--- a/src/components/apps/AppSettingsPageClient.tsx
+++ b/src/components/apps/AppSettingsPageClient.tsx
@@ -2,122 +2,81 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import DashboardLayout from "@/components/DashboardLayout";
 import AppSettingsScreen from "@/components/apps/AppSettingsScreen";
 import AppStatusBadge from "@/components/apps/AppStatusBadge";
-import type { AppFormData, AppState } from "@/components/apps/AppWizard";
+import {
+  cacheLoadedApp,
+  loadedAppFromApiPayload,
+  peekLoadedApp,
+  type LoadedApp,
+} from "@/components/apps/app-settings-data";
 import type { AppSettingsTab } from "@/lib/apps/settings-paths";
-import { DEFAULT_PUBLIC_GRANT_TYPES } from "@/lib/oidc/grants";
-import { DEFAULT_OIDC_SCOPES, ensureOpenIdScope } from "@/lib/oidc/scopes";
-
-type LoadedApp = {
-  formData: Partial<AppFormData>;
-  state: AppState;
-  domains: { id: string; domain: string }[];
-  postLogoutRedirectUris: string[];
-  initiateLoginUri: string | null;
-  deviceThirdPartyInitiateLogin: boolean;
-  canEdit: boolean;
-  canDeleteApp: boolean;
-  canManageBilling: boolean;
-  ownerExternalUserId: string | null;
-};
 
 /** Shared app settings shell. Tab comes from the path (`/apps/{id}/payments`). */
 export default function AppSettingsPageClient({
   tab,
 }: Readonly<{ tab: AppSettingsTab }>) {
   const { id } = useParams<{ id: string }>();
+  const cached = peekLoadedApp(id);
 
-  const [loading, setLoading] = useState(true);
-  const [appData, setAppData] = useState<LoadedApp | null>(null);
+  const [loading, setLoading] = useState(!cached);
+  const [appData, setAppData] = useState<LoadedApp | null>(cached);
 
   useEffect(() => {
+    let cancelled = false;
+    const existing = peekLoadedApp(id);
+    if (existing) {
+      setAppData(existing);
+      setLoading(false);
+    } else {
+      setLoading(true);
+    }
+
     fetch(`/api/v1/apps/${id}`)
       .then((r) => {
         if (!r.ok) return null;
         return r.json();
       })
       .then((data) => {
+        if (cancelled) return;
         if (!data) {
-          setAppData(null);
+          if (!peekLoadedApp(id)) setAppData(null);
           return;
         }
-        setAppData({
-          formData: {
-            name: data.name || "",
-            description: data.description || "",
-            developerName: data.developerName || "",
-            websiteUrl: data.websiteUrl || "",
-            redirectUris: [],
-            allowedScopes: ensureOpenIdScope(
-              data.oidcClient?.allowedScopes || DEFAULT_OIDC_SCOPES,
-            ),
-            grantTypes:
-              data.oidcClient?.grantTypes?.split(",").filter(Boolean) ??
-              [...DEFAULT_PUBLIC_GRANT_TYPES],
-            tokenEndpointAuthMethod:
-              data.oidcClient?.tokenEndpointAuthMethod || "none",
-            backendDeviceHelper: Boolean(data.m2mOidcClient),
-            confidentialWebHelper: Boolean(data.webOidcClient),
-            confidentialWebRedirectUris: data.webOidcClient?.redirectUris || [],
-          },
-          state: {
-            id: data.id,
-            clientId: data.oidcClient?.clientId || null,
-            status: data.status,
-            hasSecret: data.oidcClient?.hasSecret || false,
-            backendHelper: data.m2mOidcClient ?? null,
-            webHelper: data.webOidcClient ?? null,
-          },
-          domains: (data.domains || []).map(
-            (d: { id: string; domain: string }) => ({
-              id: d.id,
-              domain: d.domain,
-            }),
-          ),
-          postLogoutRedirectUris:
-            data.webOidcClient?.postLogoutRedirectUris ||
-            data.oidcClient?.postLogoutRedirectUris ||
-            [],
-          initiateLoginUri: data.oidcClient?.initiateLoginUri ?? null,
-          deviceThirdPartyInitiateLogin:
-            data.oidcClient?.deviceThirdPartyInitiateLogin === true,
-          canEdit: data.canEdit === true,
-          canDeleteApp: data.canDeleteApp === true,
-          canManageBilling: data.canManageBilling === true,
-          ownerExternalUserId:
-            typeof data.ownerId === "string" && data.ownerId.trim()
-              ? data.ownerId.trim()
-              : null,
-        });
+        const loaded = loadedAppFromApiPayload(data);
+        cacheLoadedApp(id, loaded);
+        setAppData(loaded);
       })
-      .catch(() => setAppData(null))
-      .finally(() => setLoading(false));
+      .catch(() => {
+        if (!cancelled) setAppData(peekLoadedApp(id));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
-  if (loading) {
+  if (loading && !appData) {
     return (
-      <DashboardLayout>
-        <div className="text-zinc-500 text-center py-12 animate-pulse">
-          Loading app…
-        </div>
-      </DashboardLayout>
+      <div className="text-zinc-500 text-center py-12 animate-pulse">
+        Loading app…
+      </div>
     );
   }
 
   if (!appData) {
     return (
-      <DashboardLayout>
-        <div className="text-center py-12">
-          <h2 className="text-lg font-medium text-zinc-300">App not found</h2>
-        </div>
-      </DashboardLayout>
+      <div className="text-center py-12">
+        <h2 className="text-lg font-medium text-zinc-300">App not found</h2>
+      </div>
     );
   }
 
   return (
-    <DashboardLayout>
+    <>
       <div className="mb-8">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="text-2xl font-bold text-zinc-100">
@@ -128,6 +87,7 @@ export default function AppSettingsPageClient({
       </div>
 
       <AppSettingsScreen
+        key={id}
         appId={id}
         initialData={appData.formData}
         initialState={appData.state}
@@ -143,6 +103,6 @@ export default function AppSettingsPageClient({
         ownerExternalUserId={appData.ownerExternalUserId}
         initialTab={tab}
       />
-    </DashboardLayout>
+    </>
   );
 }

--- a/src/components/apps/AppSettingsPageClient.tsx
+++ b/src/components/apps/AppSettingsPageClient.tsx
@@ -96,11 +96,9 @@ export default function AppSettingsPageClient({
       .finally(() => setLoading(false));
   }, [id]);
 
-  const resolvedAppName = appData?.formData.name || null;
-
   if (loading) {
     return (
-      <DashboardLayout appName={null}>
+      <DashboardLayout>
         <div className="text-zinc-500 text-center py-12 animate-pulse">
           Loading app…
         </div>
@@ -110,7 +108,7 @@ export default function AppSettingsPageClient({
 
   if (!appData) {
     return (
-      <DashboardLayout appName={null}>
+      <DashboardLayout>
         <div className="text-center py-12">
           <h2 className="text-lg font-medium text-zinc-300">App not found</h2>
         </div>
@@ -119,7 +117,7 @@ export default function AppSettingsPageClient({
   }
 
   return (
-    <DashboardLayout appName={resolvedAppName}>
+    <DashboardLayout>
       <div className="mb-8">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="text-2xl font-bold text-zinc-100">

--- a/src/components/apps/AppSettingsRouteShell.tsx
+++ b/src/components/apps/AppSettingsRouteShell.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import { appSettingsTabFromPathname } from "@/lib/apps/settings-paths";
+
+/**
+ * Keeps the settings client mounted across `/apps/{id}/{tab}` navigations
+ * so the navbar (from the parent layout) does not wait on a remounted fetch.
+ */
+export default function AppSettingsRouteShell({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  const pathname = usePathname();
+  const tab = appSettingsTabFromPathname(pathname);
+
+  if (!tab) {
+    return children;
+  }
+
+  return <AppSettingsPageClient tab={tab} />;
+}

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -157,6 +157,36 @@ export default function AppSettingsScreen({
     [],
   );
 
+  const markPrimarySecretGenerated = useCallback(() => {
+    setAppState((s) => ({ ...s, hasSecret: true }));
+    updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
+  }, [updateFormData]);
+
+  const markBackendSecretGenerated = useCallback(() => {
+    setAppState((s) => ({
+      ...s,
+      backendHelper: s.backendHelper
+        ? { ...s.backendHelper, hasSecret: true }
+        : s.backendHelper,
+    }));
+  }, []);
+
+  const markWebSecretGenerated = useCallback(() => {
+    setAppState((s) => ({
+      ...s,
+      webHelper: s.webHelper
+        ? { ...s.webHelper, hasSecret: true }
+        : s.webHelper,
+    }));
+  }, []);
+
+  const handlePostLogoutRedirectUrisChange = useCallback(
+    (uris: string[]) => {
+      updatePostLogoutRedirectUris(uris);
+    },
+    [updatePostLogoutRedirectUris],
+  );
+
   const syncCredentialsFromServer = useCallback(async () => {
     const res = await fetch(`/api/v1/apps/${appId}`);
     if (!res.ok) {
@@ -323,6 +353,22 @@ export default function AppSettingsScreen({
   const showWebCredentialsTab =
     Boolean(formData.confidentialWebHelper) || Boolean(appState.webHelper);
 
+  const credentialsTestingStep = {
+    appId,
+    appState,
+    formData,
+    domains,
+    onChange: updateFormData,
+    onDomainsChange: setDomains,
+    onSecretGenerated: markPrimarySecretGenerated,
+    onBackendSecretGenerated: markBackendSecretGenerated,
+    onWebSecretGenerated: markWebSecretGenerated,
+    ownerExternalUserId,
+    readOnly: !canEdit,
+    postLogoutRedirectUris,
+    onPostLogoutRedirectUrisChange: handlePostLogoutRedirectUrisChange,
+    showPostLogoutRedirectUris,
+  };
 
   return (
     <div className="max-w-3xl">
@@ -440,59 +486,14 @@ export default function AppSettingsScreen({
             label="Public / SDK"
             prefix="app_"
             description="For SDKs, CLIs, and device login. No secret — public only."
-            accentClass="border-emerald-500/25 bg-emerald-500/5"
             labelClass="text-emerald-200/90"
             prefixClass="text-emerald-400/70"
             expanded={expandedCredentials.has("public")}
             onToggle={() => toggleCredential("public")}
           >
-            <TestingStep
-              appId={appId}
-              clientId={appState.clientId}
-              grantTypes={formData.grantTypes}
-              tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
-              redirectUris={formData.redirectUris}
-              allowedScopes={formData.allowedScopes}
-              hasSecret={appState.hasSecret}
-              backendHelper={appState.backendHelper}
-              backendDeviceHelper={formData.backendDeviceHelper}
-              webHelper={appState.webHelper}
-              confidentialWebHelper={formData.confidentialWebHelper}
-              confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
-              initiateLoginUri={formData.initiateLoginUri}
-              deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
-              domains={domains}
-              onChange={updateFormData}
-              onDomainsChange={setDomains}
-              onSecretGenerated={() => {
-                setAppState((s) => ({ ...s, hasSecret: true }));
-                updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
-              }}
-              onBackendSecretGenerated={() => {
-                setAppState((s) => ({
-                  ...s,
-                  backendHelper: s.backendHelper
-                    ? { ...s.backendHelper, hasSecret: true }
-                    : s.backendHelper,
-                }));
-              }}
-              onWebSecretGenerated={() => {
-                setAppState((s) => ({
-                  ...s,
-                  webHelper: s.webHelper
-                    ? { ...s.webHelper, hasSecret: true }
-                    : s.webHelper,
-                }));
-              }}
-              ownerExternalUserId={ownerExternalUserId}
-              readOnly={!canEdit}
+            <CredentialsTestingStep
               activeClient="public"
-              hideHeader
-              postLogoutRedirectUris={postLogoutRedirectUris}
-              onPostLogoutRedirectUrisChange={(uris) =>
-                updatePostLogoutRedirectUris(uris)
-              }
-              showPostLogoutRedirectUris={showPostLogoutRedirectUris}
+              {...credentialsTestingStep}
             />
           </CredentialAccordionSection>
 
@@ -503,59 +504,14 @@ export default function AppSettingsScreen({
               label="M2M / Builder"
               prefix="m2m_"
               description="Server credentials for Builder APIs and device approval."
-              accentClass="border-cyan-500/25 bg-cyan-500/5"
               labelClass="text-cyan-200/90"
               prefixClass="text-cyan-400/70"
               expanded={expandedCredentials.has("m2m")}
               onToggle={() => toggleCredential("m2m")}
             >
-              <TestingStep
-                appId={appId}
-                clientId={appState.clientId}
-                grantTypes={formData.grantTypes}
-                tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
-                redirectUris={formData.redirectUris}
-                allowedScopes={formData.allowedScopes}
-                hasSecret={appState.hasSecret}
-                backendHelper={appState.backendHelper}
-                backendDeviceHelper={formData.backendDeviceHelper}
-                webHelper={appState.webHelper}
-                confidentialWebHelper={formData.confidentialWebHelper}
-                confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
-                initiateLoginUri={formData.initiateLoginUri}
-                deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
-                domains={domains}
-                onChange={updateFormData}
-                onDomainsChange={setDomains}
-                onSecretGenerated={() => {
-                  setAppState((s) => ({ ...s, hasSecret: true }));
-                  updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
-                }}
-                onBackendSecretGenerated={() => {
-                  setAppState((s) => ({
-                    ...s,
-                    backendHelper: s.backendHelper
-                      ? { ...s.backendHelper, hasSecret: true }
-                      : s.backendHelper,
-                  }));
-                }}
-                onWebSecretGenerated={() => {
-                  setAppState((s) => ({
-                    ...s,
-                    webHelper: s.webHelper
-                      ? { ...s.webHelper, hasSecret: true }
-                      : s.webHelper,
-                  }));
-                }}
-                ownerExternalUserId={ownerExternalUserId}
-                readOnly={!canEdit}
+              <CredentialsTestingStep
                 activeClient="m2m"
-                hideHeader
-                postLogoutRedirectUris={postLogoutRedirectUris}
-                onPostLogoutRedirectUrisChange={(uris) =>
-                  updatePostLogoutRedirectUris(uris)
-                }
-                showPostLogoutRedirectUris={showPostLogoutRedirectUris}
+                {...credentialsTestingStep}
               />
             </CredentialAccordionSection>
           )}
@@ -567,59 +523,14 @@ export default function AppSettingsScreen({
               label="Web SSO"
               prefix="web_"
               description="Confidential client for portal single sign-on."
-              accentClass="border-violet-500/25 bg-violet-500/5"
               labelClass="text-violet-200/90"
               prefixClass="text-violet-400/70"
               expanded={expandedCredentials.has("web")}
               onToggle={() => toggleCredential("web")}
             >
-              <TestingStep
-                appId={appId}
-                clientId={appState.clientId}
-                grantTypes={formData.grantTypes}
-                tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
-                redirectUris={formData.redirectUris}
-                allowedScopes={formData.allowedScopes}
-                hasSecret={appState.hasSecret}
-                backendHelper={appState.backendHelper}
-                backendDeviceHelper={formData.backendDeviceHelper}
-                webHelper={appState.webHelper}
-                confidentialWebHelper={formData.confidentialWebHelper}
-                confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
-                initiateLoginUri={formData.initiateLoginUri}
-                deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
-                domains={domains}
-                onChange={updateFormData}
-                onDomainsChange={setDomains}
-                onSecretGenerated={() => {
-                  setAppState((s) => ({ ...s, hasSecret: true }));
-                  updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
-                }}
-                onBackendSecretGenerated={() => {
-                  setAppState((s) => ({
-                    ...s,
-                    backendHelper: s.backendHelper
-                      ? { ...s.backendHelper, hasSecret: true }
-                      : s.backendHelper,
-                  }));
-                }}
-                onWebSecretGenerated={() => {
-                  setAppState((s) => ({
-                    ...s,
-                    webHelper: s.webHelper
-                      ? { ...s.webHelper, hasSecret: true }
-                      : s.webHelper,
-                  }));
-                }}
-                ownerExternalUserId={ownerExternalUserId}
-                readOnly={!canEdit}
+              <CredentialsTestingStep
                 activeClient="web"
-                hideHeader
-                postLogoutRedirectUris={postLogoutRedirectUris}
-                onPostLogoutRedirectUrisChange={(uris) =>
-                  updatePostLogoutRedirectUris(uris)
-                }
-                showPostLogoutRedirectUris={showPostLogoutRedirectUris}
+                {...credentialsTestingStep}
               />
             </CredentialAccordionSection>
           )}
@@ -696,12 +607,77 @@ export default function AppSettingsScreen({
   );
 }
 
+function CredentialsTestingStep({
+  activeClient,
+  appId,
+  appState,
+  formData,
+  domains,
+  onChange,
+  onDomainsChange,
+  onSecretGenerated,
+  onBackendSecretGenerated,
+  onWebSecretGenerated,
+  ownerExternalUserId,
+  readOnly,
+  postLogoutRedirectUris,
+  onPostLogoutRedirectUrisChange,
+  showPostLogoutRedirectUris,
+}: Readonly<{
+  activeClient: CredentialsClientTab;
+  appId: string;
+  appState: AppState;
+  formData: AppFormData;
+  domains: { id: string; domain: string }[];
+  onChange: (updates: Partial<AppFormData>) => void;
+  onDomainsChange: (domains: { id: string; domain: string }[]) => void;
+  onSecretGenerated: () => void;
+  onBackendSecretGenerated: () => void;
+  onWebSecretGenerated: () => void;
+  ownerExternalUserId: string | null;
+  readOnly: boolean;
+  postLogoutRedirectUris: string[];
+  onPostLogoutRedirectUrisChange: (uris: string[]) => void;
+  showPostLogoutRedirectUris: boolean;
+}>) {
+  return (
+    <TestingStep
+      appId={appId}
+      clientId={appState.clientId}
+      grantTypes={formData.grantTypes}
+      tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
+      redirectUris={formData.redirectUris}
+      allowedScopes={formData.allowedScopes}
+      hasSecret={appState.hasSecret}
+      backendHelper={appState.backendHelper}
+      backendDeviceHelper={formData.backendDeviceHelper}
+      webHelper={appState.webHelper}
+      confidentialWebHelper={formData.confidentialWebHelper}
+      confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
+      initiateLoginUri={formData.initiateLoginUri}
+      deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
+      domains={domains}
+      onChange={onChange}
+      onDomainsChange={onDomainsChange}
+      onSecretGenerated={onSecretGenerated}
+      onBackendSecretGenerated={onBackendSecretGenerated}
+      onWebSecretGenerated={onWebSecretGenerated}
+      ownerExternalUserId={ownerExternalUserId}
+      readOnly={readOnly}
+      activeClient={activeClient}
+      hideHeader
+      postLogoutRedirectUris={postLogoutRedirectUris}
+      onPostLogoutRedirectUrisChange={onPostLogoutRedirectUrisChange}
+      showPostLogoutRedirectUris={showPostLogoutRedirectUris}
+    />
+  );
+}
+
 function CredentialAccordionSection({
   id,
   label,
   prefix,
   description,
-  accentClass,
   labelClass,
   prefixClass,
   expanded,
@@ -712,7 +688,6 @@ function CredentialAccordionSection({
   label: string;
   prefix: string;
   description: string;
-  accentClass: string;
   labelClass: string;
   prefixClass: string;
   expanded: boolean;
@@ -720,21 +695,23 @@ function CredentialAccordionSection({
   children: React.ReactNode;
 }>) {
   return (
-    <div className={`rounded-xl border overflow-hidden ${accentClass}`}>
+    <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] overflow-hidden">
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={expanded}
         aria-controls={`credential-panel-${id}`}
-        className="flex w-full items-center justify-between px-5 py-4 text-left hover:bg-white/[0.02] transition-colors"
+        className="flex w-full items-start justify-between gap-3 px-5 py-4 text-left hover:bg-white/[0.03] transition-colors"
       >
-        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 min-w-0">
-          <span className={`text-sm font-semibold ${labelClass}`}>{label}</span>
-          <code className={`font-mono text-xs ${prefixClass}`}>{prefix}</code>
-          <span className="text-xs text-zinc-500">{description}</span>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <span className={`text-sm font-semibold ${labelClass}`}>{label}</span>
+            <code className={`font-mono text-xs ${prefixClass}`}>{prefix}</code>
+          </div>
+          <p className="text-xs text-zinc-500 mt-0.5">{description}</p>
         </div>
         <svg
-          className={`w-4 h-4 shrink-0 ml-3 text-zinc-500 transition-transform duration-200 ${
+          className={`w-4 h-4 shrink-0 mt-0.5 text-zinc-500 transition-transform duration-200 ${
             expanded ? "rotate-180" : ""
           }`}
           fill="none"
@@ -748,7 +725,7 @@ function CredentialAccordionSection({
       {expanded && (
         <div
           id={`credential-panel-${id}`}
-          className="border-t border-zinc-800/60 p-5 sm:p-6 space-y-8"
+          className="border-t border-white/[0.06] px-5 py-5 sm:px-6 sm:py-6"
         >
           {children}
         </div>

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -725,14 +725,14 @@ function CredentialAccordionSection({
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
-      {expanded && (
-        <div
-          id={`credential-panel-${id}`}
-          className="border-t border-white/[0.06] px-5 py-5 sm:px-6 sm:py-6"
-        >
-          {children}
-        </div>
-      )}
+      <div
+        id={`credential-panel-${id}`}
+        hidden={!expanded}
+        inert={!expanded}
+        className="border-t border-white/[0.06] px-5 py-5 sm:px-6 sm:py-6"
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import AppInfoStep from "./steps/AppInfoStep";
 import AppModeStep from "./steps/AppModeStep";
@@ -228,11 +227,8 @@ export default function AppSettingsScreen({
   }, [appId]);
 
   useEffect(() => {
-    if (integrationSection !== "credentials") {
-      return;
-    }
     void syncCredentialsFromServer();
-  }, [integrationSection, syncCredentialsFromServer]);
+  }, [syncCredentialsFromServer]);
 
   const saveChanges = useCallback(async () => {
     if (!canEdit) return;
@@ -392,13 +388,11 @@ export default function AppSettingsScreen({
         )}
       </div>
 
-      {integrationSection === "profile" && (
-        <div
-          id="panel-profile"
-          role="tabpanel"
-          aria-labelledby="tab-profile"
-          className="space-y-10 pb-6"
-        >
+      <SettingsTabPanel
+        id="profile"
+        active={integrationSection === "profile"}
+        className="space-y-10 pb-6"
+      >
           <section className="space-y-4">
             <AppInfoStep data={formData} onChange={updateFormData} readOnly={!canEdit} />
           </section>
@@ -451,16 +445,13 @@ export default function AppSettingsScreen({
               )}
             </section>
           )}
-        </div>
-      )}
+      </SettingsTabPanel>
 
-      {integrationSection === "credentials" && (
-        <div
-          id="panel-credentials"
-          role="tabpanel"
-          aria-labelledby="tab-credentials"
-          className="space-y-6 pb-6"
-        >
+      <SettingsTabPanel
+        id="credentials"
+        active={integrationSection === "credentials"}
+        className="space-y-6 pb-6"
+      >
           <div className="flex items-start justify-between gap-3">
             <div>
               <h2 className="text-lg font-semibold text-zinc-100 mb-1">
@@ -542,28 +533,15 @@ export default function AppSettingsScreen({
             tokenUrl={tokenUrl}
             signerSessionUrl={signerSessionUrl}
           />
-        </div>
-      )}
+      </SettingsTabPanel>
 
-      {integrationSection === "plans" && (
-        <div
-          id="panel-plans"
-          role="tabpanel"
-          aria-labelledby="tab-plans"
-        >
-          <PlansTab appId={appId} canEdit={canEdit} />
-        </div>
-      )}
+      <SettingsTabPanel id="plans" active={integrationSection === "plans"}>
+        <PlansTab appId={appId} canEdit={canEdit} />
+      </SettingsTabPanel>
 
-      {integrationSection === "payments" && (
-        <div
-          id="panel-payments"
-          role="tabpanel"
-          aria-labelledby="tab-payments"
-        >
-          <PaymentsTab appId={appId} canManageBilling={canManageBilling} />
-        </div>
-      )}
+      <SettingsTabPanel id="payments" active={integrationSection === "payments"}>
+        <PaymentsTab appId={appId} canManageBilling={canManageBilling} />
+      </SettingsTabPanel>
 
       {/* Save - only shown for non-plans/payments tabs */}
       {integrationSection !== "plans" && integrationSection !== "payments" && (
@@ -603,6 +581,31 @@ export default function AppSettingsScreen({
         </div>
       </div>
       )}
+    </div>
+  );
+}
+
+function SettingsTabPanel({
+  id,
+  active,
+  className,
+  children,
+}: Readonly<{
+  id: AppSettingsTab;
+  active: boolean;
+  className?: string;
+  children: React.ReactNode;
+}>) {
+  return (
+    <div
+      id={`panel-${id}`}
+      role="tabpanel"
+      aria-labelledby={`tab-${id}`}
+      hidden={!active}
+      inert={!active}
+      className={className}
+    >
+      {children}
     </div>
   );
 }

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -68,16 +68,7 @@ function mergeFormData(
   };
 }
 
-const INTEGRATION_TABS = [
-  { id: "profile", label: "App profile" },
-  { id: "credentials", label: "Credentials & URLs" },
-  { id: "plans", label: "Billing Plans" },
-  { id: "payments", label: "Payments" },
-] as const satisfies ReadonlyArray<{ id: AppSettingsTab; label: string }>;
-
-type IntegrationSection = AppSettingsTab;
-
-function resolveInitialTab(tab: string | undefined): IntegrationSection {
+function resolveInitialTab(tab: string | undefined): AppSettingsTab {
   return normalizeAppSettingsTab(tab);
 }
 
@@ -395,31 +386,6 @@ export default function AppSettingsScreen({
           </div>
         )}
       </div>
-
-      <nav
-        className="flex flex-wrap gap-1 border-b border-zinc-800 pb-3 mb-6"
-        aria-label="Integration settings sections"
-      >
-        {INTEGRATION_TABS.map(({ id, label }) => {
-          const selected = integrationSection === id;
-          return (
-            <Link
-              key={id}
-              id={`tab-${id}`}
-              href={appSettingsPath(appId, id)}
-              scroll={false}
-              aria-current={selected ? "page" : undefined}
-              className={`px-3 py-2 text-sm font-medium rounded-t-md border-b-2 -mb-px transition-colors ${
-                selected
-                  ? "border-emerald-500 text-emerald-400 bg-zinc-900/50"
-                  : "border-transparent text-zinc-500 hover:text-zinc-300"
-              }`}
-            >
-              {label}
-            </Link>
-          );
-        })}
-      </nav>
 
       {integrationSection === "profile" && (
         <div

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import AppInfoStep from "./steps/AppInfoStep";
 import AppModeStep from "./steps/AppModeStep";
 import TestingStep, {
@@ -17,7 +17,6 @@ import {
   type AppState,
 } from "./AppWizard";
 import {
-  appSettingsPath,
   normalizeAppSettingsTab,
   type AppSettingsTab,
 } from "@/lib/apps/settings-paths";
@@ -87,7 +86,6 @@ export default function AppSettingsScreen({
   initialTab,
 }: Readonly<Props>) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [formData, setFormData] = useState<AppFormData>(() =>
     mergeFormData(initialData, initialInitiateLoginUri ?? null, initialDeviceThirdPartyInitiateLogin),
   );
@@ -107,20 +105,22 @@ export default function AppSettingsScreen({
   const messageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const integrationSection = resolveInitialTab(initialTab);
 
-  const clientParam = searchParams.get("client");
-  const credentialsClient: CredentialsClientTab =
-    clientParam === "m2m" || clientParam === "web" || clientParam === "public"
-      ? clientParam
-      : "public";
-
-  const credentialsClientHref = useCallback(
-    (client: CredentialsClientTab) => {
-      const path = appSettingsPath(appId, "credentials");
-      if (client === "public") return path;
-      return `${path}?client=${encodeURIComponent(client)}`;
-    },
-    [appId],
+  // Which credential accordion sections are expanded (all open by default)
+  const [expandedCredentials, setExpandedCredentials] = useState<Set<CredentialsClientTab>>(
+    () => new Set<CredentialsClientTab>(["public", "m2m", "web"]),
   );
+
+  const toggleCredential = useCallback((client: CredentialsClientTab) => {
+    setExpandedCredentials((prev) => {
+      const next = new Set(prev);
+      if (next.has(client)) {
+        next.delete(client);
+      } else {
+        next.add(client);
+      }
+      return next;
+    });
+  }, []);
 
   const showMessage = useCallback((msg: string) => {
     setMessage(msg);
@@ -323,47 +323,6 @@ export default function AppSettingsScreen({
   const showWebCredentialsTab =
     Boolean(formData.confidentialWebHelper) || Boolean(appState.webHelper);
 
-  const credentialsClientTabs = useMemo(
-    () =>
-      (
-        [
-          {
-            id: "public" as const,
-            label: "Public / SDK",
-            hint: "app_",
-            show: true,
-          },
-          {
-            id: "m2m" as const,
-            label: "M2M / Builder",
-            hint: "m2m_",
-            show: showM2mCredentialsTab,
-          },
-          {
-            id: "web" as const,
-            label: "Web SSO",
-            hint: "web_",
-            show: showWebCredentialsTab,
-          },
-        ] as const
-      ).filter((tab) => tab.show),
-    [showM2mCredentialsTab, showWebCredentialsTab],
-  );
-
-  useEffect(() => {
-    if (
-      (credentialsClient === "m2m" && !showM2mCredentialsTab) ||
-      (credentialsClient === "web" && !showWebCredentialsTab)
-    ) {
-      router.replace(appSettingsPath(appId, "credentials"), { scroll: false });
-    }
-  }, [
-    appId,
-    credentialsClient,
-    router,
-    showM2mCredentialsTab,
-    showWebCredentialsTab,
-  ]);
 
   return (
     <div className="max-w-3xl">
@@ -454,7 +413,7 @@ export default function AppSettingsScreen({
           id="panel-credentials"
           role="tabpanel"
           aria-labelledby="tab-credentials"
-          className="space-y-8 pb-6"
+          className="space-y-6 pb-6"
         >
           <div className="flex items-start justify-between gap-3">
             <div>
@@ -462,7 +421,7 @@ export default function AppSettingsScreen({
                 Credentials &amp; URLs
               </h2>
               <p className="text-sm text-zinc-500">
-                SDK, Builder, and portal credentials — each on its own tab.
+                SDK, Builder, and portal credentials — expand each section to configure.
               </p>
             </div>
             <a
@@ -475,44 +434,80 @@ export default function AppSettingsScreen({
             </a>
           </div>
 
-          <div className="rounded-xl border border-zinc-800 bg-zinc-950/40 overflow-hidden">
-            <nav
-              className="flex flex-wrap gap-0 border-b border-zinc-800 bg-zinc-900/50"
-              aria-label="OIDC client credentials"
-            >
-              {credentialsClientTabs.map((tab) => {
-                  const selected = credentialsClient === tab.id;
-                  return (
-                    <Link
-                      key={tab.id}
-                      id={`credentials-client-tab-${tab.id}`}
-                      href={credentialsClientHref(tab.id)}
-                      scroll={false}
-                      aria-current={selected ? "page" : undefined}
-                      className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
-                        selected
-                          ? "border-emerald-500 text-zinc-100 bg-zinc-900/80"
-                          : "border-transparent text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900/40"
-                      }`}
-                    >
-                      {tab.label}{" "}
-                      <code
-                        className={`font-mono text-xs ${
-                          selected ? "text-zinc-400" : "text-zinc-600"
-                        }`}
-                      >
-                        {tab.hint}
-                      </code>
-                    </Link>
-                  );
-                })}
-            </nav>
+          {/* Public / SDK — always shown */}
+          <CredentialAccordionSection
+            id="public"
+            label="Public / SDK"
+            prefix="app_"
+            description="For SDKs, CLIs, and device login. No secret — public only."
+            accentClass="border-emerald-500/25 bg-emerald-500/5"
+            labelClass="text-emerald-200/90"
+            prefixClass="text-emerald-400/70"
+            expanded={expandedCredentials.has("public")}
+            onToggle={() => toggleCredential("public")}
+          >
+            <TestingStep
+              appId={appId}
+              clientId={appState.clientId}
+              grantTypes={formData.grantTypes}
+              tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
+              redirectUris={formData.redirectUris}
+              allowedScopes={formData.allowedScopes}
+              hasSecret={appState.hasSecret}
+              backendHelper={appState.backendHelper}
+              backendDeviceHelper={formData.backendDeviceHelper}
+              webHelper={appState.webHelper}
+              confidentialWebHelper={formData.confidentialWebHelper}
+              confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
+              initiateLoginUri={formData.initiateLoginUri}
+              deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
+              domains={domains}
+              onChange={updateFormData}
+              onDomainsChange={setDomains}
+              onSecretGenerated={() => {
+                setAppState((s) => ({ ...s, hasSecret: true }));
+                updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
+              }}
+              onBackendSecretGenerated={() => {
+                setAppState((s) => ({
+                  ...s,
+                  backendHelper: s.backendHelper
+                    ? { ...s.backendHelper, hasSecret: true }
+                    : s.backendHelper,
+                }));
+              }}
+              onWebSecretGenerated={() => {
+                setAppState((s) => ({
+                  ...s,
+                  webHelper: s.webHelper
+                    ? { ...s.webHelper, hasSecret: true }
+                    : s.webHelper,
+                }));
+              }}
+              ownerExternalUserId={ownerExternalUserId}
+              readOnly={!canEdit}
+              activeClient="public"
+              hideHeader
+              postLogoutRedirectUris={postLogoutRedirectUris}
+              onPostLogoutRedirectUrisChange={(uris) =>
+                updatePostLogoutRedirectUris(uris)
+              }
+              showPostLogoutRedirectUris={showPostLogoutRedirectUris}
+            />
+          </CredentialAccordionSection>
 
-            <div
-              id={`credentials-client-panel-${credentialsClient}`}
-              role="tabpanel"
-              aria-labelledby={`credentials-client-tab-${credentialsClient}`}
-              className="p-5 sm:p-6 space-y-8"
+          {/* M2M / Builder — only when enabled */}
+          {showM2mCredentialsTab && (
+            <CredentialAccordionSection
+              id="m2m"
+              label="M2M / Builder"
+              prefix="m2m_"
+              description="Server credentials for Builder APIs and device approval."
+              accentClass="border-cyan-500/25 bg-cyan-500/5"
+              labelClass="text-cyan-200/90"
+              prefixClass="text-cyan-400/70"
+              expanded={expandedCredentials.has("m2m")}
+              onToggle={() => toggleCredential("m2m")}
             >
               <TestingStep
                 appId={appId}
@@ -554,7 +549,7 @@ export default function AppSettingsScreen({
                 }}
                 ownerExternalUserId={ownerExternalUserId}
                 readOnly={!canEdit}
-                activeClient={credentialsClient}
+                activeClient="m2m"
                 hideHeader
                 postLogoutRedirectUris={postLogoutRedirectUris}
                 onPostLogoutRedirectUrisChange={(uris) =>
@@ -562,8 +557,72 @@ export default function AppSettingsScreen({
                 }
                 showPostLogoutRedirectUris={showPostLogoutRedirectUris}
               />
-            </div>
-          </div>
+            </CredentialAccordionSection>
+          )}
+
+          {/* Web SSO — only when enabled */}
+          {showWebCredentialsTab && (
+            <CredentialAccordionSection
+              id="web"
+              label="Web SSO"
+              prefix="web_"
+              description="Confidential client for portal single sign-on."
+              accentClass="border-violet-500/25 bg-violet-500/5"
+              labelClass="text-violet-200/90"
+              prefixClass="text-violet-400/70"
+              expanded={expandedCredentials.has("web")}
+              onToggle={() => toggleCredential("web")}
+            >
+              <TestingStep
+                appId={appId}
+                clientId={appState.clientId}
+                grantTypes={formData.grantTypes}
+                tokenEndpointAuthMethod={formData.tokenEndpointAuthMethod}
+                redirectUris={formData.redirectUris}
+                allowedScopes={formData.allowedScopes}
+                hasSecret={appState.hasSecret}
+                backendHelper={appState.backendHelper}
+                backendDeviceHelper={formData.backendDeviceHelper}
+                webHelper={appState.webHelper}
+                confidentialWebHelper={formData.confidentialWebHelper}
+                confidentialWebRedirectUris={formData.confidentialWebRedirectUris}
+                initiateLoginUri={formData.initiateLoginUri}
+                deviceThirdPartyInitiateLogin={formData.deviceThirdPartyInitiateLogin}
+                domains={domains}
+                onChange={updateFormData}
+                onDomainsChange={setDomains}
+                onSecretGenerated={() => {
+                  setAppState((s) => ({ ...s, hasSecret: true }));
+                  updateFormData({ tokenEndpointAuthMethod: "client_secret_post" });
+                }}
+                onBackendSecretGenerated={() => {
+                  setAppState((s) => ({
+                    ...s,
+                    backendHelper: s.backendHelper
+                      ? { ...s.backendHelper, hasSecret: true }
+                      : s.backendHelper,
+                  }));
+                }}
+                onWebSecretGenerated={() => {
+                  setAppState((s) => ({
+                    ...s,
+                    webHelper: s.webHelper
+                      ? { ...s.webHelper, hasSecret: true }
+                      : s.webHelper,
+                  }));
+                }}
+                ownerExternalUserId={ownerExternalUserId}
+                readOnly={!canEdit}
+                activeClient="web"
+                hideHeader
+                postLogoutRedirectUris={postLogoutRedirectUris}
+                onPostLogoutRedirectUrisChange={(uris) =>
+                  updatePostLogoutRedirectUris(uris)
+                }
+                showPostLogoutRedirectUris={showPostLogoutRedirectUris}
+              />
+            </CredentialAccordionSection>
+          )}
 
           <ReferenceEndpointsSection
             clientId={appState.clientId || ""}
@@ -632,6 +691,67 @@ export default function AppSettingsScreen({
           </button>
         </div>
       </div>
+      )}
+    </div>
+  );
+}
+
+function CredentialAccordionSection({
+  id,
+  label,
+  prefix,
+  description,
+  accentClass,
+  labelClass,
+  prefixClass,
+  expanded,
+  onToggle,
+  children,
+}: Readonly<{
+  id: string;
+  label: string;
+  prefix: string;
+  description: string;
+  accentClass: string;
+  labelClass: string;
+  prefixClass: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className={`rounded-xl border overflow-hidden ${accentClass}`}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-controls={`credential-panel-${id}`}
+        className="flex w-full items-center justify-between px-5 py-4 text-left hover:bg-white/[0.02] transition-colors"
+      >
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 min-w-0">
+          <span className={`text-sm font-semibold ${labelClass}`}>{label}</span>
+          <code className={`font-mono text-xs ${prefixClass}`}>{prefix}</code>
+          <span className="text-xs text-zinc-500">{description}</span>
+        </div>
+        <svg
+          className={`w-4 h-4 shrink-0 ml-3 text-zinc-500 transition-transform duration-200 ${
+            expanded ? "rotate-180" : ""
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {expanded && (
+        <div
+          id={`credential-panel-${id}`}
+          className="border-t border-zinc-800/60 p-5 sm:p-6 space-y-8"
+        >
+          {children}
+        </div>
       )}
     </div>
   );

--- a/src/components/apps/AppSettingsSegmentPage.tsx
+++ b/src/components/apps/AppSettingsSegmentPage.tsx
@@ -1,0 +1,7 @@
+/**
+ * Settings URLs are real routes so the left nav can prefetch them.
+ * The visible chrome lives in `AppSettingsRouteShell` (app detail layout).
+ */
+export default function AppSettingsSegmentPage() {
+  return null;
+}

--- a/src/components/apps/app-settings-data.test.ts
+++ b/src/components/apps/app-settings-data.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cacheLoadedApp,
+  loadedAppFromApiPayload,
+  peekLoadedApp,
+} from "./app-settings-data";
+
+test("loadedAppFromApiPayload maps API fields and defaults", () => {
+  const loaded = loadedAppFromApiPayload({
+    id: "app_1",
+    name: "Demo",
+    status: "active",
+    ownerId: " user_1 ",
+    canEdit: true,
+    canDeleteApp: true,
+    canManageBilling: false,
+    oidcClient: {
+      clientId: "app_1",
+      allowedScopes: "openid",
+      grantTypes: "authorization_code,refresh_token",
+      tokenEndpointAuthMethod: "none",
+      hasSecret: false,
+      postLogoutRedirectUris: ["https://app.example/out"],
+      initiateLoginUri: "https://app.example/login",
+      deviceThirdPartyInitiateLogin: true,
+    },
+    m2mOidcClient: { clientId: "m2m_1", hasSecret: true },
+    webOidcClient: {
+      clientId: "web_1",
+      hasSecret: true,
+      redirectUris: ["https://app.example/cb"],
+    },
+    domains: [{ id: "d1", domain: "https://app.example" }],
+  });
+
+  assert.equal(loaded.formData.name, "Demo");
+  assert.deepEqual(loaded.formData.grantTypes, [
+    "authorization_code",
+    "refresh_token",
+  ]);
+  assert.equal(loaded.formData.backendDeviceHelper, true);
+  assert.equal(loaded.formData.confidentialWebHelper, true);
+  assert.deepEqual(loaded.formData.confidentialWebRedirectUris, [
+    "https://app.example/cb",
+  ]);
+  assert.equal(loaded.state.clientId, "app_1");
+  assert.equal(loaded.state.backendHelper?.clientId, "m2m_1");
+  assert.equal(loaded.canEdit, true);
+  assert.equal(loaded.canManageBilling, false);
+  assert.equal(loaded.ownerExternalUserId, "user_1");
+  assert.deepEqual(loaded.postLogoutRedirectUris, ["https://app.example/out"]);
+  assert.equal(loaded.deviceThirdPartyInitiateLogin, true);
+});
+
+test("peekLoadedApp returns the cached app for an id", () => {
+  const loaded = loadedAppFromApiPayload({
+    id: "app_cache",
+    name: "Cached",
+    status: "active",
+  });
+  cacheLoadedApp("app_cache", loaded);
+  assert.equal(peekLoadedApp("app_cache")?.formData.name, "Cached");
+  assert.equal(peekLoadedApp("app_missing"), null);
+});

--- a/src/components/apps/app-settings-data.ts
+++ b/src/components/apps/app-settings-data.ts
@@ -1,0 +1,112 @@
+import type { AppFormData, AppState } from "@/components/apps/AppWizard";
+import { DEFAULT_PUBLIC_GRANT_TYPES } from "@/lib/oidc/grants";
+import { DEFAULT_OIDC_SCOPES, ensureOpenIdScope } from "@/lib/oidc/scopes";
+
+export type LoadedApp = {
+  formData: Partial<AppFormData>;
+  state: AppState;
+  domains: { id: string; domain: string }[];
+  postLogoutRedirectUris: string[];
+  initiateLoginUri: string | null;
+  deviceThirdPartyInitiateLogin: boolean;
+  canEdit: boolean;
+  canDeleteApp: boolean;
+  canManageBilling: boolean;
+  ownerExternalUserId: string | null;
+};
+
+export type AppSettingsApiPayload = {
+  id?: string;
+  name?: string;
+  description?: string;
+  developerName?: string;
+  websiteUrl?: string;
+  status?: string;
+  ownerId?: string;
+  canEdit?: boolean;
+  canDeleteApp?: boolean;
+  canManageBilling?: boolean;
+  oidcClient?: {
+    clientId?: string;
+    allowedScopes?: string;
+    grantTypes?: string;
+    tokenEndpointAuthMethod?: AppFormData["tokenEndpointAuthMethod"];
+    hasSecret?: boolean;
+    postLogoutRedirectUris?: string[];
+    initiateLoginUri?: string | null;
+    deviceThirdPartyInitiateLogin?: boolean;
+  } | null;
+  m2mOidcClient?: { clientId: string; hasSecret: boolean } | null;
+  webOidcClient?: {
+    clientId: string;
+    hasSecret: boolean;
+    redirectUris?: string[];
+    postLogoutRedirectUris?: string[];
+  } | null;
+  domains?: { id: string; domain: string }[];
+};
+
+const loadedAppCache = new Map<string, LoadedApp>();
+
+export function peekLoadedApp(appId: string): LoadedApp | null {
+  return loadedAppCache.get(appId) ?? null;
+}
+
+export function cacheLoadedApp(appId: string, data: LoadedApp): void {
+  loadedAppCache.set(appId, data);
+}
+
+export function loadedAppFromApiPayload(data: AppSettingsApiPayload): LoadedApp {
+  return {
+    formData: {
+      name: data.name || "",
+      description: data.description || "",
+      developerName: data.developerName || "",
+      websiteUrl: data.websiteUrl || "",
+      redirectUris: [],
+      allowedScopes: ensureOpenIdScope(
+        data.oidcClient?.allowedScopes || DEFAULT_OIDC_SCOPES,
+      ),
+      grantTypes:
+        data.oidcClient?.grantTypes?.split(",").filter(Boolean) ??
+        [...DEFAULT_PUBLIC_GRANT_TYPES],
+      tokenEndpointAuthMethod:
+        data.oidcClient?.tokenEndpointAuthMethod || "none",
+      backendDeviceHelper: Boolean(data.m2mOidcClient),
+      confidentialWebHelper: Boolean(data.webOidcClient),
+      confidentialWebRedirectUris: data.webOidcClient?.redirectUris || [],
+    },
+    state: {
+      id: data.id ?? null,
+      clientId: data.oidcClient?.clientId || null,
+      status: data.status ?? "",
+      hasSecret: data.oidcClient?.hasSecret || false,
+      backendHelper: data.m2mOidcClient ?? null,
+      webHelper: data.webOidcClient
+        ? {
+            clientId: data.webOidcClient.clientId,
+            hasSecret: data.webOidcClient.hasSecret,
+            redirectUris: data.webOidcClient.redirectUris ?? [],
+          }
+        : null,
+    },
+    domains: (data.domains || []).map((d) => ({
+      id: d.id,
+      domain: d.domain,
+    })),
+    postLogoutRedirectUris:
+      data.webOidcClient?.postLogoutRedirectUris ||
+      data.oidcClient?.postLogoutRedirectUris ||
+      [],
+    initiateLoginUri: data.oidcClient?.initiateLoginUri ?? null,
+    deviceThirdPartyInitiateLogin:
+      data.oidcClient?.deviceThirdPartyInitiateLogin === true,
+    canEdit: data.canEdit === true,
+    canDeleteApp: data.canDeleteApp === true,
+    canManageBilling: data.canManageBilling === true,
+    ownerExternalUserId:
+      typeof data.ownerId === "string" && data.ownerId.trim()
+        ? data.ownerId.trim()
+        : null,
+  };
+}

--- a/src/components/apps/steps/TestingStep.tsx
+++ b/src/components/apps/steps/TestingStep.tsx
@@ -73,7 +73,7 @@ interface Props {
    * Credentials & URLs client sub-tabs). When null, render the legacy stacked layout.
    */
   activeClient?: CredentialsClientTab | null;
-  /** When true, omit the page title (parent renders it above client sub-tabs). */
+  /** When true, omit the page title and inner card chrome (parent accordion already frames the section). */
   hideHeader?: boolean;
   /** Post-logout redirects on the web_ client (saved with Save changes). */
   postLogoutRedirectUris?: string[];
@@ -89,6 +89,10 @@ function secretActionLabel(generating: boolean, hasSecret: boolean): string {
   if (generating) return "Generating...";
   if (hasSecret) return "Rotate Secret";
   return "Generate Secret";
+}
+
+function clientPanelClass(embedded: boolean, framedClass: string): string {
+  return embedded ? "space-y-5" : framedClass;
 }
 
 function isValidInitiateLoginUri(uri: string): boolean {
@@ -1625,7 +1629,7 @@ export function AuthCodeFlowTestSection({
     showInitiateLogin && backendDeviceHelper && hasDeviceCode;
 
   return (
-    <div className="space-y-5 p-5 rounded-xl border border-zinc-800 bg-zinc-900/30">
+    <div className="space-y-5 pt-5 border-t border-zinc-800/80">
       {showEmptyRedirectHint ? <AuthCodeMissingRedirectHint title={title} /> : null}
 
       {showRedirectUriEditor ? (
@@ -1971,7 +1975,7 @@ export default function TestingStep({
       : "Test a client-credentials token for Builder APIs.";
 
   return (
-    <div className="space-y-8">
+    <div className={hideHeader ? "space-y-0" : "space-y-8"}>
       {hideHeader ? null : (
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -1999,17 +2003,24 @@ export default function TestingStep({
       {copyError && <p className="text-xs text-red-400 mt-2">{copyError}</p>}
 
       {showPrimaryCredentials && primaryIsConfidential ? (
-        <div className="p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-4">
-          <div>
-            <h3 className="text-sm font-semibold text-emerald-200/90">
-              Public / SDK{" "}
-              <code className="font-mono text-emerald-300/80 font-normal">(app_)</code>
-            </h3>
-            <p className="text-xs text-zinc-500 mt-1">
+        <div className={clientPanelClass(hideHeader, "p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-4")}>
+          {hideHeader ? (
+            <p className="text-xs text-zinc-500">
               Legacy confidential primary client. Prefer enabling M2M / Web siblings on App
               profile for new integrations.
             </p>
-          </div>
+          ) : (
+            <div>
+              <h3 className="text-sm font-semibold text-emerald-200/90">
+                Public / SDK{" "}
+                <code className="font-mono text-emerald-300/80 font-normal">(app_)</code>
+              </h3>
+              <p className="text-xs text-zinc-500 mt-1">
+                Legacy confidential primary client. Prefer enabling M2M / Web siblings on App
+                profile for new integrations.
+              </p>
+            </div>
+          )}
           <div>
             <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
             <div className="flex items-center gap-2">
@@ -2073,16 +2084,18 @@ export default function TestingStep({
       ) : null}
 
       {showPublicPanel && !primaryIsConfidential ? (
-        <div className="p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-5">
-          <div>
-            <h3 className="text-sm font-semibold text-emerald-200/90">
-              Public / SDK{" "}
-              <code className="font-mono text-emerald-300/80 font-normal">(app_)</code>
-            </h3>
-            <p className="text-xs text-zinc-500 mt-1">
-              For SDKs, CLIs, and device login. No secret — public only.
-            </p>
-          </div>
+        <div className={clientPanelClass(hideHeader, "p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-5")}>
+          {hideHeader ? null : (
+            <div>
+              <h3 className="text-sm font-semibold text-emerald-200/90">
+                Public / SDK{" "}
+                <code className="font-mono text-emerald-300/80 font-normal">(app_)</code>
+              </h3>
+              <p className="text-xs text-zinc-500 mt-1">
+                For SDKs, CLIs, and device login. No secret — public only.
+              </p>
+            </div>
+          )}
 
           {showPrimaryCredentials ? (
             <div>
@@ -2104,7 +2117,15 @@ export default function TestingStep({
             </div>
           ) : null}
 
-          <div className="space-y-3 border-t border-emerald-500/15 pt-4">
+          <div
+            className={`space-y-3 ${
+              hideHeader && !showPrimaryCredentials
+                ? ""
+                : hideHeader
+                  ? "border-t border-zinc-800/80 pt-5"
+                  : "border-t border-emerald-500/15 pt-4"
+            }`}
+          >
             <div>
               <h4 className="text-xs font-semibold text-zinc-200">Domain allowlist</h4>
               <p className="text-xs text-zinc-500 mt-1">
@@ -2133,7 +2154,13 @@ export default function TestingStep({
       ) : null}
 
       {showPublicPanel && primaryIsConfidential ? (
-        <div className="p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-4">
+        <div
+          className={
+            hideHeader
+              ? "space-y-4 border-t border-zinc-800/80 pt-5"
+              : "p-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 space-y-4"
+          }
+        >
           <div>
             <h4 className="text-xs font-semibold text-zinc-200">Domain allowlist</h4>
             <p className="text-xs text-zinc-500 mt-1">
@@ -2151,14 +2178,18 @@ export default function TestingStep({
       ) : null}
 
       {showM2mCredentials && backendHelper ? (
-        <div className="p-4 rounded-xl border border-cyan-500/20 bg-cyan-500/5 space-y-3">
-            <h3 className="text-sm font-semibold text-cyan-200/90">
-              M2M / Builder{" "}
-              <code className="font-mono text-cyan-300/80 font-normal">(m2m_)</code>
-            </h3>
-            <p className="text-xs text-zinc-500">
-              For Builder APIs and server-side device approval. Keep the secret off public apps.
-            </p>
+        <div className={clientPanelClass(hideHeader, "p-4 rounded-xl border border-cyan-500/20 bg-cyan-500/5 space-y-3")}>
+          {hideHeader ? null : (
+            <>
+              <h3 className="text-sm font-semibold text-cyan-200/90">
+                M2M / Builder{" "}
+                <code className="font-mono text-cyan-300/80 font-normal">(m2m_)</code>
+              </h3>
+              <p className="text-xs text-zinc-500">
+                For Builder APIs and server-side device approval. Keep the secret off public apps.
+              </p>
+            </>
+          )}
             <div>
               <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
               <div className="flex items-center gap-2">
@@ -2233,14 +2264,18 @@ export default function TestingStep({
       ) : null}
 
       {showWebCredentials && webHelper ? (
-        <div className="p-4 rounded-xl border border-violet-500/20 bg-violet-500/5 space-y-3">
-            <h3 className="text-sm font-semibold text-violet-200/90">
-              Web single sign-on (SSO){" "}
-              <code className="font-mono text-violet-300/80 font-normal">(web_)</code>
-            </h3>
-            <p className="text-xs text-zinc-500">
-              For portal SSO (auth code + secret). Redirects live here; domains on Public / SDK.
-            </p>
+        <div className={clientPanelClass(hideHeader, "p-4 rounded-xl border border-violet-500/20 bg-violet-500/5 space-y-3")}>
+          {hideHeader ? null : (
+            <>
+              <h3 className="text-sm font-semibold text-violet-200/90">
+                Web single sign-on (SSO){" "}
+                <code className="font-mono text-violet-300/80 font-normal">(web_)</code>
+              </h3>
+              <p className="text-xs text-zinc-500">
+                For portal SSO (auth code + secret). Redirects live here; domains on Public / SDK.
+              </p>
+            </>
+          )}
             <div>
               <div className="block text-xs font-medium text-zinc-400 mb-1">Client ID</div>
               <div className="flex items-center gap-2">
@@ -2272,7 +2307,7 @@ export default function TestingStep({
               />
             </div>
             {showPostLogoutRedirectUris && onPostLogoutRedirectUrisChange ? (
-              <div className="space-y-3 pt-2 border-t border-violet-500/15">
+              <div className={`space-y-3 pt-2 border-t ${hideHeader ? "border-zinc-800/80" : "border-violet-500/15"}`}>
                 <div>
                   <label
                     htmlFor={postLogoutUriInputId}
@@ -2408,7 +2443,13 @@ export default function TestingStep({
       ) : null}
 
       {showAuthTestSection ? (
-        <div className="p-4 rounded-xl border border-zinc-800 bg-zinc-900/30 space-y-4">
+        <div
+          className={
+            hideHeader
+              ? "space-y-4 border-t border-zinc-800/80 pt-6"
+              : "p-4 rounded-xl border border-zinc-800 bg-zinc-900/30 space-y-4"
+          }
+        >
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0">
               <h3 className="text-sm font-semibold text-zinc-200">
@@ -2489,7 +2530,13 @@ export default function TestingStep({
       ) : null}
 
       {showM2mOnlyExchange ? (
-        <div className="space-y-4 p-5 rounded-xl border border-zinc-800 bg-zinc-900/30">
+        <div
+          className={
+            hideHeader
+              ? "space-y-4"
+              : "space-y-4 p-5 rounded-xl border border-zinc-800 bg-zinc-900/30"
+          }
+        >
           <div className="flex items-center gap-2">
             <div className="w-2 h-2 rounded-full bg-cyan-500" />
             <h3 className="text-sm font-semibold text-zinc-200">M2M token exchange</h3>

--- a/src/lib/apps/settings-paths.test.ts
+++ b/src/lib/apps/settings-paths.test.ts
@@ -43,5 +43,12 @@ test("appSettingsAbsoluteUrl keeps callback query on path", () => {
 test("appSettingsTabFromPathname", () => {
   assert.equal(appSettingsTabFromPathname("/apps/app_1"), "profile");
   assert.equal(appSettingsTabFromPathname("/apps/app_1/payments"), "payments");
+  assert.equal(appSettingsTabFromPathname("/apps/app_1/settings"), "profile");
+  assert.equal(appSettingsTabFromPathname("/apps/app_1/auth"), "profile");
+  assert.equal(
+    appSettingsTabFromPathname("/apps/app_1/discovery-profiles"),
+    "plans",
+  );
   assert.equal(appSettingsTabFromPathname("/apps/app_1/identities"), null);
+  assert.equal(appSettingsTabFromPathname("/apps/app_1/usage"), null);
 });

--- a/src/lib/apps/settings-paths.ts
+++ b/src/lib/apps/settings-paths.ts
@@ -78,6 +78,12 @@ export function appSettingsTabFromPathname(pathname: string): AppSettingsTab | n
   if (isAppSettingsTab(parts[2])) {
     return parts[2];
   }
+  if (parts[2] === "settings" || parts[2] === "auth") {
+    return "profile";
+  }
+  if (parts[2] === "discovery-profiles" || parts[2] === "network-discovery") {
+    return "plans";
+  }
   // Nested non-tab routes (identities, usage, …) — not a settings tab page.
   return null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redesigns all App Settings navigation from horizontal tab bars to easier-to-navigate vertical structures. Two changes across two commits:

---

### 1. App-level settings → nested left side nav panel

When navigating to any `/apps/<id>/*` path, the **My Apps** sidebar entry becomes an expanded section with five sub-links nested below it:

- App Profile → `/apps/<id>`
- Credentials & URLs → `/apps/<id>/credentials`
- Billing Plans → `/apps/<id>/plans`
- Payments → `/apps/<id>/payments`
- **Usage** → `/apps/<id>/usage` _(previously not reachable from settings at all)_

The app name appears as a subtitle in the expanded section (once loaded). A `← My Apps` back-link sits above the sub-items. The horizontal tab bar in `AppSettingsScreen` is removed entirely.

**Files changed:** `DashboardLayout.tsx`, `AppSettingsScreen.tsx`, `AppSettingsPageClient.tsx`, `BillingUsageDashboard.tsx`

---

### 2. OIDC credential sections → vertical expandable accordion

The three credential sub-sections (Public / SDK, M2M / Builder, Web SSO) were horizontal tabs driven by a `?client=` URL query parameter. Replaced with independently collapsible vertical accordion panels:

- Each panel has a clickable header showing the client label, prefix badge (`app_` / `m2m_` / `web_`), and a short description
- Color-coded headers match the existing emerald / cyan / violet palette
- All sections expand by default; users can collapse what they don't need
- M2M and Web sections still only appear when those sibling clients are enabled
- `?client=` URL param navigation and the associated redirect effect are removed

**Files changed:** `AppSettingsScreen.tsx`

---

### Verification

- `npx tsc --noEmit` → exit 0
- `npm run lint` → 0 errors (2 pre-existing warnings in unrelated file)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f8d47ed-d4a4-4486-b272-e59d43aae158?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f8d47ed-d4a4-4486-b272-e59d43aae158&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

