### PR TITLE
feat(plans): pay-per-use included usage allowance

### DIFF
--- a/src/app/api/v1/apps/[id]/plans/route.test.ts
+++ b/src/app/api/v1/apps/[id]/plans/route.test.ts
@@ -292,6 +292,32 @@ test("plans POST accepts subscription with retail overageRateUsd", async (t) => 
   assert.equal(planRows[0].includedUsdMicros, "20000000");
 });
 
+test("plans POST accepts pay-per-use with includedUsdMicros", async (t) => {
+  const app = await seedDeveloperAppWithClient({ status: "approved" });
+  authorizedApp = app;
+  t.after(async () => {
+    authorizedApp = null;
+    await cleanupTestApp(app);
+  });
+
+  const created = await postPlan(app.clientId, {
+    name: "Pay as you go with included",
+    type: "usage",
+    priceAmount: "0",
+    priceCurrency: "USD",
+    includedUsdMicros: "5000000",
+  });
+  assert.equal(created.status, 201);
+
+  const planRows = await db
+    .select()
+    .from(plans)
+    .where(eq(plans.id, created.body.id as string))
+    .limit(1);
+  assert.equal(planRows[0]?.type, "usage");
+  assert.equal(planRows[0]?.includedUsdMicros, "5000000");
+});
+
 test("plans POST accepts billingCycle and rejects invalid values", async (t) => {
   const app = await seedDeveloperAppWithClient({ status: "approved" });
   authorizedApp = app;

--- a/src/components/apps/PlansTab.tsx
+++ b/src/components/apps/PlansTab.tsx
@@ -800,37 +800,40 @@ function PlanDraftForm({
       )}
 
       {draft.type === "subscription" && (
-        <>
-          <div>
-            <label
-              htmlFor={`${idPrefix}-price`}
-              className="mb-1 flex items-center gap-1.5 text-xs text-zinc-500"
-            >
-              {billingCyclePriceLabel(draft.billingCycle, draft.priceCurrency)}
-              <InfoTooltip
-                href={OPENMETER_DOCS.flatFee}
-                wide
-                label={
-                  "Maps to an OpenMeter flat_fee rate card (subscription_fee).\n" +
-                  "Recurring charge billed each billing cadence when amount is greater than $0."
-                }
-              />
-            </label>
-            <DollarCentsInput
-              id={`${idPrefix}-price`}
-              value={draft.priceAmount}
-              onChange={(priceAmount) => onChange({ ...draft, priceAmount })}
-              placeholder="0.00"
-              disabled={!canEdit}
-              aria-label={billingCyclePriceLabel(draft.billingCycle, draft.priceCurrency)}
+        <div>
+          <label
+            htmlFor={`${idPrefix}-price`}
+            className="mb-1 flex items-center gap-1.5 text-xs text-zinc-500"
+          >
+            {billingCyclePriceLabel(draft.billingCycle, draft.priceCurrency)}
+            <InfoTooltip
+              href={OPENMETER_DOCS.flatFee}
+              wide
+              label={
+                "Maps to an OpenMeter flat_fee rate card (subscription_fee).\n" +
+                "Recurring charge billed each billing cadence when amount is greater than $0."
+              }
             />
-          </div>
-          <div>
+          </label>
+          <DollarCentsInput
+            id={`${idPrefix}-price`}
+            value={draft.priceAmount}
+            onChange={(priceAmount) => onChange({ ...draft, priceAmount })}
+            placeholder="0.00"
+            disabled={!canEdit}
+            aria-label={billingCyclePriceLabel(draft.billingCycle, draft.priceCurrency)}
+          />
+        </div>
+      )}
+
+      {(draft.type === "subscription" || draft.type === "usage") && (
+        <div>
           <label
             htmlFor={`${idPrefix}-included`}
             className="mb-1 flex items-center gap-1.5 text-xs text-zinc-500"
           >
-            Included usage allowance (per billing cycle)
+            Included usage allowance
+            {draft.type === "subscription" ? " (per billing cycle)" : " (per month)"}
             <InfoTooltip
               href={OPENMETER_DOCS.usageDiscount}
               wide
@@ -848,8 +851,13 @@ function PlanDraftForm({
             disabled={!canEdit}
             aria-label="Included usage allowance in dollars"
           />
-          </div>
-        </>
+          {draft.type === "usage" && (
+            <p className="mt-1 text-xs text-zinc-500">
+              Leave blank for no included allowance. Usage draws this down first, then prepaid
+              credits, then invoiced overage.
+            </p>
+          )}
+        </div>
       )}
 
       <div className="space-y-2">
@@ -962,7 +970,8 @@ function buildPlanPayload(
   _existing: PlanRow | null,
 ): Record<string, unknown> {
   const includedUsdMicros =
-    draft.type === "subscription" && draft.includedUsdDisplay
+    (draft.type === "subscription" || draft.type === "usage") &&
+    draft.includedUsdDisplay
       ? displayToUsdMicros(draft.includedUsdDisplay)
       : null;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebases prepaid-discount plan work onto latest `main`.

Pay-per-use (`usage`) plans can now set an included usage allowance in the app Plans UI. Previously that field was only shown for subscription plans.

- Plans tab shows **Included usage allowance (per month)** for pay-per-use drafts, with helper copy that usage draws the allowance first, then prepaid credits, then invoiced overage.
- Plan create/update payload includes `includedUsdMicros` for both `subscription` and `usage` types.
- Adds an API test that POST `/plans` accepts `type: "usage"` with `includedUsdMicros`.

## Test plan

- [ ] Create a pay-per-use plan with an included allowance and confirm it saves.
- [ ] Create a pay-per-use plan with the allowance left blank and confirm it stays unset.
- [ ] Confirm subscription plans still show **Included usage allowance (per billing cycle)** and still persist the value.
- [ ] Run `npm test -- src/app/api/v1/apps/[id]/plans/route.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7feb59b0-9da0-4fb2-8904-e1eab952ced6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7feb59b0-9da0-4fb2-8904-e1eab952ced6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

