### PR TITLE
Keep app settings pages mounted across left-nav tab switches

### DIFF
--- a/src/app/apps/[id]/auth/page.tsx
+++ b/src/app/apps/[id]/auth/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
 /** Auth settings live under App profile. */
-export default function AppAuthPage() {
-  return <AppSettingsPageClient tab="profile" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/credentials/page.tsx
+++ b/src/app/apps/[id]/credentials/page.tsx
@@ -1,7 +1,3 @@
-"use client";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
-
-export default function AppCredentialsPage() {
-  return <AppSettingsPageClient tab="credentials" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/discovery-profiles/page.tsx
+++ b/src/app/apps/[id]/discovery-profiles/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
 /** Discovery profiles live under Billing Plans. */
-export default function AppDiscoveryProfilesPage() {
-  return <AppSettingsPageClient tab="plans" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/identities/[externalUserId]/page.tsx
+++ b/src/app/apps/[id]/identities/[externalUserId]/page.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import AppSectionBreadcrumb from "@/components/apps/AppSectionBreadcrumb";
-import DashboardLayout from "@/components/DashboardLayout";
 import IdentityLifecycleActions from "@/components/identities/IdentityLifecycleActions";
 import IdentityRequestLog from "@/components/identities/IdentityRequestLog";
 import UsageBreakdownChart from "@/components/UsageBreakdownChart";
@@ -146,7 +145,7 @@ export default async function AppIdentityDetailPage({
   }
 
   return (
-    <DashboardLayout>
+    <>
       <AppSectionBreadcrumb
         appId={id}
         appName={app.name}
@@ -235,6 +234,6 @@ export default async function AppIdentityDetailPage({
       </section>
 
       <IdentityRequestLog appId={id} externalUserId={externalUserId} />
-    </DashboardLayout>
+    </>
   );
 }

--- a/src/app/apps/[id]/identities/page.tsx
+++ b/src/app/apps/[id]/identities/page.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import AppSectionBreadcrumb from "@/components/apps/AppSectionBreadcrumb";
-import DashboardLayout from "@/components/DashboardLayout";
 import IdentitiesTable from "@/components/identities/IdentitiesTable";
 import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
@@ -50,7 +49,7 @@ export default async function AppIdentitiesPage({
     : [];
 
   return (
-    <DashboardLayout>
+    <>
       <AppSectionBreadcrumb appId={id} appName={app.name} section="Identities" />
 
       <div className="mb-6 flex flex-col gap-3 sm:mb-8 sm:flex-row sm:items-start sm:justify-between">
@@ -77,6 +76,6 @@ export default async function AppIdentitiesPage({
           Usage metering is not configured, so per-identity usage is unavailable.
         </div>
       )}
-    </DashboardLayout>
+    </>
   );
 }

--- a/src/app/apps/[id]/layout.tsx
+++ b/src/app/apps/[id]/layout.tsx
@@ -1,0 +1,10 @@
+import AppSettingsRouteShell from "@/components/apps/AppSettingsRouteShell";
+
+/** Keep the settings client mounted while switching left-nav tabs. */
+export default function AppDetailLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <AppSettingsRouteShell>{children}</AppSettingsRouteShell>;
+}

--- a/src/app/apps/[id]/page.tsx
+++ b/src/app/apps/[id]/page.tsx
@@ -1,7 +1,3 @@
-"use client";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
-
-export default function AppDetailPage() {
-  return <AppSettingsPageClient tab="profile" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/payments/page.tsx
+++ b/src/app/apps/[id]/payments/page.tsx
@@ -1,7 +1,3 @@
-"use client";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
-
-export default function AppPaymentsPage() {
-  return <AppSettingsPageClient tab="payments" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/plans/page.tsx
+++ b/src/app/apps/[id]/plans/page.tsx
@@ -1,7 +1,3 @@
-"use client";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
-
-export default function AppPlansPage() {
-  return <AppSettingsPageClient tab="plans" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/profile/page.tsx
+++ b/src/app/apps/[id]/profile/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
 /** Alias of App profile (`/apps/[id]`). */
-export default function AppProfilePage() {
-  return <AppSettingsPageClient tab="profile" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/settings/page.tsx
+++ b/src/app/apps/[id]/settings/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import AppSettingsSegmentPage from "@/components/apps/AppSettingsSegmentPage";
 
 /** Alias of App profile (`/apps/[id]`). */
-export default function AppSettingsPage() {
-  return <AppSettingsPageClient tab="profile" />;
-}
+export default AppSettingsSegmentPage;

--- a/src/app/apps/[id]/usage/page.tsx
+++ b/src/app/apps/[id]/usage/page.tsx
@@ -8,5 +8,5 @@ export default async function AppUsagePage({
   params: Promise<{ id: string }>;
 }>) {
   const { id } = await params;
-  return <BillingUsageDashboard filterAppId={id} />;
+  return <BillingUsageDashboard filterAppId={id} wrapLayout={false} />;
 }

--- a/src/app/apps/layout.tsx
+++ b/src/app/apps/layout.tsx
@@ -1,0 +1,10 @@
+import DashboardLayout from "@/components/DashboardLayout";
+
+/** Persist the dashboard chrome across My Apps, create, and app detail tabs. */
+export default function AppsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <DashboardLayout>{children}</DashboardLayout>;
+}

--- a/src/app/apps/new/page.tsx
+++ b/src/app/apps/new/page.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import DashboardLayout from "@/components/DashboardLayout";
 import AppWizard from "@/components/apps/AppWizard";
 
 export default function NewAppPage() {
-  return (
-    <DashboardLayout>
-      <AppWizard />
-    </DashboardLayout>
-  );
+  return <AppWizard />;
 }

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -6,7 +6,6 @@ import { redirect } from "next/navigation";
 import { db } from "@/db/index";
 import { signerConfig } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import DashboardLayout from "@/components/DashboardLayout";
 import AppsListSection from "@/components/apps/AppsListSection";
 import AdminAppsHome from "@/components/apps/AdminAppsHome";
 import MyAppsShortcutTiles from "@/components/apps/MyAppsShortcutTiles";
@@ -39,11 +38,7 @@ export default async function AppsPage({
   const params = await searchParams;
 
   if (role === "admin" || role === "operator") {
-    return (
-      <DashboardLayout>
-        <AdminMyApps userId={userId} />
-      </DashboardLayout>
-    );
+    return <AdminMyApps userId={userId} />;
   }
 
   if (userId && (await developerNeedsOnboarding(userId))) {
@@ -51,12 +46,10 @@ export default async function AppsPage({
   }
 
   return (
-    <DashboardLayout>
-      <DeveloperMyApps
-        userId={userId}
-        showSetupBanner={params.setup === "1"}
-      />
-    </DashboardLayout>
+    <DeveloperMyApps
+      userId={userId}
+      showSetupBanner={params.setup === "1"}
+    />
   );
 }
 

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -701,10 +701,13 @@ function BillingUsageBody({
 export default function BillingUsageDashboard({
   filterAppId,
   fundPanel,
+  wrapLayout = true,
 }: Readonly<{
   filterAppId?: string | null;
   /** Optional MoonPay / prepaid top-up panel (app owners on pay-per-use). */
   fundPanel?: ReactNode;
+  /** When false, the parent route already provides DashboardLayout. */
+  wrapLayout?: boolean;
 }>) {
   const { data: session, status: authStatus } = useSession();
   const pathname = usePathname();
@@ -780,8 +783,8 @@ export default function BillingUsageDashboard({
     };
   }, [filterAppId, activeTab, retryToken, showTabs]);
 
-  return (
-    <DashboardLayout>
+  const body = (
+    <>
       {fundPanel}
       {state.status === "loading" ? (
         <>
@@ -829,6 +832,12 @@ export default function BillingUsageDashboard({
           activeTab={activeTab}
         />
       ) : null}
-    </DashboardLayout>
+    </>
   );
+
+  if (!wrapLayout) {
+    return body;
+  }
+
+  return <DashboardLayout>{body}</DashboardLayout>;
 }

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -152,6 +152,16 @@ export default function DashboardLayout({
     }
   }, [status, router]);
 
+  const appDetailMatch = pathname.match(/^\/apps\/(app_[^/]+)/);
+  const activeAppId = appDetailMatch?.[1] ?? null;
+
+  useEffect(() => {
+    if (!activeAppId) return;
+    for (const sub of APP_SUB_NAV_ITEMS) {
+      router.prefetch(`/apps/${activeAppId}${sub.href}`);
+    }
+  }, [activeAppId, router]);
+
   if (status === "loading") {
     return (
       <div className="flex h-screen w-full bg-zinc-950">
@@ -249,10 +259,6 @@ export default function DashboardLayout({
             const adminItems = navItems.filter((i) => i.group === "Admin");
             const resourceItems = navItems.filter((i) => i.group === "Resources");
             const otherItems = navItems.filter((i) => !i.group);
-
-            // Detect if we're inside an app detail page: /apps/<appId>/...
-            const appDetailMatch = pathname.match(/^\/apps\/(app_[^/]+)/);
-            const activeAppId = appDetailMatch?.[1] ?? null;
 
             const renderNavLink = (item: NavItem, isActive: boolean) => {
               const linkClass = `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-150 ${

--- a/src/components/apps/AppSettingsPageClient.tsx
+++ b/src/components/apps/AppSettingsPageClient.tsx
@@ -87,6 +87,7 @@ export default function AppSettingsPageClient({
       </div>
 
       <AppSettingsScreen
+        key={id}
         appId={id}
         initialData={appData.formData}
         initialState={appData.state}

--- a/src/components/apps/AppSettingsPageClient.tsx
+++ b/src/components/apps/AppSettingsPageClient.tsx
@@ -2,122 +2,81 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import DashboardLayout from "@/components/DashboardLayout";
 import AppSettingsScreen from "@/components/apps/AppSettingsScreen";
 import AppStatusBadge from "@/components/apps/AppStatusBadge";
-import type { AppFormData, AppState } from "@/components/apps/AppWizard";
+import {
+  cacheLoadedApp,
+  loadedAppFromApiPayload,
+  peekLoadedApp,
+  type LoadedApp,
+} from "@/components/apps/app-settings-data";
 import type { AppSettingsTab } from "@/lib/apps/settings-paths";
-import { DEFAULT_PUBLIC_GRANT_TYPES } from "@/lib/oidc/grants";
-import { DEFAULT_OIDC_SCOPES, ensureOpenIdScope } from "@/lib/oidc/scopes";
-
-type LoadedApp = {
-  formData: Partial<AppFormData>;
-  state: AppState;
-  domains: { id: string; domain: string }[];
-  postLogoutRedirectUris: string[];
-  initiateLoginUri: string | null;
-  deviceThirdPartyInitiateLogin: boolean;
-  canEdit: boolean;
-  canDeleteApp: boolean;
-  canManageBilling: boolean;
-  ownerExternalUserId: string | null;
-};
 
 /** Shared app settings shell. Tab comes from the path (`/apps/{id}/payments`). */
 export default function AppSettingsPageClient({
   tab,
 }: Readonly<{ tab: AppSettingsTab }>) {
   const { id } = useParams<{ id: string }>();
+  const cached = peekLoadedApp(id);
 
-  const [loading, setLoading] = useState(true);
-  const [appData, setAppData] = useState<LoadedApp | null>(null);
+  const [loading, setLoading] = useState(!cached);
+  const [appData, setAppData] = useState<LoadedApp | null>(cached);
 
   useEffect(() => {
+    let cancelled = false;
+    const existing = peekLoadedApp(id);
+    if (existing) {
+      setAppData(existing);
+      setLoading(false);
+    } else {
+      setLoading(true);
+    }
+
     fetch(`/api/v1/apps/${id}`)
       .then((r) => {
         if (!r.ok) return null;
         return r.json();
       })
       .then((data) => {
+        if (cancelled) return;
         if (!data) {
-          setAppData(null);
+          if (!peekLoadedApp(id)) setAppData(null);
           return;
         }
-        setAppData({
-          formData: {
-            name: data.name || "",
-            description: data.description || "",
-            developerName: data.developerName || "",
-            websiteUrl: data.websiteUrl || "",
-            redirectUris: [],
-            allowedScopes: ensureOpenIdScope(
-              data.oidcClient?.allowedScopes || DEFAULT_OIDC_SCOPES,
-            ),
-            grantTypes:
-              data.oidcClient?.grantTypes?.split(",").filter(Boolean) ??
-              [...DEFAULT_PUBLIC_GRANT_TYPES],
-            tokenEndpointAuthMethod:
-              data.oidcClient?.tokenEndpointAuthMethod || "none",
-            backendDeviceHelper: Boolean(data.m2mOidcClient),
-            confidentialWebHelper: Boolean(data.webOidcClient),
-            confidentialWebRedirectUris: data.webOidcClient?.redirectUris || [],
-          },
-          state: {
-            id: data.id,
-            clientId: data.oidcClient?.clientId || null,
-            status: data.status,
-            hasSecret: data.oidcClient?.hasSecret || false,
-            backendHelper: data.m2mOidcClient ?? null,
-            webHelper: data.webOidcClient ?? null,
-          },
-          domains: (data.domains || []).map(
-            (d: { id: string; domain: string }) => ({
-              id: d.id,
-              domain: d.domain,
-            }),
-          ),
-          postLogoutRedirectUris:
-            data.webOidcClient?.postLogoutRedirectUris ||
-            data.oidcClient?.postLogoutRedirectUris ||
-            [],
-          initiateLoginUri: data.oidcClient?.initiateLoginUri ?? null,
-          deviceThirdPartyInitiateLogin:
-            data.oidcClient?.deviceThirdPartyInitiateLogin === true,
-          canEdit: data.canEdit === true,
-          canDeleteApp: data.canDeleteApp === true,
-          canManageBilling: data.canManageBilling === true,
-          ownerExternalUserId:
-            typeof data.ownerId === "string" && data.ownerId.trim()
-              ? data.ownerId.trim()
-              : null,
-        });
+        const loaded = loadedAppFromApiPayload(data);
+        cacheLoadedApp(id, loaded);
+        setAppData(loaded);
       })
-      .catch(() => setAppData(null))
-      .finally(() => setLoading(false));
+      .catch(() => {
+        if (!cancelled) setAppData(peekLoadedApp(id));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
-  if (loading) {
+  if (loading && !appData) {
     return (
-      <DashboardLayout>
-        <div className="text-zinc-500 text-center py-12 animate-pulse">
-          Loading app…
-        </div>
-      </DashboardLayout>
+      <div className="text-zinc-500 text-center py-12 animate-pulse">
+        Loading app…
+      </div>
     );
   }
 
   if (!appData) {
     return (
-      <DashboardLayout>
-        <div className="text-center py-12">
-          <h2 className="text-lg font-medium text-zinc-300">App not found</h2>
-        </div>
-      </DashboardLayout>
+      <div className="text-center py-12">
+        <h2 className="text-lg font-medium text-zinc-300">App not found</h2>
+      </div>
     );
   }
 
   return (
-    <DashboardLayout>
+    <>
       <div className="mb-8">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="text-2xl font-bold text-zinc-100">
@@ -143,6 +102,6 @@ export default function AppSettingsPageClient({
         ownerExternalUserId={appData.ownerExternalUserId}
         initialTab={tab}
       />
-    </DashboardLayout>
+    </>
   );
 }

--- a/src/components/apps/AppSettingsRouteShell.tsx
+++ b/src/components/apps/AppSettingsRouteShell.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import AppSettingsPageClient from "@/components/apps/AppSettingsPageClient";
+import { appSettingsTabFromPathname } from "@/lib/apps/settings-paths";
+
+/**
+ * Keeps the settings client mounted across `/apps/{id}/{tab}` navigations
+ * so the navbar (from the parent layout) does not wait on a remounted fetch.
+ */
+export default function AppSettingsRouteShell({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  const pathname = usePathname();
+  const tab = appSettingsTabFromPathname(pathname);
+
+  if (!tab) {
+    return children;
+  }
+
+  return <AppSettingsPageClient tab={tab} />;
+}

--- a/src/components/apps/AppSettingsScreen.tsx
+++ b/src/components/apps/AppSettingsScreen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import AppInfoStep from "./steps/AppInfoStep";
 import AppModeStep from "./steps/AppModeStep";
@@ -228,11 +227,8 @@ export default function AppSettingsScreen({
   }, [appId]);
 
   useEffect(() => {
-    if (integrationSection !== "credentials") {
-      return;
-    }
     void syncCredentialsFromServer();
-  }, [integrationSection, syncCredentialsFromServer]);
+  }, [syncCredentialsFromServer]);
 
   const saveChanges = useCallback(async () => {
     if (!canEdit) return;
@@ -392,13 +388,11 @@ export default function AppSettingsScreen({
         )}
       </div>
 
-      {integrationSection === "profile" && (
-        <div
-          id="panel-profile"
-          role="tabpanel"
-          aria-labelledby="tab-profile"
-          className="space-y-10 pb-6"
-        >
+      <SettingsTabPanel
+        id="profile"
+        active={integrationSection === "profile"}
+        className="space-y-10 pb-6"
+      >
           <section className="space-y-4">
             <AppInfoStep data={formData} onChange={updateFormData} readOnly={!canEdit} />
           </section>
@@ -451,16 +445,13 @@ export default function AppSettingsScreen({
               )}
             </section>
           )}
-        </div>
-      )}
+      </SettingsTabPanel>
 
-      {integrationSection === "credentials" && (
-        <div
-          id="panel-credentials"
-          role="tabpanel"
-          aria-labelledby="tab-credentials"
-          className="space-y-6 pb-6"
-        >
+      <SettingsTabPanel
+        id="credentials"
+        active={integrationSection === "credentials"}
+        className="space-y-6 pb-6"
+      >
           <div className="flex items-start justify-between gap-3">
             <div>
               <h2 className="text-lg font-semibold text-zinc-100 mb-1">
@@ -542,28 +533,15 @@ export default function AppSettingsScreen({
             tokenUrl={tokenUrl}
             signerSessionUrl={signerSessionUrl}
           />
-        </div>
-      )}
+      </SettingsTabPanel>
 
-      {integrationSection === "plans" && (
-        <div
-          id="panel-plans"
-          role="tabpanel"
-          aria-labelledby="tab-plans"
-        >
-          <PlansTab appId={appId} canEdit={canEdit} />
-        </div>
-      )}
+      <SettingsTabPanel id="plans" active={integrationSection === "plans"}>
+        <PlansTab appId={appId} canEdit={canEdit} />
+      </SettingsTabPanel>
 
-      {integrationSection === "payments" && (
-        <div
-          id="panel-payments"
-          role="tabpanel"
-          aria-labelledby="tab-payments"
-        >
-          <PaymentsTab appId={appId} canManageBilling={canManageBilling} />
-        </div>
-      )}
+      <SettingsTabPanel id="payments" active={integrationSection === "payments"}>
+        <PaymentsTab appId={appId} canManageBilling={canManageBilling} />
+      </SettingsTabPanel>
 
       {/* Save - only shown for non-plans/payments tabs */}
       {integrationSection !== "plans" && integrationSection !== "payments" && (
@@ -603,6 +581,31 @@ export default function AppSettingsScreen({
         </div>
       </div>
       )}
+    </div>
+  );
+}
+
+function SettingsTabPanel({
+  id,
+  active,
+  className,
+  children,
+}: Readonly<{
+  id: AppSettingsTab;
+  active: boolean;
+  className?: string;
+  children: React.ReactNode;
+}>) {
+  return (
+    <div
+      id={`panel-${id}`}
+      role="tabpanel"
+      aria-labelledby={`tab-${id}`}
+      hidden={!active}
+      inert={!active}
+      className={className}
+    >
+      {children}
     </div>
   );
 }

--- a/src/components/apps/AppSettingsSegmentPage.tsx
+++ b/src/components/apps/AppSettingsSegmentPage.tsx
@@ -1,0 +1,7 @@
+/**
+ * Settings URLs are real routes so the left nav can prefetch them.
+ * The visible chrome lives in `AppSettingsRouteShell` (app detail layout).
+ */
+export default function AppSettingsSegmentPage() {
+  return null;
+}

--- a/src/components/apps/app-settings-data.test.ts
+++ b/src/components/apps/app-settings-data.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cacheLoadedApp,
+  loadedAppFromApiPayload,
+  peekLoadedApp,
+} from "./app-settings-data";
+
+test("loadedAppFromApiPayload maps API fields and defaults", () => {
+  const loaded = loadedAppFromApiPayload({
+    id: "app_1",
+    name: "Demo",
+    status: "active",
+    ownerId: " user_1 ",
+    canEdit: true,
+    canDeleteApp: true,
+    canManageBilling: false,
+    oidcClient: {
+      clientId: "app_1",
+      allowedScopes: "openid",
+      grantTypes: "authorization_code,refresh_token",
+      tokenEndpointAuthMethod: "none",
+      hasSecret: false,
+      postLogoutRedirectUris: ["https://app.example/out"],
+      initiateLoginUri: "https://app.example/login",
+      deviceThirdPartyInitiateLogin: true,
+    },
+    m2mOidcClient: { clientId: "m2m_1", hasSecret: true },
+    webOidcClient: {
+      clientId: "web_1",
+      hasSecret: true,
+      redirectUris: ["https://app.example/cb"],
+    },
+    domains: [{ id: "d1", domain: "https://app.example" }],
+  });
+
+  assert.equal(loaded.formData.name, "Demo");
+  assert.deepEqual(loaded.formData.grantTypes, [
+    "authorization_code",
+    "refresh_token",
+  ]);
+  assert.equal(loaded.formData.backendDeviceHelper, true);
+  assert.equal(loaded.formData.confidentialWebHelper, true);
+  assert.deepEqual(loaded.formData.confidentialWebRedirectUris, [
+    "https://app.example/cb",
+  ]);
+  assert.equal(loaded.state.clientId, "app_1");
+  assert.equal(loaded.state.backendHelper?.clientId, "m2m_1");
+  assert.equal(loaded.canEdit, true);
+  assert.equal(loaded.canManageBilling, false);
+  assert.equal(loaded.ownerExternalUserId, "user_1");
+  assert.deepEqual(loaded.postLogoutRedirectUris, ["https://app.example/out"]);
+  assert.equal(loaded.deviceThirdPartyInitiateLogin, true);
+});
+
+test("peekLoadedApp returns the cached app for an id", () => {
+  const loaded = loadedAppFromApiPayload({
+    id: "app_cache",
+    name: "Cached",
+    status: "active",
+  });
+  cacheLoadedApp("app_cache", loaded);
+  assert.equal(peekLoadedApp("app_cache")?.formData.name, "Cached");
+  assert.equal(peekLoadedApp("app_missing"), null);
+});

--- a/src/components/apps/app-settings-data.ts
+++ b/src/components/apps/app-settings-data.ts
@@ -82,7 +82,13 @@ export function loadedAppFromApiPayload(data: AppSettingsApiPayload): LoadedApp 
       status: data.status ?? "",
       hasSecret: data.oidcClient?.hasSecret || false,
       backendHelper: data.m2mOidcClient ?? null,
-      webHelper: data.webOidcClient ?? null,
+      webHelper: data.webOidcClient
+        ? {
+            clientId: data.webOidcClient.clientId,
+            hasSecret: data.webOidcClient.hasSecret,
+            redirectUris: data.webOidcClient.redirectUris ?? [],
+          }
+        : null,
     },
     domains: (data.domains || []).map((d) => ({
       id: d.id,

--- a/src/components/apps/app-settings-data.ts
+++ b/src/components/apps/app-settings-data.ts
@@ -1,0 +1,106 @@
+import type { AppFormData, AppState } from "@/components/apps/AppWizard";
+import { DEFAULT_PUBLIC_GRANT_TYPES } from "@/lib/oidc/grants";
+import { DEFAULT_OIDC_SCOPES, ensureOpenIdScope } from "@/lib/oidc/scopes";
+
+export type LoadedApp = {
+  formData: Partial<AppFormData>;
+  state: AppState;
+  domains: { id: string; domain: string }[];
+  postLogoutRedirectUris: string[];
+  initiateLoginUri: string | null;
+  deviceThirdPartyInitiateLogin: boolean;
+  canEdit: boolean;
+  canDeleteApp: boolean;
+  canManageBilling: boolean;
+  ownerExternalUserId: string | null;
+};
+
+export type AppSettingsApiPayload = {
+  id?: string;
+  name?: string;
+  description?: string;
+  developerName?: string;
+  websiteUrl?: string;
+  status?: string;
+  ownerId?: string;
+  canEdit?: boolean;
+  canDeleteApp?: boolean;
+  canManageBilling?: boolean;
+  oidcClient?: {
+    clientId?: string;
+    allowedScopes?: string;
+    grantTypes?: string;
+    tokenEndpointAuthMethod?: AppFormData["tokenEndpointAuthMethod"];
+    hasSecret?: boolean;
+    postLogoutRedirectUris?: string[];
+    initiateLoginUri?: string | null;
+    deviceThirdPartyInitiateLogin?: boolean;
+  } | null;
+  m2mOidcClient?: { clientId: string; hasSecret: boolean } | null;
+  webOidcClient?: {
+    clientId: string;
+    hasSecret: boolean;
+    redirectUris?: string[];
+    postLogoutRedirectUris?: string[];
+  } | null;
+  domains?: { id: string; domain: string }[];
+};
+
+const loadedAppCache = new Map<string, LoadedApp>();
+
+export function peekLoadedApp(appId: string): LoadedApp | null {
+  return loadedAppCache.get(appId) ?? null;
+}
+
+export function cacheLoadedApp(appId: string, data: LoadedApp): void {
+  loadedAppCache.set(appId, data);
+}
+
+export function loadedAppFromApiPayload(data: AppSettingsApiPayload): LoadedApp {
+  return {
+    formData: {
+      name: data.name || "",
+      description: data.description || "",
+      developerName: data.developerName || "",
+      websiteUrl: data.websiteUrl || "",
+      redirectUris: [],
+      allowedScopes: ensureOpenIdScope(
+        data.oidcClient?.allowedScopes || DEFAULT_OIDC_SCOPES,
+      ),
+      grantTypes:
+        data.oidcClient?.grantTypes?.split(",").filter(Boolean) ??
+        [...DEFAULT_PUBLIC_GRANT_TYPES],
+      tokenEndpointAuthMethod:
+        data.oidcClient?.tokenEndpointAuthMethod || "none",
+      backendDeviceHelper: Boolean(data.m2mOidcClient),
+      confidentialWebHelper: Boolean(data.webOidcClient),
+      confidentialWebRedirectUris: data.webOidcClient?.redirectUris || [],
+    },
+    state: {
+      id: data.id ?? null,
+      clientId: data.oidcClient?.clientId || null,
+      status: data.status ?? "",
+      hasSecret: data.oidcClient?.hasSecret || false,
+      backendHelper: data.m2mOidcClient ?? null,
+      webHelper: data.webOidcClient ?? null,
+    },
+    domains: (data.domains || []).map((d) => ({
+      id: d.id,
+      domain: d.domain,
+    })),
+    postLogoutRedirectUris:
+      data.webOidcClient?.postLogoutRedirectUris ||
+      data.oidcClient?.postLogoutRedirectUris ||
+      [],
+    initiateLoginUri: data.oidcClient?.initiateLoginUri ?? null,
+    deviceThirdPartyInitiateLogin:
+      data.oidcClient?.deviceThirdPartyInitiateLogin === true,
+    canEdit: data.canEdit === true,
+    canDeleteApp: data.canDeleteApp === true,
+    canManageBilling: data.canManageBilling === true,
+    ownerExternalUserId:
+      typeof data.ownerId === "string" && data.ownerId.trim()
+        ? data.ownerId.trim()
+        : null,
+  };
+}

--- a/src/lib/apps/settings-paths.test.ts
+++ b/src/lib/apps/settings-paths.test.ts
@@ -43,5 +43,12 @@ test("appSettingsAbsoluteUrl keeps callback query on path", () => {
 test("appSettingsTabFromPathname", () => {
   assert.equal(appSettingsTabFromPathname("/apps/app_1"), "profile");
   assert.equal(appSettingsTabFromPathname("/apps/app_1/payments"), "payments");
+  assert.equal(appSettingsTabFromPathname("/apps/app_1/settings"), "profile");
+  assert.equal(appSettingsTabFromPathname("/apps/app_1/auth"), "profile");
+  assert.equal(
+    appSettingsTabFromPathname("/apps/app_1/discovery-profiles"),
+    "plans",
+  );
   assert.equal(appSettingsTabFromPathname("/apps/app_1/identities"), null);
+  assert.equal(appSettingsTabFromPathname("/apps/app_1/usage"), null);
 });

--- a/src/lib/apps/settings-paths.ts
+++ b/src/lib/apps/settings-paths.ts
@@ -78,6 +78,12 @@ export function appSettingsTabFromPathname(pathname: string): AppSettingsTab | n
   if (isAppSettingsTab(parts[2])) {
     return parts[2];
   }
+  if (parts[2] === "settings" || parts[2] === "auth") {
+    return "profile";
+  }
+  if (parts[2] === "discovery-profiles" || parts[2] === "network-discovery") {
+    return "plans";
+  }
   // Nested non-tab routes (identities, usage, …) — not a settings tab page.
   return null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

App settings tabs now live in the left nav as real routes. Each click remounted `DashboardLayout` and `AppSettingsPageClient`, which re-gated on the session, refetched `/api/v1/apps/:id`, and lazy-mounted Plans/Payments. That made tab switches feel like a full page load.

This keeps the dashboard chrome and settings client mounted while switching tabs.

## Changes

- Add `src/app/apps/layout.tsx` so the sidebar persists across My Apps, create, and app detail.
- Add `src/app/apps/[id]/layout.tsx` with `AppSettingsRouteShell` so the settings client stays mounted; tab pages are URL placeholders for prefetch.
- Cache the loaded app payload so returning from Usage/Identities does not flash “Loading app…”.
- Keep Profile, Credentials, Plans, and Payments mounted (hidden when inactive) so their data is already warm.
- Prefetch all app sub-nav routes from the sidebar.
- Unwrap nested `DashboardLayout` on identities and per-app usage.

## Testing

- `npx tsc --noEmit` passed
- Unit tests for settings path aliases and API payload mapping passed
- ESLint on touched files passed
- Snyk and SonarQube CLIs are not available in this environment; those remain CI checks on the PR

[Verification log](https://cursor.com/agents/bc-c5229049-c030-40df-9129-241aa5f1dbf1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_load_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5229049-c030-40df-9129-241aa5f1dbf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5229049-c030-40df-9129-241aa5f1dbf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

