### PR TITLE
feat(billing): credit sandbox Merchant Connect onto sbx_eu_ customers

### DIFF
--- a/docs/ops-sandbox-merchant-connect.md
+++ b/docs/ops-sandbox-merchant-connect.md
@@ -34,9 +34,19 @@ Dashboard endpoints pointed at production hosts and copy those new secrets.
 
 Leave Konnect / `OPENMETER_STRIPE_APP_ID` on the **live** Stripe app. Owner Plane A
 stays live; only Merchant Connect (Plane B) uses the sandbox key when
-`app_billing_config.stripe_livemode = false`. Sandbox webhooks restore payment
-methods and drive settlement collect; they never grant production Konnect
-prepaid (`usd_credits`) for owner or merchant top-ups.
+`app_billing_config.stripe_livemode = false`.
+
+Sandbox merchant payers are a **separate** OpenMeter customer:
+`sbx_eu_{end_users.id}`. Live merchant wallets stay `eu_{id}`. Test-card
+top-ups on the sandbox webhook plane grant prepaid credits onto `sbx_eu_…`
+only when that plane matches the app's `stripe_livemode`. Owner top-ups on
+the sandbox plane are still ignored — they must not mint production owner
+prepaid. Switching Sandbox → Live (or back) is a different customer; the
+active balance does not follow.
+
+Sandbox merchant customers pin to the existing OpenMeter **sandbox / free**
+billing profile, not Custom Invoicing. Live merchant customers stay on
+Custom Invoicing + settlement metadata.
 
 ### 3. Smoke
 
@@ -45,10 +55,13 @@ prepaid (`usd_credits`) for owner or merchant top-ups.
    you want real charges.
 2. Complete Account Link with Stripe test data
 3. Attach `pm_card_visa` for an end user
-4. `POST …/billing/collect` → settlement charges on the sandbox connected account
-5. Confirm Konnect custom-invoicing `payment/status` completes
+4. Add sandbox credit (Checkout $10). Confirm Konnect prepaid lands on
+   `sbx_eu_{end_users.id}`, not production `eu_{id}`
+5. `POST …/billing/collect` → settlement charges on the sandbox connected account
 
 ### 4. Going live later
 
 Disconnect Connect, switch **Live**, run a new Account Link. Sandbox `acct_` is
-not promotable — live is a new connected account on the live platform.
+not promotable — live is a new connected account on the live platform. The
+live end-user payer is `eu_{id}` again (empty until a live top-up); sandbox
+`sbx_eu_{id}` prepaid stays on the sandbox customer.

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.test.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.test.ts
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import type { Session } from "next-auth";
 
 import { platformControlledFieldsError } from "@/lib/billing/platform-controlled-fields";
+import {
+  resetBillingIdentityCache,
+  resolveOpenMeterBillingIdentity,
+} from "@/lib/openmeter/billing-identity";
+import { upsertAppBillingConfig } from "@/lib/openmeter/billing-profiles";
+import {
+  buildSandboxEndUserCustomerKey,
+  isSandboxEndUserCustomerKey,
+} from "@/lib/openmeter/customer-key";
 import { setProviderAppSessionResolverForTests } from "@/lib/provider-apps";
 import { test } from "@/test-utils/db-guard";
 import {
@@ -78,4 +88,54 @@ test("PATCH /billing/stripe allows platform-controlled fields for admins", async
   // Admin clears the 403 guard. Downstream OpenMeter/Stripe may still fail
   // without live credentials — those are not authorization failures.
   assert.notEqual(res.status, 403);
+});
+
+test("PATCH stripeLivemode busts billing identity cache", async (t) => {
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  const previousTtl = process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS;
+  process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS = "300";
+  installSession(app, "developer");
+  t.after(async () => {
+    if (previousTtl === undefined) {
+      delete process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS;
+    } else {
+      process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS = previousTtl;
+    }
+    resetBillingIdentityCache();
+    setProviderAppSessionResolverForTests(null);
+    await cleanupTestApp(app);
+  });
+
+  const endUserId = `ext-${randomUUID()}`;
+  await upsertAppBillingConfig(app.clientId, {
+    billingMode: "merchant",
+    stripeLivemode: true,
+  });
+  resetBillingIdentityCache();
+  const live = await resolveOpenMeterBillingIdentity({
+    clientId: app.clientId,
+    externalUserId: endUserId,
+  });
+  assert.equal(isSandboxEndUserCustomerKey(live.payerCustomerKey), false);
+
+  const { PATCH } = await import("./route");
+  const res = await PATCH(
+    new Request(`http://localhost/api/v1/apps/${app.clientId}/billing/stripe`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ stripeLivemode: false }),
+    }) as never,
+    { params: Promise.resolve({ id: app.clientId }) },
+  );
+  assert.equal(res.status, 200);
+
+  const sandbox = await resolveOpenMeterBillingIdentity({
+    clientId: app.clientId,
+    externalUserId: endUserId,
+  });
+  assert.ok(isSandboxEndUserCustomerKey(sandbox.payerCustomerKey));
+  assert.equal(
+    sandbox.payerCustomerKey,
+    buildSandboxEndUserCustomerKey(sandbox.actorEndUserId),
+  );
 });

--- a/src/app/api/v1/apps/[id]/billing/stripe/route.ts
+++ b/src/app/api/v1/apps/[id]/billing/stripe/route.ts
@@ -540,9 +540,13 @@ export async function PATCH(
       parsed.fields,
     );
     // Drop cached (clientId, externalUserId) → identity rows so the next mint
-    // / debt / webhook resolve sees the new billingMode immediately. JWT TTL
-    // still bounds already-issued sessions (mint-forward).
-    if (parsed.fields.billingMode !== undefined) {
+    // / debt / webhook resolve sees the new billingMode or stripeLivemode
+    // immediately (merchant payers are eu_ vs sbx_eu_). JWT TTL still bounds
+    // already-issued sessions (mint-forward).
+    if (
+      parsed.fields.billingMode !== undefined ||
+      parsed.fields.stripeLivemode !== undefined
+    ) {
       resetBillingIdentityCache();
     }
     const status = await getStripeConnectStatus(access.auth.app.id);

--- a/src/app/webhooks/stripe/handle-post.ts
+++ b/src/app/webhooks/stripe/handle-post.ts
@@ -64,6 +64,33 @@ function verifyWebhookSecretKind(input: {
   return null;
 }
 
+async function ignoredIfWebhookLivemodeMismatch(
+  clientId: string,
+  livemode: boolean,
+  context: string,
+): Promise<Response | null> {
+  let livemodeMatches: boolean;
+  try {
+    livemodeMatches = await appLivemodeMatchesWebhookPlane(clientId, livemode);
+  } catch (err) {
+    logHandlerError(`${context} livemode match`, err);
+    return NextResponse.json({ error: "handler_failed" }, { status: 500 });
+  }
+  if (!livemodeMatches) {
+    console.warn(
+      TAG,
+      `${context} ignored: livemode mismatch`,
+      sanitizeForLog(clientId),
+    );
+    return NextResponse.json({
+      received: true,
+      ignored: "livemode_mismatch",
+      clientId,
+    });
+  }
+  return null;
+}
+
 function stripeEventAccount(rawBody: string): string | null {
   let parsed: unknown;
   try {
@@ -378,12 +405,6 @@ async function settleMerchantTopUp(input: {
   amountUsdMicros: bigint;
   livemode: boolean;
 }): Promise<Response> {
-  if (!input.livemode) {
-    return NextResponse.json({
-      received: true,
-      ignored: "sandbox_merchant_grant",
-    });
-  }
   const account = stripeEventAccount(input.rawBody);
   if (!account) {
     return NextResponse.json({
@@ -410,6 +431,15 @@ async function settleMerchantTopUp(input: {
       received: true,
       ignored: "connect_account_mismatch",
     });
+  }
+
+  const livemodeMismatch = await ignoredIfWebhookLivemodeMismatch(
+    input.clientId,
+    input.livemode,
+    "merchant top-up",
+  );
+  if (livemodeMismatch) {
+    return livemodeMismatch;
   }
 
   try {
@@ -462,13 +492,11 @@ async function authorizeLegacyAutoTopUpTenancy(input: {
         ignored: "connect_account_mismatch",
       });
     }
-    if (!input.livemode) {
-      return NextResponse.json({
-        received: true,
-        ignored: "sandbox_merchant_grant",
-      });
-    }
-    return null;
+    return ignoredIfWebhookLivemodeMismatch(
+      input.clientId,
+      input.livemode,
+      "auto-topup",
+    );
   }
 
   if (!input.livemode) {
@@ -713,10 +741,12 @@ function eventTypeFromRawBody(rawBody: string): string | null {
  *
  * Owner top-up grants require the live webhook plane, the platform webhook
  * secret, and a platform (non-Connect) event. Sandbox ingress never credits
- * Konnect prepaid wallets (owner or merchant). Merchant end-user top-ups and
- * Connect auto top-ups on the live plane require a Connect `account` field
- * matching the app's Connected Account. `account.updated` is bound to the
- * webhook plane's livemode so sandbox ingress cannot flip live Connect flags.
+ * the owner's live prepaid wallet. Merchant end-user top-ups and Connect
+ * auto top-ups grant when the webhook plane matches the app's stripeLivemode
+ * and the Connect `account` matches the app's Connected Account — sandbox
+ * grants land on `sbx_eu_{end_users.id}`, not production `eu_{id}`.
+ * `account.updated` is bound to the webhook plane's livemode so sandbox
+ * ingress cannot flip live Connect flags.
  * Platform auto top-ups require the platform secret plus `owner:{userId}`
  * ownership of `client_id`. Auto-topup settlement also requires PI currency
  * to match `app_billing_config.default_currency`. Payment-method restore from

--- a/src/app/webhooks/stripe/route.test.ts
+++ b/src/app/webhooks/stripe/route.test.ts
@@ -780,6 +780,7 @@ function withSandboxWebhookEnv(t: { after: (fn: () => void) => void }): void {
   process.env.STRIPE_SANDBOX_WEBHOOK_SECRET = SANDBOX_PLATFORM_SECRET;
   process.env.STRIPE_SANDBOX_CONNECT_WEBHOOK_SECRET = SANDBOX_CONNECT_SECRET;
   __setResolveAppBillingCurrencyForTests(async () => "usd");
+  __setResolveAppLivemodeForWebhookForTests(async () => false);
 }
 
 async function postSignedSandbox(
@@ -824,9 +825,37 @@ test("POST sandbox owner top-up does not grant production credits", async (t) =>
   assert.equal(granted, false);
 });
 
-test("POST sandbox merchant Connect top-up does not grant production credits", async (t) => {
+test("POST sandbox merchant Connect top-up grants sandbox-plane credits", async (t) => {
   withSandboxWebhookEnv(t);
   __setMerchantTopUpAccountMatchesForTests(async () => true);
+  const calls: Array<Record<string, unknown>> = [];
+  __setGrantAllowanceUsdMicrosForTests(async (input) => {
+    calls.push({ ...input, amountUsdMicros: input.amountUsdMicros.toString() });
+    return {
+      externalUserId: input.externalUserId,
+      source: input.source,
+      grantedUsdMicros: input.amountUsdMicros.toString(),
+      featureKey: "usd_credits",
+      balance: null,
+    };
+  });
+
+  const rawBody = merchantTopUpEventBody("checkout.session.completed", {
+    account: "acct_sandbox_1",
+  });
+  const res = await postSignedSandbox(rawBody, SANDBOX_CONNECT_SECRET);
+  assert.equal(res.status, 200);
+  const json = (await res.json()) as { credited?: boolean; ignored?: string };
+  assert.equal(json.credited, true);
+  assert.equal(json.ignored, undefined);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.externalUserId, "eu_route_1");
+});
+
+test("POST sandbox merchant Connect top-up ignores live app livemode mismatch", async (t) => {
+  withSandboxWebhookEnv(t);
+  __setMerchantTopUpAccountMatchesForTests(async () => true);
+  __setResolveAppLivemodeForWebhookForTests(async () => true);
   let granted = false;
   __setGrantAllowanceUsdMicrosForTests(async () => {
     granted = true;
@@ -846,7 +875,7 @@ test("POST sandbox merchant Connect top-up does not grant production credits", a
   assert.equal(res.status, 200);
   const json = (await res.json()) as { credited?: boolean; ignored?: string };
   assert.equal(json.credited, undefined);
-  assert.equal(json.ignored, "sandbox_merchant_grant");
+  assert.equal(json.ignored, "livemode_mismatch");
   assert.equal(granted, false);
 });
 
@@ -876,7 +905,7 @@ test("POST sandbox platform auto-topup does not grant owner credits", async (t) 
   assert.equal(granted, false);
 });
 
-test("POST sandbox Connect auto-topup does not grant production credits", async (t) => {
+test("POST sandbox Connect auto-topup grants sandbox-plane credits", async (t) => {
   withSandboxWebhookEnv(t);
   __setMerchantTopUpAccountMatchesForTests(async () => true);
   let granted = false;
@@ -895,9 +924,9 @@ test("POST sandbox Connect auto-topup does not grant production credits", async 
   const res = await postSignedSandbox(rawBody, SANDBOX_CONNECT_SECRET);
   assert.equal(res.status, 200);
   const json = (await res.json()) as { credited?: boolean; ignored?: string };
-  assert.equal(json.credited, undefined);
-  assert.equal(json.ignored, "sandbox_merchant_grant");
-  assert.equal(granted, false);
+  assert.equal(json.credited, true);
+  assert.equal(json.ignored, undefined);
+  assert.equal(granted, true);
 });
 
 test("POST sandbox setup_intent restore ignores live app livemode mismatch", async (t) => {

--- a/src/app/webhooks/stripe/sandbox/route.ts
+++ b/src/app/webhooks/stripe/sandbox/route.ts
@@ -9,9 +9,9 @@ export const runtime = "nodejs";
  *   POST {PUBLIC_ORIGIN}/webhooks/stripe/sandbox
  *
  * Secrets: STRIPE_SANDBOX_WEBHOOK_SECRET, STRIPE_SANDBOX_CONNECT_WEBHOOK_SECRET.
- * This route never grants Konnect prepaid credits (owner or merchant).
- * Merchant Connect events still restore payment methods and drive Stripe
- * settlement collect; they do not mint production usd_credits.
+ * Owner top-ups are never granted on this plane. Merchant Connect top-ups
+ * grant onto the sandbox payer (`sbx_eu_…`) when the app's stripeLivemode
+ * is false. Events still restore payment methods and drive settlement collect.
  */
 export async function POST(request: Request): Promise<Response> {
   return handleStripeWebhookPost(

--- a/src/lib/billing/app-user-ledger.test.ts
+++ b/src/lib/billing/app-user-ledger.test.ts
@@ -123,3 +123,43 @@ test("loadAppUserBillingLedger marks degraded when meter query reports fallback"
     ),
   );
 });
+
+test("loadAppUserBillingLedger queries the sandbox identity customer, not the compound key", async () => {
+  const grantKeys: string[] = [];
+  const usageSubjects: string[][] = [];
+  const deps = createDeps({
+    resolveOpenMeterBillingIdentity: async () => ({
+      customerKey: "sbx_eu_end-1",
+      payerCustomerKey: "sbx_eu_end-1",
+      payerKind: "end_user",
+      isOwner: false,
+      sharesOwnerCostRail: false,
+      actorEndUserId: "eu_end-1",
+      actorExternalUserId: "external_1",
+      publicClientId: "pc_test",
+      developerAppId: "app_1",
+      legacyCompoundCustomerKey: "pc_test:external_1",
+    }),
+    listAppUserCreditGrants: async (input) => {
+      grantKeys.push(input.customerKey);
+      return [];
+    },
+    isHostedAdminClientAvailable: () => true,
+    querySubjectDailyFeeUsage: async (input) => {
+      usageSubjects.push([...input.subjects]);
+      return [];
+    },
+  });
+
+  await loadAppUserBillingLedger(
+    {
+      appId: "app_1",
+      publicClientId: "pc_test",
+      externalUserId: "external_1",
+    },
+    deps,
+  );
+
+  assert.deepEqual(grantKeys, ["sbx_eu_end-1"]);
+  assert.deepEqual(usageSubjects, [["sbx_eu_end-1", "pc_test:external_1"]]);
+});

--- a/src/lib/billing/app-user-ledger.ts
+++ b/src/lib/billing/app-user-ledger.ts
@@ -17,9 +17,13 @@ import {
   getHostedAdminClient,
   isHostedAdminClientAvailable,
 } from "@/lib/openmeter/admin-client";
+import {
+  appUserOpenMeterLookupKeys,
+  resolveOpenMeterBillingIdentity,
+} from "@/lib/openmeter/billing-identity";
 import { getHostedOpenMeterUrl } from "@/lib/openmeter/constants";
 import { buildOpenMeterCustomerKey } from "@/lib/openmeter/customer-key";
-import { ensureOpenMeterCustomer } from "@/lib/openmeter/customers";
+import { findOpenMeterCustomerByKey } from "@/lib/openmeter/customers";
 import { querySubjectDailyFeeUsage } from "@/lib/openmeter/daily-fee-usage";
 import { getTrialCreditBalance } from "@/lib/openmeter/entitlements";
 import {
@@ -67,8 +71,7 @@ function withSoftTimeout<T>(input: {
 }
 
 async function listAppUserCreditGrants(input: {
-  publicClientId: string;
-  externalUserId: string;
+  customerKey: string;
   onDegraded?: () => void;
 }): Promise<LedgerGrantInput[]> {
   if (!isHostedAdminClientAvailable()) {
@@ -80,12 +83,15 @@ async function listAppUserCreditGrants(input: {
   }
 
   const client = getHostedAdminClient();
-  const customerKey = buildOpenMeterCustomerKey(
-    input.publicClientId,
-    input.externalUserId,
-  );
+  const customerKey = input.customerKey.trim();
+  if (!customerKey) {
+    return [];
+  }
   try {
-    const customer = await ensureOpenMeterCustomer(client, customerKey);
+    const customer = await findOpenMeterCustomerByKey(client, customerKey);
+    if (!customer?.id) {
+      return [];
+    }
     const grants = await listKonnectCreditGrants({
       customerId: customer.id,
       apiKey,
@@ -184,6 +190,7 @@ type AppUserBillingLedgerDeps = {
   isHostedAdminClientAvailable: typeof isHostedAdminClientAvailable;
   getHostedAdminClient: typeof getHostedAdminClient;
   querySubjectDailyFeeUsage: typeof querySubjectDailyFeeUsage;
+  resolveOpenMeterBillingIdentity?: typeof resolveOpenMeterBillingIdentity;
 };
 
 const DEFAULT_APP_USER_BILLING_LEDGER_DEPS: AppUserBillingLedgerDeps = {
@@ -218,12 +225,24 @@ export async function loadAppUserBillingLedger(input: {
   const meterClientId = await deps.resolveOpenMeterMeterClientId(input.appId).catch(
     () => publicClientId,
   );
-  const customerKey = buildOpenMeterCustomerKey(meterClientId, externalUserId);
+  const resolveIdentity =
+    deps.resolveOpenMeterBillingIdentity ?? resolveOpenMeterBillingIdentity;
+  let customerKey = buildOpenMeterCustomerKey(meterClientId, externalUserId);
+  let usageSubjects = [customerKey];
+  try {
+    const identity = await resolveIdentity({
+      clientId: publicClientId,
+      externalUserId,
+    });
+    customerKey = identity.customerKey;
+    usageSubjects = appUserOpenMeterLookupKeys(identity);
+  } catch {
+    // Keep the compound key when identity cannot be resolved (tests / offline).
+  }
 
   const [konnectGrants, discount, balance, history] = await Promise.all([
     deps.listAppUserCreditGrants({
-      publicClientId: meterClientId,
-      externalUserId,
+      customerKey,
       onDegraded: () => {
         degraded = true;
       },
@@ -272,7 +291,7 @@ export async function loadAppUserBillingLedger(input: {
     dailyUsage = await withSoftTimeout({
       promise: deps.querySubjectDailyFeeUsage({
         client: deps.getHostedAdminClient(),
-        subjects: [customerKey],
+        subjects: usageSubjects,
         start: cycle.start,
         end: cycle.end,
         logLabel: "app-user-ledger",

--- a/src/lib/billing/end-users.ts
+++ b/src/lib/billing/end-users.ts
@@ -61,9 +61,10 @@ export async function findOrCreateAppEndUser(
 }
 
 /**
- * Map a canonical OpenMeter end-user key (`eu_{end_users.id}`) back to the
- * integrator `external_user_id` used by `app_users` prefs and Connect
- * customers. Non-`eu_` values pass through unchanged.
+ * Map a canonical OpenMeter end-user key (`eu_{end_users.id}` or sandbox
+ * `sbx_eu_{end_users.id}`) back to the integrator `external_user_id` used
+ * by `app_users` prefs and Connect customers. Other values pass through
+ * unchanged.
  */
 export async function resolveAppUserExternalIdFromCustomerKey(
   externalUserId: string,

--- a/src/lib/openmeter/app-user-subscription-history.ts
+++ b/src/lib/openmeter/app-user-subscription-history.ts
@@ -14,9 +14,8 @@ import {
   getHostedAdminClient,
   isHostedAdminClientAvailable,
 } from "@/lib/openmeter/admin-client";
-import { buildOpenMeterCustomerKey } from "@/lib/openmeter/customer-key";
+import { resolveAppUserOpenMeterLookupKeys } from "@/lib/openmeter/billing-identity";
 import { findOpenMeterCustomerByKey } from "@/lib/openmeter/customers";
-import { resolveOpenMeterMeterClientId } from "@/lib/openmeter/meter-client-id";
 import { buildOpenMeterPlanKey } from "@/lib/openmeter/plan-naming";
 import { isLiveSubscriptionStatus } from "@/lib/openmeter/subscription-state";
 import {
@@ -174,10 +173,18 @@ async function lookupCustomerId(
   clientId: string,
   externalUserId: string,
 ): Promise<string | null> {
-  const publicClientId = await resolveOpenMeterMeterClientId(clientId);
-  const key = buildOpenMeterCustomerKey(publicClientId, externalUserId);
-  const existing = await findOpenMeterCustomerByKey(client, key);
-  return existing?.id?.trim() || null;
+  const keys = await resolveAppUserOpenMeterLookupKeys({
+    clientId,
+    externalUserId,
+  });
+  for (const key of keys) {
+    const existing = await findOpenMeterCustomerByKey(client, key);
+    const id = existing?.id?.trim();
+    if (id) {
+      return id;
+    }
+  }
+  return null;
 }
 
 export type ListAppUserSubscriptionHistoryDeps = {

--- a/src/lib/openmeter/billing-identity.test.ts
+++ b/src/lib/openmeter/billing-identity.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import nodeTest from "node:test";
 
 import {
+  appUserOpenMeterLookupKeys,
   appUserRetailCustomerKey,
   AppUserOwnerWalletMutationError,
   assertAppUserRetailBillingSubject,
@@ -104,6 +105,40 @@ nodeTest("appUserRetailCustomerKey keeps end-user cards off the owner wallet", (
       developerAppId: "app_demo",
     }),
     "owner-uuid",
+  );
+});
+
+nodeTest("appUserOpenMeterLookupKeys prefers sandbox payer over live actor and owner", () => {
+  assert.deepEqual(
+    appUserOpenMeterLookupKeys({
+      customerKey: "sbx_eu_end-user-1",
+      payerCustomerKey: "sbx_eu_end-user-1",
+      payerKind: "end_user",
+      isOwner: false,
+      sharesOwnerCostRail: false,
+      actorEndUserId: "eu_end-user-1",
+      actorExternalUserId: "ext-9",
+      publicClientId: "app_demo",
+      developerAppId: "app_demo",
+      legacyCompoundCustomerKey: "app_demo:ext-9",
+    }),
+    ["sbx_eu_end-user-1", "app_demo:ext-9"],
+  );
+  assert.deepEqual(
+    appUserOpenMeterLookupKeys({
+      customerKey: "owner-uuid",
+      payerCustomerKey: "owner-uuid",
+      payerKind: "platform_user",
+      payerPlatformUserId: "owner-uuid",
+      isOwner: false,
+      sharesOwnerCostRail: true,
+      actorEndUserId: "eu_end-user-1",
+      actorExternalUserId: "ext-9",
+      publicClientId: "app_demo",
+      developerAppId: "app_demo",
+      legacyCompoundCustomerKey: "app_demo:ext-9",
+    }),
+    ["eu_end-user-1", "app_demo:ext-9"],
   );
 });
 

--- a/src/lib/openmeter/billing-identity.test.ts
+++ b/src/lib/openmeter/billing-identity.test.ts
@@ -24,7 +24,9 @@ import {
   buildOpenMeterCustomerKey,
   buildOwnerCustomerKey,
   buildOwnerWireSubject,
+  buildSandboxEndUserCustomerKey,
   isEndUserCustomerKey,
+  isSandboxEndUserCustomerKey,
 } from "@/lib/openmeter/customer-key";
 import { upsertAppBillingConfig } from "@/lib/openmeter/billing-profiles";
 import { test } from "@/test-utils/db-guard";
@@ -74,6 +76,20 @@ nodeTest("appUserRetailCustomerKey keeps end-user cards off the owner wallet", (
       developerAppId: "app_demo",
     }),
     "eu_end-user-1",
+  );
+  assert.equal(
+    appUserRetailCustomerKey({
+      customerKey: "sbx_eu_end-user-1",
+      payerCustomerKey: "sbx_eu_end-user-1",
+      payerKind: "end_user",
+      isOwner: false,
+      sharesOwnerCostRail: false,
+      actorEndUserId: "eu_end-user-1",
+      actorExternalUserId: "ext-9",
+      publicClientId: "app_demo",
+      developerAppId: "app_demo",
+    }),
+    "sbx_eu_end-user-1",
   );
   assert.equal(
     appUserRetailCustomerKey({
@@ -242,12 +258,15 @@ test("owner_rollup end-user shares the owner wallet with eu_ actor", async (t) =
   );
 });
 
-test("merchant end-user bills stable eu_ customer", async (t) => {
+test("live merchant end-user bills stable eu_ customer", async (t) => {
   const seeded = await seedDeveloperAppWithClient();
   t.after(async () => cleanupTestApp(seeded));
   const endUserId = `ext-${randomUUID()}`;
 
-  await upsertAppBillingConfig(seeded.clientId, { billingMode: "merchant" });
+  await upsertAppBillingConfig(seeded.clientId, {
+    billingMode: "merchant",
+    stripeLivemode: true,
+  });
   resetBillingIdentityCache();
   const identity = await resolveOpenMeterBillingIdentity({
     clientId: seeded.clientId,
@@ -278,6 +297,37 @@ test("merchant end-user bills stable eu_ customer", async (t) => {
     identity.payerCustomerKey,
     buildEndUserCustomerKey(identity.actorEndUserId.replace(/^eu_/, "")),
   );
+});
+
+test("sandbox merchant end-user bills sbx_eu_ customer", async (t) => {
+  const seeded = await seedDeveloperAppWithClient();
+  t.after(async () => cleanupTestApp(seeded));
+  const endUserId = `ext-${randomUUID()}`;
+
+  await upsertAppBillingConfig(seeded.clientId, {
+    billingMode: "merchant",
+    stripeLivemode: false,
+  });
+  resetBillingIdentityCache();
+  const identity = await resolveOpenMeterBillingIdentity({
+    clientId: seeded.clientId,
+    externalUserId: endUserId,
+  });
+  assert.equal(identity.isOwner, false);
+  assert.equal(identity.sharesOwnerCostRail, false);
+  assert.equal(identity.payerKind, "end_user");
+  assert.ok(isSandboxEndUserCustomerKey(identity.payerCustomerKey));
+  assert.ok(isEndUserCustomerKey(identity.payerCustomerKey));
+  assert.equal(identity.customerKey, identity.payerCustomerKey);
+  assert.notEqual(identity.actorEndUserId, identity.payerCustomerKey);
+  assert.equal(appUserRetailCustomerKey(identity), identity.customerKey);
+  assert.equal(
+    identity.payerCustomerKey,
+    buildSandboxEndUserCustomerKey(identity.actorEndUserId),
+  );
+  assert.deepEqual(billingSubjectClaim(identity), {
+    billing_subject_key: identity.payerCustomerKey,
+  });
 });
 
 test("normal app owner bills shared owner wallet", async (t) => {

--- a/src/lib/openmeter/billing-identity.test.ts
+++ b/src/lib/openmeter/billing-identity.test.ts
@@ -334,7 +334,7 @@ test("live merchant end-user bills stable eu_ customer", async (t) => {
   );
 });
 
-test("cached merchant identity follows stripeLivemode after cache reset", async (t) => {
+test("cached merchant identity follows stripeLivemode without cache reset", async (t) => {
   const seeded = await seedDeveloperAppWithClient();
   const previousTtl = process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS;
   process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS = "300";
@@ -361,14 +361,9 @@ test("cached merchant identity follows stripeLivemode after cache reset", async 
   assert.ok(isEndUserCustomerKey(live.payerCustomerKey));
   assert.equal(isSandboxEndUserCustomerKey(live.payerCustomerKey), false);
 
+  // Livemode is part of the identity cache key. A sandbox Connect top-up in
+  // the same process must not reuse the live `eu_` payer from the TTL cache.
   await upsertAppBillingConfig(seeded.clientId, { stripeLivemode: false });
-  const stale = await resolveOpenMeterBillingIdentity({
-    clientId: seeded.clientId,
-    externalUserId: endUserId,
-  });
-  assert.equal(stale.payerCustomerKey, live.payerCustomerKey);
-
-  resetBillingIdentityCache();
   const sandbox = await resolveOpenMeterBillingIdentity({
     clientId: seeded.clientId,
     externalUserId: endUserId,
@@ -378,6 +373,8 @@ test("cached merchant identity follows stripeLivemode after cache reset", async 
     sandbox.payerCustomerKey,
     buildSandboxEndUserCustomerKey(sandbox.actorEndUserId),
   );
+  assert.equal(sandbox.actorEndUserId, live.actorEndUserId);
+  assert.notEqual(sandbox.payerCustomerKey, live.payerCustomerKey);
 });
 
 test("sandbox merchant end-user bills sbx_eu_ customer", async (t) => {

--- a/src/lib/openmeter/billing-identity.test.ts
+++ b/src/lib/openmeter/billing-identity.test.ts
@@ -299,6 +299,52 @@ test("live merchant end-user bills stable eu_ customer", async (t) => {
   );
 });
 
+test("cached merchant identity follows stripeLivemode after cache reset", async (t) => {
+  const seeded = await seedDeveloperAppWithClient();
+  const previousTtl = process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS;
+  process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS = "300";
+  t.after(async () => {
+    if (previousTtl === undefined) {
+      delete process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS;
+    } else {
+      process.env.BILLING_IDENTITY_CACHE_TTL_SECONDS = previousTtl;
+    }
+    resetBillingIdentityCache();
+    await cleanupTestApp(seeded);
+  });
+  const endUserId = `ext-${randomUUID()}`;
+
+  await upsertAppBillingConfig(seeded.clientId, {
+    billingMode: "merchant",
+    stripeLivemode: true,
+  });
+  resetBillingIdentityCache();
+  const live = await resolveOpenMeterBillingIdentity({
+    clientId: seeded.clientId,
+    externalUserId: endUserId,
+  });
+  assert.ok(isEndUserCustomerKey(live.payerCustomerKey));
+  assert.equal(isSandboxEndUserCustomerKey(live.payerCustomerKey), false);
+
+  await upsertAppBillingConfig(seeded.clientId, { stripeLivemode: false });
+  const stale = await resolveOpenMeterBillingIdentity({
+    clientId: seeded.clientId,
+    externalUserId: endUserId,
+  });
+  assert.equal(stale.payerCustomerKey, live.payerCustomerKey);
+
+  resetBillingIdentityCache();
+  const sandbox = await resolveOpenMeterBillingIdentity({
+    clientId: seeded.clientId,
+    externalUserId: endUserId,
+  });
+  assert.ok(isSandboxEndUserCustomerKey(sandbox.payerCustomerKey));
+  assert.equal(
+    sandbox.payerCustomerKey,
+    buildSandboxEndUserCustomerKey(sandbox.actorEndUserId),
+  );
+});
+
 test("sandbox merchant end-user bills sbx_eu_ customer", async (t) => {
   const seeded = await seedDeveloperAppWithClient();
   t.after(async () => cleanupTestApp(seeded));

--- a/src/lib/openmeter/billing-identity.ts
+++ b/src/lib/openmeter/billing-identity.ts
@@ -424,7 +424,9 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
  * App→client→owner mappings change only on rare admin operations, but the
  * remote-signer hot path resolves them many times per request across mint,
  * provisioning, and balance reads. Cache per (clientId, externalUserId) so a
- * webhook invocation costs at most one Neon identity round-trip.
+ * webhook invocation costs at most one Neon identity round-trip. Merchant
+ * payer keys also depend on stripeLivemode — billing PATCH must reset this
+ * cache when livemode or billingMode changes.
  */
 let identityCache: ReturnType<
   typeof createAsyncTtlCache<ResolvedBillingIdentity>

--- a/src/lib/openmeter/billing-identity.ts
+++ b/src/lib/openmeter/billing-identity.ts
@@ -167,6 +167,29 @@ export function appUserRetailCustomerKey(
   return identity.customerKey;
 }
 
+/**
+ * OpenMeter keys to read for an app-user wallet (grants, usage, invoices).
+ * Retail/payer first (`eu_…` live, `sbx_eu_…` sandbox); never the owner
+ * wallet on owner_rollup. Legacy compound is dual-read only.
+ */
+export function appUserOpenMeterLookupKeys(
+  identity: ResolvedBillingIdentity,
+): string[] {
+  const retail = appUserRetailCustomerKey(identity);
+  const keys = [retail];
+  if (
+    identity.customerKey !== retail &&
+    !identity.sharesOwnerCostRail
+  ) {
+    keys.push(identity.customerKey);
+  }
+  const legacy = identity.legacyCompoundCustomerKey?.trim();
+  if (legacy && legacy !== retail) {
+    keys.push(legacy);
+  }
+  return [...new Set(keys.filter((key) => key.trim()))];
+}
+
 /** Owner wallet id when this identity's cost rail is the shared owner customer. */
 export function ownerCostRailUserId(
   identity: ResolvedBillingIdentity,
@@ -568,6 +591,30 @@ async function resolveOpenMeterBillingIdentityUncached(input: {
     developerAppId: app.developerAppId,
     legacyCompoundCustomerKey: actorIds.legacyCompoundCustomerKey,
   });
+}
+
+/**
+ * Keys to look up for an app-user in OpenMeter. Identity first (`eu_…` /
+ * `sbx_eu_…`); compound fallback when identity cannot be resolved.
+ */
+export async function resolveAppUserOpenMeterLookupKeys(input: {
+  clientId: string;
+  externalUserId: string;
+}): Promise<string[]> {
+  const clientId = input.clientId.trim();
+  const externalUserId = input.externalUserId.trim();
+  if (!clientId || !externalUserId) {
+    return [];
+  }
+  try {
+    const identity = await resolveOpenMeterBillingIdentity({
+      clientId,
+      externalUserId,
+    });
+    return appUserOpenMeterLookupKeys(identity);
+  } catch {
+    return [buildOpenMeterCustomerKey(clientId, externalUserId)];
+  }
 }
 
 /** True when this external user id is the owner of the given app. */

--- a/src/lib/openmeter/billing-identity.ts
+++ b/src/lib/openmeter/billing-identity.ts
@@ -446,10 +446,10 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
 /**
  * App→client→owner mappings change only on rare admin operations, but the
  * remote-signer hot path resolves them many times per request across mint,
- * provisioning, and balance reads. Cache per (clientId, externalUserId) so a
- * webhook invocation costs at most one Neon identity round-trip. Merchant
- * payer keys also depend on stripeLivemode — billing PATCH must reset this
- * cache when livemode or billingMode changes.
+ * provisioning, and balance reads. Merchant payer keys also depend on
+ * stripeLivemode (`eu_` vs `sbx_eu_`), so the app row is always re-read and
+ * the identity cache is keyed by billing plane. findOrCreateAppEndUser still
+ * runs at most once per (client, user, plane) within the TTL.
  */
 let identityCache: ReturnType<
   typeof createAsyncTtlCache<ResolvedBillingIdentity>
@@ -464,6 +464,17 @@ function getIdentityCache() {
 
 export function resetBillingIdentityCache(): void {
   identityCache = null;
+}
+
+function identityCacheKey(input: {
+  clientId: string;
+  externalUserId: string;
+  app: AppIdentityRow | null;
+}): string {
+  const plane = input.app
+    ? `${input.app.billingMode}\u0000${input.app.stripeLivemode ? "1" : "0"}`
+    : "";
+  return `${input.clientId}\u0000${input.externalUserId}\u0000${plane}`;
 }
 
 /**
@@ -481,17 +492,25 @@ export async function resolveOpenMeterBillingIdentity(input: {
     throw new Error("externalUserId is required");
   }
   const clientId = input.clientId.trim();
-  return getIdentityCache().get(`${clientId}\u0000${externalUserId}`, () =>
-    resolveOpenMeterBillingIdentityUncached({ clientId, externalUserId }),
+  const app = await loadAppIdentity(clientId);
+  return getIdentityCache().get(
+    identityCacheKey({ clientId, externalUserId, app }),
+    () =>
+      resolveOpenMeterBillingIdentityUncached({
+        clientId,
+        externalUserId,
+        app,
+      }),
   );
 }
 
 async function resolveOpenMeterBillingIdentityUncached(input: {
   clientId: string;
   externalUserId: string;
+  app: AppIdentityRow | null;
 }): Promise<ResolvedBillingIdentity> {
   const externalUserId = input.externalUserId;
-  const app = await loadAppIdentity(input.clientId);
+  const app = input.app;
   if (!app) {
     // Fall back: treat input clientId as public id (tests / scripts).
     // Only wire `owner:{id}` marks owners here — bare UUIDs are common end-user ids.

--- a/src/lib/openmeter/billing-identity.ts
+++ b/src/lib/openmeter/billing-identity.ts
@@ -9,6 +9,7 @@ import {
   buildOpenMeterCustomerKey,
   buildOwnerCustomerKey,
   buildOwnerWireSubject,
+  buildSandboxEndUserCustomerKey,
   isEndUserCustomerKey,
   isOwnerWireSubject,
   normalizePlatformUserId,
@@ -19,7 +20,7 @@ import {
 /** JWT claim: owner_rollup end-user tokens name the app owner's wallet (legacy). */
 export const COST_OWNER_USER_ID_CLAIM = "cost_owner_user_id";
 
-/** JWT claim: OpenMeter payer customer key (owner bare id or `eu_…`). */
+/** JWT claim: OpenMeter payer customer key (owner bare id, `eu_…`, or `sbx_eu_…`). */
 export const BILLING_SUBJECT_KEY_CLAIM = "billing_subject_key";
 
 /** Separator between payer and actor in the wire `usage_subject`. */
@@ -72,6 +73,8 @@ type AppIdentityRow = {
   ownerId: string;
   isPlatformDefault: boolean;
   billingMode: "owner_rollup" | "merchant";
+  /** Merchant Connect Stripe plane. Missing config reads as live. */
+  stripeLivemode: boolean;
 };
 
 function platformUserIdentity(input: {
@@ -148,13 +151,17 @@ async function resolveEndUserActorIds(input: {
 
 /**
  * OpenMeter customer for app-user retail billing (payment methods, Checkout).
- * End-users use `eu_{end_users.id}` even under owner_rollup so cards never
- * land on the owner wallet. Owners and Explorers use the owner customer key.
+ * Owner-rollup end-users keep `eu_{end_users.id}` so cards never land on the
+ * owner wallet. Merchant sandbox payers use `sbx_eu_{id}` (the identity
+ * customer key). Owners and Explorers use the owner customer key.
  */
 export function appUserRetailCustomerKey(
   identity: ResolvedBillingIdentity,
 ): string {
-  if (isEndUserCustomerKey(identity.actorEndUserId)) {
+  if (
+    identity.sharesOwnerCostRail &&
+    isEndUserCustomerKey(identity.actorEndUserId)
+  ) {
     return identity.actorEndUserId;
   }
   return identity.customerKey;
@@ -369,6 +376,7 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
     ownerId: developerApps.ownerId,
     isPlatformDefault: developerApps.isPlatformDefault,
     billingMode: appBillingConfig.billingMode,
+    stripeLivemode: appBillingConfig.stripeLivemode,
   };
 
   const byPublic = await db
@@ -386,6 +394,7 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
       ownerId: byPublic[0].ownerId,
       isPlatformDefault: byPublic[0].isPlatformDefault === 1,
       billingMode: billingModeFromRow(byPublic[0].billingMode),
+      stripeLivemode: byPublic[0].stripeLivemode !== false,
     };
   }
 
@@ -407,6 +416,7 @@ async function loadAppIdentity(clientIdOrAppId: string): Promise<AppIdentityRow 
     ownerId: row.ownerId,
     isPlatformDefault: row.isPlatformDefault === 1,
     billingMode: billingModeFromRow(row.billingMode),
+    stripeLivemode: row.stripeLivemode !== false,
   };
 }
 
@@ -435,7 +445,7 @@ export function resetBillingIdentityCache(): void {
  * Resolve the OpenMeter billing customer for an (app, external user) pair.
  * App owners and owner_rollup end-users share the owner's `{users.id}` wallet;
  * platform-default (Livepeer Direct) members bill their own owner wallet;
- * merchant end-users bill their stable `eu_{end_users.id}` customer.
+ * merchant end-users bill `eu_{end_users.id}` (live) or `sbx_eu_{id}` (sandbox).
  */
 export async function resolveOpenMeterBillingIdentity(input: {
   clientId: string;
@@ -542,8 +552,12 @@ async function resolveOpenMeterBillingIdentityUncached(input: {
     });
   }
 
+  const payerCustomerKey = app.stripeLivemode
+    ? actorIds.endUserCustomerKey
+    : buildSandboxEndUserCustomerKey(actorIds.endUserCustomerKey);
+
   return endUserIdentity({
-    payerCustomerKey: actorIds.endUserCustomerKey,
+    payerCustomerKey,
     payerKind: "end_user",
     sharesOwnerCostRail: false,
     actorEndUserId: actorIds.actorEndUserId,

--- a/src/lib/openmeter/billing-profiles.ts
+++ b/src/lib/openmeter/billing-profiles.ts
@@ -373,7 +373,17 @@ export async function prepareAppCustomerStripeBilling(input: {
     process.env.OPENMETER_MERCHANT_BILLING_PROFILE_ID?.trim() ||
     null;
 
-  // Merchant plane: pin to Custom Invoicing profile (no platform Stripe charge).
+  // Merchant sandbox payers (`sbx_eu_…`) stay on the namespace sandbox
+  // profile — Custom Invoicing + settlement metadata belong on live `eu_…`.
+  if (config?.billingMode === "merchant" && config.stripeLivemode === false) {
+    await applyFreeBillingProfileToCustomer({
+      client: input.client,
+      customerId: input.customerId,
+    });
+    return;
+  }
+
+  // Live merchant plane: pin to Custom Invoicing (no platform Stripe charge).
   // Credits-first Starter users stay on this profile too — Sandbox is wrong
   // because it fake-pays invoices and bypasses settlement / Connect.
   if (config?.billingMode === "merchant") {

--- a/src/lib/openmeter/customer-key.ts
+++ b/src/lib/openmeter/customer-key.ts
@@ -34,6 +34,13 @@ export const OWNER_CUSTOMER_KEY_PREFIX = "owner:";
 export const END_USER_CUSTOMER_PREFIX = "eu_";
 
 /**
+ * Sandbox Merchant Connect payer prefix. Live wallets stay `eu_{id}`; sandbox
+ * (`stripeLivemode=false`) uses `sbx_eu_{id}` so test-card grants never share
+ * the production prepaid customer.
+ */
+export const SANDBOX_END_USER_CUSTOMER_PREFIX = "sbx_";
+
+/**
  * Canonical OpenMeter customer key for a platform owner: bare `{users.id}`.
  * Credits and included usage live on this single customer across all apps.
  */
@@ -49,6 +56,11 @@ export function buildEndUserCustomerKey(endUserId: string): string {
   if (!trimmed) {
     return "";
   }
+  if (trimmed.startsWith(SANDBOX_END_USER_CUSTOMER_PREFIX)) {
+    return buildEndUserCustomerKey(
+      trimmed.slice(SANDBOX_END_USER_CUSTOMER_PREFIX.length),
+    );
+  }
   if (trimmed.startsWith(END_USER_CUSTOMER_PREFIX)) {
     return trimmed;
   }
@@ -56,9 +68,17 @@ export function buildEndUserCustomerKey(endUserId: string): string {
 }
 
 /**
- * True when `key` is a canonical end-user customer key (`eu_…`).
+ * Sandbox Merchant Connect payer key: `sbx_eu_{end_users.id}`.
  */
-export function isEndUserCustomerKey(key: string): boolean {
+export function buildSandboxEndUserCustomerKey(endUserId: string): string {
+  const live = buildEndUserCustomerKey(endUserId);
+  if (!live) {
+    return "";
+  }
+  return `${SANDBOX_END_USER_CUSTOMER_PREFIX}${live}`;
+}
+
+function isLiveEndUserCustomerKey(key: string): boolean {
   const trimmed = key.trim();
   return (
     trimmed.startsWith(END_USER_CUSTOMER_PREFIX) &&
@@ -67,11 +87,33 @@ export function isEndUserCustomerKey(key: string): boolean {
 }
 
 /**
- * Strip the `eu_` prefix, or return null when the key is not an end-user key.
+ * True when `key` is a sandbox end-user payer key (`sbx_eu_…`).
+ */
+export function isSandboxEndUserCustomerKey(key: string): boolean {
+  const trimmed = key.trim();
+  const prefixed = `${SANDBOX_END_USER_CUSTOMER_PREFIX}${END_USER_CUSTOMER_PREFIX}`;
+  return trimmed.startsWith(prefixed) && trimmed.length > prefixed.length;
+}
+
+/**
+ * True when `key` is an end-user customer key (`eu_…` or sandbox `sbx_eu_…`).
+ */
+export function isEndUserCustomerKey(key: string): boolean {
+  return isLiveEndUserCustomerKey(key) || isSandboxEndUserCustomerKey(key);
+}
+
+/**
+ * Strip `sbx_` / `eu_` prefixes to the `end_users.id`, or null when not an
+ * end-user key.
  */
 export function parseEndUserCustomerKey(key: string): string | null {
   const trimmed = key.trim();
-  if (!isEndUserCustomerKey(trimmed)) {
+  if (isSandboxEndUserCustomerKey(trimmed)) {
+    return parseEndUserCustomerKey(
+      trimmed.slice(SANDBOX_END_USER_CUSTOMER_PREFIX.length),
+    );
+  }
+  if (!isLiveEndUserCustomerKey(trimmed)) {
     return null;
   }
   return trimmed.slice(END_USER_CUSTOMER_PREFIX.length) || null;
@@ -90,8 +132,8 @@ export function buildOwnerWireSubject(userId: string): string {
  * - bare `{users.id}` (canonical)
  * - `owner:{users.id}` (legacy customer key / wire subject)
  *
- * End-user customer keys (`eu_…`) and compound `app_…:externalUserId` keys
- * are never owner wallets.
+ * End-user customer keys (`eu_…` / `sbx_eu_…`) and compound
+ * `app_…:externalUserId` keys are never owner wallets.
  */
 export function isOwnerCustomerKey(key: string): boolean {
   const trimmed = key.trim();

--- a/src/lib/openmeter/invoices.ts
+++ b/src/lib/openmeter/invoices.ts
@@ -7,16 +7,15 @@ import {
   classifyInvoiceLineKind,
   type InvoiceLineSummary,
 } from "@/lib/billing/invoice-line-labels";
+import { resolveAppUserOpenMeterLookupKeys } from "@/lib/openmeter/billing-identity";
 import {
   buildOwnerCustomerKey,
   buildOwnerWireSubject,
 } from "@/lib/openmeter/customer-key";
-import { buildOpenMeterCustomerKey } from "./customer-key";
 import {
   findOpenMeterCustomerByKey,
   listTenantCustomerIds,
 } from "./customers";
-import { resolveOpenMeterMeterClientId } from "./meter-client-id";
 
 /**
  * Invoice line rounding policy:
@@ -396,30 +395,34 @@ export async function getOwnerWalletInvoice(input: {
 
 /**
  * Lookup-only end-user customer for invoice/PM reads.
- * Always uses compound `{publicClientId}:{externalUserId}` — never the owner
- * wallet path from {@link ensureOpenMeterCustomerForAppUser}.
+ * Uses the billing identity (`eu_…` live, `sbx_eu_…` sandbox) and dual-reads
+ * the legacy compound key. Never the owner wallet on owner_rollup.
  */
 async function lookupAppUserCustomer(input: {
   client: OpenMeter;
   clientId: string;
   externalUserId: string;
 }): Promise<{ id: string; key: string } | null> {
-  const publicClientId = await resolveOpenMeterMeterClientId(input.clientId);
   const externalUserId = input.externalUserId.trim();
-  if (!publicClientId || !externalUserId) {
+  if (!input.clientId.trim() || !externalUserId) {
     return null;
   }
-  const key = buildOpenMeterCustomerKey(publicClientId, externalUserId);
-  const existing = await findOpenMeterCustomerByKey(input.client, key);
-  const id = existing?.id?.trim();
-  if (!id) {
-    return null;
+  const keys = await resolveAppUserOpenMeterLookupKeys({
+    clientId: input.clientId,
+    externalUserId,
+  });
+  for (const key of keys) {
+    const existing = await findOpenMeterCustomerByKey(input.client, key);
+    const id = existing?.id?.trim();
+    if (id) {
+      return { id, key };
+    }
   }
-  return { id, key };
+  return null;
 }
 
 /**
- * End-user invoices for one app user (`{publicClientId}:{externalUserId}`).
+ * End-user invoices for one app user (identity customer, plus legacy compound).
  * Lookup-only — does not create customers or resolve owner wallets.
  */
 export async function listAppUserInvoices(input: {

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -77,9 +77,11 @@ test("owner customer key helpers use bare user id", async () => {
     buildOwnerCustomerKey,
     buildOwnerWireSubject,
     buildEndUserCustomerKey,
+    buildSandboxEndUserCustomerKey,
     isOwnerCustomerKey,
     isEndUserCustomerKey,
     isOwnerWireSubject,
+    isSandboxEndUserCustomerKey,
     parseOwnerCustomerKey,
     parseEndUserCustomerKey,
     parseCustomerKey,
@@ -91,6 +93,23 @@ test("owner customer key helpers use bare user id", async () => {
   assert.equal(buildOwnerWireSubject("uuid-1"), "owner:uuid-1");
   assert.equal(buildEndUserCustomerKey("eu-id-1"), "eu_eu-id-1");
   assert.equal(buildEndUserCustomerKey("eu_eu-id-1"), "eu_eu-id-1");
+  assert.equal(
+    buildSandboxEndUserCustomerKey("eu-id-1"),
+    "sbx_eu_eu-id-1",
+  );
+  assert.equal(
+    buildSandboxEndUserCustomerKey("eu_eu-id-1"),
+    "sbx_eu_eu-id-1",
+  );
+  assert.equal(isSandboxEndUserCustomerKey("sbx_eu_eu-id-1"), true);
+  assert.equal(isSandboxEndUserCustomerKey("eu_eu-id-1"), false);
+  assert.equal(isEndUserCustomerKey("sbx_eu_eu-id-1"), true);
+  assert.equal(isOwnerCustomerKey("sbx_eu_eu-id-1"), false);
+  assert.equal(parseEndUserCustomerKey("sbx_eu_eu-id-1"), "eu-id-1");
+  assert.deepEqual(parseCustomerKey("sbx_eu_eu-id-1"), {
+    kind: "end_user",
+    endUserId: "eu-id-1",
+  });
   assert.equal(isOwnerCustomerKey("uuid-1"), true);
   assert.equal(isOwnerCustomerKey("owner:uuid-1"), true);
   assert.equal(isOwnerCustomerKey("app_x:uuid-1"), false);

--- a/src/lib/openmeter/starter-subscription.ts
+++ b/src/lib/openmeter/starter-subscription.ts
@@ -212,7 +212,8 @@ export async function recoverStarterBillingProfile(
 }
 
 /**
- * Eager Custom Invoicing pin for merchant Starter users (before create).
+ * Eager merchant billing-profile pin for Starter users (before create).
+ * Live merchant: Custom Invoicing. Sandbox merchant: free/sandbox profile.
  * @internal Exported for unit tests.
  */
 export async function pinMerchantCustomInvoicingIfNeeded(

--- a/src/lib/openmeter/subscriptions-billing.ts
+++ b/src/lib/openmeter/subscriptions-billing.ts
@@ -11,7 +11,10 @@ import {
   isMerchantConnectPaymentsReady,
 } from "@/lib/stripe/merchant-connect";
 import { getHostedAdminClient } from "./admin-client";
-import { assertAppUserRetailBillingSubject } from "./billing-identity";
+import {
+  assertAppUserRetailBillingSubject,
+  resolveOpenMeterBillingIdentity,
+} from "./billing-identity";
 import {
   applyFreeBillingProfileToCustomer,
   applyTenantBillingProfileToCustomer,
@@ -183,10 +186,19 @@ async function upsertNeonSubscriptionCache(input: {
   status: string;
   stripeCheckoutSessionId?: string | null;
 }): Promise<void> {
-  const customerKey = buildOpenMeterCustomerKey(
+  let customerKey = buildOpenMeterCustomerKey(
     input.clientId,
     input.externalUserId,
   );
+  try {
+    const identity = await resolveOpenMeterBillingIdentity({
+      clientId: input.clientId,
+      externalUserId: input.externalUserId,
+    });
+    customerKey = identity.customerKey;
+  } catch {
+    // Keep the compound key when identity cannot be resolved.
+  }
   const existing = await db
     .select()
     .from(subscriptions)

--- a/src/lib/stripe/auto-topup.db.test.ts
+++ b/src/lib/stripe/auto-topup.db.test.ts
@@ -8,7 +8,10 @@ import {
   findOrCreateAppEndUser,
   resolveAppUserExternalIdFromCustomerKey,
 } from "@/lib/billing/end-users";
-import { buildEndUserCustomerKey } from "@/lib/openmeter/customer-key";
+import {
+  buildEndUserCustomerKey,
+  buildSandboxEndUserCustomerKey,
+} from "@/lib/openmeter/customer-key";
 import {
   loadAppUserAutoTopUpPrefs,
   saveAppUserAutoTopUpPrefs,
@@ -95,6 +98,12 @@ test("resolveAppUserExternalIdFromCustomerKey maps eu_ keys to the integrator id
 
   assert.equal(
     await resolveAppUserExternalIdFromCustomerKey(customerKey),
+    externalUserId,
+  );
+  assert.equal(
+    await resolveAppUserExternalIdFromCustomerKey(
+      buildSandboxEndUserCustomerKey(created.id),
+    ),
     externalUserId,
   );
   assert.equal(

--- a/src/lib/stripe/merchant-connect.db.test.ts
+++ b/src/lib/stripe/merchant-connect.db.test.ts
@@ -15,8 +15,8 @@ import {
   upsertAppBillingConfig,
 } from "@/lib/openmeter/billing-profiles";
 import {
-  buildEndUserCustomerKey,
   buildOpenMeterCustomerKey,
+  buildSandboxEndUserCustomerKey,
 } from "@/lib/openmeter/customer-key";
 import {
   applyConnectedAccountWebhookUpdate,
@@ -29,7 +29,7 @@ import {
   seedDeveloperAppWithClient,
 } from "@/test-utils/fixtures";
 
-test("upsertAppUserStripeCustomer persists the canonical eu_ key, not a compound key", async (t) => {
+test("upsertAppUserStripeCustomer persists the canonical sandbox sbx_eu_ key, not a compound key", async (t) => {
   const app = await seedDeveloperAppWithClient({
     name: `StripeMap ${randomUUID().slice(0, 8)}`,
   });
@@ -45,7 +45,7 @@ test("upsertAppUserStripeCustomer persists the canonical eu_ key, not a compound
     app.clientId,
     externalUserId,
   );
-  const canonicalKey = buildEndUserCustomerKey(endUserRowId);
+  const canonicalKey = buildSandboxEndUserCustomerKey(endUserRowId);
   const legacyKey = buildOpenMeterCustomerKey(app.clientId, externalUserId);
 
   await upsertAppUserStripeCustomer({


### PR DESCRIPTION
## Summary

Production sandbox Merchant Connect can accept test-card top-ups without minting prepaid on the live `eu_{end_users.id}` wallet.

- Live merchant payers stay `eu_{id}`.
- Sandbox merchant (`stripeLivemode=false`) payers are `sbx_eu_{id}`, pinned to the existing OpenMeter sandbox/free billing profile.
- Sandbox webhook grants run only when the webhook plane matches the app livemode and the Connect `account` matches. Credits land on `sbx_eu_…`.
- Owner Plane A stays live: sandbox owner top-ups are still ignored.

Switching Sandbox ↔ Live is a different OpenMeter customer; balance does not follow.

## Test plan

- [x] `npx tsc --noEmit`
- [x] Focused tests: customer keys, billing identity (`eu_` vs `sbx_eu_`), sandbox merchant grant / livemode mismatch webhooks
- [ ] Production ComfyPeer sandbox: link a payment method
- [ ] Add $10 credit — Konnect prepaid lands on `sbx_eu_{id}`, not production `eu_{id}`
- [ ] Owner sandbox top-up still does not credit the live owner wallet