### PR TITLE
feat(usage): identity filter search and middle-truncated ids

### DIFF
--- a/src/components/AppFilterDropdown.test.ts
+++ b/src/components/AppFilterDropdown.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  filterButtonLabel,
+  optionMatchesQuery,
+  visibleFilterOptions,
+  type AppFilterOption,
+} from "@/components/AppFilterDropdown";
+
+const ids: AppFilterOption[] = [
+  { value: "eu_43eac8e3fe4dd854633da7a23fb", label: "eu_43eac8e3fe4dd854633da7a23fb" },
+  { value: "eu_cb8da10f6dcc418d86e26a936ee", label: "eu_cb8da10f6dcc418d86e26a936ee" },
+  { value: "e2e-merchant-01affcc-1787032125", label: "e2e-merchant-01affcc-1787032125" },
+];
+
+test("startsWith matches a full id or a prefix, not a middle or suffix fragment", () => {
+  const id = ids[0]!;
+  assert.equal(optionMatchesQuery(id, id.value, "startsWith"), true);
+  assert.equal(optionMatchesQuery(id, "eu_43eac", "startsWith"), true);
+  assert.equal(optionMatchesQuery(id, "EU_43", "startsWith"), true);
+  assert.equal(optionMatchesQuery(id, "8e3fe4dd", "startsWith"), false);
+  assert.equal(optionMatchesQuery(id, "a23fb", "startsWith"), false);
+});
+
+test("includes still matches a substring anywhere", () => {
+  const id = ids[0]!;
+  assert.equal(optionMatchesQuery(id, "8e3fe4dd", "includes"), true);
+  assert.equal(optionMatchesQuery(id, "a23fb", "includes"), true);
+});
+
+test("visibleFilterOptions keeps original order of prefix matches", () => {
+  const visible = visibleFilterOptions(ids, "eu_", "startsWith");
+  assert.deepEqual(
+    visible.map((o) => o.value),
+    [ids[0]!.value, ids[1]!.value],
+  );
+  assert.deepEqual(visibleFilterOptions(ids, "e2e-", "startsWith"), [ids[2]]);
+  assert.deepEqual(visibleFilterOptions(ids, "nope", "startsWith"), []);
+});
+
+test("filterButtonLabel middle-truncates a single selected id", () => {
+  const long = ids[0]!.label;
+  const shown = filterButtonLabel(ids, [ids[0]!.value], "No identities", "All identities", 24);
+  assert.equal(shown.length, 24);
+  assert.equal(shown.startsWith("eu_"), true);
+  assert.equal(shown.endsWith(long.slice(-11)), true);
+  assert.equal(
+    filterButtonLabel(ids, ids.map((o) => o.value), "No identities", "All identities", 24),
+    "All identities",
+  );
+});

--- a/src/components/AppFilterDropdown.tsx
+++ b/src/components/AppFilterDropdown.tsx
@@ -1,17 +1,46 @@
 "use client";
 
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState, type RefObject } from "react";
+
+import { truncateMiddle } from "@/lib/truncate-middle";
 
 export type AppFilterOption = {
   value: string;
   label: string;
 };
 
-function filterButtonLabel(
+export type FilterSearchMatch = "includes" | "startsWith";
+
+export function optionMatchesQuery(
+  option: AppFilterOption,
+  query: string,
+  match: FilterSearchMatch = "includes",
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const value = option.value.toLowerCase();
+  const label = option.label.toLowerCase();
+  if (match === "startsWith") {
+    return value.startsWith(q) || label.startsWith(q);
+  }
+  return value.includes(q) || label.includes(q);
+}
+
+export function visibleFilterOptions(
+  options: AppFilterOption[],
+  query: string,
+  match: FilterSearchMatch,
+): AppFilterOption[] {
+  if (!query.trim()) return options;
+  return options.filter((o) => optionMatchesQuery(o, query, match));
+}
+
+export function filterButtonLabel(
   options: AppFilterOption[],
   selectedValues: string[],
   emptyLabel: string,
   allLabel: string,
+  maxLabelLength?: number,
 ): string {
   if (options.length === 0) {
     return emptyLabel;
@@ -23,9 +52,108 @@ function filterButtonLabel(
     return allLabel;
   }
   if (selectedValues.length === 1) {
-    return options.find((o) => o.value === selectedValues[0])?.label ?? "1 selected";
+    const raw =
+      options.find((o) => o.value === selectedValues[0])?.label ?? "1 selected";
+    return maxLabelLength ? truncateMiddle(raw, maxLabelLength) : raw;
   }
   return `${selectedValues.length} selected`;
+}
+
+function optionDisplayLabel(label: string, maxLabelLength?: number): string {
+  return maxLabelLength ? truncateMiddle(label, maxLabelLength) : label;
+}
+
+function FilterSearchInput({
+  inputRef,
+  query,
+  placeholder,
+  onQueryChange,
+  onEscape,
+}: Readonly<{
+  inputRef: RefObject<HTMLInputElement | null>;
+  query: string;
+  placeholder: string;
+  onQueryChange: (value: string) => void;
+  onEscape: () => void;
+}>) {
+  return (
+    <div className="shrink-0 border-b border-zinc-800 px-2 py-2">
+      <input
+        ref={inputRef}
+        type="search"
+        value={query}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onEscape();
+          }
+        }}
+        className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-2 py-1.5 text-xs text-zinc-100 placeholder:text-zinc-500 focus:border-emerald-600/60 focus:outline-none"
+      />
+    </div>
+  );
+}
+
+function FilterOptionsList({
+  listId,
+  legendLabel,
+  options,
+  selectedSet,
+  maxLabelLength,
+  emptyLabel,
+  onToggle,
+}: Readonly<{
+  listId: string;
+  legendLabel: string;
+  options: AppFilterOption[];
+  selectedSet: Set<string>;
+  maxLabelLength?: number;
+  emptyLabel: string;
+  onToggle: (value: string) => void;
+}>) {
+  if (options.length === 0) {
+    return <p className="px-3 py-3 text-sm text-zinc-500">{emptyLabel}</p>;
+  }
+  return (
+    <fieldset className="relative m-0 min-h-0 flex-1 overflow-auto border-0 p-0">
+      <legend className="absolute h-px w-px overflow-hidden whitespace-nowrap p-0 [clip:rect(0,0,0,0)]">
+        {legendLabel}
+      </legend>
+      {options.map((opt) => {
+        const selected = selectedSet.has(opt.value);
+        const checkboxId = `${listId}-${opt.value}`;
+        const shown = optionDisplayLabel(opt.label, maxLabelLength);
+        return (
+          <label
+            key={opt.value}
+            htmlFor={checkboxId}
+            title={opt.label}
+            className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+          >
+            <input
+              id={checkboxId}
+              type="checkbox"
+              checked={selected}
+              onChange={() => onToggle(opt.value)}
+              className="h-3.5 w-3.5 shrink-0 rounded border-zinc-600 bg-zinc-900 text-emerald-600 focus:ring-emerald-500/40"
+            />
+            <span
+              className={`min-w-0 ${
+                maxLabelLength ? "font-mono text-xs whitespace-nowrap" : "truncate"
+              }`}
+            >
+              {shown}
+            </span>
+          </label>
+        );
+      })}
+    </fieldset>
+  );
 }
 
 /**
@@ -40,6 +168,10 @@ export default function AppFilterDropdown({
   emptyLabel = "No applications",
   allLabel = "All applications",
   legendLabel,
+  searchable = false,
+  searchPlaceholder = "Search…",
+  searchMatch = "includes",
+  maxLabelLength,
 }: Readonly<{
   options: AppFilterOption[];
   selectedValues: string[];
@@ -50,12 +182,22 @@ export default function AppFilterDropdown({
   allLabel?: string;
   /** Visually hidden fieldset legend; defaults from `label`. */
   legendLabel?: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  searchMatch?: FilterSearchMatch;
+  /** Middle-ellipsis labels longer than this (start and end stay visible). */
+  maxLabelLength?: number;
 }>) {
   const listId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
 
-  const close = useCallback(() => setOpen(false), []);
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -68,9 +210,18 @@ export default function AppFilterDropdown({
     return () => document.removeEventListener("mousedown", onDoc);
   }, [open, close]);
 
+  useEffect(() => {
+    if (open && searchable) {
+      searchRef.current?.focus();
+    }
+  }, [open, searchable]);
+
   const allSelected =
     options.length > 0 && selectedValues.length === options.length;
   const selectedSet = new Set(selectedValues);
+  const visibleOptions = searchable
+    ? visibleFilterOptions(options, query, searchMatch)
+    : options;
 
   const toggleValue = (value: string) => {
     if (selectedSet.has(value)) {
@@ -82,6 +233,17 @@ export default function AppFilterDropdown({
 
   const selectAll = () => onChange(options.map((o) => o.value));
   const clearAll = () => onChange([]);
+  const buttonLabel = filterButtonLabel(
+    options,
+    selectedValues,
+    emptyLabel,
+    allLabel,
+    maxLabelLength,
+  );
+  const buttonTitle =
+    selectedValues.length === 1
+      ? (options.find((o) => o.value === selectedValues[0])?.label ?? buttonLabel)
+      : buttonLabel;
 
   return (
     <div ref={containerRef} className="relative shrink-0">
@@ -89,12 +251,16 @@ export default function AppFilterDropdown({
         type="button"
         aria-expanded={open}
         aria-controls={listId}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          if (open) close();
+          else setOpen(true);
+        }}
+        title={buttonTitle}
         className="inline-flex items-center gap-2 rounded-lg border border-zinc-700/80 bg-zinc-900/60 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:border-zinc-600 hover:bg-zinc-800/80"
       >
         <span className="text-zinc-500">{label}</span>
-        <span className="max-w-[12rem] truncate">
-          {filterButtonLabel(options, selectedValues, emptyLabel, allLabel)}
+        <span className={`max-w-[12rem] truncate ${maxLabelLength ? "font-mono" : ""}`}>
+          {buttonLabel}
         </span>
         <svg
           className={`h-3.5 w-3.5 text-zinc-500 transition-transform ${open ? "rotate-180" : ""}`}
@@ -110,9 +276,11 @@ export default function AppFilterDropdown({
       {open ? (
         <div
           id={listId}
-          className="absolute right-0 z-50 mt-1 w-64 max-h-72 overflow-auto rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-lg"
+          className={`absolute right-0 z-50 mt-1 flex max-h-80 flex-col overflow-hidden rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-lg ${
+            searchable ? "w-80" : "w-64"
+          }`}
         >
-          <div className="flex items-center justify-between gap-2 border-b border-zinc-800 px-3 py-2">
+          <div className="flex shrink-0 items-center justify-between gap-2 border-b border-zinc-800 px-3 py-2">
             <button
               type="button"
               onClick={selectAll}
@@ -131,35 +299,25 @@ export default function AppFilterDropdown({
             </button>
           </div>
 
-          {options.length === 0 ? (
-            <p className="px-3 py-3 text-sm text-zinc-500">{emptyLabel}</p>
-          ) : (
-            <fieldset className="relative m-0 border-0 p-0">
-              <legend className="absolute h-px w-px overflow-hidden whitespace-nowrap p-0 [clip:rect(0,0,0,0)]">
-                {legendLabel ?? `Filter by ${label.toLowerCase()}`}
-              </legend>
-              {options.map((opt) => {
-                const selected = selectedSet.has(opt.value);
-                const checkboxId = `${listId}-${opt.value}`;
-                return (
-                  <label
-                    key={opt.value}
-                    htmlFor={checkboxId}
-                    className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm text-zinc-200 hover:bg-zinc-800"
-                  >
-                    <input
-                      id={checkboxId}
-                      type="checkbox"
-                      checked={selected}
-                      onChange={() => toggleValue(opt.value)}
-                      className="h-3.5 w-3.5 shrink-0 rounded border-zinc-600 bg-zinc-900 text-emerald-600 focus:ring-emerald-500/40"
-                    />
-                    <span className="truncate">{opt.label}</span>
-                  </label>
-                );
-              })}
-            </fieldset>
-          )}
+          {searchable && options.length > 0 ? (
+            <FilterSearchInput
+              inputRef={searchRef}
+              query={query}
+              placeholder={searchPlaceholder}
+              onQueryChange={setQuery}
+              onEscape={close}
+            />
+          ) : null}
+
+          <FilterOptionsList
+            listId={listId}
+            legendLabel={legendLabel ?? `Filter by ${label.toLowerCase()}`}
+            options={options.length === 0 ? [] : visibleOptions}
+            selectedSet={selectedSet}
+            maxLabelLength={maxLabelLength}
+            emptyLabel={options.length === 0 ? emptyLabel : "No matches"}
+            onToggle={toggleValue}
+          />
         </div>
       ) : null}
     </div>

--- a/src/components/AppFilterDropdown.tsx
+++ b/src/components/AppFilterDropdown.tsx
@@ -259,7 +259,7 @@ export default function AppFilterDropdown({
         className="inline-flex items-center gap-2 rounded-lg border border-zinc-700/80 bg-zinc-900/60 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:border-zinc-600 hover:bg-zinc-800/80"
       >
         <span className="text-zinc-500">{label}</span>
-        <span className={`max-w-[12rem] truncate ${maxLabelLength ? "font-mono" : ""}`}>
+        <span className={`max-w-[12rem] ${maxLabelLength ? "font-mono whitespace-nowrap" : "truncate"}`}>
           {buttonLabel}
         </span>
         <svg

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -22,6 +22,10 @@ import type {
 import { resolveOwnerBillingPressure } from "@/lib/billing/owner-billing-pressure";
 import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
 import type { OwnerBillingSubscriptionRow } from "@/lib/owner-billing-data";
+import {
+  deriveFilteredView,
+  type ChartDimension,
+} from "@/lib/usage/dashboard-filtered-view";
 
 /** Client-safe dashboard payload (bigints as strings). */
 type BillingUsageDashboardClientPayload = {
@@ -46,9 +50,6 @@ type BillingUsageDashboardClientPayload = {
 };
 
 type UsageTab = "mine" | "all";
-
-/** Chart series split: app × pipeline/model (default) or app × identity. */
-type ChartDimension = "pipeline" | "identity";
 
 type LoadState =
   | { status: "loading" }
@@ -104,90 +105,6 @@ function UsageLoadingShell({
       </div>
     </div>
   );
-}
-
-function deriveFilteredView(
-  data: BillingUsageDashboardClientPayload,
-  selectedPublicClientIds: string[],
-  historyScope: "own" | "all",
-  chartDimension: ChartDimension,
-  selectedIdentityIds: string[],
-  allIdentityIds: string[],
-) {
-  const allIds = data.orderedApps.map((a) => a.publicClientId);
-  const allSelected =
-    allIds.length > 0 && selectedPublicClientIds.length === allIds.length;
-  const noneSelected = selectedPublicClientIds.length === 0;
-  const selectedSet = new Set(selectedPublicClientIds);
-
-  const allIdentitiesSelected =
-    allIdentityIds.length === 0 ||
-    selectedIdentityIds.length === allIdentityIds.length;
-  const identitySet = new Set(selectedIdentityIds);
-
-  const baseSeries =
-    chartDimension === "identity" ? data.chartSeriesByIdentity : data.chartSeries;
-
-  let filteredSeries = baseSeries;
-  if (!allSelected) {
-    filteredSeries = noneSelected
-      ? []
-      : baseSeries.filter((s) => selectedSet.has(s.appId));
-  }
-  // Identity series carry the identity in `jobType`, so the filter applies only
-  // to that dimension; pipeline/model series stay app-filtered.
-  if (chartDimension === "identity" && !allIdentitiesSelected) {
-    filteredSeries = filteredSeries.filter((s) => identitySet.has(s.jobType));
-  }
-
-  let filteredAppUsage = data.appUsage;
-  if (!allSelected) {
-    filteredAppUsage = noneSelected
-      ? []
-      : data.appUsage.filter((e) => selectedSet.has(e.app.publicClientId));
-  }
-  if (!allIdentitiesSelected) {
-    filteredAppUsage = filteredAppUsage
-      .map((entry) => {
-        const byUser = entry.byUser.filter((u) =>
-          identitySet.has(u.externalUserId ?? u.endUserId),
-        );
-        const requestCount = byUser.reduce((sum, u) => sum + u.requestCount, 0);
-        const networkFeeUsdMicros = byUser
-          .reduce((sum, u) => sum + BigInt(u.networkFeeUsdMicros || "0"), 0n)
-          .toString();
-        return {
-          ...entry,
-          byUser,
-          requestCount,
-          networkFeeUsdMicros,
-          endUserBillableUsdMicros: networkFeeUsdMicros,
-        };
-      })
-      .filter((entry) => entry.byUser.length > 0);
-  }
-  filteredAppUsage = filteredAppUsage.filter((e) => e.requestCount > 0);
-
-  // Admin All Usage + all apps selected: omit clientId filter so request
-  // history uses the unrestricted platform event list (avoids a huge id-set
-  // post-filter). Session list discovers apps from those events server-side.
-  // Subset selection still passes the dropdown ids. Own scope unchanged.
-  let historyClientIds: string[];
-  if (allSelected && historyScope === "all") {
-    historyClientIds = [];
-  } else if (allSelected) {
-    historyClientIds = data.orderedApps.map((a) => a.publicClientId);
-  } else {
-    historyClientIds = selectedPublicClientIds;
-  }
-
-  return {
-    filteredSeries,
-    filteredAppUsage,
-    historyClientIds,
-    // Request history covers every identity unless the filter narrows it.
-    historyIdentityIds: allIdentitiesSelected ? [] : selectedIdentityIds,
-  };
 }
 
 function ActiveSubscriptionSummary({
@@ -494,6 +411,10 @@ function BillingPeriodPanel({
               label="Identities"
               emptyLabel="No identities"
               allLabel="All identities"
+              searchable
+              searchPlaceholder="Search identities…"
+              searchMatch="startsWith"
+              maxLabelLength={24}
             />
           ) : null}
         </div>

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -16,6 +16,7 @@ import {
   formatUsdMicrosString,
   formatUsdMicrosSummary,
 } from "@/lib/format-usd-micros";
+import { truncateMiddle } from "@/lib/truncate-middle";
 import {
   buildRequestsCsv,
   buildRequestsCsvFilename,
@@ -174,10 +175,10 @@ function RequestRow({
           {row.externalUserId ? (
             <Link
               href={`/apps/${encodeURIComponent(row.clientId)}/identities/${encodeURIComponent(row.externalUserId)}`}
-              className="block max-w-[10rem] truncate font-mono text-xs text-zinc-400 transition-colors hover:text-emerald-400"
+              className="block max-w-[10rem] font-mono text-xs text-zinc-400 transition-colors hover:text-emerald-400"
               title={row.externalUserId}
             >
-              {row.externalUserId}
+              {truncateMiddle(row.externalUserId, 20)}
             </Link>
           ) : (
             <span className="text-xs text-zinc-600">—</span>
@@ -635,7 +636,7 @@ function HistoryToolbar({
           >
             <span className="text-zinc-600">Scope</span>
             <span className={`truncate ${copy.scopeChipMono ? "font-mono" : ""}`}>
-              {copy.scopeChip}
+              {copy.scopeChipMono ? truncateMiddle(copy.scopeChip, 24) : copy.scopeChip}
             </span>
           </span>
           {identityFilterActive && onClearIdentityFilter ? (

--- a/src/components/identities/IdentitiesTable.tsx
+++ b/src/components/identities/IdentitiesTable.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 
 import { formatBillableDuration, formatBillingUtcDate } from "@/lib/billing-format";
 import { formatUsdMicrosString } from "@/lib/format-usd-micros";
+import { truncateMiddle } from "@/lib/truncate-middle";
 import type { AppIdentityRow } from "@/lib/usage/identity-rollup";
 
 type SortKey = "fee" | "requests" | "duration" | "lastActive";
@@ -183,9 +184,7 @@ export default function IdentitiesTable({
                   className="font-mono text-xs text-zinc-200 hover:text-emerald-400 transition-colors"
                   title={row.externalUserId}
                 >
-                  {row.externalUserId.length > 28
-                    ? `${row.externalUserId.slice(0, 26)}…`
-                    : row.externalUserId}
+                  {truncateMiddle(row.externalUserId, 28)}
                 </Link>
                 {row.email ? (
                   <p className="mt-0.5 truncate text-[11px] text-zinc-600">{row.email}</p>

--- a/src/lib/truncate-middle.test.ts
+++ b/src/lib/truncate-middle.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { truncateMiddle } from "@/lib/truncate-middle";
+
+test("truncateMiddle leaves short ids unchanged", () => {
+  assert.equal(truncateMiddle("eu_short", 24), "eu_short");
+  assert.equal(truncateMiddle("abc", 3), "abc");
+  assert.equal(truncateMiddle("", 24), "");
+});
+
+test("truncateMiddle keeps the start and end of long ids", () => {
+  const id = "eu_43eac8e3fe4dd854633da7a23fb";
+  const shown = truncateMiddle(id, 24);
+  assert.equal(shown.length, 24);
+  assert.equal(shown.startsWith("eu_"), true);
+  assert.equal(shown.endsWith("a23fb"), true);
+  assert.equal(shown.includes("…"), true);
+  assert.notEqual(shown, id);
+  assert.equal(shown, `${id.slice(0, 12)}…${id.slice(-11)}`);
+});
+
+test("truncateMiddle rejects non-positive budgets", () => {
+  assert.equal(truncateMiddle("eu_abc", 0), "");
+  assert.equal(truncateMiddle("eu_abc", -1), "");
+  assert.equal(truncateMiddle("eu_abc", 2), "eu");
+});

--- a/src/lib/truncate-middle.ts
+++ b/src/lib/truncate-middle.ts
@@ -1,0 +1,13 @@
+/**
+ * Keep the start and end of a long id visible; drop characters from the middle.
+ * Short strings are returned unchanged.
+ */
+export function truncateMiddle(value: string, maxLength: number): string {
+  if (maxLength <= 0) return "";
+  if (value.length <= maxLength) return value;
+  if (maxLength <= 2) return value.slice(0, maxLength);
+  const budget = maxLength - 1;
+  const head = Math.ceil(budget / 2);
+  const tail = Math.floor(budget / 2);
+  return `${value.slice(0, head)}…${value.slice(value.length - tail)}`;
+}

--- a/src/lib/usage/dashboard-filtered-view.test.ts
+++ b/src/lib/usage/dashboard-filtered-view.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  BillingAppRow,
+  BillingAppUsageSummary,
+  BillingChartSeries,
+  BillingUserUsageRow,
+} from "@/lib/billing-usage-dashboard-data";
+import {
+  deriveFilteredView,
+  historyClientIdsForView,
+} from "@/lib/usage/dashboard-filtered-view";
+
+function appRow(id: string): BillingAppRow {
+  return {
+    id,
+    name: id,
+    ownerId: "owner",
+    ownerName: null,
+    ownerEmail: null,
+    publicClientId: id,
+    usageKind: "tenant",
+  };
+}
+
+function userRow(
+  externalUserId: string,
+  requestCount: number,
+): BillingUserUsageRow {
+  return {
+    endUserId: externalUserId,
+    externalUserId,
+    userType: "system_managed",
+    userLabel: externalUserId,
+    identifier: externalUserId,
+    requestCount,
+    totalFeeWei: "0",
+    totalUnits: "0",
+    networkFeeUsdMicros: String(requestCount * 1000),
+    byPipelineModel: [],
+  };
+}
+
+function appUsage(
+  appId: string,
+  users: BillingUserUsageRow[],
+): BillingAppUsageSummary {
+  const requestCount = users.reduce((sum, u) => sum + u.requestCount, 0);
+  return {
+    app: appRow(appId),
+    requestCount,
+    totalFeeWei: "0",
+    totalUnits: "0",
+    networkFeeUsdMicros: "0",
+    endUserBillableUsdMicros: "0",
+    byUser: users,
+    byPipelineModel: [],
+  };
+}
+
+function series(
+  appId: string,
+  jobType: string,
+): BillingChartSeries {
+  return {
+    appId,
+    appName: appId,
+    jobType,
+    totalRequests: 1,
+    points: [],
+  };
+}
+
+const source = {
+  orderedApps: [appRow("app_a"), appRow("app_b")],
+  chartSeries: [series("app_a", "pipe/model"), series("app_b", "pipe/model")],
+  chartSeriesByIdentity: [
+    series("app_a", "eu_alpha"),
+    series("app_a", "eu_beta"),
+    series("app_b", "eu_alpha"),
+  ],
+  appUsage: [
+    appUsage("app_a", [userRow("eu_alpha", 3), userRow("eu_beta", 2)]),
+    appUsage("app_b", [userRow("eu_alpha", 1)]),
+  ],
+};
+
+test("historyClientIdsForView omits ids for admin all-apps", () => {
+  assert.deepEqual(
+    historyClientIdsForView(true, "all", ["app_a", "app_b"], ["app_a", "app_b"]),
+    [],
+  );
+  assert.deepEqual(
+    historyClientIdsForView(true, "own", ["app_a", "app_b"], ["app_a", "app_b"]),
+    ["app_a", "app_b"],
+  );
+  assert.deepEqual(
+    historyClientIdsForView(false, "all", ["app_a", "app_b"], ["app_a"]),
+    ["app_a"],
+  );
+});
+
+test("deriveFilteredView leaves everything when all apps and identities are selected", () => {
+  const derived = deriveFilteredView(
+    source,
+    ["app_a", "app_b"],
+    "own",
+    "pipeline",
+    ["eu_alpha", "eu_beta"],
+    ["eu_alpha", "eu_beta"],
+  );
+  assert.equal(derived.filteredSeries.length, 2);
+  assert.equal(derived.filteredAppUsage.length, 2);
+  assert.deepEqual(derived.historyClientIds, ["app_a", "app_b"]);
+  assert.deepEqual(derived.historyIdentityIds, []);
+});
+
+test("deriveFilteredView narrows identity series and request history", () => {
+  const derived = deriveFilteredView(
+    source,
+    ["app_a"],
+    "own",
+    "identity",
+    ["eu_beta"],
+    ["eu_alpha", "eu_beta"],
+  );
+  assert.deepEqual(
+    derived.filteredSeries.map((s) => `${s.appId}:${s.jobType}`),
+    ["app_a:eu_beta"],
+  );
+  assert.equal(derived.filteredAppUsage.length, 1);
+  assert.deepEqual(
+    derived.filteredAppUsage[0]?.byUser.map((u) => u.externalUserId),
+    ["eu_beta"],
+  );
+  assert.equal(derived.filteredAppUsage[0]?.requestCount, 2);
+  assert.deepEqual(derived.historyClientIds, ["app_a"]);
+  assert.deepEqual(derived.historyIdentityIds, ["eu_beta"]);
+});
+
+test("deriveFilteredView returns empty series when no apps are selected", () => {
+  const derived = deriveFilteredView(
+    source,
+    [],
+    "own",
+    "pipeline",
+    ["eu_alpha", "eu_beta"],
+    ["eu_alpha", "eu_beta"],
+  );
+  assert.deepEqual(derived.filteredSeries, []);
+  assert.deepEqual(derived.filteredAppUsage, []);
+  assert.deepEqual(derived.historyClientIds, []);
+});

--- a/src/lib/usage/dashboard-filtered-view.ts
+++ b/src/lib/usage/dashboard-filtered-view.ts
@@ -1,0 +1,137 @@
+import type {
+  BillingAppUsageSummary,
+  BillingChartSeries,
+} from "@/lib/billing-usage-dashboard-data";
+
+export type ChartDimension = "pipeline" | "identity";
+
+export type DashboardFilterSource = {
+  orderedApps: { publicClientId: string }[];
+  chartSeries: BillingChartSeries[];
+  chartSeriesByIdentity: BillingChartSeries[];
+  appUsage: BillingAppUsageSummary[];
+};
+
+function applyAppSelection<T>(
+  items: T[],
+  allSelected: boolean,
+  noneSelected: boolean,
+  belongsToSelectedApp: (item: T) => boolean,
+): T[] {
+  if (allSelected) return items;
+  if (noneSelected) return [];
+  return items.filter(belongsToSelectedApp);
+}
+
+/** Identity series carry the identity in `jobType`; pipeline/model series stay app-filtered. */
+function applyIdentitySeriesFilter(
+  series: BillingChartSeries[],
+  chartDimension: ChartDimension,
+  allIdentitiesSelected: boolean,
+  identitySet: Set<string>,
+): BillingChartSeries[] {
+  if (chartDimension !== "identity" || allIdentitiesSelected) {
+    return series;
+  }
+  return series.filter((s) => identitySet.has(s.jobType));
+}
+
+function restrictAppUsageToIdentities(
+  entry: BillingAppUsageSummary,
+  identitySet: Set<string>,
+): BillingAppUsageSummary {
+  const byUser = entry.byUser.filter((u) =>
+    identitySet.has(u.externalUserId ?? u.endUserId),
+  );
+  const requestCount = byUser.reduce((sum, u) => sum + u.requestCount, 0);
+  const networkFeeUsdMicros = byUser
+    .reduce((sum, u) => sum + BigInt(u.networkFeeUsdMicros || "0"), 0n)
+    .toString();
+  return {
+    ...entry,
+    byUser,
+    requestCount,
+    networkFeeUsdMicros,
+    endUserBillableUsdMicros: networkFeeUsdMicros,
+  };
+}
+
+function applyIdentityAppUsageFilter(
+  appUsage: BillingAppUsageSummary[],
+  allIdentitiesSelected: boolean,
+  identitySet: Set<string>,
+): BillingAppUsageSummary[] {
+  if (allIdentitiesSelected) return appUsage;
+  return appUsage
+    .map((entry) => restrictAppUsageToIdentities(entry, identitySet))
+    .filter((entry) => entry.byUser.length > 0);
+}
+
+/**
+ * Admin All Usage + all apps selected: omit clientId filter so request
+ * history uses the unrestricted platform event list. Subset selection still
+ * passes the dropdown ids. Own scope always sends the selected (or all) ids.
+ */
+export function historyClientIdsForView(
+  allSelected: boolean,
+  historyScope: "own" | "all",
+  allPublicClientIds: string[],
+  selectedPublicClientIds: string[],
+): string[] {
+  if (!allSelected) return selectedPublicClientIds;
+  if (historyScope === "all") return [];
+  return allPublicClientIds;
+}
+
+export function deriveFilteredView(
+  data: DashboardFilterSource,
+  selectedPublicClientIds: string[],
+  historyScope: "own" | "all",
+  chartDimension: ChartDimension,
+  selectedIdentityIds: string[],
+  allIdentityIds: string[],
+) {
+  const allIds = data.orderedApps.map((a) => a.publicClientId);
+  const allSelected =
+    allIds.length > 0 && selectedPublicClientIds.length === allIds.length;
+  const noneSelected = selectedPublicClientIds.length === 0;
+  const selectedSet = new Set(selectedPublicClientIds);
+
+  const allIdentitiesSelected =
+    allIdentityIds.length === 0 ||
+    selectedIdentityIds.length === allIdentityIds.length;
+  const identitySet = new Set(selectedIdentityIds);
+
+  const baseSeries =
+    chartDimension === "identity" ? data.chartSeriesByIdentity : data.chartSeries;
+
+  const filteredSeries = applyIdentitySeriesFilter(
+    applyAppSelection(baseSeries, allSelected, noneSelected, (s) =>
+      selectedSet.has(s.appId),
+    ),
+    chartDimension,
+    allIdentitiesSelected,
+    identitySet,
+  );
+
+  const filteredAppUsage = applyIdentityAppUsageFilter(
+    applyAppSelection(data.appUsage, allSelected, noneSelected, (e) =>
+      selectedSet.has(e.app.publicClientId),
+    ),
+    allIdentitiesSelected,
+    identitySet,
+  ).filter((e) => e.requestCount > 0);
+
+  return {
+    filteredSeries,
+    filteredAppUsage,
+    historyClientIds: historyClientIdsForView(
+      allSelected,
+      historyScope,
+      allIds,
+      selectedPublicClientIds,
+    ),
+    // Request history covers every identity unless the filter narrows it.
+    historyIdentityIds: allIdentitiesSelected ? [] : selectedIdentityIds,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Identities dropdown on Usage shows full `eu_…` ids that overflow the menu, with no way to find one by typing. CSS truncation also cuts the **end**, so ids that share a prefix look identical.

PR 484 also has an open SonarCloud issue ([typescript:S3776](https://sonarcloud.io/project/issues?pullRequest=484&open=AaBBFl5twx_LP-O_bVOe&id=pymthouse_pymthouse)): `deriveFilteredView` in `BillingUsageDashboard.tsx` is cognitive complexity 16 (limit 15).

## Change

- Identities filter is searchable. Matching is **starts-with** on the full id (case-insensitive), so `eu_43`, `EU_43EAC`, or the complete id all hit the same row; a middle or suffix fragment does not.
- Long ids render with a **middle** ellipsis (`eu_43eac8e3f…633da7a23fb`) in the dropdown, the closed button, the Identities table, the request-log identity column, and the scope chip. Hover still shows the full id.
- `deriveFilteredView` moves to `src/lib/usage/dashboard-filtered-view.ts` and is split into small helpers so the S3776 hot spot is gone.

Apps / Source dropdowns are unchanged (no search, no middle-truncation).

## Tests

- `truncateMiddle` keeps start and end, leaves short strings alone.
- `optionMatchesQuery` / `visibleFilterOptions` cover full id, prefix, case-insensitive prefix, and rejection of middle/suffix fragments.
- `deriveFilteredView` covers all-selected, identity narrowing, and empty app selection.

`npx tsc --noEmit` and eslint on the touched files are clean. 11/11 new unit tests pass. Snyk/SonarCloud tokens are not available in this environment; those checks will run on the PR. Merging this into #484 should close the S3776 finding.

## Manual verification

Walkthrough of the Identities dropdown (prefix search, suffix-no-match, single selected middle-truncated trigger):

[identities-filter-search-walkthrough.mp4](https://cursor.com/agents/bc-ec94d2c7-03e9-4c8b-9e3b-b494f3263b0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidentities-filter-search-walkthrough.mp4)

Open menu with middle-truncated ids:

[Identities dropdown showing middle-truncated user ids](https://cursor.com/agents/bc-ec94d2c7-03e9-4c8b-9e3b-b494f3263b0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidentities-dropdown-middle-truncate.webp)

Prefix `eu_43` keeps one row:

[Identities search filtered to eu_43 prefix](https://cursor.com/agents/bc-ec94d2c7-03e9-4c8b-9e3b-b494f3263b0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidentities-search-prefix.webp)

Suffix `a23fb` is not a starts-with match:

[Identities search showing No matches for a suffix](https://cursor.com/agents/bc-ec94d2c7-03e9-4c8b-9e3b-b494f3263b0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidentities-search-suffix-no-match.webp)

Closed button after selecting one identity:

[Identities trigger showing one middle-truncated id](https://cursor.com/agents/bc-ec94d2c7-03e9-4c8b-9e3b-b494f3263b0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidentities-closed-single-id.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec94d2c7-03e9-4c8b-9e3b-b494f3263b0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec94d2c7-03e9-4c8b-9e3b-b494f3263b0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

