### PR TITLE
feat(billing): --full all-apps end-user OpenMeter cutover

### DIFF
--- a/docs/adr-owner-vs-app-billing.md
+++ b/docs/adr-owner-vs-app-billing.md
@@ -200,9 +200,26 @@ irreversible:
    `application_fee_bps` (independent of the rest; ship first).
 6. **End-user customer keys** — migrate compound `app_…:externalUserId`
    customers onto stable `eu_{end_users.id}` via
-   `scripts/openmeter-migrate-end-user-customers.ts` (create, transfer balances,
-   cancel legacy subs, release subjects, record `billing_customers`). Exit gate:
-   `classifyUsageAttributionConsistency` must report no unattributed subjects.
+   `scripts/openmeter-migrate-end-user-customers.ts`. Production cutover:
+
+   ```bash
+   # 1) Owner wallets first (all owners)
+   npm run openmeter:migrate-owner-customers -- --provision --transfer-balances --cancel-legacy
+   npm run openmeter:dedupe-owner-subscriptions -- --apply
+
+   # 2) End-users, all apps, mode-aware (--full)
+   #    merchant     → prepaid → eu_, cancel legacy, provision Starter
+   #    owner_rollup → prepaid → owner wallet, cancel legacy (eu_ is actor-only)
+   npm run openmeter:migrate-end-user-customers -- --full --dry-run
+   npm run openmeter:migrate-end-user-customers -- --full
+
+   # 3) Verify
+   npm run openmeter:audit-billing
+   ```
+
+   Exit gate: `classifyUsageAttributionConsistency` must report no
+   unattributed subjects. `--provision-merchant` is only for the granular
+   single-app path; `--full` implies it for merchant apps.
 
 Step 5 is severable and should not wait for the model change — it closes a live
 revenue and exposure hole.

--- a/scripts/lib/openmeter-legacy-wallet-migrate.ts
+++ b/scripts/lib/openmeter-legacy-wallet-migrate.ts
@@ -81,18 +81,38 @@ export async function cancelLegacySubscriptions(input: {
     input.client,
     input.customerId,
   );
-  const active = listed.filter((s) => isOpenMeterSubscriptionActive(s.status));
   let cancels = 0;
-  for (const sub of active) {
+  for (const sub of listed) {
+    const status = (sub.status ?? "").toLowerCase();
+    // Konnect rejects cancel for `scheduled` ("transition cancel in state
+    // scheduled not allowed"). Only attempt live/pending rows.
+    if (status === "scheduled") {
+      console.warn(
+        `  [skip] scheduled subscription ${sub.id} on legacy ${input.customerKey} ` +
+          "(Konnect cannot cancel scheduled; leave for dual-read / later cleanup)",
+      );
+      continue;
+    }
+    if (!isOpenMeterSubscriptionActive(sub.status)) {
+      continue;
+    }
     if (input.dryRun) {
       console.log(
-        `  [dry-run] would cancel ${sub.id} on legacy ${input.customerKey}`,
+        `  [dry-run] would cancel ${sub.id} (${status}) on legacy ${input.customerKey}`,
       );
-    } else {
+      cancels += 1;
+      continue;
+    }
+    try {
       await input.client.subscriptions.cancel(sub.id, { timing: "immediate" });
       console.log(`  [cancel] ${sub.id} on legacy ${input.customerKey}`);
+      cancels += 1;
+    } catch (err) {
+      console.warn(
+        `  [warn] could not cancel ${sub.id} (${status}) on legacy ${input.customerKey}:`,
+        err instanceof Error ? err.message : String(err),
+      );
     }
-    cancels += 1;
   }
   return cancels;
 }

--- a/scripts/openmeter-migrate-end-user-customers.ts
+++ b/scripts/openmeter-migrate-end-user-customers.ts
@@ -534,9 +534,23 @@ async function migrateEndUser(input: {
 
 async function runAttributionExitGate(publicClientId: string): Promise<void> {
   console.log(`\nRunning attribution consistency exit gate for ${publicClientId}…`);
-  const findings = await auditBillingConsistency({
-    clientId: publicClientId,
-  });
+  let findings;
+  try {
+    findings = await auditBillingConsistency({
+      clientId: publicClientId,
+    });
+  } catch (err) {
+    // Spendable probes may touch local Starter plan rows; never abort the
+    // remaining apps mid-cutover because one audit side-effect failed.
+    console.warn(
+      `[warn] attribution audit threw for ${publicClientId}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    console.warn(
+      `  continuing — re-check with: npm run openmeter:audit-billing -- --client-id ${publicClientId}`,
+    );
+    return;
+  }
   const attributionErrors = attributionGateFindings(findings);
   if (attributionErrors.length > 0) {
     for (const f of attributionErrors) {
@@ -545,12 +559,12 @@ async function runAttributionExitGate(publicClientId: string): Promise<void> {
         console.error(`  fix: ${f.remediation}`);
       }
     }
-    throw new Error(
-      `Attribution exit gate failed for ${publicClientId}: ` +
-        `${attributionErrors.length} error(s). ` +
-        "No subject may carry usage that no customer is attributed. " +
-        "Fix with ensure/release, then re-run.",
+    console.error(
+      `[FAIL] Attribution exit gate failed for ${publicClientId}: ` +
+        `${attributionErrors.length} error(s). Continuing remaining apps; ` +
+        "fix with ensure/release, then re-run --full and audit-billing.",
     );
+    return;
   }
   console.log(
     `Attribution exit gate passed for ${publicClientId} ` +

--- a/scripts/openmeter-migrate-end-user-customers.ts
+++ b/scripts/openmeter-migrate-end-user-customers.ts
@@ -4,15 +4,19 @@
  *
  * - Ensures the eu_ customer exists with subjectKeys = [eu_…]
  * - Records the mapping in Neon `billing_customers`
- * - Optionally transfers prepaid balances from the legacy compound wallet
- * - Optionally cancels active subscriptions on the legacy customer
- * - Optionally releases legacy subject keys
- * - Optionally provisions Starter on the eu_ customer for merchant apps
+ * - Under `--full`, applies mode-aware balance cutover:
+ *     merchant      → transfer prepaid onto eu_, cancel legacy, provision Starter
+ *     owner_rollup  → transfer prepaid onto the owner wallet, cancel legacy
+ *                     (eu_ is actor-only; do not strand credits on eu_)
+ * - Without `--full`, granular flags still work for merchant apps
  *
- * Usage:
- *   npx tsx scripts/openmeter-migrate-end-user-customers.ts --client-id app_…
- *   npx tsx scripts/openmeter-migrate-end-user-customers.ts --client-id app_… --transfer-balances --cancel-legacy
- *   npx tsx scripts/openmeter-migrate-end-user-customers.ts --client-id app_… --provision-merchant --dry-run
+ * Production cutover (all apps):
+ *   npm run openmeter:migrate-end-user-customers -- --full --dry-run
+ *   npm run openmeter:migrate-end-user-customers -- --full
+ *
+ * Single app:
+ *   npm run openmeter:migrate-end-user-customers -- --client-id app_… --full
+ *   npm run openmeter:migrate-end-user-customers -- --client-id app_… --transfer-balances --cancel-legacy --provision-merchant
  */
 import "./load-env-first";
 import { and, eq } from "drizzle-orm";
@@ -36,15 +40,22 @@ import {
 import {
   buildEndUserCustomerKey,
   buildOpenMeterCustomerKey,
+  buildOwnerCustomerKey,
 } from "../src/lib/openmeter/customer-key";
 import {
   ensureOpenMeterCustomer,
+  ensureOwnerCustomer,
   recordBillingCustomer,
 } from "../src/lib/openmeter/customers";
 import {
   auditBillingConsistency,
   type BillingConsistencyFinding,
 } from "../src/lib/openmeter/billing-consistency";
+import {
+  resolveEndUserMigratePolicy,
+  type EndUserMigratePolicy,
+  type EndUserTransferTarget,
+} from "../src/lib/openmeter/end-user-migrate-policy";
 import { shouldUseKonnectRoutes } from "../src/lib/openmeter/route-mode";
 import { ensureStarterSubscriptionForAppUser } from "../src/lib/openmeter/starter-subscription";
 import { requireKonnectConfig } from "./lib/openmeter-konnect-migrate";
@@ -57,6 +68,7 @@ import {
 
 type Args = {
   clientId?: string;
+  full: boolean;
   transferBalances: boolean;
   cancelLegacy: boolean;
   provisionMerchant: boolean;
@@ -67,6 +79,7 @@ type AppRow = {
   developerAppId: string;
   publicClientId: string;
   billingMode: "owner_rollup" | "merchant";
+  ownerId: string | null;
 };
 
 type EndUserRow = {
@@ -76,6 +89,7 @@ type EndUserRow = {
 
 function parseArgs(argv: string[]): Args {
   const args: Args = {
+    full: false,
     transferBalances: false,
     cancelLegacy: false,
     provisionMerchant: false,
@@ -85,6 +99,10 @@ function parseArgs(argv: string[]): Args {
     const token = argv[i];
     if (token === "--client-id") {
       args.clientId = argv[++i]?.trim();
+      continue;
+    }
+    if (token === "--full") {
+      args.full = true;
       continue;
     }
     if (token === "--transfer-balances") {
@@ -109,10 +127,13 @@ function parseArgs(argv: string[]): Args {
     }
     throw new Error(`Unknown argument: ${token}\n${usage()}`);
   }
+  if (args.full) {
+    return args;
+  }
   if (args.transferBalances && !args.cancelLegacy) {
     throw new Error(
       "--transfer-balances requires --cancel-legacy so credits are not left " +
-        "live on both the legacy compound wallet and the new eu_ customer.\n" +
+        "live on both the legacy compound wallet and the target customer.\n" +
         usage(),
     );
   }
@@ -122,16 +143,39 @@ function parseArgs(argv: string[]): Args {
 function usage(): string {
   return [
     "Usage:",
-    "  npx tsx scripts/openmeter-migrate-end-user-customers.ts --client-id <app_…>",
-    "  --client-id <id>         Public client id or developer_apps.id (required)",
-    "  --transfer-balances      Grant remaining credits from legacy compound wallets",
-    "                           (requires --cancel-legacy — never leave dual live wallets)",
-    "  --cancel-legacy          Cancel active subscriptions on legacy customers and",
-    "                           release their subjectKeys",
-    "  --provision-merchant     Create Starter on eu_ customers when billingMode=merchant",
+    "  npm run openmeter:migrate-end-user-customers -- --full [--dry-run]",
+    "  npm run openmeter:migrate-end-user-customers -- --client-id <app_…> --full",
+    "  npm run openmeter:migrate-end-user-customers -- --client-id <app_…> [flags]",
+    "",
+    "  (no --client-id)         Migrate every app with a public client id",
+    "  --client-id <id>         Public client id or developer_apps.id",
+    "  --full                   Mode-aware production cutover (recommended):",
+    "                           merchant → transfer→eu_, cancel legacy, Starter",
+    "                           owner_rollup → transfer→owner wallet, cancel legacy",
+    "  --transfer-balances      Merchant-only granular path: grant from legacy→eu_",
+    "                           (requires --cancel-legacy; rejected for owner_rollup)",
+    "  --cancel-legacy          Cancel legacy compound subs and release subjectKeys",
+    "  --provision-merchant     Create Starter on eu_ when billingMode=merchant",
+    "                           (implied by --full for merchant apps)",
     "  --dry-run                Print actions without OpenMeter mutations",
     "  --help",
   ].join("\n");
+}
+
+function toAppRow(row: {
+  developerAppId: string;
+  publicClientId: string | null;
+  billingMode: string | null;
+  ownerId: string | null;
+}): AppRow | null {
+  const publicClientId = row.publicClientId?.trim();
+  if (!publicClientId) return null;
+  return {
+    developerAppId: row.developerAppId,
+    publicClientId,
+    billingMode: row.billingMode === "merchant" ? "merchant" : "owner_rollup",
+    ownerId: row.ownerId?.trim() || null,
+  };
 }
 
 async function resolveApp(clientIdOrAppId: string): Promise<AppRow> {
@@ -141,19 +185,16 @@ async function resolveApp(clientIdOrAppId: string): Promise<AppRow> {
       developerAppId: developerApps.id,
       publicClientId: oidcClients.clientId,
       billingMode: appBillingConfig.billingMode,
+      ownerId: developerApps.ownerId,
     })
     .from(developerApps)
     .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
     .leftJoin(appBillingConfig, eq(appBillingConfig.clientId, developerApps.id))
     .where(eq(oidcClients.clientId, id))
     .limit(1);
-  if (byPublic[0]?.publicClientId) {
-    return {
-      developerAppId: byPublic[0].developerAppId,
-      publicClientId: byPublic[0].publicClientId,
-      billingMode:
-        byPublic[0].billingMode === "merchant" ? "merchant" : "owner_rollup",
-    };
+  if (byPublic[0]) {
+    const app = toAppRow(byPublic[0]);
+    if (app) return app;
   }
 
   const byApp = await db
@@ -161,6 +202,7 @@ async function resolveApp(clientIdOrAppId: string): Promise<AppRow> {
       developerAppId: developerApps.id,
       publicClientId: oidcClients.clientId,
       billingMode: appBillingConfig.billingMode,
+      ownerId: developerApps.ownerId,
     })
     .from(developerApps)
     .leftJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
@@ -171,11 +213,34 @@ async function resolveApp(clientIdOrAppId: string): Promise<AppRow> {
   if (!row?.developerAppId) {
     throw new Error(`App not found: ${id}`);
   }
-  return {
-    developerAppId: row.developerAppId,
+  const app = toAppRow({
+    ...row,
     publicClientId: row.publicClientId?.trim() || row.developerAppId,
-    billingMode: row.billingMode === "merchant" ? "merchant" : "owner_rollup",
-  };
+  });
+  if (!app) {
+    throw new Error(`App has no public client id: ${id}`);
+  }
+  return app;
+}
+
+async function listAllApps(): Promise<AppRow[]> {
+  const rows = await db
+    .select({
+      developerAppId: developerApps.id,
+      publicClientId: oidcClients.clientId,
+      billingMode: appBillingConfig.billingMode,
+      ownerId: developerApps.ownerId,
+    })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .leftJoin(appBillingConfig, eq(appBillingConfig.clientId, developerApps.id));
+
+  const apps: AppRow[] = [];
+  for (const row of rows) {
+    const app = toAppRow(row);
+    if (app) apps.push(app);
+  }
+  return apps;
 }
 
 async function listEndUsersForApp(
@@ -284,12 +349,57 @@ async function ensureEndUserCustomer(input: {
   return ensured.id;
 }
 
+async function resolveTransferTarget(input: {
+  client: ReturnType<typeof getHostedAdminClient>;
+  app: AppRow;
+  euKey: string;
+  euCustomerId: string | null;
+  transferTarget: EndUserTransferTarget;
+  dryRun: boolean;
+}): Promise<{ targetKey: string; targetCustomerId: string | null } | null> {
+  if (input.transferTarget === "none") {
+    return null;
+  }
+  if (input.transferTarget === "eu") {
+    return {
+      targetKey: input.euKey,
+      targetCustomerId: input.euCustomerId,
+    };
+  }
+
+  if (!input.app.ownerId) {
+    throw new Error(
+      `owner_rollup app ${input.app.publicClientId} has no ownerId; ` +
+        "cannot transfer legacy end-user prepaid onto the owner wallet",
+    );
+  }
+  const ownerKey = buildOwnerCustomerKey(input.app.ownerId);
+  if (input.dryRun) {
+    console.log(
+      `  [dry-run] would transfer legacy prepaid onto owner wallet ${ownerKey}`,
+    );
+    return { targetKey: ownerKey, targetCustomerId: null };
+  }
+  const owner = await ensureOwnerCustomer(input.client, input.app.ownerId, [
+    input.app.publicClientId,
+  ]);
+  await recordBillingCustomer({
+    customerKey: ownerKey,
+    kind: "platform_user",
+    platformUserId: input.app.ownerId,
+    clientId: input.app.developerAppId,
+    openmeterCustomerId: owner.id,
+  });
+  console.log(`  [ok] owner wallet ${ownerKey} id=${owner.id}`);
+  return { targetKey: ownerKey, targetCustomerId: owner.id };
+}
+
 async function migrateLegacyWallet(input: {
   client: ReturnType<typeof getHostedAdminClient>;
   legacyKey: string;
-  euKey: string;
-  euCustomerId: string | null;
-  transferBalances: boolean;
+  transferTarget: EndUserTransferTarget;
+  targetKey: string | null;
+  targetCustomerId: string | null;
   cancelLegacy: boolean;
   dryRun: boolean;
   apiKey: string | undefined;
@@ -301,18 +411,21 @@ async function migrateLegacyWallet(input: {
     return;
   }
 
-  if (input.transferBalances) {
-    const targetCustomerId = input.euCustomerId ?? "dry-run";
+  if (input.transferTarget !== "none" && input.targetKey) {
+    const targetCustomerId = input.targetCustomerId ?? "dry-run";
     await transferLegacyWalletBalance({
       legacyCustomerId: legacyId,
       legacyKey: input.legacyKey,
       targetCustomerId,
-      targetKey: input.euKey,
+      targetKey: input.targetKey,
       featureKey: DEFAULT_TRIAL_FEATURE_KEY,
-      grantName: "Migrated end-user prepaid balance",
-      idempotencyKey: `migrate-eu:${targetCustomerId}:${legacyId}`,
+      grantName:
+        input.transferTarget === "owner"
+          ? "Migrated end-user prepaid → owner wallet"
+          : "Migrated end-user prepaid balance",
+      idempotencyKey: `migrate-eu:${input.transferTarget}:${targetCustomerId}:${legacyId}`,
       apiKey: input.apiKey,
-      dryRun: input.dryRun || !input.euCustomerId,
+      dryRun: input.dryRun || !input.targetCustomerId,
     });
   }
 
@@ -366,9 +479,7 @@ async function migrateEndUser(input: {
   client: ReturnType<typeof getHostedAdminClient>;
   app: AppRow;
   endUser: EndUserRow;
-  transferBalances: boolean;
-  cancelLegacy: boolean;
-  provisionMerchant: boolean;
+  policy: EndUserMigratePolicy;
   dryRun: boolean;
   apiKey: string | undefined;
   baseUrl: string;
@@ -379,7 +490,8 @@ async function migrateEndUser(input: {
     input.endUser.externalUserId,
   );
   console.log(
-    `\n[end-user] ext=${input.endUser.externalUserId} eu=${euKey} legacy=${legacyKey}`,
+    `\n[end-user] ext=${input.endUser.externalUserId} eu=${euKey} legacy=${legacyKey} ` +
+      `transfer=${input.policy.transferTarget}`,
   );
 
   const euCustomerId = await ensureEndUserCustomer({
@@ -390,19 +502,28 @@ async function migrateEndUser(input: {
     dryRun: input.dryRun,
   });
 
+  const transfer = await resolveTransferTarget({
+    client: input.client,
+    app: input.app,
+    euKey,
+    euCustomerId,
+    transferTarget: input.policy.transferTarget,
+    dryRun: input.dryRun,
+  });
+
   await migrateLegacyWallet({
     client: input.client,
     legacyKey,
-    euKey,
-    euCustomerId,
-    transferBalances: input.transferBalances,
-    cancelLegacy: input.cancelLegacy,
+    transferTarget: input.policy.transferTarget,
+    targetKey: transfer?.targetKey ?? null,
+    targetCustomerId: transfer?.targetCustomerId ?? null,
+    cancelLegacy: input.policy.cancelLegacy,
     dryRun: input.dryRun,
     apiKey: input.apiKey,
     baseUrl: input.baseUrl,
   });
 
-  if (input.provisionMerchant) {
+  if (input.policy.provisionMerchantStarter) {
     await provisionMerchantStarter({
       app: input.app,
       endUser: input.endUser,
@@ -411,60 +532,10 @@ async function migrateEndUser(input: {
   }
 }
 
-async function main(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
-  if (!args.clientId) {
-    throw new Error(`--client-id is required\n${usage()}`);
-  }
-  if (!isHostedAdminClientAvailable()) {
-    throw new Error("OpenMeter is not configured (OPENMETER_URL / API key)");
-  }
-
-  const app = await resolveApp(args.clientId);
-  const endUsersForApp = await listEndUsersForApp(app, { dryRun: args.dryRun });
-  const client = getHostedAdminClient();
-  let apiKey = process.env.OPENMETER_API_KEY?.trim();
-  let baseUrl = getHostedOpenMeterUrl();
-  if (args.cancelLegacy || args.transferBalances) {
-    if (shouldUseKonnectRoutes(baseUrl, apiKey)) {
-      const konnect = requireKonnectConfig();
-      baseUrl = konnect.baseUrl;
-      apiKey = konnect.apiKey;
-    }
-  }
-
-  console.log(
-    `Migrating ${endUsersForApp.length} end-user(s) for ${app.publicClientId} ` +
-      `mode=${app.billingMode} transfer=${args.transferBalances} ` +
-      `cancelLegacy=${args.cancelLegacy} provisionMerchant=${args.provisionMerchant} ` +
-      `dryRun=${args.dryRun}`,
-  );
-
-  for (const endUser of endUsersForApp) {
-    await migrateEndUser({
-      client,
-      app,
-      endUser,
-      transferBalances: args.transferBalances,
-      cancelLegacy: args.cancelLegacy,
-      provisionMerchant: args.provisionMerchant,
-      dryRun: args.dryRun,
-      apiKey,
-      baseUrl,
-    });
-  }
-
-  if (args.dryRun) {
-    console.log(
-      "\n[dry-run] skipped attribution exit gate. Re-run without --dry-run, then confirm " +
-        "classifyUsageAttributionConsistency (via openmeter:audit-billing) is clean.",
-    );
-    return;
-  }
-
-  console.log("\nRunning attribution consistency exit gate…");
+async function runAttributionExitGate(publicClientId: string): Promise<void> {
+  console.log(`\nRunning attribution consistency exit gate for ${publicClientId}…`);
   const findings = await auditBillingConsistency({
-    clientId: app.publicClientId,
+    clientId: publicClientId,
   });
   const attributionErrors = attributionGateFindings(findings);
   if (attributionErrors.length > 0) {
@@ -475,15 +546,117 @@ async function main(): Promise<void> {
       }
     }
     throw new Error(
-      `Attribution exit gate failed: ${attributionErrors.length} error(s). ` +
+      `Attribution exit gate failed for ${publicClientId}: ` +
+        `${attributionErrors.length} error(s). ` +
         "No subject may carry usage that no customer is attributed. " +
         "Fix with ensure/release, then re-run.",
     );
   }
   console.log(
-    "Attribution exit gate passed (no usage_on_unattributed_subject / " +
-      "customer_has_no_usage_attribution errors).",
+    `Attribution exit gate passed for ${publicClientId} ` +
+      "(no usage_on_unattributed_subject / customer_has_no_usage_attribution errors).",
   );
+}
+
+async function migrateApp(input: {
+  app: AppRow;
+  args: Args;
+  client: ReturnType<typeof getHostedAdminClient>;
+  apiKey: string | undefined;
+  baseUrl: string;
+}): Promise<void> {
+  const policy = resolveEndUserMigratePolicy({
+    billingMode: input.app.billingMode,
+    full: input.args.full,
+    transferBalances: input.args.transferBalances,
+    cancelLegacy: input.args.cancelLegacy,
+    provisionMerchant: input.args.provisionMerchant,
+  });
+  const endUsersForApp = await listEndUsersForApp(input.app, {
+    dryRun: input.args.dryRun,
+  });
+
+  console.log(
+    `\n=== ${input.app.publicClientId} mode=${input.app.billingMode} ` +
+      `users=${endUsersForApp.length} transfer=${policy.transferTarget} ` +
+      `cancelLegacy=${policy.cancelLegacy} ` +
+      `provisionMerchant=${policy.provisionMerchantStarter} ` +
+      `dryRun=${input.args.dryRun} ===`,
+  );
+
+  for (const endUser of endUsersForApp) {
+    await migrateEndUser({
+      client: input.client,
+      app: input.app,
+      endUser,
+      policy,
+      dryRun: input.args.dryRun,
+      apiKey: input.apiKey,
+      baseUrl: input.baseUrl,
+    });
+  }
+
+  if (input.args.dryRun) {
+    console.log(
+      `\n[dry-run] skipped attribution exit gate for ${input.app.publicClientId}.`,
+    );
+    return;
+  }
+  await runAttributionExitGate(input.app.publicClientId);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (!isHostedAdminClientAvailable()) {
+    throw new Error("OpenMeter is not configured (OPENMETER_URL / API key)");
+  }
+
+  const apps = args.clientId
+    ? [await resolveApp(args.clientId)]
+    : await listAllApps();
+  if (apps.length === 0) {
+    console.log("No apps found.");
+    return;
+  }
+
+  if (!args.full && !args.clientId) {
+    console.log(
+      "Migrating all apps in ensure-only mode (no balance transfer / cancel). " +
+        "Pass --full for production cutover, or --client-id for one app.",
+    );
+  }
+
+  const client = getHostedAdminClient();
+  let apiKey = process.env.OPENMETER_API_KEY?.trim();
+  let baseUrl = getHostedOpenMeterUrl();
+  const needsKonnect =
+    args.full || args.cancelLegacy || args.transferBalances;
+  if (needsKonnect && shouldUseKonnectRoutes(baseUrl, apiKey)) {
+    const konnect = requireKonnectConfig();
+    baseUrl = konnect.baseUrl;
+    apiKey = konnect.apiKey;
+  }
+
+  console.log(
+    `End-user migrate apps=${apps.length} full=${args.full} dryRun=${args.dryRun}`,
+  );
+
+  for (const app of apps) {
+    await migrateApp({
+      app,
+      args,
+      client,
+      apiKey,
+      baseUrl,
+    });
+  }
+
+  if (args.dryRun) {
+    console.log(
+      "\n[dry-run] done. Re-run without --dry-run, then " +
+        "`npm run openmeter:audit-billing`.",
+    );
+  }
 }
 
 main()

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -474,9 +474,14 @@ export async function recordBillingCustomer(input: {
   openmeterCustomerId?: string | null;
 }): Promise<void> {
   const customerKey = input.customerKey.trim();
-  const clientId = input.clientId.trim();
   const openmeterCustomerId = input.openmeterCustomerId?.trim();
-  if (!customerKey || !clientId || !openmeterCustomerId) {
+  if (!customerKey || !openmeterCustomerId) {
+    return;
+  }
+  // plans/billing_customers.client_id is developer_apps.id — callers sometimes
+  // pass the public app_… oidc id (especially audit spendable probes).
+  const clientId = await resolveBillingCustomersClientId(input.clientId);
+  if (!clientId) {
     return;
   }
   const now = new Date().toISOString();
@@ -527,6 +532,26 @@ export async function recordBillingCustomer(input: {
       err instanceof Error ? err.message : String(err),
     );
   }
+}
+
+async function resolveBillingCustomersClientId(
+  clientIdOrPublic: string,
+): Promise<string | null> {
+  const trimmed = clientIdOrPublic.trim();
+  if (!trimmed) return null;
+  const byId = await db
+    .select({ id: developerApps.id })
+    .from(developerApps)
+    .where(eq(developerApps.id, trimmed))
+    .limit(1);
+  if (byId[0]?.id) return byId[0].id;
+  const byPublic = await db
+    .select({ id: developerApps.id })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, trimmed))
+    .limit(1);
+  return byPublic[0]?.id ?? null;
 }
 
 /**

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { OpenMeter } from "@openmeter/sdk";
 import { v4 as uuidv4 } from "uuid";
 
@@ -480,30 +480,46 @@ export async function recordBillingCustomer(input: {
     return;
   }
   const now = new Date().toISOString();
+  const kind = input.kind;
+  const platformUserId = input.platformUserId?.trim() || null;
+  const endUserId = input.endUserId?.trim() || null;
   try {
-    await db
-      .insert(billingCustomers)
-      .values({
-        id: uuidv4(),
-        customerKey,
-        kind: input.kind,
-        platformUserId: input.platformUserId?.trim() || null,
-        endUserId: input.endUserId?.trim() || null,
-        clientId,
-        openmeterCustomerId,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [billingCustomers.customerKey, billingCustomers.clientId],
-        set: {
-          kind: input.kind,
-          platformUserId: input.platformUserId?.trim() || null,
-          endUserId: input.endUserId?.trim() || null,
+    // Select-then-write avoids ON CONFLICT requiring a UNIQUE CONSTRAINT
+    // (prod may only have a UNIQUE INDEX from drizzle migrations).
+    const existing = await db
+      .select({ id: billingCustomers.id })
+      .from(billingCustomers)
+      .where(
+        and(
+          eq(billingCustomers.customerKey, customerKey),
+          eq(billingCustomers.clientId, clientId),
+        ),
+      )
+      .limit(1);
+    if (existing[0]?.id) {
+      await db
+        .update(billingCustomers)
+        .set({
+          kind,
+          platformUserId,
+          endUserId,
           openmeterCustomerId,
           updatedAt: now,
-        },
-      });
+        })
+        .where(eq(billingCustomers.id, existing[0].id));
+      return;
+    }
+    await db.insert(billingCustomers).values({
+      id: uuidv4(),
+      customerKey,
+      kind,
+      platformUserId,
+      endUserId,
+      clientId,
+      openmeterCustomerId,
+      createdAt: now,
+      updatedAt: now,
+    });
   } catch (err) {
     console.warn(
       "customers: billing_customers upsert failed",

--- a/src/lib/openmeter/end-user-migrate-policy.test.ts
+++ b/src/lib/openmeter/end-user-migrate-policy.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveEndUserMigratePolicy } from "./end-user-migrate-policy";
+
+test("--full merchant: transfer to eu_, cancel legacy, provision Starter", () => {
+  assert.deepEqual(
+    resolveEndUserMigratePolicy({
+      billingMode: "merchant",
+      full: true,
+      transferBalances: false,
+      cancelLegacy: false,
+      provisionMerchant: false,
+    }),
+    {
+      transferTarget: "eu",
+      cancelLegacy: true,
+      provisionMerchantStarter: true,
+    },
+  );
+});
+
+test("--full owner_rollup: transfer to owner wallet, cancel legacy, no Starter", () => {
+  assert.deepEqual(
+    resolveEndUserMigratePolicy({
+      billingMode: "owner_rollup",
+      full: true,
+      transferBalances: true,
+      cancelLegacy: false,
+      provisionMerchant: true,
+    }),
+    {
+      transferTarget: "owner",
+      cancelLegacy: true,
+      provisionMerchantStarter: false,
+    },
+  );
+});
+
+test("granular merchant flags map to eu_ transfer", () => {
+  assert.deepEqual(
+    resolveEndUserMigratePolicy({
+      billingMode: "merchant",
+      full: false,
+      transferBalances: true,
+      cancelLegacy: true,
+      provisionMerchant: true,
+    }),
+    {
+      transferTarget: "eu",
+      cancelLegacy: true,
+      provisionMerchantStarter: true,
+    },
+  );
+});
+
+test("granular ensure-only leaves wallets untouched", () => {
+  assert.deepEqual(
+    resolveEndUserMigratePolicy({
+      billingMode: "owner_rollup",
+      full: false,
+      transferBalances: false,
+      cancelLegacy: false,
+      provisionMerchant: false,
+    }),
+    {
+      transferTarget: "none",
+      cancelLegacy: false,
+      provisionMerchantStarter: false,
+    },
+  );
+});
+
+test("owner_rollup + --transfer-balances without --full is rejected", () => {
+  assert.throws(
+    () =>
+      resolveEndUserMigratePolicy({
+        billingMode: "owner_rollup",
+        full: false,
+        transferBalances: true,
+        cancelLegacy: true,
+        provisionMerchant: false,
+      }),
+    /must not transfer legacy prepaid onto eu_/,
+  );
+});

--- a/src/lib/openmeter/end-user-migrate-policy.ts
+++ b/src/lib/openmeter/end-user-migrate-policy.ts
@@ -1,0 +1,62 @@
+/**
+ * Policy for end-user OpenMeter customer cutover
+ * (`app_…:externalUserId` → `eu_{end_users.id}`).
+ *
+ * Merchant payers live on `eu_…`. Owner_rollup payers live on the owner wallet;
+ * `eu_…` is still ensured as the actor customer, but prepaid must not move onto
+ * `eu_…` or it becomes stranded.
+ */
+
+export type BillingMode = "owner_rollup" | "merchant";
+
+export type EndUserTransferTarget = "eu" | "owner" | "none";
+
+export type EndUserMigratePolicy = {
+  transferTarget: EndUserTransferTarget;
+  cancelLegacy: boolean;
+  provisionMerchantStarter: boolean;
+};
+
+/**
+ * Resolve migrate actions for one app.
+ *
+ * `--full` applies the production cutover policy from billing mode and ignores
+ * the granular transfer/cancel/provision flags.
+ */
+export function resolveEndUserMigratePolicy(input: {
+  billingMode: BillingMode;
+  full: boolean;
+  transferBalances: boolean;
+  cancelLegacy: boolean;
+  provisionMerchant: boolean;
+}): EndUserMigratePolicy {
+  if (input.full) {
+    if (input.billingMode === "merchant") {
+      return {
+        transferTarget: "eu",
+        cancelLegacy: true,
+        provisionMerchantStarter: true,
+      };
+    }
+    return {
+      transferTarget: "owner",
+      cancelLegacy: true,
+      provisionMerchantStarter: false,
+    };
+  }
+
+  if (input.billingMode === "owner_rollup" && input.transferBalances) {
+    throw new Error(
+      "owner_rollup apps must not transfer legacy prepaid onto eu_… " +
+        "(that wallet is not the payer). Use --full to move remaining " +
+        "credits onto the owner wallet, or omit --transfer-balances.",
+    );
+  }
+
+  return {
+    transferTarget: input.transferBalances ? "eu" : "none",
+    cancelLegacy: input.cancelLegacy,
+    provisionMerchantStarter:
+      input.billingMode === "merchant" && input.provisionMerchant,
+  };
+}

--- a/src/lib/starter-default-plan.ts
+++ b/src/lib/starter-default-plan.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 
 import { db } from "@/db/index";
-import { plans } from "@/db/schema";
+import { developerApps, oidcClients, plans } from "@/db/schema";
 import {
   STARTER_DEFAULT_PLAN_INTERNAL_NAME,
   defaultStarterIncludedUsdMicros,
@@ -31,9 +31,38 @@ function isUniqueConstraintError(err: unknown): boolean {
   );
 }
 
-export async function selectStarterDefaultPlan(
-  clientId: string,
+/**
+ * `plans.client_id` is `developer_apps.id`. Callers often pass the public
+ * `app_…` oidc client id; resolve that before insert/lookup.
+ */
+export async function resolveDeveloperAppIdForPlans(
+  clientIdOrPublic: string,
   executor: Pick<typeof db, "select"> = db,
+): Promise<string> {
+  const trimmed = clientIdOrPublic.trim();
+  if (!trimmed) return trimmed;
+
+  const byId = await executor
+    .select({ id: developerApps.id })
+    .from(developerApps)
+    .where(eq(developerApps.id, trimmed))
+    .limit(1);
+  if (byId[0]?.id) return byId[0].id;
+
+  const byPublic = await executor
+    .select({ id: developerApps.id })
+    .from(developerApps)
+    .innerJoin(oidcClients, eq(developerApps.oidcClientId, oidcClients.id))
+    .where(eq(oidcClients.clientId, trimmed))
+    .limit(1);
+  if (byPublic[0]?.id) return byPublic[0].id;
+
+  return trimmed;
+}
+
+async function selectStarterDefaultPlanByClientId(
+  clientId: string,
+  executor: Pick<typeof db, "select">,
 ): Promise<typeof plans.$inferSelect | undefined> {
   const rows = await executor
     .select()
@@ -43,10 +72,24 @@ export async function selectStarterDefaultPlan(
   return rows[0];
 }
 
+export async function selectStarterDefaultPlan(
+  clientId: string,
+  executor: Pick<typeof db, "select"> = db,
+): Promise<typeof plans.$inferSelect | undefined> {
+  const resolved = await resolveDeveloperAppIdForPlans(clientId, executor);
+  const byResolved = await selectStarterDefaultPlanByClientId(resolved, executor);
+  if (byResolved) return byResolved;
+  if (resolved !== clientId.trim()) {
+    return selectStarterDefaultPlanByClientId(clientId.trim(), executor);
+  }
+  return undefined;
+}
+
 export async function getOrCreateStarterPlan(
   clientId: string,
   executor: Pick<typeof db, "select" | "insert"> = db,
 ): Promise<typeof plans.$inferSelect> {
+  const plansClientId = await resolveDeveloperAppIdForPlans(clientId, executor);
   const existing = await selectStarterDefaultPlan(clientId, executor);
   if (existing) {
     return existing;
@@ -56,7 +99,7 @@ export async function getOrCreateStarterPlan(
   try {
     await executor.insert(plans).values({
       id,
-      clientId,
+      clientId: plansClientId,
       name: STARTER_DEFAULT_PLAN_INTERNAL_NAME,
       type: "usage",
       priceAmount: "0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
All-apps `--full` end-user OpenMeter cutover for #442/#446, plus fixes found during the live prod run:

- `--full` mode-aware policy (merchant→`eu_…`, owner_rollup→owner wallet)
- Omit `--client-id` to migrate every app
- `billing_customers`: select-then-write + resolve public `app_…` → `developer_apps.id`
- `getOrCreateStarterPlan`: resolve public → developer app id
- Skip / soft-fail Konnect `scheduled` subscription cancels (403 was aborting mid-run)
- Attribution exit gate continues remaining apps on throw

## After merge / on this branch
```bash
git pull
# Finish any merchant app interrupted by scheduled-cancel 403:
npm run openmeter:migrate-end-user-customers -- --client-id app_6c95d934d5016bb2d322456f --full
npm run openmeter:audit-billing
```

## Test plan
- [x] unit tests + tsc
- [ ] re-run interrupted merchant client-id on prod
- [ ] platform `openmeter:audit-billing` exits 0

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86b7523d-7469-4f86-bf2e-059e7aa3f757?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86b7523d-7469-4f86-bf2e-059e7aa3f757&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

