### PR TITLE
fix(collector): payer#actor wire split without Kong meter migration

### DIFF
--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -18,12 +18,23 @@
 #
 # Identity (go-livepeer Kafka wire -> normalized CloudEvent egress):
 # - Upstream auth_id stays client_id:usage_subject (webhook -> go-livepeer state -> Kafka).
-# - For app owners, webhook maps JWT sub (bare user id) to usage_subject owner:{users.id}
-#   so auth_id is app_…:owner:{id}. The collector strips the owner: prefix so CloudEvent
-#   subject / openmeter_customer_key = bare {users.id} (canonical shared Konnect customer).
-#   data.client_id retains the app id; data.usage_subject / external_user_id are bare ids.
-# - End-users keep CloudEvent subject = full compound auth_id.
-# - data.client_id / data.usage_subject always retain the parsed tenant + subject.
+# - Wire usage_subject may be:
+#     owner:{users.id}              — owner self-usage (legacy / no actor split)
+#     owner:{users.id}#actorExtId   — owner_rollup end-user (payer#actor)
+#     eu_{end_users.id}#actorExtId  — merchant end-user (payer#actor)
+#     actorExtId / app:actorExtId   — legacy compound / bare end-user
+# - CloudEvent subject / openmeter_customer_key = payer (bare owner id or eu_…).
+# - data.external_user_id = actor (integrator external id) for meter groupBy.
+# - data.billing_subject_key / billing_subject_kind / actor_end_user_id added in schema v2.
+# - data.client_id retains the app id for tenant attribution.
+#
+# Kong / OpenMeter meter backward compatibility:
+# - Existing meters (network_fee_usd_micros, signed_ticket_count, analytics) still
+#   groupBy only $.client_id + $.external_user_id. No meter slug or groupBy changes.
+# - No "#" in the wire → same CE subject / external_user_id mapping as pre-v2
+#   (owner: strip; end-user compound auth_id subject). Safe to deploy before JWT
+#   producers start emitting payer#actor.
+# - Extra data.* fields are CloudEvent-only; Konnect meters ignore unknown paths.
 #
 # Pipeline / model (wire -> CloudEvent dims):
 # - Preferred: Kafka pipeline is "base:model" (e.g. live-video-to-video:comfyui). Split on
@@ -132,18 +143,67 @@ pipeline:
         let is_compound = $colon > 0 && $colon < $auth_id.length() - 1
         let client_id = if $is_compound { $auth_id.slice(0, $colon) } else { $auth_id }
         let usage_subject_parsed = if $is_compound { $auth_id.slice($colon + 1) } else { $auth_id }
-        # Owner wallet: wire usage_subject is owner:{users.id}; CE subject = bare id.
-        # End-users: meter subject = full compound auth_id.
-        let is_owner_subject = $usage_subject_parsed.index_of("owner:") == 0
-        let usage_subject_type = if $is_owner_subject { "app_owner" } else { "external_user_id" }
-        let owner_bare_id = if $is_owner_subject {
-          $usage_subject_parsed.slice("owner:".length())
+
+        # Payer#actor split (schema v2). No "#" means legacy single-subject form.
+        let hash = $usage_subject_parsed.index_of("#")
+        let has_actor_split = $hash > 0 && $hash < $usage_subject_parsed.length() - 1
+        let payer_wire = if $has_actor_split {
+          $usage_subject_parsed.slice(0, $hash)
         } else {
           $usage_subject_parsed
         }
-        let openmeter_subject = if $is_owner_subject { $owner_bare_id } else { $auth_id }
+        let actor_external_user_id = if $has_actor_split {
+          $usage_subject_parsed.slice($hash + 1)
+        } else {
+          ""
+        }
+
+        let is_owner_subject = $payer_wire.index_of("owner:") == 0
+        let is_end_user_customer = $payer_wire.index_of("eu_") == 0
+        let usage_subject_type = if $is_owner_subject {
+          "app_owner"
+        } else {
+          "external_user_id"
+        }
+        let billing_subject_kind = if $is_owner_subject {
+          "owner_wallet"
+        } else if $is_end_user_customer {
+          "app_user_wallet"
+        } else {
+          "legacy_compound"
+        }
+        let owner_bare_id = if $is_owner_subject {
+          $payer_wire.slice("owner:".length())
+        } else {
+          $payer_wire
+        }
+        # CE subject = payer customer key (bare owner id, eu_…, or legacy compound auth_id).
+        let openmeter_subject = if $is_owner_subject {
+          $owner_bare_id
+        } else if $is_end_user_customer {
+          $payer_wire
+        } else if $has_actor_split {
+          $payer_wire
+        } else {
+          $auth_id
+        }
         let openmeter_customer_key = $openmeter_subject
-        let usage_subject_out = if $is_owner_subject { $owner_bare_id } else { $usage_subject_parsed }
+        let usage_subject_out = if $is_owner_subject { $owner_bare_id } else { $payer_wire }
+        # Actor for meter groupBy — never overwrite with the payer.
+        let external_user_id_out = if $actor_external_user_id != "" {
+          $actor_external_user_id
+        } else if $is_owner_subject {
+          $owner_bare_id
+        } else if $is_end_user_customer {
+          $payer_wire
+        } else {
+          $usage_subject_parsed
+        }
+        let actor_end_user_id_out = if $is_end_user_customer {
+          $payer_wire
+        } else {
+          ""
+        }
 
         let eth_usd = meta("eth_usd_price").number()
         root = if $eth_usd == null { throw("eth_usd price cache miss") }
@@ -213,10 +273,14 @@ pipeline:
             "subject": $openmeter_subject,
             "time": $data.current_time.or(now()),
             "data": {
+              "schema_version": "2",
               "client_id": $client_id,
               "usage_subject": $usage_subject_out,
               "usage_subject_type": $usage_subject_type,
-              "external_user_id": $usage_subject_out,
+              "external_user_id": $external_user_id_out,
+              "billing_subject_key": $openmeter_customer_key,
+              "billing_subject_kind": $billing_subject_kind,
+              "actor_end_user_id": $actor_end_user_id_out,
               "network_fee_usd_micros": $fee_usd_micros,
               "pipeline": $pipeline_out,
               "model_id": $model_id_out,

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -219,9 +219,11 @@ async function ensureOwnerCustomerUncached(
     trimmedOwnerId,
     uniqueClientIds,
   );
+  // Neon (`listOwnedPublicClientIds`) is the source of truth for owned apps.
+  // Do not write comma-joined client ids into Konnect labels — Kong rejects
+  // commas and values over 63 chars (`labels.* [max_length]` / `[pattern]`).
   const metadata: Record<string, string> = {
     pymthouse_owner_user_id: trimmedOwnerId,
-    pymthouse_owned_client_ids: uniqueClientIds.join(","),
   };
 
   const existing = await findOpenMeterCustomerByKey(client, ownerKey);

--- a/src/lib/openmeter/konnect-routes.test.ts
+++ b/src/lib/openmeter/konnect-routes.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./konnect-plan-body";
 import {
   buildKonnectMeterQueryBody,
+  isKonnectLabelValue,
   isKonnectMeterQueryGet,
   mapKonnectMeterGranularity,
   normalizeKonnectMeterQueryResponse,
@@ -20,6 +21,7 @@ import {
   rewriteKonnectRequestBody,
   rewriteKonnectRequestUrl,
   rewriteKonnectSearchParams,
+  sanitizeKonnectLabels,
 } from "./konnect-routes";
 import { createKonnectFetch } from "./konnect-fetch";
 
@@ -324,6 +326,36 @@ test("rewriteKonnectRequestBody maps customer metadata to labels", () => {
     (rewritten as { metadata?: unknown }).metadata,
     undefined,
   );
+});
+
+test("rewriteKonnectRequestBody drops Kong-invalid customer label values", () => {
+  assert.equal(isKonnectLabelValue("app_aaa"), true);
+  assert.equal(isKonnectLabelValue("app_aaa,app_bbb"), false);
+  assert.equal(isKonnectLabelValue("a".repeat(64)), false);
+  assert.deepEqual(
+    sanitizeKonnectLabels({
+      pymthouse_owner_user_id: "uuid-1",
+      pymthouse_owned_client_ids: "app_aaa,app_bbb",
+    }),
+    { pymthouse_owner_user_id: "uuid-1" },
+  );
+
+  const rewritten = rewriteKonnectRequestBody(
+    "/v3/openmeter/api/v1/customers/cust_1",
+    "PUT",
+    {
+      name: "uuid-1",
+      usageAttribution: { subjectKeys: ["uuid-1"] },
+      metadata: {
+        pymthouse_owner_user_id: "uuid-1",
+        pymthouse_owned_client_ids: "app_aaa,app_bbb",
+      },
+    },
+  ) as { labels?: Record<string, string> };
+
+  assert.deepEqual(rewritten.labels, {
+    pymthouse_owner_user_id: "uuid-1",
+  });
 });
 
 test("normalizeKonnectCustomerRecord merges labels into metadata", () => {

--- a/src/lib/openmeter/konnect-routes.ts
+++ b/src/lib/openmeter/konnect-routes.ts
@@ -442,6 +442,30 @@ function stringRecord(value: unknown): Record<string, string> {
 }
 
 /**
+ * Kong customer label values: max 63 chars, must match
+ * `^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$` (no commas/spaces).
+ * Drop anything that would 400 the PUT — callers treat SDK `metadata` as soft KV.
+ */
+const KONNECT_LABEL_VALUE_RE =
+  /^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$/;
+
+export function isKonnectLabelValue(value: string): boolean {
+  return value.length > 0 && value.length <= 63 && KONNECT_LABEL_VALUE_RE.test(value);
+}
+
+export function sanitizeKonnectLabels(
+  labels: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(labels)) {
+    if (isKonnectLabelValue(value)) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
  * Konnect stores customer KV under `labels` and silently discards `metadata`.
  * The OpenMeter SDK reads/writes `metadata`, so merge labels into metadata on
  * the way in and map metadata → labels on the way out.
@@ -485,7 +509,7 @@ function rewriteKonnectCustomerRequestBody(body: unknown): unknown {
   const record = { ...(snake as Record<string, unknown>) };
   const fromLabels = stringRecord(record.labels);
   const fromMetadata = stringRecord(record.metadata);
-  const merged = { ...fromLabels, ...fromMetadata };
+  const merged = sanitizeKonnectLabels({ ...fromLabels, ...fromMetadata });
   delete record.metadata;
   if (Object.keys(merged).length > 0) {
     record.labels = merged;

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -4,7 +4,7 @@ import type { OpenMeter } from "@openmeter/sdk";
 
 import { buildOpenMeterCustomerKey, parseOpenMeterCustomerKey } from "./customer-key";
 import { buildBillingProfileSupplier } from "./billing-profiles";
-import { ensureOpenMeterCustomer, ensureOwnerCustomerWireSubjects } from "./customers";
+import { ensureOpenMeterCustomer, ensureOwnerCustomerWireSubjects, resetEnsuredCustomerCacheForTests } from "./customers";
 import { listOwnerWalletInvoices, listTenantInvoices } from "./invoices";
 import { mapPymthousePlanToOpenMeterCreate } from "./plans-sync";
 import {
@@ -757,6 +757,7 @@ test("ensureOpenMeterCustomer returns existing id and key", async () => {
 });
 
 test("ensureOpenMeterCustomer repairs missing usageAttribution subjectKeys", async () => {
+  resetEnsuredCustomerCacheForTests();
   let updatedSubjectKeys: string[] | undefined;
   const client = {
     customers: {
@@ -785,6 +786,7 @@ test("ensureOpenMeterCustomer repairs missing usageAttribution subjectKeys", asy
 });
 
 test("ensureOpenMeterCustomer preserves settlement metadata on subject-key repair", async () => {
+  resetEnsuredCustomerCacheForTests();
   let updatedMetadata: Record<string, string> | undefined;
   const settlement = {
     stripe_charge_model: "direct",
@@ -841,6 +843,7 @@ test("ensureOpenMeterCustomer creates customer when missing", async () => {
 });
 
 test("ensureOwnerCustomer attaches transitional keys only on create", async () => {
+  resetEnsuredCustomerCacheForTests();
   let updatedSubjectKeys: string[] | undefined;
   let createdBody: {
     key?: string;
@@ -902,6 +905,7 @@ test("ensureOwnerCustomer attaches transitional keys only on create", async () =
 });
 
 test("ensureOwnerCustomer keeps settlement subject only on existing customers", async () => {
+  resetEnsuredCustomerCacheForTests();
   let updateCalls = 0;
   let updatedSubjectKeys: string[] | undefined;
   const ownerKey = "uuid-1";
@@ -948,7 +952,8 @@ test("ensureOwnerCustomer keeps settlement subject only on existing customers", 
   // Bare settlement key already present; update re-sends the same set (Konnect
   // PUT is a full replace, so omitting it would wipe subject_keys).
   assert.deepEqual(updatedSubjectKeys, [ownerKey]);
-  assert.equal(customerRecord.metadata.pymthouse_owned_client_ids, "app_aaa,app_bbb");
+  assert.equal(customerRecord.metadata.pymthouse_owner_user_id, "uuid-1");
+  assert.equal(customerRecord.metadata.pymthouse_owned_client_ids, undefined);
   assert.ok(updateCalls >= 1);
 });
 


### PR DESCRIPTION
## Summary
- Teach the OpenMeter collector to split \`usage_subject\` on \`#\` into payer (CloudEvent subject) and actor (\`data.external_user_id\`) while keeping the pre-v2 mapping when \`#\` is absent.
- Leave existing Kong meter groupBy (\`$.client_id\`, \`$.external_user_id\`) unchanged — no meter slug or dimension migration.
- **Production fix:** stop writing comma-joined \`pymthouse_owned_client_ids\` on owner customers (Kong label max 63 / pattern rejects commas). That 400 was failing \`ensureOwnerCustomer\` → \`provisionAppUserBilling\` / apps activation lookup. Sanitize outbound Konnect labels so any other invalid metadata cannot 400 a customer PUT.

## Test plan
- [ ] Deploy app + collector; confirm \`apps/[id] GET\` and app-user provision no longer 400 on \`labels.pymthouse_owned_client_ids\`
- [ ] Confirm owner ensure still stamps \`pymthouse_owner_user_id\` and leaves owned-app list to Neon
- [ ] Deploy collector only; confirm legacy \`app_…:owner:{id}\` and compound end-user \`auth_id\` events still ingest
- [ ] Ingest \`client_id:owner:{id}#{ext}\` → CE \`subject\` bare owner id, \`data.external_user_id\` = \`{ext}\`
- [ ] Confirm \`network_fee_usd_micros\` / \`signed_ticket_count\` queries by \`client_id\` + \`external_user_id\` still return rows