### PR TITLE
Bump remote signer image to sha-264fc6ba8c67c03cd53824d55b13a53721f07577

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,7 @@ DATABASE_URL=postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neond
 # Start the full stack so Kafka events reach the OpenMeter collector:
 #   docker compose -f docker-compose.clearinghouse.railway.yml --env-file .env.local up -d --build
 # go-livepeer binary source for signer-dmz-local build (published CI image by default):
-# LIVEPEER_IMAGE=livepeer/go-livepeer:sha-9d92ee43300fead9cbcece0867ba04814e3ed218
+# LIVEPEER_IMAGE=livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577
 # Or build DMZ only: ./scripts/build-local-signer.sh
 # Standalone signer (no kafka): docker compose up -d signer-dmz
 # The local compose image is signer-dmz: Apache validates RS256 bearer tokens

--- a/config/railway/stack.json
+++ b/config/railway/stack.json
@@ -28,7 +28,7 @@
       "manifest": "deploy/pymthouse-signer-test/railway.json",
       "environments": ["preview", "production"],
       "description": "A/B 'latest' remote signer DMZ, deployed in both preview and production. Same webhook/OIDC/Kafka and signing identity as pymthouse (the 'stable' signer); LIVEPEER_IMAGE matches the prod Dockerfile default. Entrypoint defaults BYOC_PER_CAP_PRICING=on for this service name. Apps opt in via LATEST_SIGNER_APPS on the Next app.",
-      "livepeerImage": "livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78",
+      "livepeerImage": "livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577",
       "byocPerCapPricing": true
     },
     "pymthouse-signer-test-preview-only": {
@@ -36,7 +36,7 @@
       "manifest": "deploy/pymthouse-signer-test-preview-only/railway.json",
       "environments": ["preview"],
       "description": "Preview-only A/B signer DMZ. Shares pymthouse signing identity; must receive the same ETH_RPC_URL / OIDC / webhook env as other signers via railway-apply-stack-env.sh. Never deploy to production.",
-      "livepeerImage": "livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78",
+      "livepeerImage": "livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577",
       "byocPerCapPricing": true
     }
   }

--- a/docker-compose.clearinghouse.railway.yml
+++ b/docker-compose.clearinghouse.railway.yml
@@ -58,7 +58,7 @@ services:
       dockerfile: docker/signer-dmz/Dockerfile
       target: signer-dmz-local
       args:
-        LIVEPEER_IMAGE: ${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78}
+        LIVEPEER_IMAGE: ${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577}
     restart: unless-stopped
     ports:
       - target: 8080

--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -5,7 +5,7 @@
 #   signer-dmz      — production; livepeer from livepeer/go-livepeer Docker image (Railway single service).
 
 # Base image for signer-dmz-local (override: docker build --build-arg LIVEPEER_IMAGE=...).
-ARG LIVEPEER_IMAGE=livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78
+ARG LIVEPEER_IMAGE=livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577
 
 FROM debian:bookworm-slim AS build-mod
 

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -2,7 +2,7 @@
 # Copies livepeer + required CUDA NPP libs from the official image — do not wget
 # a bare binary into debian:slim; the binary links libnppig.so and other NPP libs.
 
-FROM livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78 AS livepeer-src
+FROM livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577 AS livepeer-src
 
 FROM debian:bookworm-slim
 

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -16,8 +16,8 @@ Everything needed to run the go-livepeer signer with an optional **Apache + mod_
 | Image | Dockerfile | go-livepeer source | Use |
 |-------|------------|--------------------|-----|
 | `pymthouse/signer-dmz:local` | `Dockerfile` → `signer-dmz-local` | `../go-livepeer` via `lpclearinghouse` | **Local dev** with PymtHouse (`docker-compose.yml`) |
-| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78` | **Production** (Railway / Render) and prod smoke tests |
-| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78` | **Livepeer only** (no Apache; not for public deploy) |
+| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577` | **Production** (Railway / Render) and prod smoke tests |
+| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577` | **Livepeer only** (no Apache; not for public deploy) |
 
 ### Force rebuild
 

--- a/scripts/build-local-signer.sh
+++ b/scripts/build-local-signer.sh
@@ -3,7 +3,7 @@
 #
 # Default (fast): pull a published go-livepeer image and copy livepeer into the DMZ.
 #   ./scripts/build-local-signer.sh
-#   LIVEPEER_IMAGE=livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78 ./scripts/build-local-signer.sh
+#   LIVEPEER_IMAGE=livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577 ./scripts/build-local-signer.sh
 #
 # From local checkout (slow — full CGO/FFmpeg build via lpclearinghouse):
 #   LIVEPEER_IMAGE= ./scripts/build-local-signer.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GO_LIVEPEER_DIR="${GO_LIVEPEER_DIR:-${ROOT}/../go-livepeer}"
 LPCLEARINGHOUSE_DIR="${LPCLEARINGHOUSE_DIR:-${ROOT}/../lpclearinghouse}"
-LIVEPEER_IMAGE="${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-4c0796460277e6db069fb9131891ab9f3401aa78}"
+LIVEPEER_IMAGE="${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577}"
 SIGNER_DMZ_IMAGE="${SIGNER_DMZ_IMAGE:-pymthouse/signer-dmz:local}"
 
 if [[ -n "${LIVEPEER_IMAGE}" ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pin `livepeer/go-livepeer` to `sha-264fc6ba8c67c03cd53824d55b13a53721f07577` across Dockerfiles, compose, Railway stack, build scripts, and docs.

The published image is [go-livepeer@264fc6ba](https://github.com/livepeer/go-livepeer/commit/264fc6ba8c67c03cd53824d55b13a53721f07577). It encodes a constrained model ID into the remote-signer `create_signed_ticket` Kafka `pipeline` field as `base:model` (for example `live-video-to-video:comfyui`). The OpenMeter collector already splits on the first `:` into `pipeline` + `model_id`.

## Changes

- `docker/signer-dmz/Dockerfile` and `Dockerfile.signer` default/FROM pin
- `docker-compose.clearinghouse.railway.yml` `LIVEPEER_IMAGE` default
- `config/railway/stack.json` `livepeerImage` for `pymthouse-signer-test` and `pymthouse-signer-test-preview-only`
- `scripts/build-local-signer.sh` default
- Docs: `docker/signer-dmz/README.md`, `.env.example`

## Verification

- `npx tsc --noEmit` passed
- Docker Hub tag `livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577` is active (`amd64`, digest `sha256:5e8cb7461fcceb55df06892b2a00a4f5957164b559b159985b80a03733fe796b`)
- No remaining `sha-4c079646…` pins
- Local Snyk/SonarQube CLIs and tokens are not available in this environment; those checks run in CI on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7497c327-6697-4e89-bf00-b0e9931eaa7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7497c327-6697-4e89-bf00-b0e9931eaa7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

