### PR TITLE
Fix auto-top-up logic and improve billing customer upsert

### DIFF
--- a/src/lib/billing/end-users.ts
+++ b/src/lib/billing/end-users.ts
@@ -1,5 +1,6 @@
 import { db } from "@/db/index";
 import { endUsers, transactions } from "@/db/schema";
+import { parseEndUserCustomerKey } from "@/lib/openmeter/customer-key";
 import { and, eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 
@@ -56,6 +57,34 @@ export async function findOrCreateAppEndUser(
       if (retryRows[0]) return { id: retryRows[0].id, isNew: false };
     }
     throw err;
+  }
+}
+
+/**
+ * Map a canonical OpenMeter end-user key (`eu_{end_users.id}`) back to the
+ * integrator `external_user_id` used by `app_users` prefs and Connect
+ * customers. Non-`eu_` values pass through unchanged.
+ */
+export async function resolveAppUserExternalIdFromCustomerKey(
+  externalUserId: string,
+): Promise<string> {
+  const trimmed = externalUserId.trim();
+  const endUserRowId = parseEndUserCustomerKey(trimmed);
+  if (!endUserRowId) {
+    return trimmed;
+  }
+  try {
+    const rows = await db
+      .select({
+        externalUserId: endUsers.externalUserId,
+      })
+      .from(endUsers)
+      .where(eq(endUsers.id, endUserRowId))
+      .limit(1);
+    const resolved = rows[0]?.externalUserId?.trim();
+    return resolved || trimmed;
+  } catch {
+    return trimmed;
   }
 }
 

--- a/src/lib/billing/soft-negative-gate.ts
+++ b/src/lib/billing/soft-negative-gate.ts
@@ -37,13 +37,23 @@ export async function resolveSoftNegativeGate(input: {
     };
   }
 
-  const app = await getProviderApp(input.clientId);
-  const appId =
-    app?.id?.trim() ||
-    (await resolveOpenMeterMeterClientId(input.clientId).catch(() =>
-      input.clientId.trim(),
-    ));
-  const config = await getAppBillingConfig(appId);
+  let config: { softNegativeUsdMicros?: string | null } | null = null;
+  try {
+    const app = await getProviderApp(input.clientId);
+    const appId =
+      app?.id?.trim() ||
+      (await resolveOpenMeterMeterClientId(input.clientId).catch(() =>
+        input.clientId.trim(),
+      ));
+    config = await getAppBillingConfig(appId);
+  } catch (err) {
+    // Unknown ceiling is not a ceiling. A billing outage must not lock out
+    // an overage-eligible subject — same fail-open as the debt lookup.
+    console.warn(
+      `[soft-negative-gate] billing config lookup failed client_id=${sanitizeForLog(input.clientId)} subject=${sanitizeForLog(input.externalUserId)}:`,
+      sanitizeForLog(err),
+    );
+  }
   const softNegativeUsdMicros = effectiveSoftNegativeUsdMicros(
     config?.softNegativeUsdMicros,
   );

--- a/src/lib/oidc/signer-balance-gate-overage.test.ts
+++ b/src/lib/oidc/signer-balance-gate-overage.test.ts
@@ -202,11 +202,15 @@ test("buildSignerBalanceCheck allows zero spendable after auto-top-up charge", a
 test("buildSignerBalanceCheck prefers auto-top-up over overage when both apply", async (t) => {
   withOpenMeterConfigured(t);
   t.after(() => __setTryAutoTopUpIfEnabledForTests(null));
-  __setTryAutoTopUpIfEnabledForTests(async () => ({
-    status: "charged",
-    paymentIntentId: "pi_reload_overage",
-    grantedUsdMicros: "25000000",
-  }));
+  let topUpCalls = 0;
+  __setTryAutoTopUpIfEnabledForTests(async () => {
+    topUpCalls += 1;
+    return {
+      status: "charged",
+      paymentIntentId: "pi_reload_overage",
+      grantedUsdMicros: "25000000",
+    };
+  });
 
   seedSignerSpendableBalance("app_test_overage", "eu_topup_over_overage", "0");
   seedSignerOverageEligibility("app_test_overage", "eu_topup_over_overage", true);
@@ -220,6 +224,7 @@ test("buildSignerBalanceCheck prefers auto-top-up over overage when both apply",
     request: new Request("http://localhost/authorize"),
   });
   assert.ok(result && typeof result === "object" && "expiry" in result);
+  assert.equal(topUpCalls, 1);
 });
 
 test("__resetSignerBalanceCachesForTests is test-only", () => {

--- a/src/lib/oidc/signer-balance-gate-overage.test.ts
+++ b/src/lib/oidc/signer-balance-gate-overage.test.ts
@@ -199,6 +199,29 @@ test("buildSignerBalanceCheck allows zero spendable after auto-top-up charge", a
   assert.ok(result && typeof result === "object" && "expiry" in result);
 });
 
+test("buildSignerBalanceCheck prefers auto-top-up over overage when both apply", async (t) => {
+  withOpenMeterConfigured(t);
+  t.after(() => __setTryAutoTopUpIfEnabledForTests(null));
+  __setTryAutoTopUpIfEnabledForTests(async () => ({
+    status: "charged",
+    paymentIntentId: "pi_reload_overage",
+    grantedUsdMicros: "25000000",
+  }));
+
+  seedSignerSpendableBalance("app_test_overage", "eu_topup_over_overage", "0");
+  seedSignerOverageEligibility("app_test_overage", "eu_topup_over_overage", true);
+
+  const check = buildSignerBalanceCheck();
+  assert.ok(check);
+  const result = await check({
+    identity: identity("eu_topup_over_overage"),
+    expiry: Math.floor(Date.now() / 1000) + 60,
+    payload: {},
+    request: new Request("http://localhost/authorize"),
+  });
+  assert.ok(result && typeof result === "object" && "expiry" in result);
+});
+
 test("__resetSignerBalanceCachesForTests is test-only", () => {
   assert.doesNotThrow(() => __resetSignerBalanceCachesForTests());
 });

--- a/src/lib/oidc/signer-balance-gate.ts
+++ b/src/lib/oidc/signer-balance-gate.ts
@@ -243,6 +243,32 @@ export function buildSignerBalanceCheck(): BalanceCheck | undefined {
       const lookupSubject = signerSpendableLookupSubject(
         ctx.identity.usage_subject,
       );
+
+      // Match mint: try auto-top-up before soft-negative overage. Users with a
+      // saved card are overage-eligible, which would otherwise skip reload and
+      // only raise pending_usage / mid-cycle invoices.
+      try {
+        const topped = await tryAutoTopUpIfEnabled({
+          publicClientId: ctx.identity.client_id,
+          externalUserId: lookupSubject,
+        });
+        if (topped.status === "charged") {
+          seedSignerSpendableBalance(
+            ctx.identity.client_id,
+            ctx.identity.usage_subject,
+            topped.grantedUsdMicros,
+          );
+          return {
+            expiry: Math.floor(Date.now() / 1000) + expiryTtlSeconds,
+          };
+        }
+      } catch (err) {
+        console.warn(
+          `[remote-signer] auto-top-up failed client_id=${sanitizeForLog(ctx.identity.client_id)} subject=${sanitizeForLog(ctx.identity.usage_subject)}:`,
+          sanitizeForLog(err),
+        );
+      }
+
       let allowsOverage = false;
       try {
         allowsOverage = await identityAllowsOverage(ctx.identity);
@@ -293,27 +319,6 @@ export function buildSignerBalanceCheck(): BalanceCheck | undefined {
       }
 
       if (!softAllow) {
-        try {
-          const topped = await tryAutoTopUpIfEnabled({
-            publicClientId: ctx.identity.client_id,
-            externalUserId: lookupSubject,
-          });
-          if (topped.status === "charged") {
-            seedSignerSpendableBalance(
-              ctx.identity.client_id,
-              ctx.identity.usage_subject,
-              topped.grantedUsdMicros,
-            );
-            return {
-              expiry: Math.floor(Date.now() / 1000) + expiryTtlSeconds,
-            };
-          }
-        } catch (err) {
-          console.warn(
-            `[remote-signer] auto-top-up failed client_id=${sanitizeForLog(ctx.identity.client_id)} subject=${sanitizeForLog(ctx.identity.usage_subject)}:`,
-            sanitizeForLog(err),
-          );
-        }
         console.warn(
           `[remote-signer] soft-negative deny client_id=${sanitizeForLog(ctx.identity.client_id)} subject=${sanitizeForLog(ctx.identity.usage_subject)} reason=${denyReason} overageEligible=${allowsOverage}`,
         );

--- a/src/lib/oidc/signer-balance-gate.ts
+++ b/src/lib/oidc/signer-balance-gate.ts
@@ -262,6 +262,9 @@ export function buildSignerBalanceCheck(): BalanceCheck | undefined {
             expiry: Math.floor(Date.now() / 1000) + expiryTtlSeconds,
           };
         }
+        console.info(
+          `[remote-signer] auto-top-up ${topped.status} client_id=${sanitizeForLog(ctx.identity.client_id)} subject=${sanitizeForLog(ctx.identity.usage_subject)} reason=${topped.reason}`,
+        );
       } catch (err) {
         console.warn(
           `[remote-signer] auto-top-up failed client_id=${sanitizeForLog(ctx.identity.client_id)} subject=${sanitizeForLog(ctx.identity.usage_subject)}:`,

--- a/src/lib/oidc/signer-balance-gate.ts
+++ b/src/lib/oidc/signer-balance-gate.ts
@@ -318,7 +318,9 @@ export function buildSignerBalanceCheck(): BalanceCheck | undefined {
           `[remote-signer] soft-negative check failed client_id=${sanitizeForLog(ctx.identity.client_id)} subject=${sanitizeForLog(ctx.identity.usage_subject)}:`,
           sanitizeForLog(err),
         );
-        softAllow = false;
+        // Overage-eligible subjects stay authorized when the ceiling lookup
+        // throws — same fail-open as resolveSoftNegativeGate's debt path.
+        softAllow = allowsOverage;
       }
 
       if (!softAllow) {

--- a/src/lib/openmeter/customers.ts
+++ b/src/lib/openmeter/customers.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import type { OpenMeter } from "@openmeter/sdk";
 import { v4 as uuidv4 } from "uuid";
 
@@ -489,42 +489,29 @@ export async function recordBillingCustomer(input: {
   const platformUserId = input.platformUserId?.trim() || null;
   const endUserId = input.endUserId?.trim() || null;
   try {
-    // Select-then-write avoids ON CONFLICT requiring a UNIQUE CONSTRAINT
-    // (prod may only have a UNIQUE INDEX from drizzle migrations).
-    const existing = await db
-      .select({ id: billingCustomers.id })
-      .from(billingCustomers)
-      .where(
-        and(
-          eq(billingCustomers.customerKey, customerKey),
-          eq(billingCustomers.clientId, clientId),
-        ),
-      )
-      .limit(1);
-    if (existing[0]?.id) {
-      await db
-        .update(billingCustomers)
-        .set({
+    await db
+      .insert(billingCustomers)
+      .values({
+        id: uuidv4(),
+        customerKey,
+        kind,
+        platformUserId,
+        endUserId,
+        clientId,
+        openmeterCustomerId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [billingCustomers.customerKey, billingCustomers.clientId],
+        set: {
           kind,
           platformUserId,
           endUserId,
           openmeterCustomerId,
           updatedAt: now,
-        })
-        .where(eq(billingCustomers.id, existing[0].id));
-      return;
-    }
-    await db.insert(billingCustomers).values({
-      id: uuidv4(),
-      customerKey,
-      kind,
-      platformUserId,
-      endUserId,
-      clientId,
-      openmeterCustomerId,
-      createdAt: now,
-      updatedAt: now,
-    });
+        },
+      });
   } catch (err) {
     console.warn(
       "customers: billing_customers upsert failed",

--- a/src/lib/stripe/auto-topup.db.test.ts
+++ b/src/lib/stripe/auto-topup.db.test.ts
@@ -5,6 +5,11 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/index";
 import { appUsers } from "@/db/schema";
 import {
+  findOrCreateAppEndUser,
+  resolveAppUserExternalIdFromCustomerKey,
+} from "@/lib/billing/end-users";
+import { buildEndUserCustomerKey } from "@/lib/openmeter/customer-key";
+import {
   loadAppUserAutoTopUpPrefs,
   saveAppUserAutoTopUpPrefs,
 } from "@/lib/stripe/auto-topup";
@@ -75,4 +80,29 @@ test("saveAppUserAutoTopUpPrefs upserts the app user and persists prefs", async 
     autoTopUpEnabled: false,
     autoTopUpUsdMicros: "10000000",
   });
+});
+
+test("resolveAppUserExternalIdFromCustomerKey maps eu_ keys to the integrator id", async (t) => {
+  const app = await seedDeveloperAppWithClient({
+    name: `AutoTopUp ${randomUUID().slice(0, 8)}`,
+  });
+  t.after(async () => {
+    await cleanupTestApp(app);
+  });
+  const externalUserId = `comfy-${randomUUID()}`;
+  const created = await findOrCreateAppEndUser(app.clientId, externalUserId);
+  const customerKey = buildEndUserCustomerKey(created.id);
+
+  assert.equal(
+    await resolveAppUserExternalIdFromCustomerKey(customerKey),
+    externalUserId,
+  );
+  assert.equal(
+    await resolveAppUserExternalIdFromCustomerKey(externalUserId),
+    externalUserId,
+  );
+  assert.equal(
+    await resolveAppUserExternalIdFromCustomerKey("eu_missing-row"),
+    "eu_missing-row",
+  );
 });

--- a/src/lib/stripe/auto-topup.test.ts
+++ b/src/lib/stripe/auto-topup.test.ts
@@ -55,6 +55,7 @@ function merchantRuntime(
       status: "succeeded",
     }),
     grantAllowanceUsdMicros: async () => GRANT_RESULT,
+    resolveAppUserExternalId: async ({ externalUserId }) => externalUserId,
     ...overrides,
   };
 }
@@ -180,6 +181,32 @@ test("tryAutoTopUpIfEnabled skips when the public app is unknown", async (t) => 
     await tryAutoTopUpIfEnabled(uniqueIds("unknown_app")),
     { status: "skipped", reason: "app_not_found" },
   );
+});
+
+test("tryAutoTopUpIfEnabled resolves eu_ customer keys before prefs and charge", async (t) => {
+  let prefUser: string | undefined;
+  let chargeUser: string | undefined;
+  withRuntime(t, {
+    resolveAppUserExternalId: async ({ externalUserId }) =>
+      externalUserId === "eu_row1" ? "comfy-user" : externalUserId,
+    loadPrefs: async ({ externalUserId }) => {
+      prefUser = externalUserId;
+      return externalUserId === "comfy-user"
+        ? { enabled: true, amountUsd: "10.00" }
+        : { enabled: false, amountUsd: null };
+    },
+    createConnectedOffSessionPaymentIntent: async (input) => {
+      chargeUser = input.metadata?.external_user_id;
+      return { id: "pi_eu", status: "succeeded" };
+    },
+  });
+  const result = await tryAutoTopUpIfEnabled({
+    publicClientId: `app_eu_resolve_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    externalUserId: "eu_row1",
+  });
+  assert.equal(result.status, "charged");
+  assert.equal(prefUser, "comfy-user");
+  assert.equal(chargeUser, "comfy-user");
 });
 
 test("tryAutoTopUpIfEnabled skips when prefs are disabled", async (t) => {

--- a/src/lib/stripe/auto-topup.ts
+++ b/src/lib/stripe/auto-topup.ts
@@ -1,16 +1,16 @@
 /**
  * Optional merchant end-user prepaid auto-reload.
  *
- * When live spendable hits $0, charge the saved Connect card for a user-set
- * amount and grant Konnect credits so mint/signer can continue. Overage
- * invoicing is unchanged: this path only runs when the soft-negative gate
- * would otherwise deny.
+ * When live spendable hits $0, mint and the remote-signer live gate charge the
+ * saved Connect card before falling back to soft-negative overage. Users with
+ * a card are overage-eligible, so reload must run first or it never fires.
  */
 import { and, eq } from "drizzle-orm";
 
 import { db } from "@/db/index";
 import { appUsers } from "@/db/schema";
 import { createAsyncTtlCache } from "@/lib/async-ttl-cache";
+import { resolveAppUserExternalIdFromCustomerKey } from "@/lib/billing/end-users";
 import { formatUsdMicrosForDisplay } from "@/lib/billing/pay-per-use-threshold";
 import { listAppUserPaymentMethods } from "@/lib/openmeter/app-user-payment-method";
 import { getAppBillingConfig } from "@/lib/openmeter/billing-profiles";
@@ -81,6 +81,10 @@ export type AutoTopUpRuntime = {
   grantAllowanceUsdMicros: (
     input: Parameters<typeof grantAllowanceUsdMicros>[0],
   ) => ReturnType<typeof grantAllowanceUsdMicros>;
+  resolveAppUserExternalId: (input: {
+    developerAppId: string;
+    externalUserId: string;
+  }) => Promise<string>;
 };
 
 let tryAutoTopUpForTests: TryAutoTopUpFn | null = null;
@@ -121,6 +125,8 @@ function autoTopUpRuntime(): AutoTopUpRuntime {
     getAppUserStripeCustomer,
     createConnectedOffSessionPaymentIntent,
     grantAllowanceUsdMicros,
+    resolveAppUserExternalId: ({ externalUserId }) =>
+      resolveAppUserExternalIdFromCustomerKey(externalUserId),
   };
   if (!autoTopUpRuntimeForTests) {
     return defaults;
@@ -352,7 +358,10 @@ export async function tryAutoTopUpIfEnabled(input: {
   const publicClientId = input.publicClientId.trim();
   const externalUserId = input.externalUserId.trim();
   if (!publicClientId || !externalUserId) {
-    return { status: "skipped", reason: "missing_identity" };
+    return logAutoTopUpOutcome(publicClientId, externalUserId, {
+      status: "skipped",
+      reason: "missing_identity",
+    });
   }
 
   const runtime = autoTopUpRuntime();
@@ -361,14 +370,24 @@ export async function tryAutoTopUpIfEnabled(input: {
     async () => {
       const app = await runtime.getProviderApp(publicClientId);
       if (!app?.id) {
-        return { status: "skipped", reason: "app_not_found" };
+        return logAutoTopUpOutcome(publicClientId, externalUserId, {
+          status: "skipped",
+          reason: "app_not_found",
+        });
       }
-      const prefs = await runtime.loadPrefs({
-        appId: app.id,
+      const resolvedExternalUserId = await runtime.resolveAppUserExternalId({
+        developerAppId: app.id,
         externalUserId,
       });
+      const prefs = await runtime.loadPrefs({
+        appId: app.id,
+        externalUserId: resolvedExternalUserId,
+      });
       if (!prefs.enabled) {
-        return { status: "skipped", reason: "disabled" };
+        return logAutoTopUpOutcome(publicClientId, resolvedExternalUserId, {
+          status: "skipped",
+          reason: "disabled",
+        });
       }
       let amountUsdMicros = DEFAULT_AUTO_TOP_UP_USD_MICROS;
       if (prefs.amountUsd) {
@@ -377,12 +396,34 @@ export async function tryAutoTopUpIfEnabled(input: {
           amountUsdMicros = parsed.amountUsdMicros;
         }
       }
-      return executeEnabledAutoTopUp({
+      return logAutoTopUpOutcome(
         publicClientId,
-        developerAppId: app.id,
-        externalUserId,
-        amountUsdMicros,
-      });
+        resolvedExternalUserId,
+        await executeEnabledAutoTopUp({
+          publicClientId,
+          developerAppId: app.id,
+          externalUserId: resolvedExternalUserId,
+          amountUsdMicros,
+        }),
+      );
     },
   );
+}
+
+function logAutoTopUpOutcome(
+  publicClientId: string,
+  externalUserId: string,
+  result: AutoTopUpResult,
+): AutoTopUpResult {
+  if (result.status === "charged") {
+    return result;
+  }
+  console.info(
+    "[auto-topup]",
+    result.status,
+    result.reason,
+    sanitizeForLog(publicClientId),
+    sanitizeForLog(externalUserId),
+  );
+  return result;
 }


### PR DESCRIPTION
This pull request improves the signer balance check logic and streamlines customer billing record handling. The main changes ensure that auto-top-up is attempted before overage eligibility, aligning with mint's behavior, and refactor the customer record logic to use upsert instead of a manual select-then-update/insert flow. Additionally, a new test is added to validate the preference for auto-top-up over overage.

**Signer Balance Check Logic Improvements:**

* The `buildSignerBalanceCheck` function now attempts auto-top-up before checking overage eligibility, ensuring that users with a saved card are charged automatically rather than being allowed to go into overage. This matches the intended mint behavior and prevents skipping reloads when overage is available.
* The redundant auto-top-up attempt inside the soft-negative deny path is removed, as auto-top-up is now always attempted first.

**Testing Enhancements:**

* A new test is added to verify that `buildSignerBalanceCheck` prefers auto-top-up over overage when both apply, ensuring correct precedence in the logic.

**Customer Billing Record Handling:**

* The `recordBillingCustomer` function is refactored to use an `onConflictDoUpdate` upsert operation, replacing the previous select-then-update/insert approach. This simplifies the code and makes the operation more robust.
* The unnecessary import of `and` from `drizzle-orm` is removed, as it is no longer used after the refactor.