### PR TITLE
fix(usage): show per-identity request history to app owners and admins

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -500,9 +500,10 @@ Session-authenticated (NextAuth). Default UI view is **sessions** (`groupBy=sess
 | `cursor` | Opaque pagination cursor from a prior response |
 | `limit` | Page size (default 25, max 50) |
 | `clientId` | Optional public OIDC `app_…` id to restrict to one app (used by `/apps/{id}/usage`). Repeatable / comma-separated `clientIds` for multi-app filters. **Required for `groupBy=session`.** |
-| `scope` | `own` (default) — signed-in viewer’s usage subject(s) only. `all` — **platform admins only**; platform-wide history for the selected `clientId`(s) (All Usage tab). Non-admins receive `403`. |
+| `scope` | `own` (default) — apps the viewer owns or administers (every identity on them) plus apps where the viewer only holds an `app_users` membership (their own usage subjects there). `all` — **platform admins only**; platform-wide history for the selected `clientId`(s) (All Usage tab). Non-admins receive `403`. |
+| `externalUserId` | Optional identity filter (repeatable, or comma-separated `externalUserIds`). Narrows rows to those `external_user_id` values within whatever the scope already authorizes. |
 
-Do **not** pass `externalUserId` — for `scope=own` the server derives subjects from the session (`users.id` plus `app_users.external_user_id` rows matching the session email). Responses include `items`, `nextCursor`, `openMeterConfigured`, `scope`, and `groupBy`.
+`scope=own` never trusts the requested `clientId`s on their own: the server intersects them with the viewer's owned/administered apps and memberships, so an unauthorized app returns no rows. The identity filter likewise only narrows — on membership-only apps it is intersected with the viewer's own subjects (`users.id` plus `app_users.external_user_id` rows matching the session email). Responses include `items`, `nextCursor`, `openMeterConfigured`, `scope`, and `groupBy`.
 
 Per-request fees in the UI are valued exactly from `feeWei × ethUsdPrice` (full sub-micro precision). Session fees are rounded up once at the session/read boundary (same policy as Usage API `groupBy=manifest` totals).
 

--- a/src/app/api/v1/apps/[id]/identities/[externalUserId]/requests/route.ts
+++ b/src/app/api/v1/apps/[id]/identities/[externalUserId]/requests/route.ts
@@ -20,10 +20,10 @@ function parseLimit(raw: string | null): number {
 /**
  * Signed-ticket request log for one identity on one app.
  *
- * Authorization is app ownership, deliberately not viewer-subject scope: an app
- * owner may read any identity under their own app, which is why this lives here
- * rather than on `/api/v1/me/usage/requests` (that route rejects
- * `externalUserId` outright so viewers cannot read other identities).
+ * Authorization is app ownership: an app owner may read any identity under their
+ * own app. `/api/v1/me/usage/requests` covers the same ground for the Usage page
+ * (owned/administered apps read app-wide, optionally filtered by identity);
+ * this route stays for the app-scoped identity detail page.
  */
 export async function GET(
   request: Request,

--- a/src/components/AppFilterDropdown.test.ts
+++ b/src/components/AppFilterDropdown.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  filterButtonLabel,
+  optionMatchesQuery,
+  visibleFilterOptions,
+  type AppFilterOption,
+} from "@/components/AppFilterDropdown";
+
+const ids: AppFilterOption[] = [
+  { value: "eu_43eac8e3fe4dd854633da7a23fb", label: "eu_43eac8e3fe4dd854633da7a23fb" },
+  { value: "eu_cb8da10f6dcc418d86e26a936ee", label: "eu_cb8da10f6dcc418d86e26a936ee" },
+  { value: "e2e-merchant-01affcc-1787032125", label: "e2e-merchant-01affcc-1787032125" },
+];
+
+test("startsWith matches a full id or a prefix, not a middle or suffix fragment", () => {
+  const id = ids[0]!;
+  assert.equal(optionMatchesQuery(id, id.value, "startsWith"), true);
+  assert.equal(optionMatchesQuery(id, "eu_43eac", "startsWith"), true);
+  assert.equal(optionMatchesQuery(id, "EU_43", "startsWith"), true);
+  assert.equal(optionMatchesQuery(id, "8e3fe4dd", "startsWith"), false);
+  assert.equal(optionMatchesQuery(id, "a23fb", "startsWith"), false);
+});
+
+test("includes still matches a substring anywhere", () => {
+  const id = ids[0]!;
+  assert.equal(optionMatchesQuery(id, "8e3fe4dd", "includes"), true);
+  assert.equal(optionMatchesQuery(id, "a23fb", "includes"), true);
+});
+
+test("visibleFilterOptions keeps original order of prefix matches", () => {
+  const visible = visibleFilterOptions(ids, "eu_", "startsWith");
+  assert.deepEqual(
+    visible.map((o) => o.value),
+    [ids[0]!.value, ids[1]!.value],
+  );
+  assert.deepEqual(visibleFilterOptions(ids, "e2e-", "startsWith"), [ids[2]]);
+  assert.deepEqual(visibleFilterOptions(ids, "nope", "startsWith"), []);
+});
+
+test("filterButtonLabel middle-truncates a single selected id", () => {
+  const long = ids[0]!.label;
+  const shown = filterButtonLabel(ids, [ids[0]!.value], "No identities", "All identities", 24);
+  assert.equal(shown.length, 24);
+  assert.equal(shown.startsWith("eu_"), true);
+  assert.equal(shown.endsWith(long.slice(-11)), true);
+  assert.equal(
+    filterButtonLabel(ids, ids.map((o) => o.value), "No identities", "All identities", 24),
+    "All identities",
+  );
+});

--- a/src/components/AppFilterDropdown.tsx
+++ b/src/components/AppFilterDropdown.tsx
@@ -1,17 +1,46 @@
 "use client";
 
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState, type RefObject } from "react";
+
+import { truncateMiddle } from "@/lib/truncate-middle";
 
 export type AppFilterOption = {
   value: string;
   label: string;
 };
 
-function filterButtonLabel(
+export type FilterSearchMatch = "includes" | "startsWith";
+
+export function optionMatchesQuery(
+  option: AppFilterOption,
+  query: string,
+  match: FilterSearchMatch = "includes",
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const value = option.value.toLowerCase();
+  const label = option.label.toLowerCase();
+  if (match === "startsWith") {
+    return value.startsWith(q) || label.startsWith(q);
+  }
+  return value.includes(q) || label.includes(q);
+}
+
+export function visibleFilterOptions(
+  options: AppFilterOption[],
+  query: string,
+  match: FilterSearchMatch,
+): AppFilterOption[] {
+  if (!query.trim()) return options;
+  return options.filter((o) => optionMatchesQuery(o, query, match));
+}
+
+export function filterButtonLabel(
   options: AppFilterOption[],
   selectedValues: string[],
   emptyLabel: string,
   allLabel: string,
+  maxLabelLength?: number,
 ): string {
   if (options.length === 0) {
     return emptyLabel;
@@ -23,9 +52,108 @@ function filterButtonLabel(
     return allLabel;
   }
   if (selectedValues.length === 1) {
-    return options.find((o) => o.value === selectedValues[0])?.label ?? "1 selected";
+    const raw =
+      options.find((o) => o.value === selectedValues[0])?.label ?? "1 selected";
+    return maxLabelLength ? truncateMiddle(raw, maxLabelLength) : raw;
   }
   return `${selectedValues.length} selected`;
+}
+
+function optionDisplayLabel(label: string, maxLabelLength?: number): string {
+  return maxLabelLength ? truncateMiddle(label, maxLabelLength) : label;
+}
+
+function FilterSearchInput({
+  inputRef,
+  query,
+  placeholder,
+  onQueryChange,
+  onEscape,
+}: Readonly<{
+  inputRef: RefObject<HTMLInputElement | null>;
+  query: string;
+  placeholder: string;
+  onQueryChange: (value: string) => void;
+  onEscape: () => void;
+}>) {
+  return (
+    <div className="shrink-0 border-b border-zinc-800 px-2 py-2">
+      <input
+        ref={inputRef}
+        type="search"
+        value={query}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onEscape();
+          }
+        }}
+        className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 placeholder:text-zinc-500 focus:border-emerald-600/60 focus:outline-none"
+      />
+    </div>
+  );
+}
+
+function FilterOptionsList({
+  listId,
+  legendLabel,
+  options,
+  selectedSet,
+  maxLabelLength,
+  emptyLabel,
+  onToggle,
+}: Readonly<{
+  listId: string;
+  legendLabel: string;
+  options: AppFilterOption[];
+  selectedSet: Set<string>;
+  maxLabelLength?: number;
+  emptyLabel: string;
+  onToggle: (value: string) => void;
+}>) {
+  if (options.length === 0) {
+    return <p className="px-3 py-3 text-sm text-zinc-500">{emptyLabel}</p>;
+  }
+  return (
+    <fieldset className="relative m-0 min-h-0 flex-1 overflow-auto border-0 p-0">
+      <legend className="absolute h-px w-px overflow-hidden whitespace-nowrap p-0 [clip:rect(0,0,0,0)]">
+        {legendLabel}
+      </legend>
+      {options.map((opt) => {
+        const selected = selectedSet.has(opt.value);
+        const checkboxId = `${listId}-${opt.value}`;
+        const shown = optionDisplayLabel(opt.label, maxLabelLength);
+        return (
+          <label
+            key={opt.value}
+            htmlFor={checkboxId}
+            title={opt.label}
+            className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+          >
+            <input
+              id={checkboxId}
+              type="checkbox"
+              checked={selected}
+              onChange={() => onToggle(opt.value)}
+              className="h-3.5 w-3.5 shrink-0 rounded border-zinc-600 bg-zinc-900 text-emerald-600 focus:ring-emerald-500/40"
+            />
+            <span
+              className={`min-w-0 ${
+                maxLabelLength ? "font-mono text-xs whitespace-nowrap" : "truncate"
+              }`}
+            >
+              {shown}
+            </span>
+          </label>
+        );
+      })}
+    </fieldset>
+  );
 }
 
 /**
@@ -40,6 +168,10 @@ export default function AppFilterDropdown({
   emptyLabel = "No applications",
   allLabel = "All applications",
   legendLabel,
+  searchable = false,
+  searchPlaceholder = "Search…",
+  searchMatch = "includes",
+  maxLabelLength,
 }: Readonly<{
   options: AppFilterOption[];
   selectedValues: string[];
@@ -50,12 +182,22 @@ export default function AppFilterDropdown({
   allLabel?: string;
   /** Visually hidden fieldset legend; defaults from `label`. */
   legendLabel?: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  searchMatch?: FilterSearchMatch;
+  /** Middle-ellipsis labels longer than this (start and end stay visible). */
+  maxLabelLength?: number;
 }>) {
   const listId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
 
-  const close = useCallback(() => setOpen(false), []);
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -68,9 +210,18 @@ export default function AppFilterDropdown({
     return () => document.removeEventListener("mousedown", onDoc);
   }, [open, close]);
 
+  useEffect(() => {
+    if (open && searchable) {
+      searchRef.current?.focus();
+    }
+  }, [open, searchable]);
+
   const allSelected =
     options.length > 0 && selectedValues.length === options.length;
   const selectedSet = new Set(selectedValues);
+  const visibleOptions = searchable
+    ? visibleFilterOptions(options, query, searchMatch)
+    : options;
 
   const toggleValue = (value: string) => {
     if (selectedSet.has(value)) {
@@ -82,6 +233,17 @@ export default function AppFilterDropdown({
 
   const selectAll = () => onChange(options.map((o) => o.value));
   const clearAll = () => onChange([]);
+  const buttonLabel = filterButtonLabel(
+    options,
+    selectedValues,
+    emptyLabel,
+    allLabel,
+    maxLabelLength,
+  );
+  const buttonTitle =
+    selectedValues.length === 1
+      ? (options.find((o) => o.value === selectedValues[0])?.label ?? buttonLabel)
+      : buttonLabel;
 
   return (
     <div ref={containerRef} className="relative shrink-0">
@@ -89,12 +251,16 @@ export default function AppFilterDropdown({
         type="button"
         aria-expanded={open}
         aria-controls={listId}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          if (open) close();
+          else setOpen(true);
+        }}
+        title={buttonTitle}
         className="inline-flex items-center gap-2 rounded-lg border border-zinc-700/80 bg-zinc-900/60 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:border-zinc-600 hover:bg-zinc-800/80"
       >
         <span className="text-zinc-500">{label}</span>
-        <span className="max-w-[12rem] truncate">
-          {filterButtonLabel(options, selectedValues, emptyLabel, allLabel)}
+        <span className={`max-w-[12rem] ${maxLabelLength ? "font-mono whitespace-nowrap" : "truncate"}`}>
+          {buttonLabel}
         </span>
         <svg
           className={`h-3.5 w-3.5 text-zinc-500 transition-transform ${open ? "rotate-180" : ""}`}
@@ -110,9 +276,11 @@ export default function AppFilterDropdown({
       {open ? (
         <div
           id={listId}
-          className="absolute right-0 z-50 mt-1 w-64 max-h-72 overflow-auto rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-lg"
+          className={`absolute right-0 z-50 mt-1 flex max-h-80 flex-col overflow-hidden rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-lg ${
+            searchable ? "w-80" : "w-64"
+          }`}
         >
-          <div className="flex items-center justify-between gap-2 border-b border-zinc-800 px-3 py-2">
+          <div className="flex shrink-0 items-center justify-between gap-2 border-b border-zinc-800 px-3 py-2">
             <button
               type="button"
               onClick={selectAll}
@@ -131,35 +299,25 @@ export default function AppFilterDropdown({
             </button>
           </div>
 
-          {options.length === 0 ? (
-            <p className="px-3 py-3 text-sm text-zinc-500">{emptyLabel}</p>
-          ) : (
-            <fieldset className="relative m-0 border-0 p-0">
-              <legend className="absolute h-px w-px overflow-hidden whitespace-nowrap p-0 [clip:rect(0,0,0,0)]">
-                {legendLabel ?? `Filter by ${label.toLowerCase()}`}
-              </legend>
-              {options.map((opt) => {
-                const selected = selectedSet.has(opt.value);
-                const checkboxId = `${listId}-${opt.value}`;
-                return (
-                  <label
-                    key={opt.value}
-                    htmlFor={checkboxId}
-                    className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm text-zinc-200 hover:bg-zinc-800"
-                  >
-                    <input
-                      id={checkboxId}
-                      type="checkbox"
-                      checked={selected}
-                      onChange={() => toggleValue(opt.value)}
-                      className="h-3.5 w-3.5 shrink-0 rounded border-zinc-600 bg-zinc-900 text-emerald-600 focus:ring-emerald-500/40"
-                    />
-                    <span className="truncate">{opt.label}</span>
-                  </label>
-                );
-              })}
-            </fieldset>
-          )}
+          {searchable && options.length > 0 ? (
+            <FilterSearchInput
+              inputRef={searchRef}
+              query={query}
+              placeholder={searchPlaceholder}
+              onQueryChange={setQuery}
+              onEscape={close}
+            />
+          ) : null}
+
+          <FilterOptionsList
+            listId={listId}
+            legendLabel={legendLabel ?? `Filter by ${label.toLowerCase()}`}
+            options={options.length === 0 ? [] : visibleOptions}
+            selectedSet={selectedSet}
+            maxLabelLength={maxLabelLength}
+            emptyLabel={options.length === 0 ? emptyLabel : "No matches"}
+            onToggle={toggleValue}
+          />
         </div>
       ) : null}
     </div>

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -185,6 +185,8 @@ function deriveFilteredView(
     filteredSeries,
     filteredAppUsage,
     historyClientIds,
+    // Request history covers every identity unless the filter narrows it.
+    historyIdentityIds: allIdentitiesSelected ? [] : selectedIdentityIds,
   };
 }
 
@@ -327,22 +329,23 @@ function SignedTicketsBlock({
   historyScope,
   orderedApps,
   historyClientIds,
+  historyIdentityIds,
+  onClearIdentityFilter,
 }: Readonly<{
   needsSelection: boolean;
   scope: "all" | "single";
-  /** Viewer-own vs platform-wide admin history. */
+  /** Own/administered apps vs platform-wide admin history. */
   historyScope: "own" | "all";
   orderedApps: BillingAppRow[];
   historyClientIds: string[];
+  /** Identity filter from the Identities dropdown; empty means all. */
+  historyIdentityIds: string[];
+  onClearIdentityFilter: () => void;
 }>) {
-  const isPlatform = historyScope === "all";
-  const title = isPlatform
-    ? "Signed ticket requests"
-    : "Your signed ticket requests";
   if (needsSelection) {
     return (
       <section className="mb-6 sm:mb-8 rounded-xl border border-zinc-800 bg-zinc-900/30 p-4 sm:p-5">
-        <h2 className="text-sm font-semibold text-zinc-200">{title}</h2>
+        <h2 className="text-sm font-semibold text-zinc-200">Requests</h2>
         <p className="text-sm text-zinc-500 py-6 text-center">
           Select at least one application to view request history.
         </p>
@@ -355,6 +358,8 @@ function SignedTicketsBlock({
         clientId={scope === "single" ? orderedApps[0]?.publicClientId : null}
         clientIds={scope === "single" ? null : historyClientIds}
         historyScope={historyScope}
+        externalUserIds={historyIdentityIds}
+        onClearIdentityFilter={onClearIdentityFilter}
       />
     </div>
   );
@@ -679,6 +684,8 @@ function BillingUsageBody({
         historyScope={historyScope}
         orderedApps={orderedApps}
         historyClientIds={derived.historyClientIds}
+        historyIdentityIds={derived.historyIdentityIds}
+        onClearIdentityFilter={() => setSelectedIdentityIds(allIdentityIds)}
       />
 
       <AppUsageList

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -22,6 +22,10 @@ import type {
 import { resolveOwnerBillingPressure } from "@/lib/billing/owner-billing-pressure";
 import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
 import type { OwnerBillingSubscriptionRow } from "@/lib/owner-billing-data";
+import {
+  deriveFilteredView,
+  type ChartDimension,
+} from "@/lib/usage/dashboard-filtered-view";
 
 /** Client-safe dashboard payload (bigints as strings). */
 type BillingUsageDashboardClientPayload = {
@@ -46,9 +50,6 @@ type BillingUsageDashboardClientPayload = {
 };
 
 type UsageTab = "mine" | "all";
-
-/** Chart series split: app × pipeline/model (default) or app × identity. */
-type ChartDimension = "pipeline" | "identity";
 
 type LoadState =
   | { status: "loading" }
@@ -104,90 +105,6 @@ function UsageLoadingShell({
       </div>
     </div>
   );
-}
-
-function deriveFilteredView(
-  data: BillingUsageDashboardClientPayload,
-  selectedPublicClientIds: string[],
-  historyScope: "own" | "all",
-  chartDimension: ChartDimension,
-  selectedIdentityIds: string[],
-  allIdentityIds: string[],
-) {
-  const allIds = data.orderedApps.map((a) => a.publicClientId);
-  const allSelected =
-    allIds.length > 0 && selectedPublicClientIds.length === allIds.length;
-  const noneSelected = selectedPublicClientIds.length === 0;
-  const selectedSet = new Set(selectedPublicClientIds);
-
-  const allIdentitiesSelected =
-    allIdentityIds.length === 0 ||
-    selectedIdentityIds.length === allIdentityIds.length;
-  const identitySet = new Set(selectedIdentityIds);
-
-  const baseSeries =
-    chartDimension === "identity" ? data.chartSeriesByIdentity : data.chartSeries;
-
-  let filteredSeries = baseSeries;
-  if (!allSelected) {
-    filteredSeries = noneSelected
-      ? []
-      : baseSeries.filter((s) => selectedSet.has(s.appId));
-  }
-  // Identity series carry the identity in `jobType`, so the filter applies only
-  // to that dimension; pipeline/model series stay app-filtered.
-  if (chartDimension === "identity" && !allIdentitiesSelected) {
-    filteredSeries = filteredSeries.filter((s) => identitySet.has(s.jobType));
-  }
-
-  let filteredAppUsage = data.appUsage;
-  if (!allSelected) {
-    filteredAppUsage = noneSelected
-      ? []
-      : data.appUsage.filter((e) => selectedSet.has(e.app.publicClientId));
-  }
-  if (!allIdentitiesSelected) {
-    filteredAppUsage = filteredAppUsage
-      .map((entry) => {
-        const byUser = entry.byUser.filter((u) =>
-          identitySet.has(u.externalUserId ?? u.endUserId),
-        );
-        const requestCount = byUser.reduce((sum, u) => sum + u.requestCount, 0);
-        const networkFeeUsdMicros = byUser
-          .reduce((sum, u) => sum + BigInt(u.networkFeeUsdMicros || "0"), 0n)
-          .toString();
-        return {
-          ...entry,
-          byUser,
-          requestCount,
-          networkFeeUsdMicros,
-          endUserBillableUsdMicros: networkFeeUsdMicros,
-        };
-      })
-      .filter((entry) => entry.byUser.length > 0);
-  }
-  filteredAppUsage = filteredAppUsage.filter((e) => e.requestCount > 0);
-
-  // Admin All Usage + all apps selected: omit clientId filter so request
-  // history uses the unrestricted platform event list (avoids a huge id-set
-  // post-filter). Session list discovers apps from those events server-side.
-  // Subset selection still passes the dropdown ids. Own scope unchanged.
-  let historyClientIds: string[];
-  if (allSelected && historyScope === "all") {
-    historyClientIds = [];
-  } else if (allSelected) {
-    historyClientIds = data.orderedApps.map((a) => a.publicClientId);
-  } else {
-    historyClientIds = selectedPublicClientIds;
-  }
-
-  return {
-    filteredSeries,
-    filteredAppUsage,
-    historyClientIds,
-    // Request history covers every identity unless the filter narrows it.
-    historyIdentityIds: allIdentitiesSelected ? [] : selectedIdentityIds,
-  };
 }
 
 function ActiveSubscriptionSummary({
@@ -494,6 +411,10 @@ function BillingPeriodPanel({
               label="Identities"
               emptyLabel="No identities"
               allLabel="All identities"
+              searchable
+              searchPlaceholder="Search identities…"
+              searchMatch="startsWith"
+              maxLabelLength={24}
             />
           ) : null}
         </div>

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -16,6 +16,7 @@ import {
   formatUsdMicrosString,
   formatUsdMicrosSummary,
 } from "@/lib/format-usd-micros";
+import { truncateMiddle } from "@/lib/truncate-middle";
 import {
   buildRequestsCsv,
   buildRequestsCsvFilename,
@@ -174,10 +175,10 @@ function RequestRow({
           {row.externalUserId ? (
             <Link
               href={`/apps/${encodeURIComponent(row.clientId)}/identities/${encodeURIComponent(row.externalUserId)}`}
-              className="block max-w-[10rem] truncate font-mono text-xs text-zinc-400 transition-colors hover:text-emerald-400"
+              className="block max-w-[10rem] font-mono text-xs text-zinc-400 transition-colors hover:text-emerald-400"
               title={row.externalUserId}
             >
-              {row.externalUserId}
+              {truncateMiddle(row.externalUserId, 20)}
             </Link>
           ) : (
             <span className="text-xs text-zinc-600">—</span>
@@ -635,7 +636,7 @@ function HistoryToolbar({
           >
             <span className="text-zinc-600">Scope</span>
             <span className={`truncate ${copy.scopeChipMono ? "font-mono" : ""}`}>
-              {copy.scopeChip}
+              {copy.scopeChipMono ? truncateMiddle(copy.scopeChip, 24) : copy.scopeChip}
             </span>
           </span>
           {identityFilterActive && onClearIdentityFilter ? (

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -79,13 +79,37 @@ function normalizeClientIds(
   ].sort((a, b) => a.localeCompare(b));
 }
 
-function historyCopy(scope: HistoryScope): {
+function historyCopy(
+  scope: HistoryScope,
+  identityIds: string[],
+): {
   title: string;
   /** Scope shown as a chip beside the title, not as prose. */
   scopeChip: string;
+  /** Chip holds a raw identity id, so render it monospaced. */
+  scopeChipMono?: boolean;
   emptySessions: string;
   emptyRequests: string;
 } {
+  if (identityIds.length === 1) {
+    return {
+      title: "Requests",
+      scopeChip: identityIds[0],
+      scopeChipMono: true,
+      emptySessions: "No sessions for this identity in this billing cycle.",
+      emptyRequests: "No requests for this identity in this billing cycle.",
+    };
+  }
+  if (identityIds.length > 1) {
+    return {
+      title: "Requests",
+      scopeChip: `${identityIds.length} identities`,
+      emptySessions:
+        "No sessions for the selected identities in this billing cycle.",
+      emptyRequests:
+        "No requests for the selected identities in this billing cycle.",
+    };
+  }
   if (scope === "all") {
     return {
       title: "Requests",
@@ -96,9 +120,9 @@ function historyCopy(scope: HistoryScope): {
   }
   return {
     title: "Requests",
-    scopeChip: "Your usage identity",
-    emptySessions: "No sessions for your usage identity in this billing cycle.",
-    emptyRequests: "No requests for your usage identity in this billing cycle.",
+    scopeChip: "All identities on your apps",
+    emptySessions: "No sessions for your apps in this billing cycle.",
+    emptyRequests: "No requests for your apps in this billing cycle.",
   };
 }
 
@@ -572,11 +596,13 @@ function HistoryToolbar({
   fromDate,
   toDate,
   rangeActive,
+  identityFilterActive,
   viewMode,
   requests,
   onFromDateChange,
   onToDateChange,
   onClearRange,
+  onClearIdentityFilter,
   onDownloadCsv,
   onViewModeChange,
 }: Readonly<{
@@ -584,11 +610,13 @@ function HistoryToolbar({
   fromDate: string;
   toDate: string;
   rangeActive: boolean;
+  identityFilterActive: boolean;
   viewMode: ViewMode;
   requests: SignedTicketRequestRow[];
   onFromDateChange: (value: string) => void;
   onToDateChange: (value: string) => void;
   onClearRange: () => void;
+  onClearIdentityFilter?: () => void;
   onDownloadCsv: () => void;
   onViewModeChange: (mode: ViewMode) => void;
 }>) {
@@ -598,12 +626,27 @@ function HistoryToolbar({
         <div className="flex flex-wrap items-center gap-2">
           <h2 className="text-sm font-semibold text-zinc-200">{copy.title}</h2>
           <span
-            className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-black/20 px-2 py-0.5 text-[11px] text-zinc-400"
-            title="Rows are limited to this identity scope. Change it with the identity filter above."
+            className="inline-flex max-w-full items-center gap-1 rounded-full border border-zinc-700 bg-black/20 px-2 py-0.5 text-[11px] text-zinc-400"
+            title={
+              identityFilterActive
+                ? `Rows are limited to ${copy.scopeChip}. Change it with the Identities filter above.`
+                : "Rows cover every identity on the selected apps. Narrow them with the Identities filter above."
+            }
           >
             <span className="text-zinc-600">Scope</span>
-            {copy.scopeChip}
+            <span className={`truncate ${copy.scopeChipMono ? "font-mono" : ""}`}>
+              {copy.scopeChip}
+            </span>
           </span>
+          {identityFilterActive && onClearIdentityFilter ? (
+            <button
+              type="button"
+              onClick={onClearIdentityFilter}
+              className="text-[11px] text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline"
+            >
+              Show all identities
+            </button>
+          ) : null}
         </div>
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <label className="flex items-center gap-1 text-[11px] text-zinc-500">
@@ -753,16 +796,22 @@ export default function SignedTicketRequestHistory({
   clientId,
   clientIds,
   historyScope = "own",
+  externalUserIds,
+  onClearIdentityFilter,
 }: Readonly<{
   /** Public OIDC client_id when scoped to a single app. */
   clientId?: string | null;
   /** Public OIDC client_ids when scoped to a subset of apps. */
   clientIds?: string[] | null;
   /**
-   * `own` — viewer usage subjects only (default).
+   * `own` — apps the viewer owns or administers, every identity (default).
    * `all` — platform-wide history for admins (All Usage tab).
    */
   historyScope?: HistoryScope;
+  /** Identity filter (external_user_id); empty means all identities. */
+  externalUserIds?: string[] | null;
+  /** Resets the page-level Identities filter from inside this panel. */
+  onClearIdentityFilter?: () => void;
 }>) {
   const [viewMode, setViewMode] = useState<ViewMode>("session");
   const [sessions, setSessions] = useState<SignedTicketSessionRow[]>([]);
@@ -775,7 +824,18 @@ export default function SignedTicketRequestHistory({
   const [fromDate, setFromDate] = useState("");
   const [toDate, setToDate] = useState("");
 
-  const copy = historyCopy(historyScope);
+  const resolvedIdentityIds = useMemo(
+    () =>
+      [
+        ...new Set(
+          (externalUserIds ?? []).map((id) => id.trim()).filter(Boolean),
+        ),
+      ].sort((a, b) => a.localeCompare(b)),
+    [externalUserIds],
+  );
+  const identityIdsKey = resolvedIdentityIds.join(",");
+
+  const copy = historyCopy(historyScope, resolvedIdentityIds);
   // Both bounds are required together; the API rejects a half-open range.
   const rangeActive = Boolean(fromDate && toDate);
 
@@ -805,6 +865,9 @@ export default function SignedTicketRequestHistory({
       for (const id of resolvedClientIds) {
         params.append("clientId", id);
       }
+      for (const id of resolvedIdentityIds) {
+        params.append("externalUserId", id);
+      }
 
       const res = await fetch(`/api/v1/me/usage/requests?${params.toString()}`, {
         method: "GET",
@@ -827,7 +890,7 @@ export default function SignedTicketRequestHistory({
         mode,
       };
     },
-    [resolvedClientIds, historyScope, fromDate, toDate],
+    [resolvedClientIds, resolvedIdentityIds, historyScope, fromDate, toDate],
   );
 
   useEffect(() => {
@@ -864,7 +927,15 @@ export default function SignedTicketRequestHistory({
     return () => {
       cancelled = true;
     };
-  }, [fetchPage, clientIdsKey, historyScope, viewMode, fromDate, toDate]);
+  }, [
+    fetchPage,
+    clientIdsKey,
+    identityIdsKey,
+    historyScope,
+    viewMode,
+    fromDate,
+    toDate,
+  ]);
 
   async function onLoadMore() {
     if (!nextCursor || loadingMore) {
@@ -901,6 +972,7 @@ export default function SignedTicketRequestHistory({
         fromDate={fromDate}
         toDate={toDate}
         rangeActive={rangeActive}
+        identityFilterActive={resolvedIdentityIds.length > 0}
         viewMode={viewMode}
         requests={requests}
         onFromDateChange={setFromDate}
@@ -909,6 +981,7 @@ export default function SignedTicketRequestHistory({
           setFromDate("");
           setToDate("");
         }}
+        onClearIdentityFilter={onClearIdentityFilter}
         onDownloadCsv={downloadCsv}
         onViewModeChange={setViewMode}
       />

--- a/src/components/identities/IdentitiesTable.tsx
+++ b/src/components/identities/IdentitiesTable.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 
 import { formatBillableDuration, formatBillingUtcDate } from "@/lib/billing-format";
 import { formatUsdMicrosString } from "@/lib/format-usd-micros";
+import { truncateMiddle } from "@/lib/truncate-middle";
 import type { AppIdentityRow } from "@/lib/usage/identity-rollup";
 
 type SortKey = "fee" | "requests" | "duration" | "lastActive";
@@ -183,9 +184,7 @@ export default function IdentitiesTable({
                   className="font-mono text-xs text-zinc-200 hover:text-emerald-400 transition-colors"
                   title={row.externalUserId}
                 >
-                  {row.externalUserId.length > 28
-                    ? `${row.externalUserId.slice(0, 26)}…`
-                    : row.externalUserId}
+                  {truncateMiddle(row.externalUserId, 28)}
                 </Link>
                 {row.email ? (
                   <p className="mt-0.5 truncate text-[11px] text-zinc-600">{row.email}</p>

--- a/src/lib/openmeter/signed-ticket-events.test.ts
+++ b/src/lib/openmeter/signed-ticket-events.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { CREATE_SIGNED_TICKET_EVENT_TYPE } from "./constants";
 import {
   aggregateManifestSessionEventStats,
+  buildSubjectMatchKeys,
   coerceIngestedEvent,
   coerceIngestedEvents,
   collectAdminSubjectsFromMeterRows,
@@ -11,11 +12,14 @@ import {
   eventClientId,
   eventMatchesAdminSignedTicket,
   eventMatchesClientIdFilter,
+  eventMatchesUsageSubjectKeys,
   eventMatchesViewerSubjects,
   eventUsageSubject,
   enrichSessionRowWithEventStats,
   isSignedTicketSessionEnded,
   listAdminSignedTicketSessions,
+  listDeveloperSignedTicketRequests,
+  listDeveloperSignedTicketSessions,
   listEndUserSignedTicketSessions,
   manifestMeterRowToSessionRow,
   normalizeSignedTicketEvent,
@@ -648,6 +652,161 @@ test("manifestMeterRowToSessionRow maps meter fields and defaults", () => {
   assert.equal(row.pipeline, "unknown");
   assert.equal(row.modelId, "unknown");
   assert.equal(row.feeWei, "99");
+});
+
+test("buildSubjectMatchKeys expands owner and normalized forms", () => {
+  assert.equal(buildSubjectMatchKeys(null), null);
+  assert.equal(buildSubjectMatchKeys(undefined), null);
+  assert.equal(buildSubjectMatchKeys([])?.size, 0);
+  const keys = buildSubjectMatchKeys(["owner:abc", " eu_9 "]);
+  assert.ok(keys);
+  assert.equal(keys.has("abc"), true);
+  assert.equal(keys.has("owner:abc"), true);
+  assert.equal(keys.has("eu_9"), true);
+  assert.equal(keys.has("owner:eu_9"), true);
+});
+
+test("eventMatchesUsageSubjectKeys gates on the event actor", () => {
+  const ev = sampleEvent();
+  assert.equal(eventMatchesUsageSubjectKeys(ev, null), true);
+  assert.equal(eventMatchesUsageSubjectKeys(ev, new Set()), false);
+  assert.equal(
+    eventMatchesUsageSubjectKeys(ev, buildSubjectMatchKeys(["user-123"])),
+    true,
+  );
+  assert.equal(
+    eventMatchesUsageSubjectKeys(ev, buildSubjectMatchKeys(["eu_other"])),
+    false,
+  );
+});
+
+/** OpenMeter double: meter discovery plus per-subject event listing. */
+function fakeOpenMeterClient(
+  eventsBySubject: Record<string, ReturnType<typeof sampleEvent>[]>,
+  meterRows: { subject: string; value: number; groupBy: Record<string, string> }[],
+) {
+  return {
+    meters: {
+      query: async () => ({ data: meterRows }),
+    },
+    events: {
+      list: async ({ subject }: { subject?: string }) =>
+        eventsBySubject[subject ?? ""] ?? [],
+      listV2: async () => ({ items: [] }),
+    },
+  };
+}
+
+test("listDeveloperSignedTicketRequests shows every identity on managed apps", async (t) => {
+  const { __testSetHostedOpenMeterClient, resetHostedOpenMeterClientForTests } =
+    await import("./client");
+  const tenantEvent = sampleEvent({
+    id: "evt-tenant",
+    subject: "app_abc:eu_tenant",
+    data: {
+      client_id: "app_abc",
+      external_user_id: "eu_tenant",
+      usage_subject: "eu_tenant",
+      gateway_request_id: "req-tenant",
+    },
+  });
+  const otherEvent = sampleEvent({
+    id: "evt-other",
+    subject: "app_abc:eu_other",
+    data: {
+      client_id: "app_abc",
+      external_user_id: "eu_other",
+      usage_subject: "eu_other",
+      gateway_request_id: "req-other",
+    },
+  });
+  __testSetHostedOpenMeterClient(
+    fakeOpenMeterClient(
+      {
+        "app_abc:eu_tenant": [tenantEvent],
+        "app_abc:eu_other": [otherEvent],
+      },
+      [
+        {
+          subject: "app_abc:eu_tenant",
+          value: 2,
+          groupBy: { client_id: "app_abc", external_user_id: "eu_tenant" },
+        },
+        {
+          subject: "app_abc:eu_other",
+          value: 1,
+          groupBy: { client_id: "app_abc", external_user_id: "eu_other" },
+        },
+      ],
+    ) as never,
+  );
+  t.after(() => resetHostedOpenMeterClientForTests());
+
+  const all = await listDeveloperSignedTicketRequests({
+    // The viewer owns app_abc but is neither of these identities.
+    userId: "00000000-0000-0000-0000-000000000000",
+    managedClientIds: ["app_abc"],
+    memberClientIds: [],
+    from: "2026-07-01T00:00:00.000Z",
+    to: "2026-08-01T00:00:00.000Z",
+  });
+  assert.deepEqual(
+    all.items.map((row) => row.externalUserId).sort(),
+    ["eu_other", "eu_tenant"],
+  );
+
+  const filtered = await listDeveloperSignedTicketRequests({
+    userId: "00000000-0000-0000-0000-000000000000",
+    managedClientIds: ["app_abc"],
+    memberClientIds: [],
+    externalUserIds: ["eu_other"],
+    from: "2026-07-01T00:00:00.000Z",
+    to: "2026-08-01T00:00:00.000Z",
+  });
+  assert.deepEqual(
+    filtered.items.map((row) => row.gatewayRequestId),
+    ["req-other"],
+  );
+});
+
+test("listDeveloperSignedTicketRequests stays empty without authorized apps", async () => {
+  const result = await listDeveloperSignedTicketRequests({
+    userId: "00000000-0000-0000-0000-000000000000",
+    managedClientIds: [],
+    memberClientIds: [],
+  });
+  assert.deepEqual(result.items, []);
+  assert.equal(result.nextCursor, null);
+});
+
+test("listDeveloperSignedTicketSessions reads managed apps app-wide", async (t) => {
+  const {
+    __testSetOpenMeterManifestRows,
+    __testClearOpenMeterManifestRows,
+  } = await import("./usage-read");
+  __testSetOpenMeterManifestRows("app_managed", [
+    {
+      manifestId: "managed-mid",
+      networkFeeUsdMicros: "200",
+      networkFeeUsdExact: "200",
+      feeWei: "20",
+      billableSecs: "4",
+      pipeline: "live-video-to-video",
+      modelId: "streamdiffusion",
+    },
+  ]);
+  t.after(() => __testClearOpenMeterManifestRows("app_managed"));
+
+  const result = await listDeveloperSignedTicketSessions({
+    userId: "00000000-0000-0000-0000-000000000000",
+    managedClientIds: ["app_managed"],
+    memberClientIds: [],
+    from: "2026-07-01T00:00:00.000Z",
+    to: "2026-08-01T00:00:00.000Z",
+  });
+  assert.equal(result.openMeterConfigured, true);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0]?.manifestId, "managed-mid");
 });
 
 test("enrichSessionRowWithEventStats attaches times and resolves duration", () => {

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -48,14 +48,21 @@ export type SignedTicketRequestRow = {
   eventId: string;
 };
 
-export type ListViewerSignedTicketRequestsInput = {
+/**
+ * Signed-ticket history for a signed-in developer.
+ *
+ * `managedClientIds` are apps the viewer owns or administers — every identity's
+ * requests are readable there, which is what makes per-identity request logs
+ * work on the Usage page. `memberClientIds` are apps where the viewer only holds
+ * an `app_users` membership, so those stay limited to the viewer's own subjects.
+ */
+export type ListDeveloperSignedTicketRequestsInput = {
   userId: string;
-  /**
-   * Public OIDC client_id(s) (app_…), not developer_apps.id.
-   * Prefer `clientIds`; `clientId` is kept for single-app callers.
-   */
-  clientId?: string | null;
-  clientIds?: string[] | null;
+  /** Public OIDC client_ids (app_…), not developer_apps.id. */
+  managedClientIds: string[];
+  memberClientIds: string[];
+  /** When set, only return requests for these identities (external_user_id). */
+  externalUserIds?: string[] | null;
   /** When set, only return requests for this stream/session mid. */
   manifestId?: string | null;
   cursor?: string | null;
@@ -71,6 +78,8 @@ export type ListAdminSignedTicketRequestsInput = {
    */
   clientId?: string | null;
   clientIds?: string[] | null;
+  /** When set, only return requests for these identities (external_user_id). */
+  externalUserIds?: string[] | null;
   /** When set, only return requests for this stream/session mid. */
   manifestId?: string | null;
   cursor?: string | null;
@@ -437,26 +446,12 @@ async function listSignedTicketRequestsForSubjects(input: {
     to,
   });
 
-  const actorFilter = input.actorExternalUserIds;
-  const matching = rawEvents.filter((ev) => {
-    if (!eventMatchesViewerSubjects(ev, input.subjects, clientIdFilter)) {
-      return false;
-    }
-    if (actorFilter == null) {
-      return true;
-    }
-    if (actorFilter.size === 0) {
-      return false;
-    }
-    const actor = eventUsageSubject(ev);
-    if (!actor) {
-      return false;
-    }
-    return (
-      actorFilter.has(actor) ||
-      actorFilter.has(normalizePlatformUserId(actor))
-    );
-  });
+  const actorKeys = buildSubjectMatchKeys(input.actorExternalUserIds);
+  const matching = rawEvents.filter(
+    (ev) =>
+      eventMatchesViewerSubjects(ev, input.subjects, clientIdFilter) &&
+      eventMatchesUsageSubjectKeys(ev, actorKeys),
+  );
 
   return pageSignedTicketEvents(matching, limit, offset, input.manifestId);
 }
@@ -491,9 +486,86 @@ export async function listAdminSignedTicketRequests(
     to,
   });
 
-  const matching = rawEvents.filter((ev) =>
-    eventMatchesAdminSignedTicket(ev, clientIdFilter),
+  const identityKeys = buildSubjectMatchKeys(
+    normalizeIdentityFilter(input.externalUserIds),
   );
+  const matching = rawEvents.filter(
+    (ev) =>
+      eventMatchesAdminSignedTicket(ev, clientIdFilter) &&
+      eventMatchesUsageSubjectKeys(ev, identityKeys),
+  );
+
+  return pageSignedTicketEvents(matching, limit, offset, input.manifestId);
+}
+
+/**
+ * Signed-ticket history for a developer's Usage page.
+ *
+ * Managed apps are read app-wide (all identities, optionally narrowed to
+ * selected ones); membership-only apps stay gated on the viewer's own subjects.
+ */
+export async function listDeveloperSignedTicketRequests(
+  input: ListDeveloperSignedTicketRequestsInput,
+): Promise<ListViewerSignedTicketRequestsResult> {
+  if (!requireOpenMeterForUsageReads() || !isOpenMeterEnabled()) {
+    return { items: [], nextCursor: null, openMeterConfigured: false };
+  }
+
+  const client = getHostedOpenMeterClient();
+  if (!client) {
+    return { items: [], nextCursor: null, openMeterConfigured: false };
+  }
+
+  const managed = normalizeClientIdFilter(null, input.managedClientIds);
+  const member = normalizeClientIdFilter(null, input.memberClientIds);
+  if (!managed && !member) {
+    return { items: [], nextCursor: null, openMeterConfigured: true };
+  }
+
+  const cycle = calendarMonthBoundsUtc(new Date());
+  const from = input.from?.trim() || cycle.start;
+  const to = input.to?.trim() || cycle.end;
+  const limit = clampLimit(input.limit);
+  const offset = decodeOffsetCursor(input.cursor);
+  const identityKeys = buildSubjectMatchKeys(
+    normalizeIdentityFilter(input.externalUserIds),
+  );
+
+  const viewerSubjects = member
+    ? await resolveViewerUsageSubjects(input.userId)
+    : new Set<string>();
+
+  const [managedEvents, memberEvents] = await Promise.all([
+    managed
+      ? fetchPlatformSignedTicketEvents({
+          client,
+          clientIds: managed,
+          from,
+          to,
+        })
+      : Promise.resolve([]),
+    member
+      ? fetchSignedTicketEvents({
+          client,
+          subjects: viewerSubjects,
+          clientIds: member,
+          from,
+          to,
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const matching = [...managedEvents, ...memberEvents].filter((ev) => {
+    if (!eventMatchesUsageSubjectKeys(ev, identityKeys)) {
+      return false;
+    }
+    if (managed && eventMatchesAdminSignedTicket(ev, managed)) {
+      return true;
+    }
+    return Boolean(
+      member && eventMatchesViewerSubjects(ev, viewerSubjects, member),
+    );
+  });
 
   return pageSignedTicketEvents(matching, limit, offset, input.manifestId);
 }
@@ -545,22 +617,6 @@ async function pageSignedTicketEvents(
     nextCursor,
     openMeterConfigured: true,
   };
-}
-
-export async function listViewerSignedTicketRequests(
-  input: ListViewerSignedTicketRequestsInput,
-): Promise<ListViewerSignedTicketRequestsResult> {
-  const subjects = await resolveViewerUsageSubjects(input.userId);
-  return listSignedTicketRequestsForSubjects({
-    subjects,
-    clientId: input.clientId,
-    clientIds: input.clientIds,
-    manifestId: input.manifestId,
-    cursor: input.cursor,
-    limit: input.limit,
-    from: input.from,
-    to: input.to,
-  });
 }
 
 export type ListEndUserSignedTicketRequestsInput = {
@@ -631,25 +687,77 @@ export async function listEndUserSignedTicketRequests(
 }
 
 /**
- * Session (manifest) list backed by per-manifest analytics meters — authoritative
- * cycle totals, not a sum of paged request history rows.
+ * Session (manifest) list for a developer's Usage page, backed by per-manifest
+ * analytics meters — authoritative cycle totals, not a sum of paged request rows.
+ *
+ * Managed apps are read app-wide so owners see every identity's sessions;
+ * membership-only apps stay scoped to the viewer's own subjects.
  */
-export async function listViewerSignedTicketSessions(input: {
+export async function listDeveloperSignedTicketSessions(input: {
   userId: string;
-  clientId?: string | null;
-  clientIds?: string[] | null;
+  managedClientIds: string[];
+  memberClientIds: string[];
+  externalUserIds?: string[] | null;
   cursor?: string | null;
   limit?: number;
   from?: string;
   to?: string;
 }): Promise<ListSignedTicketSessionsResult> {
-  const subjects = await resolveViewerUsageSubjects(input.userId);
-  // Always scope to the viewer's subjects — never fall back to an unfiltered
-  // app-wide meter query (that would leak other tenants' session fees).
+  if (!requireOpenMeterForUsageReads() || !isOpenMeterEnabled()) {
+    return { items: [], nextCursor: null, openMeterConfigured: false };
+  }
+
+  const managed = normalizeClientIdFilter(null, input.managedClientIds);
+  const member = normalizeClientIdFilter(null, input.memberClientIds);
+  const identityFilter = normalizeIdentityFilter(input.externalUserIds);
+
+  const memberSubjects = member
+    ? intersectSubjectFilter(
+        await resolveViewerUsageSubjects(input.userId),
+        identityFilter,
+      )
+    : null;
+
+  const [managedRows, memberRows] = await Promise.all([
+    managed
+      ? collectSignedTicketSessionRows({
+          clientIdFilter: managed,
+          externalUserIds: identityFilter,
+          from: input.from,
+          to: input.to,
+        })
+      : Promise.resolve([]),
+    member && memberSubjects
+      ? collectSignedTicketSessionRows({
+          clientIdFilter: member,
+          externalUserIds: memberSubjects,
+          from: input.from,
+          to: input.to,
+        })
+      : Promise.resolve([]),
+  ]);
+
+  return pageSignedTicketSessions(
+    [...managedRows, ...memberRows],
+    clampLimit(input.limit),
+    decodeOffsetCursor(input.cursor),
+  );
+}
+
+export async function listAdminSignedTicketSessions(input: {
+  clientId?: string | null;
+  clientIds?: string[] | null;
+  externalUserIds?: string[] | null;
+  cursor?: string | null;
+  limit?: number;
+  from?: string;
+  to?: string;
+}): Promise<ListSignedTicketSessionsResult> {
   return listSignedTicketSessionsForClientIds({
     clientId: input.clientId,
     clientIds: input.clientIds,
-    externalUserIds: subjects,
+    externalUserIds: normalizeIdentityFilter(input.externalUserIds),
+    allowPlatformDiscovery: true,
     cursor: input.cursor,
     limit: input.limit,
     from: input.from,
@@ -657,23 +765,23 @@ export async function listViewerSignedTicketSessions(input: {
   });
 }
 
-export async function listAdminSignedTicketSessions(input: {
-  clientId?: string | null;
-  clientIds?: string[] | null;
-  cursor?: string | null;
-  limit?: number;
-  from?: string;
-  to?: string;
-}): Promise<ListSignedTicketSessionsResult> {
-  return listSignedTicketSessionsForClientIds({
-    clientId: input.clientId,
-    clientIds: input.clientIds,
-    externalUserIds: null,
-    cursor: input.cursor,
-    limit: input.limit,
-    from: input.from,
-    to: input.to,
-  });
+/** Keep only viewer subjects the identity filter also selects. */
+function intersectSubjectFilter(
+  subjects: ReadonlySet<string>,
+  identityFilter: ReadonlySet<string> | null,
+): Set<string> {
+  if (!identityFilter) return new Set(subjects);
+  const keys = buildSubjectMatchKeys(identityFilter);
+  const out = new Set<string>();
+  for (const subject of subjects) {
+    if (
+      keys?.has(subject) ||
+      keys?.has(normalizePlatformUserId(subject))
+    ) {
+      out.add(subject);
+    }
+  }
+  return out;
 }
 
 export async function listEndUserSignedTicketSessions(input: {
@@ -687,6 +795,7 @@ export async function listEndUserSignedTicketSessions(input: {
   return listSignedTicketSessionsForClientIds({
     clientId: input.clientId,
     externalUserIds: new Set([input.externalUserId]),
+    allowPlatformDiscovery: false,
     cursor: input.cursor,
     limit: input.limit,
     from: input.from,
@@ -698,10 +807,12 @@ async function listSignedTicketSessionsForClientIds(input: {
   clientId?: string | null;
   clientIds?: string[] | null;
   /**
-   * Viewer/end-user subject allow-list. `null` = admin unfiltered.
+   * Subject allow-list. `null` = unfiltered (admin / app-wide managed read).
    * Empty set returns no sessions.
    */
   externalUserIds?: ReadonlySet<string> | null;
+  /** Allow discovering apps from platform events when no clientIds are given. */
+  allowPlatformDiscovery: boolean;
   cursor?: string | null;
   limit?: number;
   from?: string;
@@ -711,35 +822,57 @@ async function listSignedTicketSessionsForClientIds(input: {
     return { items: [], nextCursor: null, openMeterConfigured: false };
   }
 
+  const items = await collectSignedTicketSessionRows({
+    clientIdFilter: normalizeClientIdFilter(input.clientId, input.clientIds),
+    externalUserIds: input.externalUserIds ?? null,
+    allowPlatformDiscovery: input.allowPlatformDiscovery,
+    from: input.from,
+    to: input.to,
+  });
+
+  return pageSignedTicketSessions(
+    items,
+    clampLimit(input.limit),
+    decodeOffsetCursor(input.cursor),
+  );
+}
+
+/**
+ * Session rows for one client_id group. Callers page the merged result so
+ * multi-group reads (managed + membership apps) stay on one cursor.
+ */
+async function collectSignedTicketSessionRows(input: {
+  clientIdFilter: ReadonlySet<string> | null;
+  externalUserIds: ReadonlySet<string> | null;
+  /** Only admin All Usage discovers apps from platform events. */
+  allowPlatformDiscovery?: boolean;
+  from?: string;
+  to?: string;
+}): Promise<SignedTicketSessionRow[]> {
   const cycle = calendarMonthBoundsUtc(new Date());
   const from = input.from?.trim() || cycle.start;
   const to = input.to?.trim() || cycle.end;
-  const limit = clampLimit(input.limit);
-  const offset = decodeOffsetCursor(input.cursor);
-  let clientIdFilter = normalizeClientIdFilter(input.clientId, input.clientIds);
+  let clientIdFilter = input.clientIdFilter;
   // Match usage-read stubs: do not hit live OpenMeter during unit tests.
   const omClient =
     process.env.NODE_ENV === "test" && !openMeterUsesLiveNetworkInTests()
       ? null
       : getHostedOpenMeterClient();
 
-  // Viewer with no resolved subjects must not see app-wide sessions.
+  // A filter that selects nothing must not fall back to app-wide sessions.
   if (input.externalUserIds?.size === 0) {
-    return { items: [], nextCursor: null, openMeterConfigured: true };
+    return [];
   }
 
   // Prefetched when admin All Usage omits clientIds (platform-wide).
   let prefetchedEvents: IngestedEventLike[] | null = null;
 
   if (!clientIdFilter || clientIdFilter.size === 0) {
-    const discovered = await discoverAdminAllAppsClientIds({
-      omClient,
-      externalUserIds: input.externalUserIds,
-      from,
-      to,
-    });
+    const discovered = input.allowPlatformDiscovery
+      ? await discoverAdminAllAppsClientIds({ omClient, from, to })
+      : null;
     if (!discovered) {
-      return { items: [], nextCursor: null, openMeterConfigured: true };
+      return [];
     }
     prefetchedEvents = discovered.prefetchedEvents;
     clientIdFilter = discovered.clientIds;
@@ -774,10 +907,16 @@ async function listSignedTicketSessionsForClientIds(input: {
     externalUserIds: input.externalUserIds,
   });
 
-  const items = batches
+  return batches
     .flat()
     .map((row) => enrichSessionRowWithEventStats(row, eventStats));
+}
 
+function pageSignedTicketSessions(
+  items: SignedTicketSessionRow[],
+  limit: number,
+  offset: number,
+): ListSignedTicketSessionsResult {
   items.sort(compareSignedTicketSessions);
 
   const page = items.slice(offset, offset + limit);
@@ -798,15 +937,12 @@ async function listSignedTicketSessionsForClientIds(input: {
  */
 async function discoverAdminAllAppsClientIds(input: {
   omClient: OpenMeter | null;
-  externalUserIds?: ReadonlySet<string> | null;
   from: string;
   to: string;
 }): Promise<{
   clientIds: Set<string>;
   prefetchedEvents: IngestedEventLike[];
 } | null> {
-  // Viewer/end-user session lists always need an app filter.
-  if (input.externalUserIds != null) return null;
   if (!input.omClient) return null;
 
   // UI omits clientIds so request history can use the unrestricted event list.
@@ -941,7 +1077,7 @@ export function aggregateManifestSessionEventStats(
     if (opts?.clientIds && opts.clientIds.size > 0 && !opts.clientIds.has(clientId)) {
       continue;
     }
-    if (!eventMatchesSessionExternalFilter(ev, externalKeys)) continue;
+    if (!eventMatchesUsageSubjectKeys(ev, externalKeys)) continue;
 
     const data = ev.event.data ?? {};
     const manifestId = stringField(data, "manifest_id") || "unknown";
@@ -962,36 +1098,56 @@ function buildSessionExternalSubjectKeys(opts?: {
   externalUserId?: string | null;
   externalUserIds?: ReadonlySet<string> | null;
 }): Set<string> | null {
-  let subjectSet: ReadonlySet<string> | null = null;
   if (opts?.externalUserIds != null) {
-    subjectSet = opts.externalUserIds;
-  } else {
-    const trimmed = opts?.externalUserId?.trim();
-    if (trimmed) subjectSet = new Set([trimmed]);
+    return buildSubjectMatchKeys(opts.externalUserIds);
   }
-  if (subjectSet == null) return null;
+  const trimmed = opts?.externalUserId?.trim();
+  return trimmed ? buildSubjectMatchKeys([trimmed]) : null;
+}
 
+/**
+ * Expand usage subjects into the forms events carry: as supplied, normalized
+ * (`user:`/`owner:` stripped) and the `owner:{id}` wire form.
+ * `null` in / `null` out means "no filter"; an empty input matches nothing.
+ */
+export function buildSubjectMatchKeys(
+  subjects?: Iterable<string> | null,
+): Set<string> | null {
+  if (subjects == null) return null;
   const keys = new Set<string>();
-  for (const subject of subjectSet) {
-    keys.add(subject);
-    keys.add(normalizePlatformUserId(subject));
-    keys.add(buildOwnerWireSubject(normalizePlatformUserId(subject)));
+  for (const subject of subjects) {
+    const trimmed = subject.trim();
+    if (!trimmed) continue;
+    const normalized = normalizePlatformUserId(trimmed);
+    keys.add(trimmed);
+    keys.add(normalized);
+    keys.add(buildOwnerWireSubject(normalized));
   }
   return keys;
 }
 
-function eventMatchesSessionExternalFilter(
+/** Match an event's actor (`external_user_id`) against expanded subject keys. */
+export function eventMatchesUsageSubjectKeys(
   ev: IngestedEventLike,
-  externalKeys: ReadonlySet<string> | null,
+  keys: ReadonlySet<string> | null,
 ): boolean {
-  if (!externalKeys) return true;
-  if (externalKeys.size === 0) return false;
+  if (!keys) return true;
+  if (keys.size === 0) return false;
   const usageSubject = eventUsageSubject(ev);
   if (!usageSubject) return false;
   return (
-    externalKeys.has(usageSubject) ||
-    externalKeys.has(normalizePlatformUserId(usageSubject))
+    keys.has(usageSubject) || keys.has(normalizePlatformUserId(usageSubject))
   );
+}
+
+/** Identity filter from request params: `null`/empty means "all identities". */
+function normalizeIdentityFilter(
+  externalUserIds?: string[] | null,
+): Set<string> | null {
+  const ids = (externalUserIds ?? [])
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+  return ids.length > 0 ? new Set(ids) : null;
 }
 
 function accumulateSessionEventStat(

--- a/src/lib/truncate-middle.test.ts
+++ b/src/lib/truncate-middle.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { truncateMiddle } from "@/lib/truncate-middle";
+
+test("truncateMiddle leaves short ids unchanged", () => {
+  assert.equal(truncateMiddle("eu_short", 24), "eu_short");
+  assert.equal(truncateMiddle("abc", 3), "abc");
+  assert.equal(truncateMiddle("", 24), "");
+});
+
+test("truncateMiddle keeps the start and end of long ids", () => {
+  const id = "eu_43eac8e3fe4dd854633da7a23fb";
+  const shown = truncateMiddle(id, 24);
+  assert.equal(shown.length, 24);
+  assert.equal(shown.startsWith("eu_"), true);
+  assert.equal(shown.endsWith("a23fb"), true);
+  assert.equal(shown.includes("…"), true);
+  assert.notEqual(shown, id);
+  assert.equal(shown, `${id.slice(0, 12)}…${id.slice(-11)}`);
+});
+
+test("truncateMiddle rejects non-positive budgets", () => {
+  assert.equal(truncateMiddle("eu_abc", 0), "");
+  assert.equal(truncateMiddle("eu_abc", -1), "");
+  assert.equal(truncateMiddle("eu_abc", 2), "eu");
+});

--- a/src/lib/truncate-middle.ts
+++ b/src/lib/truncate-middle.ts
@@ -1,0 +1,13 @@
+/**
+ * Keep the start and end of a long id visible; drop characters from the middle.
+ * Short strings are returned unchanged.
+ */
+export function truncateMiddle(value: string, maxLength: number): string {
+  if (maxLength <= 0) return "";
+  if (value.length <= maxLength) return value;
+  if (maxLength <= 2) return value.slice(0, maxLength);
+  const budget = maxLength - 1;
+  const head = Math.ceil(budget / 2);
+  const tail = Math.floor(budget / 2);
+  return `${value.slice(0, head)}…${value.slice(value.length - tail)}`;
+}

--- a/src/lib/usage/dashboard-filtered-view.test.ts
+++ b/src/lib/usage/dashboard-filtered-view.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  BillingAppRow,
+  BillingAppUsageSummary,
+  BillingChartSeries,
+  BillingUserUsageRow,
+} from "@/lib/billing-usage-dashboard-data";
+import {
+  deriveFilteredView,
+  historyClientIdsForView,
+} from "@/lib/usage/dashboard-filtered-view";
+
+function appRow(id: string): BillingAppRow {
+  return {
+    id,
+    name: id,
+    ownerId: "owner",
+    ownerName: null,
+    ownerEmail: null,
+    publicClientId: id,
+    usageKind: "tenant",
+  };
+}
+
+function userRow(
+  externalUserId: string,
+  requestCount: number,
+): BillingUserUsageRow {
+  return {
+    endUserId: externalUserId,
+    externalUserId,
+    userType: "system_managed",
+    userLabel: externalUserId,
+    identifier: externalUserId,
+    requestCount,
+    totalFeeWei: "0",
+    totalUnits: "0",
+    networkFeeUsdMicros: String(requestCount * 1000),
+    byPipelineModel: [],
+  };
+}
+
+function appUsage(
+  appId: string,
+  users: BillingUserUsageRow[],
+): BillingAppUsageSummary {
+  const requestCount = users.reduce((sum, u) => sum + u.requestCount, 0);
+  return {
+    app: appRow(appId),
+    requestCount,
+    totalFeeWei: "0",
+    totalUnits: "0",
+    networkFeeUsdMicros: "0",
+    endUserBillableUsdMicros: "0",
+    byUser: users,
+    byPipelineModel: [],
+  };
+}
+
+function series(
+  appId: string,
+  jobType: string,
+): BillingChartSeries {
+  return {
+    appId,
+    appName: appId,
+    jobType,
+    totalRequests: 1,
+    points: [],
+  };
+}
+
+const source = {
+  orderedApps: [appRow("app_a"), appRow("app_b")],
+  chartSeries: [series("app_a", "pipe/model"), series("app_b", "pipe/model")],
+  chartSeriesByIdentity: [
+    series("app_a", "eu_alpha"),
+    series("app_a", "eu_beta"),
+    series("app_b", "eu_alpha"),
+  ],
+  appUsage: [
+    appUsage("app_a", [userRow("eu_alpha", 3), userRow("eu_beta", 2)]),
+    appUsage("app_b", [userRow("eu_alpha", 1)]),
+  ],
+};
+
+test("historyClientIdsForView omits ids for admin all-apps", () => {
+  assert.deepEqual(
+    historyClientIdsForView(true, "all", ["app_a", "app_b"], ["app_a", "app_b"]),
+    [],
+  );
+  assert.deepEqual(
+    historyClientIdsForView(true, "own", ["app_a", "app_b"], ["app_a", "app_b"]),
+    ["app_a", "app_b"],
+  );
+  assert.deepEqual(
+    historyClientIdsForView(false, "all", ["app_a", "app_b"], ["app_a"]),
+    ["app_a"],
+  );
+});
+
+test("deriveFilteredView leaves everything when all apps and identities are selected", () => {
+  const derived = deriveFilteredView(
+    source,
+    ["app_a", "app_b"],
+    "own",
+    "pipeline",
+    ["eu_alpha", "eu_beta"],
+    ["eu_alpha", "eu_beta"],
+  );
+  assert.equal(derived.filteredSeries.length, 2);
+  assert.equal(derived.filteredAppUsage.length, 2);
+  assert.deepEqual(derived.historyClientIds, ["app_a", "app_b"]);
+  assert.deepEqual(derived.historyIdentityIds, []);
+});
+
+test("deriveFilteredView narrows identity series and request history", () => {
+  const derived = deriveFilteredView(
+    source,
+    ["app_a"],
+    "own",
+    "identity",
+    ["eu_beta"],
+    ["eu_alpha", "eu_beta"],
+  );
+  assert.deepEqual(
+    derived.filteredSeries.map((s) => `${s.appId}:${s.jobType}`),
+    ["app_a:eu_beta"],
+  );
+  assert.equal(derived.filteredAppUsage.length, 1);
+  assert.deepEqual(
+    derived.filteredAppUsage[0]?.byUser.map((u) => u.externalUserId),
+    ["eu_beta"],
+  );
+  assert.equal(derived.filteredAppUsage[0]?.requestCount, 2);
+  assert.deepEqual(derived.historyClientIds, ["app_a"]);
+  assert.deepEqual(derived.historyIdentityIds, ["eu_beta"]);
+});
+
+test("deriveFilteredView returns empty series when no apps are selected", () => {
+  const derived = deriveFilteredView(
+    source,
+    [],
+    "own",
+    "pipeline",
+    ["eu_alpha", "eu_beta"],
+    ["eu_alpha", "eu_beta"],
+  );
+  assert.deepEqual(derived.filteredSeries, []);
+  assert.deepEqual(derived.filteredAppUsage, []);
+  assert.deepEqual(derived.historyClientIds, []);
+});

--- a/src/lib/usage/dashboard-filtered-view.ts
+++ b/src/lib/usage/dashboard-filtered-view.ts
@@ -1,0 +1,137 @@
+import type {
+  BillingAppUsageSummary,
+  BillingChartSeries,
+} from "@/lib/billing-usage-dashboard-data";
+
+export type ChartDimension = "pipeline" | "identity";
+
+export type DashboardFilterSource = {
+  orderedApps: { publicClientId: string }[];
+  chartSeries: BillingChartSeries[];
+  chartSeriesByIdentity: BillingChartSeries[];
+  appUsage: BillingAppUsageSummary[];
+};
+
+function applyAppSelection<T>(
+  items: T[],
+  allSelected: boolean,
+  noneSelected: boolean,
+  belongsToSelectedApp: (item: T) => boolean,
+): T[] {
+  if (allSelected) return items;
+  if (noneSelected) return [];
+  return items.filter(belongsToSelectedApp);
+}
+
+/** Identity series carry the identity in `jobType`; pipeline/model series stay app-filtered. */
+function applyIdentitySeriesFilter(
+  series: BillingChartSeries[],
+  chartDimension: ChartDimension,
+  allIdentitiesSelected: boolean,
+  identitySet: Set<string>,
+): BillingChartSeries[] {
+  if (chartDimension !== "identity" || allIdentitiesSelected) {
+    return series;
+  }
+  return series.filter((s) => identitySet.has(s.jobType));
+}
+
+function restrictAppUsageToIdentities(
+  entry: BillingAppUsageSummary,
+  identitySet: Set<string>,
+): BillingAppUsageSummary {
+  const byUser = entry.byUser.filter((u) =>
+    identitySet.has(u.externalUserId ?? u.endUserId),
+  );
+  const requestCount = byUser.reduce((sum, u) => sum + u.requestCount, 0);
+  const networkFeeUsdMicros = byUser
+    .reduce((sum, u) => sum + BigInt(u.networkFeeUsdMicros || "0"), 0n)
+    .toString();
+  return {
+    ...entry,
+    byUser,
+    requestCount,
+    networkFeeUsdMicros,
+    endUserBillableUsdMicros: networkFeeUsdMicros,
+  };
+}
+
+function applyIdentityAppUsageFilter(
+  appUsage: BillingAppUsageSummary[],
+  allIdentitiesSelected: boolean,
+  identitySet: Set<string>,
+): BillingAppUsageSummary[] {
+  if (allIdentitiesSelected) return appUsage;
+  return appUsage
+    .map((entry) => restrictAppUsageToIdentities(entry, identitySet))
+    .filter((entry) => entry.byUser.length > 0);
+}
+
+/**
+ * Admin All Usage + all apps selected: omit clientId filter so request
+ * history uses the unrestricted platform event list. Subset selection still
+ * passes the dropdown ids. Own scope always sends the selected (or all) ids.
+ */
+export function historyClientIdsForView(
+  allSelected: boolean,
+  historyScope: "own" | "all",
+  allPublicClientIds: string[],
+  selectedPublicClientIds: string[],
+): string[] {
+  if (!allSelected) return selectedPublicClientIds;
+  if (historyScope === "all") return [];
+  return allPublicClientIds;
+}
+
+export function deriveFilteredView(
+  data: DashboardFilterSource,
+  selectedPublicClientIds: string[],
+  historyScope: "own" | "all",
+  chartDimension: ChartDimension,
+  selectedIdentityIds: string[],
+  allIdentityIds: string[],
+) {
+  const allIds = data.orderedApps.map((a) => a.publicClientId);
+  const allSelected =
+    allIds.length > 0 && selectedPublicClientIds.length === allIds.length;
+  const noneSelected = selectedPublicClientIds.length === 0;
+  const selectedSet = new Set(selectedPublicClientIds);
+
+  const allIdentitiesSelected =
+    allIdentityIds.length === 0 ||
+    selectedIdentityIds.length === allIdentityIds.length;
+  const identitySet = new Set(selectedIdentityIds);
+
+  const baseSeries =
+    chartDimension === "identity" ? data.chartSeriesByIdentity : data.chartSeries;
+
+  const filteredSeries = applyIdentitySeriesFilter(
+    applyAppSelection(baseSeries, allSelected, noneSelected, (s) =>
+      selectedSet.has(s.appId),
+    ),
+    chartDimension,
+    allIdentitiesSelected,
+    identitySet,
+  );
+
+  const filteredAppUsage = applyIdentityAppUsageFilter(
+    applyAppSelection(data.appUsage, allSelected, noneSelected, (e) =>
+      selectedSet.has(e.app.publicClientId),
+    ),
+    allIdentitiesSelected,
+    identitySet,
+  ).filter((e) => e.requestCount > 0);
+
+  return {
+    filteredSeries,
+    filteredAppUsage,
+    historyClientIds: historyClientIdsForView(
+      allSelected,
+      historyScope,
+      allIds,
+      selectedPublicClientIds,
+    ),
+    // Request history covers every identity unless the filter narrows it.
+    historyIdentityIds: allIdentitiesSelected ? [] : selectedIdentityIds,
+  };
+}

--- a/src/lib/usage/me-usage-requests-handler.ts
+++ b/src/lib/usage/me-usage-requests-handler.ts
@@ -5,10 +5,13 @@ import { authOptions } from "@/lib/next-auth-options";
 import {
   listAdminSignedTicketRequests,
   listAdminSignedTicketSessions,
-  listViewerSignedTicketRequests,
-  listViewerSignedTicketSessions,
+  listDeveloperSignedTicketRequests,
+  listDeveloperSignedTicketSessions,
 } from "@/lib/openmeter/signed-ticket-events";
-import { resolveViewerUsageClientIds } from "@/lib/viewer-usage-clients";
+import {
+  resolveViewerUsageClientScopes,
+  type ViewerUsageClientScopes,
+} from "@/lib/viewer-usage-clients";
 import {
   isValidBoundedDateRange,
   MAX_DATE_RANGE_DAYS,
@@ -24,6 +27,35 @@ function parseUniqueClientIds(params: URLSearchParams): string[] {
       []),
   ];
   return [...new Set(clientIds)];
+}
+
+/** Optional identity filter (`?externalUserId=` repeated, or comma-separated). */
+function parseExternalUserIds(params: URLSearchParams): string[] {
+  const ids = [
+    ...params.getAll("externalUserId").map((id) => id.trim()).filter(Boolean),
+    ...(params
+      .get("externalUserIds")
+      ?.split(",")
+      .map((id) => id.trim())
+      .filter(Boolean) ?? []),
+  ];
+  return [...new Set(ids)];
+}
+
+/**
+ * Restrict requested apps to what the viewer may read, keeping the
+ * managed/membership split so managed apps can be read app-wide.
+ */
+function restrictScopesToRequested(
+  scopes: ViewerUsageClientScopes,
+  requested: string[],
+): ViewerUsageClientScopes {
+  if (requested.length === 0) return scopes;
+  const wanted = new Set(requested);
+  return {
+    managed: scopes.managed.filter((id) => wanted.has(id)),
+    member: scopes.member.filter((id) => wanted.has(id)),
+  };
 }
 
 function validateMeUsageRequestsParams(
@@ -60,20 +92,6 @@ function validateMeUsageRequestsParams(
       ),
     };
   }
-  // Never accept externalUserId — own scope is viewer subjects; all scope is
-  // platform-wide by clientId filter, not by arbitrary end-user id.
-  if (params.has("externalUserId") || params.has("external_user_id")) {
-    return {
-      error: NextResponse.json(
-        {
-          error:
-            "externalUserId is not allowed; use scope=own (viewer) or scope=all (admin) with clientId filters",
-        },
-        { status: 400 },
-      ),
-    };
-  }
-
   return { scope, groupBy };
 }
 
@@ -125,13 +143,17 @@ export async function handleMeUsageRequestsGet(
   const { scope, groupBy } = validated;
 
   const uniqueClientIds = parseUniqueClientIds(params);
-  // scope=own with no explicit filter: authorize the viewer's owned/admin apps
-  // plus app_users memberships (including personal network on the default app).
-  // Sessions require a concrete clientId set; request history benefits too.
-  let resolvedClientIds = uniqueClientIds;
-  if (scope === "own" && resolvedClientIds.length === 0) {
-    resolvedClientIds = await resolveViewerUsageClientIds(userId);
-  }
+  const externalUserIds = parseExternalUserIds(params);
+  // scope=own always resolves against the viewer's own authorization: apps they
+  // own or administer (readable app-wide, every identity) plus app_users
+  // memberships (their own subjects only). Requested clientIds only narrow it.
+  const viewerScopes =
+    scope === "own"
+      ? restrictScopesToRequested(
+          await resolveViewerUsageClientScopes(userId),
+          uniqueClientIds,
+        )
+      : { managed: [], member: [] };
 
   const cursor = params.get("cursor")?.trim() || undefined;
   const manifestId = params.get("manifestId")?.trim() || undefined;
@@ -144,22 +166,29 @@ export async function handleMeUsageRequestsGet(
   }
 
   const listInput = {
-    clientIds: resolvedClientIds.length > 0 ? resolvedClientIds : undefined,
+    externalUserIds: externalUserIds.length > 0 ? externalUserIds : undefined,
     cursor,
     limit: Number.isFinite(limit) ? limit : undefined,
     from: dateRange.from,
     to: dateRange.to,
+  };
+  const adminInput = {
+    ...listInput,
+    clientIds: uniqueClientIds.length > 0 ? uniqueClientIds : undefined,
+  };
+  const developerInput = {
+    ...listInput,
+    userId,
+    managedClientIds: viewerScopes.managed,
+    memberClientIds: viewerScopes.member,
   };
 
   try {
     if (groupBy === "session") {
       const result =
         scope === "all"
-          ? await listAdminSignedTicketSessions(listInput)
-          : await listViewerSignedTicketSessions({
-              userId,
-              ...listInput,
-            });
+          ? await listAdminSignedTicketSessions(adminInput)
+          : await listDeveloperSignedTicketSessions(developerInput);
 
       return NextResponse.json({
         items: result.items,
@@ -170,17 +199,12 @@ export async function handleMeUsageRequestsGet(
       });
     }
 
-    const requestInput = {
-      ...listInput,
-      manifestId,
-    };
-
     const result =
       scope === "all"
-        ? await listAdminSignedTicketRequests(requestInput)
-        : await listViewerSignedTicketRequests({
-            userId,
-            ...requestInput,
+        ? await listAdminSignedTicketRequests({ ...adminInput, manifestId })
+        : await listDeveloperSignedTicketRequests({
+            ...developerInput,
+            manifestId,
           });
 
     return NextResponse.json({

--- a/src/lib/viewer-usage-clients.test.ts
+++ b/src/lib/viewer-usage-clients.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/openmeter/usage-read";
 import {
   resolveViewerUsageClientIds,
+  resolveViewerUsageClientScopes,
   viewerHasAppUserMembership,
 } from "@/lib/viewer-usage-clients";
 
@@ -128,6 +129,37 @@ test("resolveViewerUsageClientIds includes owned apps and default membership", a
       true,
     );
   });
+});
+
+test("resolveViewerUsageClientScopes splits owned apps from memberships", async (t) => {
+  const ownerApp = await seedDeveloperAppWithClient({
+    name: `Owned ${randomUUID().slice(0, 8)}`,
+  });
+  t.after(async () => {
+    await cleanupTestApp(ownerApp);
+  });
+
+  const hostApp = await seedDeveloperAppWithClient({
+    name: `Host ${randomUUID().slice(0, 8)}`,
+  });
+  t.after(async () => {
+    await cleanupTestApp(hostApp);
+  });
+
+  await db.insert(appUsers).values({
+    id: randomUUID(),
+    clientId: hostApp.clientId,
+    externalUserId: ownerApp.userId,
+    status: "active",
+    role: "user",
+    createdAt: new Date().toISOString(),
+  });
+
+  const scopes = await resolveViewerUsageClientScopes(ownerApp.userId);
+  assert.equal(scopes.managed.includes(ownerApp.clientId), true);
+  assert.equal(scopes.member.includes(ownerApp.clientId), false);
+  assert.equal(scopes.member.includes(hostApp.clientId), true);
+  assert.equal(scopes.managed.includes(hostApp.clientId), false);
 });
 
 test("resolveViewerUsageClientIds excludes foreign apps without membership", async (t) => {

--- a/src/lib/viewer-usage-clients.ts
+++ b/src/lib/viewer-usage-clients.ts
@@ -11,15 +11,32 @@ import {
 import { resolvePlatformDefaultClientId } from "@/lib/platform-default-app";
 
 /**
- * Public OIDC client_ids the signed-in platform user may include in
- * `scope=own` usage history: apps they own or administer, plus any app where
- * they have an `app_users` membership (including the platform default).
+ * Usage-history visibility for one platform user, split by how much of an app
+ * they may read.
  */
-export async function resolveViewerUsageClientIds(
+export type ViewerUsageClientScopes = {
+  /**
+   * Apps the viewer owns or administers. Every identity's request history on
+   * these apps is readable (same authorization as the app identity pages).
+   */
+  managed: string[];
+  /**
+   * Apps where the viewer only holds an `app_users` membership. Restricted to
+   * the viewer's own usage subjects.
+   */
+  member: string[];
+};
+
+/**
+ * Public OIDC client_ids the signed-in platform user may include in
+ * `scope=own` usage history, split into managed (own/administer) and
+ * membership-only apps (including the platform default).
+ */
+export async function resolveViewerUsageClientScopes(
   userId: string,
-): Promise<string[]> {
+): Promise<ViewerUsageClientScopes> {
   const trimmed = userId.trim();
-  if (!trimmed) return [];
+  if (!trimmed) return { managed: [], member: [] };
 
   const [ownedRows, adminRows, memberRows] = await Promise.all([
     db
@@ -47,12 +64,25 @@ export async function resolveViewerUsageClientIds(
       .where(and(eq(appUsers.externalUserId, trimmed), eq(appUsers.status, "active"))),
   ]);
 
-  const ids = new Set<string>();
-  for (const row of [...ownedRows, ...adminRows, ...memberRows]) {
+  const managed = new Set<string>();
+  for (const row of [...ownedRows, ...adminRows]) {
     const id = row.publicClientId?.trim() || row.appId?.trim();
-    if (id) ids.add(id);
+    if (id) managed.add(id);
   }
-  return [...ids];
+  const member = new Set<string>();
+  for (const row of memberRows) {
+    const id = row.publicClientId?.trim() || row.appId?.trim();
+    if (id && !managed.has(id)) member.add(id);
+  }
+  return { managed: [...managed], member: [...member] };
+}
+
+/** Every client_id the viewer may read usage for, managed and membership-only. */
+export async function resolveViewerUsageClientIds(
+  userId: string,
+): Promise<string[]> {
+  const scopes = await resolveViewerUsageClientScopes(userId);
+  return [...scopes.managed, ...scopes.member];
 }
 
 /** True when the viewer has an app_users row on the given public client_id / app id. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the Usage page, the request log resolved `scope=own` against the **viewer's own** usage subjects (`resolveViewerUsageSubjects`). An app owner therefore saw `No requests for your usage identity in this billing cycle.` while the chart directly above showed hundreds of requests for the same app — every one of those requests belongs to an M2M / end-user identity (`eu_…`), never to the owner's own subject.

The `Identities` dropdown also only filtered the chart and the per-application breakdown; it never reached the request log, so there was no way to read the request history of one M2M identity from the Usage page.

## Change

Server (`/api/v1/me/usage/requests`):

- `resolveViewerUsageClientScopes` splits a viewer's apps into `managed` (owned or administered) and `member` (only an `app_users` membership). Managed apps are read app-wide — the same authorization the app identity pages already use — while membership-only apps stay limited to the viewer's own subjects.
- `listDeveloperSignedTicketRequests` / `listDeveloperSignedTicketSessions` replace the viewer-subject-only listings and read both groups in one paged result.
- Requested `clientId`s are now intersected with the viewer's authorized apps instead of being trusted, since managed apps are no longer subject-gated.
- The route accepts an `externalUserId` identity filter (repeatable, or comma-separated `externalUserIds`) for both `scope=own` and admin `scope=all`; membership-only apps still intersect it with the viewer's own subjects.
- Session collection and paging were split (`collectSignedTicketSessionRows` / `pageSignedTicketSessions`) so managed and membership groups merge onto one cursor, and platform-wide app discovery is now an explicit opt-in for admin All Usage.

UI:

- The `Identities` dropdown selection flows into the request log, which sends `externalUserId` filters.
- The scope chip reports what is actually shown (`All identities on your apps`, the selected identity id, or `N identities`) and offers `Show all identities` to clear the filter from the panel.
- Empty-state copy matches the new scope instead of claiming "your usage identity".

Docs: `docs/builder-api.md` now describes the `scope=own` authorization split and the identity filter instead of the old "do not pass `externalUserId`" rule.

## Tests

- New unit tests: `buildSubjectMatchKeys` / `eventMatchesUsageSubjectKeys`, `listDeveloperSignedTicketRequests` (managed app returns every identity; identity filter narrows to one; no authorized apps returns empty), `listDeveloperSignedTicketSessions` app-wide managed read.
- New DB-backed test: `resolveViewerUsageClientScopes` puts an owned app in `managed` and a membership app in `member`.
- Full suite against a live Postgres: 1524 pass, 0 fail. `npm run lint` clean (2 pre-existing warnings in an untouched file).

## Manual verification

Local run with a seeded owner + admin, one app (`storyboard`) and two M2M identities (`eu_alpha_m2m`, 7 requests; `eu_beta_m2m`, 4 requests) against a stubbed OpenMeter.

Owner at `/usage` — scope chip `All identities on your apps`, all 11 rows across both M2M identities (previously this panel was empty):

[Owner usage page showing 11 request rows across both M2M identities](https://cursor.com/agents/bc-056c879a-89fc-48fb-adc8-49af32406470/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fowner-all-identities.webp)

Owner with the `Identities` filter set to `eu_beta_m2m` — chip shows the identity, `Show all identities` resets it, and only that identity's 4 rows remain:

[Owner usage page filtered to the eu_beta_m2m identity](https://cursor.com/agents/bc-056c879a-89fc-48fb-adc8-49af32406470/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fowner-filtered-identity.webp)

Admin at `/usage/all` — chip `All identities`, all rows, identity cells link to the per-identity page:

[Admin All Usage page showing requests for both identities](https://cursor.com/agents/bc-056c879a-89fc-48fb-adc8-49af32406470/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin-all-usage.webp)

Full walkthrough:

[usage-request-log-per-identity.mp4](https://cursor.com/agents/bc-056c879a-89fc-48fb-adc8-49af32406470/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fusage-request-log-per-identity.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-056c879a-89fc-48fb-adc8-49af32406470?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-056c879a-89fc-48fb-adc8-49af32406470&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

