### PR TITLE
feat(users): discoveryUrl preference for SignerSession exchanges

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -148,11 +148,13 @@ Authorization: Basic base64(client_id:client_secret)
 | Method | Path | Required scope | Description |
 | --- | --- | --- | --- |
 | `GET` | `/api/v1/apps/{clientId}/users` | `users:read` | List provisioned users (all statuses) |
-| `POST` | `/api/v1/apps/{clientId}/users` | `users:write` | Create/upsert user (`externalUserId` required; optional `email`, `status`) |
-| `PUT` | `/api/v1/apps/{clientId}/users` | `users:write` | Update user `email` and/or `status` |
+| `POST` | `/api/v1/apps/{clientId}/users` | `users:write` | Create/upsert user (`externalUserId` required; optional `email`, `status`, `discoveryUrl`) |
+| `PUT` | `/api/v1/apps/{clientId}/users` | `users:write` | Update user `email`, `status`, and/or `discoveryUrl` |
 | `DELETE` | `/api/v1/apps/{clientId}/users?externalUserId=...` | `users:write` | Soft-deactivate user (`status: inactive`) — frees an end-user cap slot |
 
 **Status contract:** `status` is `active` or `inactive` only. New users default to `active`. `DELETE` sets `inactive`. Reactivate with `PUT`/`POST` `{ "status": "active" }` (consumes a free cap slot when the activation gate is enforced). Inactive identities cannot mint tokens or resolve API keys; they remain listed for audit and billing history.
+
+**Discovery URL preference:** Optional `discoveryUrl` (absolute `http(s)` URL) is stored on the app user and returned on list/upsert. It becomes the default `SignerSession.discovery_url` for every signer-session exchange or mint on behalf of that user. A per-request `discovery_url` form field on token exchange still overrides it. Pass `null` or `""` on `PUT`/`POST` to clear the preference.
 
 **Dashboard:** App → Identities shows every M2M identity and supports deactivate / reactivate for owners and app admins. Payments → Activation shows `active / cap` and links to Identities when the cap is reached. Raising the numeric cap is admin-only (see #401); developers reclaim capacity by deactivating unused identities.
 
@@ -175,12 +177,12 @@ Exchange a user access JWT **or** a per-app-user API key (`pmth_*`) for a short-
 | `subject_token` | User access JWT **or** per-app-user API key (`pmth_*` / composite) |
 | `subject_token_type` | API key: `urn:pymthouse:oauth:token-type:api_key` (canonical). JWT: `urn:ietf:params:oauth:token-type:access_token`. Legacy: `access_token` is still accepted for key-shaped subjects. |
 | `audience` / `resource` | Optional; when provided must match configured signer audience (issuer URL, `SIGNER_TOKEN_AUDIENCE`, or legacy `livepeer-clearinghouse` / `livepeer-remote-signer`) |
-| `discovery_url` | Optional override for network discovery (defaults to `{signer_url}/discover-orchestrators`) |
+| `discovery_url` | Optional override for network discovery (user `discoveryUrl` preference when set; else `{signer_url}/discover-orchestrators`) |
 | `caps` | Optional; repeatable capability filters for remote-signer discovery (`caps=pipeline/model`) |
 
 Optional HTTP Basic with the M2M client (`m2m_*` + secret). When omitted, the `subject_token` alone authenticates the exchange. Do not use client secrets (`pmth_cs_*`) as `subject_token`.
 
-Returns the canonical **`SignerSession`** envelope: `access_token`, `token_type`, `expires_in`, `scope`, optional `signer_url`, optional `discovery_url` (defaults to `{signer_url}/discover-orchestrators`; not OIDC metadata), optional `caps` (remote-signer capability filters), optional `issued_token_type`, optional `correlation_id`, and optional PymtHouse extensions `balanceUsdMicros` / `lifetimeGrantedUsdMicros`.
+Returns the canonical **`SignerSession`** envelope: `access_token`, `token_type`, `expires_in`, `scope`, optional `signer_url`, optional `discovery_url` (request override → user `discoveryUrl` preference → `{signer_url}/discover-orchestrators`; not OIDC metadata), optional `caps` (remote-signer capability filters), optional `issued_token_type`, optional `correlation_id`, and optional PymtHouse extensions `balanceUsdMicros` / `lifetimeGrantedUsdMicros`.
 
 Example (bare API key on the issuer token endpoint — personal key, no `{clientId}` in the URL):
 

--- a/drizzle/0052_app_user_discovery_url.sql
+++ b/drizzle/0052_app_user_discovery_url.sql
@@ -1,0 +1,4 @@
+-- Optional per-app-user preferred remote-signer discovery URL
+-- (SignerSession.discovery_url) for all exchanges on behalf of that user.
+ALTER TABLE "app_users"
+  ADD COLUMN IF NOT EXISTS "discovery_url" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1787400000000,
       "tag": "0051_app_user_auto_topup",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1787500000000,
+      "tag": "0052_app_user_discovery_url",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/v1/apps/[id]/users/route.ts
+++ b/src/app/api/v1/apps/[id]/users/route.ts
@@ -15,6 +15,7 @@ import { runActivationGate } from "@/lib/activation/app-activation";
 import { activationErrorResponse } from "@/lib/activation/problem";
 import { parseAppUserStatus, type AppUserStatus } from "@/lib/billing/app-user-status";
 import { provisionAppUserBilling } from "@/lib/billing/provision-app-user";
+import { parseDiscoveryUrlPreference } from "@/lib/app-user-discovery-url";
 import { sanitizeForLog } from "@/lib/sanitize-for-log";
 
 async function canAccessUsers(request: NextRequest, clientId: string, requiredScope: string) {
@@ -86,8 +87,10 @@ function parseUpsertUserBody(body: Record<string, unknown>): {
   externalUserId: string;
   hasEmail: boolean;
   hasStatus: boolean;
+  hasDiscoveryUrl: boolean;
   email: string | null;
   status: AppUserStatus;
+  discoveryUrl: string | null;
 } | { ok: false; response: NextResponse } {
   const externalUserId =
     typeof body.externalUserId === "string" ? body.externalUserId.trim() : "";
@@ -113,13 +116,22 @@ function parseUpsertUserBody(body: Record<string, unknown>): {
     }
     status = parsedStatus.status;
   }
+  const discoveryParsed = parseDiscoveryUrlPreference(body.discoveryUrl);
+  if (!discoveryParsed.ok) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: discoveryParsed.error }, { status: 400 }),
+    };
+  }
   return {
     ok: true,
     externalUserId,
     hasEmail,
     hasStatus,
+    hasDiscoveryUrl: discoveryParsed.present,
     email: hasEmail ? (body.email as string).trim() : null,
     status,
+    discoveryUrl: discoveryParsed.present ? discoveryParsed.discoveryUrl : null,
   };
 }
 
@@ -128,8 +140,10 @@ async function upsertAppUserRow(input: {
   externalUserId: string;
   email: string | null;
   status: AppUserStatus;
+  discoveryUrl: string | null;
   hasEmail: boolean;
   hasStatus: boolean;
+  hasDiscoveryUrl: boolean;
 }) {
   const newUser = {
     id: uuidv4(),
@@ -137,14 +151,21 @@ async function upsertAppUserRow(input: {
     externalUserId: input.externalUserId,
     email: input.email,
     status: input.status,
+    discoveryUrl: input.hasDiscoveryUrl ? input.discoveryUrl : null,
     role: "user" as const,
     createdAt: new Date().toISOString(),
   };
-  const updateSet: { email?: string | null; status?: AppUserStatus; role: "user" } = {
+  const updateSet: {
+    email?: string | null;
+    status?: AppUserStatus;
+    discoveryUrl?: string | null;
+    role: "user";
+  } = {
     role: "user",
   };
   if (input.hasEmail) updateSet.email = input.email;
   if (input.hasStatus) updateSet.status = input.status;
+  if (input.hasDiscoveryUrl) updateSet.discoveryUrl = input.discoveryUrl;
 
   const upserted = await db
     .insert(appUsers)
@@ -249,10 +270,12 @@ export async function POST(
     externalUserId: parsed.externalUserId,
     email: parsed.email,
     status: nextStatus,
+    discoveryUrl: parsed.discoveryUrl,
     hasEmail: parsed.hasEmail,
     // Persist the resolved next status so create defaults to active and
     // reactivate paths write explicitly without requiring a status field.
     hasStatus: parsed.hasStatus || activating || previousStatus == null,
+    hasDiscoveryUrl: parsed.hasDiscoveryUrl,
   });
 
   const provisionProblem = await provisionAfterUpsert(
@@ -332,6 +355,11 @@ export async function PUT(
     nextStatus = parsedStatus.status;
   }
 
+  const discoveryParsed = parseDiscoveryUrlPreference(body.discoveryUrl);
+  if (!discoveryParsed.ok) {
+    return NextResponse.json({ error: discoveryParsed.error }, { status: 400 });
+  }
+
   if (nextStatus === "active" && existing.status !== "active") {
     const gateProblem = await runProvisionGate(
       access.app.id,
@@ -348,6 +376,9 @@ export async function PUT(
     .set({
       email: typeof body.email === "string" ? body.email.trim() : existing.email,
       status: nextStatus,
+      ...(discoveryParsed.present
+        ? { discoveryUrl: discoveryParsed.discoveryUrl }
+        : {}),
       role: "user",
     })
     .where(eq(appUsers.id, existing.id));

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -308,6 +308,12 @@ export const appUsers = pgTable(
     autoTopUpEnabled: boolean("auto_top_up_enabled").notNull().default(false),
     /** Reload amount in USD micros; null falls back to $10 when enabling. */
     autoTopUpUsdMicros: text("auto_top_up_usd_micros"),
+    /**
+     * Preferred SignerSession.discovery_url for this identity.
+     * Applied on every signer-session exchange/mint for the user unless the
+     * request supplies an explicit discovery_url override.
+     */
+    discoveryUrl: text("discovery_url"),
     createdAt: text("created_at")
       .notNull()
       .$defaultFn(() => new Date().toISOString()),

--- a/src/lib/app-user-discovery-url.test.ts
+++ b/src/lib/app-user-discovery-url.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseDiscoveryUrlPreference,
+  resolveSignerSessionDiscoveryUrl,
+} from "@/lib/app-user-discovery-url";
+
+test("parseDiscoveryUrlPreference omits when undefined", () => {
+  assert.deepEqual(parseDiscoveryUrlPreference(undefined), {
+    ok: true,
+    present: false,
+  });
+});
+
+test("parseDiscoveryUrlPreference clears on null or blank", () => {
+  assert.deepEqual(parseDiscoveryUrlPreference(null), {
+    ok: true,
+    present: true,
+    discoveryUrl: null,
+  });
+  assert.deepEqual(parseDiscoveryUrlPreference("  "), {
+    ok: true,
+    present: true,
+    discoveryUrl: null,
+  });
+});
+
+test("parseDiscoveryUrlPreference accepts http(s) URLs", () => {
+  assert.deepEqual(
+    parseDiscoveryUrlPreference("https://disc.example/discover-orchestrators"),
+    {
+      ok: true,
+      present: true,
+      discoveryUrl: "https://disc.example/discover-orchestrators",
+    },
+  );
+});
+
+test("parseDiscoveryUrlPreference rejects non-URLs", () => {
+  const bad = parseDiscoveryUrlPreference("not-a-url");
+  assert.equal(bad.ok, false);
+  const wrongType = parseDiscoveryUrlPreference(1);
+  assert.equal(wrongType.ok, false);
+});
+
+test("resolveSignerSessionDiscoveryUrl prefers request then user preference", () => {
+  assert.equal(
+    resolveSignerSessionDiscoveryUrl({
+      requestOverride: "https://req.example/discover-orchestrators",
+      userPreference: "https://pref.example/discover-orchestrators",
+      signerUrl: "https://signer.example",
+    }),
+    "https://req.example/discover-orchestrators",
+  );
+  assert.equal(
+    resolveSignerSessionDiscoveryUrl({
+      userPreference: "https://pref.example/discover-orchestrators",
+      signerUrl: "https://signer.example",
+    }),
+    "https://pref.example/discover-orchestrators",
+  );
+  assert.equal(
+    resolveSignerSessionDiscoveryUrl({
+      signerUrl: "https://signer.example",
+    }),
+    "https://signer.example/discover-orchestrators",
+  );
+});

--- a/src/lib/app-user-discovery-url.ts
+++ b/src/lib/app-user-discovery-url.ts
@@ -1,0 +1,96 @@
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import { appUsers } from "@/db/schema";
+import { buildDiscoverOrchestratorsUrl } from "@/lib/discovery-service-url";
+import { getClientSignerApiUrl } from "@/lib/signer-proxy";
+
+/**
+ * Parse an optional discoveryUrl preference from a users API body.
+ * - omitted → no change
+ * - null / "" / whitespace → clear (null)
+ * - non-empty → must be absolute http(s) URL
+ */
+export function parseDiscoveryUrlPreference(
+  value: unknown,
+):
+  | { ok: true; present: false }
+  | { ok: true; present: true; discoveryUrl: string | null }
+  | { ok: false; error: string } {
+  if (value === undefined) {
+    return { ok: true, present: false };
+  }
+  if (value === null) {
+    return { ok: true, present: true, discoveryUrl: null };
+  }
+  if (typeof value !== "string") {
+    return { ok: false, error: "discoveryUrl must be a string or null" };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { ok: true, present: true, discoveryUrl: null };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return {
+      ok: false,
+      error: "discoveryUrl must be an absolute http(s) URL",
+    };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      ok: false,
+      error: "discoveryUrl must be an absolute http(s) URL",
+    };
+  }
+  return { ok: true, present: true, discoveryUrl: trimmed };
+}
+
+/** Load the stored discovery URL preference for an app user identity. */
+export async function loadAppUserDiscoveryUrl(input: {
+  appId: string;
+  externalUserId: string;
+}): Promise<string | undefined> {
+  const rows = await db
+    .select({ discoveryUrl: appUsers.discoveryUrl })
+    .from(appUsers)
+    .where(
+      and(
+        eq(appUsers.clientId, input.appId),
+        eq(appUsers.externalUserId, input.externalUserId),
+      ),
+    )
+    .limit(1);
+  const value = rows[0]?.discoveryUrl?.trim();
+  return value || undefined;
+}
+
+/**
+ * Resolve SignerSession.discovery_url:
+ * request override → user preference → derive from signer_url / app signer.
+ */
+export function resolveSignerSessionDiscoveryUrl(input: {
+  requestOverride?: string | null;
+  userPreference?: string | null;
+  publicClientId?: string | null;
+  signerUrl?: string | null;
+}): string | undefined {
+  const override = input.requestOverride?.trim();
+  if (override) return override;
+
+  const preference = input.userPreference?.trim();
+  if (preference) return preference;
+
+  const signerUrl = (
+    input.signerUrl?.trim() ||
+    getClientSignerApiUrl(input.publicClientId).trim()
+  );
+  if (!signerUrl) return undefined;
+  try {
+    return buildDiscoverOrchestratorsUrl(signerUrl);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/mcp/session.ts
+++ b/src/lib/mcp/session.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
 import { createCorrelationId } from "@/lib/audit";
+import {
+  loadAppUserDiscoveryUrl,
+  resolveSignerSessionDiscoveryUrl,
+} from "@/lib/app-user-discovery-url";
 import { createLivepeerPythonSdkToken } from "@/lib/livepeer-python-sdk-token";
 import type { McpPrincipal } from "@/lib/mcp/auth";
 import { readDiscoveryServiceUrl } from "@/lib/mcp/config";
@@ -74,14 +78,23 @@ export async function createSignerSessionForPrincipal(
       developerAppId: allowed.developerAppId,
       externalUserId: allowed.ownerId,
     });
+    const signerUrl = getClientSignerApiUrl(allowed.publicClientId);
+    const userPreference = await loadAppUserDiscoveryUrl({
+      appId: allowed.developerAppId,
+      externalUserId: allowed.ownerId,
+    });
     const session = buildSignerSessionEnvelope({
       access_token: minted.access_token,
       expires_in: minted.expires_in,
       scope: minted.scope,
       balanceUsdMicros: minted.balanceUsdMicros,
       lifetimeGrantedUsdMicros: minted.lifetimeGrantedUsdMicros,
-      signer_url: getClientSignerApiUrl(allowed.publicClientId),
-      discovery_url: getSignerDiscoveryUrl(),
+      signer_url: signerUrl,
+      discovery_url: resolveSignerSessionDiscoveryUrl({
+        userPreference,
+        publicClientId: allowed.publicClientId,
+        signerUrl,
+      }),
       issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
     });
     return {

--- a/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.test.ts
@@ -204,8 +204,7 @@ test("handleAppScopedSignerTokenExchange mints signer session from API key subje
         signerUrlAppId = appClientId ?? undefined;
         return "https://signer.example";
       },
-      getSignerDiscoveryUrl: () =>
-        "https://signer.example/discover-orchestrators",
+      loadAppUserDiscoveryUrl: async () => undefined,
     },
   );
 
@@ -257,8 +256,8 @@ test("handleAppScopedSignerTokenExchange accepts discovery_url and caps override
         lifetimeGrantedUsdMicros: "0",
       }),
       getClientSignerApiUrl: () => "https://signer.example",
-      getSignerDiscoveryUrl: () =>
-        "https://signer.example/discover-orchestrators",
+      loadAppUserDiscoveryUrl: async () =>
+        "https://pref.example/discover-orchestrators",
     },
   );
 
@@ -270,6 +269,56 @@ test("handleAppScopedSignerTokenExchange accepts discovery_url and caps override
     "live-video-to-video/streamdiffusion",
     "text-to-image/flux",
   ]);
+});
+
+test("handleAppScopedSignerTokenExchange uses user discoveryUrl preference", async () => {
+  let loadedFor: { appId: string; externalUserId: string } | undefined;
+  const session = await handleAppScopedSignerTokenExchange(
+    {
+      publicClientId: PUBLIC_ID,
+      clientId: "",
+      clientSecret: "",
+      grantType: GRANT_TYPE_TOKEN_EXCHANGE,
+      subjectToken: "pmth_abc123",
+      subjectTokenType: SUBJECT_ACCESS_TOKEN_TYPE,
+      requestedTokenType: "",
+      resource: "",
+      audiences: [],
+      correlationId: "corr-pref",
+    },
+    {
+      resolveActiveAppApiKey: async () => ({
+        apiKeyId: "key-1",
+        developerAppId: "dev-app-1",
+        publicClientId: PUBLIC_ID,
+        appUserId: "au-1",
+        externalUserId: "ext-1",
+        label: null,
+      }),
+      mintSignerJwtForExternalUser: async () => ({
+        access_token: "eyJ.signer.jwt",
+        token_type: "Bearer" as const,
+        expires_in: 300,
+        scope: "sign:job",
+        balanceUsdMicros: "0",
+        lifetimeGrantedUsdMicros: "0",
+      }),
+      getClientSignerApiUrl: () => "https://signer.example",
+      loadAppUserDiscoveryUrl: async (input) => {
+        loadedFor = input;
+        return "https://pref.example/discover-orchestrators";
+      },
+    },
+  );
+
+  assert.deepEqual(loadedFor, {
+    appId: "dev-app-1",
+    externalUserId: "ext-1",
+  });
+  assert.equal(
+    session.discovery_url,
+    "https://pref.example/discover-orchestrators",
+  );
 });
 
 test("handleAppScopedSignerTokenExchange mints from user JWT with sign:job scope", async () => {
@@ -303,7 +352,7 @@ test("handleAppScopedSignerTokenExchange mints from user JWT with sign:job scope
         lifetimeGrantedUsdMicros: "0",
       }),
       getClientSignerApiUrl: () => undefined as unknown as string,
-      getSignerDiscoveryUrl: () => undefined,
+      loadAppUserDiscoveryUrl: async () => undefined,
     },
   );
 
@@ -368,7 +417,7 @@ test("handleIssuerApiKeySignerTokenExchange resolves app from bare pmth_ subject
         };
       },
       getClientSignerApiUrl: () => "https://signer.example",
-      getSignerDiscoveryUrl: () => undefined,
+      loadAppUserDiscoveryUrl: async () => undefined,
     },
   );
 
@@ -452,7 +501,7 @@ test("handleAppScopedSignerTokenExchange accepts canonical api_key type", async 
         lifetimeGrantedUsdMicros: "0",
       }),
       getClientSignerApiUrl: () => "https://signer.example",
-      getSignerDiscoveryUrl: () => undefined,
+      loadAppUserDiscoveryUrl: async () => undefined,
     },
   );
 
@@ -546,7 +595,7 @@ test("handleIssuerApiKeySignerTokenExchange accepts canonical api_key type", asy
         lifetimeGrantedUsdMicros: "0",
       }),
       getClientSignerApiUrl: () => "https://signer.example",
-      getSignerDiscoveryUrl: () => undefined,
+      loadAppUserDiscoveryUrl: async () => undefined,
     },
   );
 

--- a/src/lib/oidc/app-scoped-signer-token-exchange.ts
+++ b/src/lib/oidc/app-scoped-signer-token-exchange.ts
@@ -4,6 +4,10 @@ import {
   resolveActiveAppApiKeyFromBearer,
 } from "@/lib/app-api-keys";
 import {
+  loadAppUserDiscoveryUrl,
+  resolveSignerSessionDiscoveryUrl,
+} from "@/lib/app-user-discovery-url";
+import {
   buildDiscoverOrchestratorsUrl,
   normalizeDiscoveryCaps,
 } from "@/lib/discovery-service-url";
@@ -317,7 +321,7 @@ export type AppScopedSignerTokenExchangeDeps = {
   resolveSubjectAccessToken: typeof resolveSubjectAccessToken;
   mintSignerJwtForExternalUser: typeof mintSignerJwtForExternalUser;
   getClientSignerApiUrl: typeof getClientSignerApiUrl;
-  getSignerDiscoveryUrl: typeof getSignerDiscoveryUrl;
+  loadAppUserDiscoveryUrl: typeof loadAppUserDiscoveryUrl;
 };
 
 const defaultAppScopedExchangeDeps: AppScopedSignerTokenExchangeDeps = {
@@ -326,7 +330,7 @@ const defaultAppScopedExchangeDeps: AppScopedSignerTokenExchangeDeps = {
   resolveSubjectAccessToken,
   mintSignerJwtForExternalUser,
   getClientSignerApiUrl,
-  getSignerDiscoveryUrl,
+  loadAppUserDiscoveryUrl,
 };
 
 export async function handleAppScopedSignerTokenExchange(
@@ -433,11 +437,16 @@ export async function handleAppScopedSignerTokenExchange(
   }
 
   const signerUrl = deps.getClientSignerApiUrl(subject.publicClientId);
-  const discoveryOverride = input.discovery_url?.trim();
-  const discoveryUrl =
-    discoveryOverride ||
-    deps.getSignerDiscoveryUrl(subject.publicClientId) ||
-    (signerUrl ? buildDiscoverOrchestratorsUrl(signerUrl) : undefined);
+  const userPreference = await deps.loadAppUserDiscoveryUrl({
+    appId: subject.developerAppId,
+    externalUserId: subject.externalUserId,
+  });
+  const discoveryUrl = resolveSignerSessionDiscoveryUrl({
+    requestOverride: input.discovery_url,
+    userPreference,
+    publicClientId: subject.publicClientId,
+    signerUrl,
+  });
 
   return buildSignerSessionEnvelope({
     access_token: minted.access_token,

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -27,8 +27,11 @@ import { hasPositiveUsdMicrosBalance } from "@/lib/format-usd-micros";
 import type { TrialCreditBalance } from "@/lib/openmeter/entitlements";
 import { getSpendableAllowanceDetails } from "@/lib/openmeter/spendable-allowance";
 import { SIGN_MINT_USER_TOKEN_SCOPE } from "@/lib/oidc/scopes";
+import {
+  loadAppUserDiscoveryUrl,
+  resolveSignerSessionDiscoveryUrl,
+} from "@/lib/app-user-discovery-url";
 import { buildSignerSessionEnvelope } from "@/lib/openapi/signer-session";
-import { buildDiscoverOrchestratorsUrl } from "@/lib/discovery-service-url";
 import { getClientSignerApiUrl } from "@/lib/signer-proxy";
 
 export { SIGN_MINT_USER_TOKEN_SCOPE };
@@ -196,11 +199,17 @@ async function loadPublicSignJobClient(appId: string) {
   return publicClient;
 }
 
-function signerSessionFromMint(
+async function signerSessionFromMint(
   minted: Awaited<ReturnType<typeof mintSignerJwtForExternalUser>>,
   publicClientId: string,
+  developerAppId: string,
+  externalUserId: string,
 ) {
   const signerUrl = getClientSignerApiUrl(publicClientId);
+  const userPreference = await loadAppUserDiscoveryUrl({
+    appId: developerAppId,
+    externalUserId,
+  });
   return buildSignerSessionEnvelope({
     access_token: minted.access_token,
     expires_in: minted.expires_in,
@@ -208,7 +217,11 @@ function signerSessionFromMint(
     balanceUsdMicros: minted.balanceUsdMicros,
     lifetimeGrantedUsdMicros: minted.lifetimeGrantedUsdMicros,
     signer_url: signerUrl,
-    discovery_url: buildDiscoverOrchestratorsUrl(signerUrl),
+    discovery_url: resolveSignerSessionDiscoveryUrl({
+      userPreference,
+      publicClientId,
+      signerUrl,
+    }),
     issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
   });
 }
@@ -592,7 +605,12 @@ export async function handleMintUserSignerToken(input: {
     developerAppId: row.appId,
     externalUserId,
   });
-  return signerSessionFromMint(minted, publicClient.clientId);
+  return signerSessionFromMint(
+    minted,
+    publicClient.clientId,
+    row.appId,
+    externalUserId,
+  );
 }
 
 export async function handleM2mOwnerSignJob(input: {
@@ -609,5 +627,10 @@ export async function handleM2mOwnerSignJob(input: {
     developerAppId: allowed.developerAppId,
     externalUserId: allowed.ownerId,
   });
-  return signerSessionFromMint(minted, allowed.publicClientId);
+  return signerSessionFromMint(
+    minted,
+    allowed.publicClientId,
+    allowed.developerAppId,
+    allowed.ownerId,
+  );
 }

--- a/src/lib/openapi/routes/apps.ts
+++ b/src/lib/openapi/routes/apps.ts
@@ -146,8 +146,19 @@ defineRouteMetadata("get", appPath(""), {
 
 registerMetadataRoutes([
   ["get", appPath("/users"), OPENAPI_TAGS.users, "List provisioned users"],
-  ["post", appPath("/users"), OPENAPI_TAGS.users, "Upsert provisioned user", { created: true }],
-  ["put", appPath("/users"), OPENAPI_TAGS.users, "Update provisioned user"],
+  [
+    "post",
+    appPath("/users"),
+    OPENAPI_TAGS.users,
+    "Upsert provisioned user (optional discoveryUrl preference)",
+    { created: true },
+  ],
+  [
+    "put",
+    appPath("/users"),
+    OPENAPI_TAGS.users,
+    "Update provisioned user (email, status, discoveryUrl)",
+  ],
   ["delete", appPath("/users"), OPENAPI_TAGS.users, "Deactivate provisioned user"],
   ["get", userPath("/keys"), OPENAPI_TAGS.users, "List user API keys", { includeExternalUserId: true }],
   [

--- a/src/lib/openapi/schemas/credentials.ts
+++ b/src/lib/openapi/schemas/credentials.ts
@@ -66,7 +66,7 @@ export const SignerSessionSchema = z
     }),
     discovery_url: z.url().optional().openapi({
       description:
-        "Remote-signer discover-orchestrators URL (default `{signer_url}/discover-orchestrators`). Not OIDC issuer metadata.",
+        "Remote-signer discover-orchestrators URL (request override → app-user discoveryUrl preference → `{signer_url}/discover-orchestrators`). Not OIDC issuer metadata.",
     }),
     caps: z
       .array(z.string().min(1))
@@ -114,7 +114,7 @@ export const TokenExchangeRequestSchema = z
     }),
     discovery_url: z.url().optional().openapi({
       description:
-        "Optional override for SignerSession.discovery_url. Defaults to `{signer_url}/discover-orchestrators`.",
+        "Optional override for SignerSession.discovery_url. When omitted, uses the app user's discoveryUrl preference if set, otherwise `{signer_url}/discover-orchestrators`.",
     }),
     caps: z
       .array(z.string().min(1))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an optional per-app-user `discoveryUrl` preference that becomes the default `SignerSession.discovery_url` on every signer-session exchange or mint for that identity.

## Behavior

- **Set/clear** via Builder users API: `POST`/`PUT /api/v1/apps/{clientId}/users` with optional `discoveryUrl` (absolute `http(s)` URL). Pass `null` or `""` to clear.
- **Returned** on user list/upsert responses (`discoveryUrl` column on `app_users`).
- **Applied** on:
  - App-scoped and issuer RFC 8693 signer session exchange
  - Direct M2M signer mint (`sign:mint_user_token` / owner `sign:job`)
  - MCP hosted signer session mint
- **Precedence**: request `discovery_url` override → user preference → `{signer_url}/discover-orchestrators`

## Verification

- `npx tsc --noEmit` — clean
- Focused unit tests (parse/resolve + token exchange preference) — 31 pass / 0 fail
- Snyk / SonarQube tokens are not available in this cloud agent environment; CI workflows will run those checks on the PR

[discovery_url_preference_tests.log](https://cursor.com/agents/bc-01a004b2-bf3b-7162-96e2-9fe25cdbaac6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscovery_url_preference_tests.log)
[typecheck.log](https://cursor.com/agents/bc-01a004b2-bf3b-7162-96e2-9fe25cdbaac6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftypecheck.log)

## Docs

- `docs/builder-api.md` updated for the users API field and SignerSession discovery resolution order

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a004b2-bf3b-7162-96e2-9fe25cdbaac6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a004b2-bf3b-7162-96e2-9fe25cdbaac6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

