### PR TITLE
fix(billing): send currency on sandbox Connect setup Checkout

### DIFF
--- a/src/lib/openmeter/stripe-checkout-session.test.ts
+++ b/src/lib/openmeter/stripe-checkout-session.test.ts
@@ -96,6 +96,37 @@ test("createOpenMeterStripeCheckoutSession uses Konnect customer billing path", 
   });
 });
 
+test("createOpenMeterStripeCheckoutSession defaults Konnect currency to USD", async (t) => {
+  withKonnectEnv(t);
+
+  let posted: unknown;
+  t.mock.method(globalThis, "fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+    posted = init?.body ? JSON.parse(String(init.body)) : null;
+    return new Response(
+      JSON.stringify({
+        url: "https://checkout.stripe.com/c/pay/cs_test_default",
+        session_id: "cs_test_default",
+      }),
+      { status: 201, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  await createOpenMeterStripeCheckoutSession({
+    client: {} as OpenMeter,
+    customerId: "01CUSTOMERULID000000000001",
+    successUrl: "https://app.example/ok",
+    cancelUrl: "https://app.example/cancel",
+  });
+
+  assert.deepEqual(posted, {
+    stripe_options: {
+      success_url: "https://app.example/ok",
+      cancel_url: "https://app.example/cancel",
+      currency: "USD",
+    },
+  });
+});
+
 test("createOpenMeterStripeCheckoutSession uses SDK on self-hosted", async (t) => {
   const previousUrl = process.env.OPENMETER_URL;
   const previousKey = process.env.OPENMETER_API_KEY;

--- a/src/lib/openmeter/stripe-checkout-session.ts
+++ b/src/lib/openmeter/stripe-checkout-session.ts
@@ -59,22 +59,13 @@ async function createKonnectStripeCheckoutSession(input: {
   cancelUrl: string;
   currency?: string;
 }): Promise<StripeCheckoutSessionResult> {
-  const body: {
-    stripe_options: {
-      success_url: string;
-      cancel_url: string;
-      currency?: string;
-    };
-  } = {
+  const body = {
     stripe_options: {
       success_url: input.successUrl,
       cancel_url: input.cancelUrl,
+      currency: (input.currency?.trim() || "USD").toUpperCase(),
     },
   };
-  const currency = input.currency?.trim().toUpperCase();
-  if (currency) {
-    body.stripe_options.currency = currency;
-  }
 
   const result = await konnectAdminFetch<KonnectCheckoutSessionResponse>(
     `/customers/${encodeURIComponent(input.customerId)}/billing/stripe/checkout-sessions`,
@@ -102,18 +93,11 @@ async function createSelfHostedStripeCheckoutSession(input: {
   cancelUrl: string;
   currency?: string;
 }): Promise<StripeCheckoutSessionResult> {
-  const options: {
-    successURL: string;
-    cancelURL: string;
-    currency?: string;
-  } = {
+  const options = {
     successURL: input.successUrl,
     cancelURL: input.cancelUrl,
+    currency: (input.currency?.trim() || "USD").toUpperCase(),
   };
-  const currency = input.currency?.trim().toUpperCase();
-  if (currency) {
-    options.currency = currency;
-  }
 
   const checkout = await input.client.apps.stripe.createCheckoutSession({
     customer: { id: input.customerId },

--- a/src/lib/openmeter/subscriptions-billing.test.ts
+++ b/src/lib/openmeter/subscriptions-billing.test.ts
@@ -309,9 +309,10 @@ dbTest(
         stripe: {
           createCheckoutSession: async (body: {
             customer: { id: string };
-            options: { successURL: string; cancelURL: string };
+            options: { successURL: string; cancelURL: string; currency?: string };
           }) => {
             assert.equal(body.customer.id, "cust_pm_gate");
+            assert.equal(body.options.currency, "USD");
             // Open redirects must be rejected — evil successUrl falls back.
             assert.match(
               body.options.successURL,

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -393,6 +393,7 @@ async function resolveCheckoutSettings(input: EndUserCheckoutInput): Promise<{
   isMerchantBilling: boolean;
   successUrl: string;
   cancelUrl: string;
+  currency: string;
 }> {
   const billingConfig = await getAppBillingConfig(input.clientId);
   const merchantReady = isMerchantConnectPaymentsReady(billingConfig);
@@ -407,6 +408,7 @@ async function resolveCheckoutSettings(input: EndUserCheckoutInput): Promise<{
   return {
     merchantReady,
     isMerchantBilling: billingConfig?.billingMode === "merchant",
+    currency: billingConfig?.defaultCurrency?.trim() || "USD",
     successUrl: resolveAppUserCheckoutReturnUrl(
       input.successUrl || billingConfig?.checkoutSuccessUrl || undefined,
       fallbackUrl,
@@ -689,6 +691,7 @@ async function createCheckoutSession(input: {
   customerKey: string;
   successUrl: string;
   cancelUrl: string;
+  currency?: string;
 }): Promise<{ checkoutUrl: string; sessionId: string | null }> {
   if (input.merchantReady) {
     const checkout = await createMerchantConnectCheckoutForUser({
@@ -709,6 +712,7 @@ async function createCheckoutSession(input: {
     customerId: input.customerId,
     successUrl: input.successUrl,
     cancelUrl: input.cancelUrl,
+    currency: input.currency,
   });
   return {
     checkoutUrl: checkout.checkoutUrl,
@@ -790,6 +794,7 @@ export async function createPaymentMethodCheckoutIfNeededForPlanChange(input: {
     customerKey: input.customerKey,
     successUrl: success,
     cancelUrl: cancel,
+    currency: billingConfig?.defaultCurrency,
   });
   await recordAppUserPaymentMethodCheckout({
     sessionId: checkout.sessionId,
@@ -854,6 +859,7 @@ export async function createEndUserCheckout(
       customerKey: customer.key,
       successUrl: checkoutSettings.successUrl,
       cancelUrl: checkoutSettings.cancelUrl,
+      currency: checkoutSettings.currency,
     });
     await recordAppUserPaymentMethodCheckout({
       sessionId: checkout.sessionId,

--- a/src/lib/stripe/connect-accounts.test.ts
+++ b/src/lib/stripe/connect-accounts.test.ts
@@ -548,6 +548,7 @@ test("createConnectedCheckoutSession setup and payment modes", async (t) => {
   });
   assert.equal(setup.sessionId, "cs_test_1");
   assert.match(bodies[0]!, /mode=setup/);
+  assert.match(bodies[0]!, /(?:^|&)currency=usd(?:&|$)/);
   assert.doesNotMatch(bodies[0]!, /payment_method_types/);
   assert.match(
     bodies[0]!,
@@ -570,6 +571,26 @@ test("createConnectedCheckoutSession setup and payment modes", async (t) => {
     bodies[1]!,
     /payment_intent_data%5Bsetup_future_usage%5D=off_session/,
   );
+});
+
+test("createConnectedCheckoutSession setup mode uses the given currency", async (t) => {
+  withEnv(t, { STRIPE_SECRET_KEY: "sk_test_unit" });
+  let body = "";
+  t.mock.method(globalThis, "fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+    body = String(init?.body ?? "");
+    return jsonResponse({ id: "cs_test_eur", url: "https://checkout.stripe.com/c/pay/cs_test_eur" });
+  });
+
+  await createConnectedCheckoutSession({
+    accountId: "acct_1",
+    customerId: "cus_1",
+    successUrl: "https://ok",
+    cancelUrl: "https://cancel",
+    mode: "setup",
+    currency: "EUR",
+  });
+  assert.match(body, /(?:^|&)currency=eur(?:&|$)/);
+  assert.doesNotMatch(body, /payment_method_types/);
 });
 
 test("createConnectedCheckoutSession fails without session url", async (t) => {

--- a/src/lib/stripe/connect-accounts.ts
+++ b/src/lib/stripe/connect-accounts.ts
@@ -481,12 +481,23 @@ function addCheckoutMetadata(
   }
 }
 
+/** Stripe Checkout / PaymentIntent currency: lowercase ISO 4217, default usd. */
+function stripeFormCurrency(value?: string): string {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || "usd";
+}
+
 function addSetupCheckoutFields(
   body: URLSearchParams,
-  metadata: Record<string, string> | undefined,
+  input: {
+    currency?: string;
+    metadata?: Record<string, string>;
+  },
 ): void {
   // Omit payment_method_types so Checkout uses Dashboard dynamic methods.
-  addCheckoutMetadata(body, metadata, "setup_intent_data[metadata]");
+  // Setup mode then requires `currency` (Stripe 400 otherwise).
+  body.set("currency", stripeFormCurrency(input.currency));
+  addCheckoutMetadata(body, input.metadata, "setup_intent_data[metadata]");
 }
 
 function addPaymentCheckoutFields(
@@ -502,7 +513,7 @@ function addPaymentCheckoutFields(
   if (typeof amount !== "number" || !Number.isInteger(amount) || amount <= 0) {
     throw new Error("amountCents must be a positive integer for payment mode");
   }
-  body.set("line_items[0][price_data][currency]", (input.currency ?? "usd").toLowerCase());
+  body.set("line_items[0][price_data][currency]", stripeFormCurrency(input.currency));
   body.set("line_items[0][price_data][unit_amount]", String(amount));
   body.set(
     "line_items[0][price_data][product_data][name]",
@@ -541,7 +552,7 @@ export async function createConnectedCheckoutSession(input: {
   body.set("success_url", input.successUrl);
   body.set("cancel_url", input.cancelUrl);
   if (mode === "setup") {
-    addSetupCheckoutFields(body, input.metadata);
+    addSetupCheckoutFields(body, input);
   } else {
     addPaymentCheckoutFields(body, input);
   }
@@ -580,7 +591,7 @@ export async function createConnectedOffSessionPaymentIntent(input: {
   }
   const body = new URLSearchParams();
   body.set("amount", String(amount));
-  body.set("currency", (input.currency ?? "usd").toLowerCase());
+  body.set("currency", stripeFormCurrency(input.currency));
   body.set("customer", input.customerId);
   body.set("payment_method", input.paymentMethodId);
   body.set("confirm", "true");
@@ -624,7 +635,7 @@ export async function createConnectedInvoice(input: {
   idempotencyKey?: string;
   livemode?: boolean;
 }): Promise<{ invoiceId: string; hostedInvoiceUrl: string | null }> {
-  const currency = (input.currency ?? "usd").toLowerCase();
+  const currency = stripeFormCurrency(input.currency);
   const idempotencyBase = input.idempotencyKey?.trim();
   const livemode = input.livemode !== false;
   const itemBody = new URLSearchParams();

--- a/src/lib/stripe/merchant-connect.ts
+++ b/src/lib/stripe/merchant-connect.ts
@@ -1266,6 +1266,7 @@ export async function createMerchantConnectCheckoutForUser(input: {
     successUrl: input.successUrl,
     cancelUrl: input.cancelUrl,
     mode: "setup",
+    currency: config!.defaultCurrency ?? "usd",
     applicationFeeBps: config!.applicationFeeBps ?? 0,
     livemode,
     metadata: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Builder API plan change (`POST /api/v1/apps/{id}/users/{externalUserId}/subscription/change`) failed on sandbox Stripe Connect with:

```
Stripe POST /v1/checkout/sessions failed (400): Missing required param: currency.
```

Plan switches that need a card create a **setup-mode** Checkout Session on the connected account. Checkout now omits `payment_method_types` so Stripe can pick methods from the Dashboard. In that configuration Stripe requires `currency`, and the session body never sent it.

## Fix

- Setup-mode Connect Checkout always sends `currency` (lowercase ISO 4217, default `usd`).
- Merchant Connect uses `app_billing_config.default_currency`.
- OpenMeter/Konnect setup Checkout always sends currency as well (default `USD`) so the same 400 cannot happen on the non-Connect path.

## Tests

- Connect setup Checkout defaults to `currency=usd` and honors an explicit currency.
- Konnect checkout defaults to `USD` when currency is omitted.
- Plan-change PM gate still creates setup Checkout with `USD`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41ee0a17-9b01-48c1-b468-f82aa9079c01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ee0a17-9b01-48c1-b468-f82aa9079c01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

