### PR TITLE
fix(merchant): Auto top-up sandbox Stripe Connect users

### DIFF
--- a/src/lib/stripe/auto-topup.test.ts
+++ b/src/lib/stripe/auto-topup.test.ts
@@ -240,18 +240,25 @@ test("tryAutoTopUpIfEnabled skips when billing config is missing", async (t) => 
   );
 });
 
-test("tryAutoTopUpIfEnabled skips sandbox livemode apps", async (t) => {
+test("tryAutoTopUpIfEnabled charges sandbox livemode apps with the sandbox key", async (t) => {
+  let charged: { livemode?: boolean } | undefined;
   withRuntime(t, {
     getAppBillingConfig: async () => ({
       billingMode: "merchant",
       stripeConnectedAccountId: "acct_1",
       stripeLivemode: false,
     }),
+    createConnectedOffSessionPaymentIntent: async (input) => {
+      charged = input;
+      return { id: "pi_sandbox", status: "succeeded" };
+    },
   });
-  assert.deepEqual(
-    await tryAutoTopUpIfEnabled(uniqueIds("sandbox")),
-    { status: "skipped", reason: "sandbox_livemode" },
-  );
+  assert.deepEqual(await tryAutoTopUpIfEnabled(uniqueIds("sandbox")), {
+    status: "charged",
+    paymentIntentId: "pi_sandbox",
+    grantedUsdMicros: "10000000",
+  });
+  assert.equal(charged?.livemode, false);
 });
 
 test("tryAutoTopUpIfEnabled skips when Connect is not ready", async (t) => {
@@ -344,6 +351,7 @@ test("tryAutoTopUpIfEnabled charges, grants, and uses the parsed amount", async 
   });
   assert.equal((charged as { amountCents: number }).amountCents, 2500);
   assert.equal((charged as { currency: string }).currency, "usd");
+  assert.equal((charged as { livemode?: boolean }).livemode, true);
   assert.equal((charged as { applicationFeeBps: number }).applicationFeeBps, 0);
   assert.equal(
     (charged as { metadata: Record<string, string> }).metadata[

--- a/src/lib/stripe/auto-topup.ts
+++ b/src/lib/stripe/auto-topup.ts
@@ -24,7 +24,10 @@ import {
   LEGACY_AUTO_TOP_UP_METADATA_FLAG,
   legacyAutoTopUpGrantIdempotencyKey,
 } from "@/lib/stripe/legacy-auto-topup";
-import { getAppUserStripeCustomer } from "@/lib/stripe/merchant-connect";
+import {
+  appStripeLivemode,
+  getAppUserStripeCustomer,
+} from "@/lib/stripe/merchant-connect";
 import {
   parseTopUpAmountUsd,
   TOP_UP_MIN_USD_MICROS,
@@ -259,9 +262,7 @@ async function executeEnabledAutoTopUp(input: {
   if (!accountId) {
     return { status: "skipped", reason: "connect_not_ready" };
   }
-  if (billingConfig.stripeLivemode === false) {
-    return { status: "skipped", reason: "sandbox_livemode" };
-  }
+  const livemode = appStripeLivemode(billingConfig);
 
   const paymentMethods = await runtime.listAppUserPaymentMethods({
     clientId: input.developerAppId,
@@ -298,7 +299,7 @@ async function executeEnabledAutoTopUp(input: {
       amountCents,
       currency: (billingConfig.defaultCurrency ?? "usd").toLowerCase(),
       applicationFeeBps: billingConfig.applicationFeeBps ?? 0,
-      livemode: true,
+      livemode,
       idempotencyKey: stripeIdempotencyKey(
         input.developerAppId,
         input.externalUserId,


### PR DESCRIPTION
## Summary
- Sandbox Merchant Connect apps (`stripeLivemode=false`) were skipped for auto top-up, so a saved card never reloaded prepaid spendable.
- The off-session PaymentIntent always used `livemode: true`, which cannot charge a sandbox Connected Account.
- Auto top-up now uses `appStripeLivemode` so sandbox apps charge with `STRIPE_SANDBOX_SECRET_KEY` and grant on the sync path.

## Test plan
- [ ] Unit: `node --import ./src/test-env.ts --import tsx --test --test-force-exit src/lib/stripe/auto-topup.test.ts`
- [ ] Sandbox merchant app with auto top-up enabled and a default Connect card
- [ ] Drain spendable, then hit `generate-live-payment` — expect a sandbox PI + grant, not 483 `Overage limit reached while payment is collected`
- [ ] Live merchant auto top-up still charges with the live platform key