### PR TITLE
feat(oidc): env-driven access/refresh TTLs (refresh default 90 days)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -301,3 +301,12 @@ NEXT_PUBLIC_AUTH_PROXY_CONFIG_ID=
 # JWKS URL stored on developer_apps for RFC 8693 token exchange (public host).
 # Defaults to https://pymthouse.com/api/v1/oidc/jwks — set for self-hosted only.
 # PLATFORM_JWKS_URL=https://your-domain.com/api/v1/oidc/jwks
+#
+# Interactive OIDC user JWTs (node-oidc-provider — device / auth-code / DCR, e.g.
+# Claude Desktop after MCP connect). Access stays short; clients refresh.
+# Grant and Session follow the refresh TTL so a rotated refresh stays valid.
+# Defaults: access 3600s (1h), refresh/grant/session 7776000s (90 days).
+# OIDC_ACCESS_TOKEN_TTL_SECONDS=3600
+# OIDC_REFRESH_TOKEN_TTL_SECONDS=7776000
+# Programmatic mint (POST …/users/{externalUserId}/token) stays 15m access + 30d
+# refresh. Signer session JWTs stay 5 minutes. Neither reads these env vars.

--- a/.env.vercel.template
+++ b/.env.vercel.template
@@ -90,6 +90,12 @@ OIDC_DEBUG_LOGS=0
 # Set to 1 to enable verbose OIDC logging
 # Only use in development/preview, not production
 
+# Interactive OIDC user JWT TTLs (device / auth-code / DCR). Defaults:
+#   access 3600s (1h), refresh/grant/session 7776000s (90 days).
+# Programmatic mint and signer JWTs do not use these.
+# OIDC_ACCESS_TOKEN_TTL_SECONDS=3600
+# OIDC_REFRESH_TOKEN_TTL_SECONDS=7776000
+
 # ========================================
 # NOTES
 # ========================================

--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -231,6 +231,23 @@ curl -sS \
 - Requested scope must be a subset of the **public app client’s** allowed scopes (see product-specific validation in code).
 - `admin` is explicitly rejected.
 - Default scope when omitted: `sign:job`.
+- Lifetimes are **not** the interactive OIDC TTLs: access is 15 minutes, refresh is 30 days. `OIDC_ACCESS_TOKEN_TTL_SECONDS` / `OIDC_REFRESH_TOKEN_TTL_SECONDS` do not apply here.
+
+---
+
+## OIDC access and refresh TTLs
+
+Interactive OIDC tokens (authorization code, device flow, DCR — e.g. Claude Desktop after MCP connect) use node-oidc-provider TTLs:
+
+| Token | Env | Default |
+| --- | --- | --- |
+| Access JWT | `OIDC_ACCESS_TOKEN_TTL_SECONDS` | `3600` (1 hour) |
+| Refresh (rotated on use) | `OIDC_REFRESH_TOKEN_TTL_SECONDS` | `7776000` (90 days) |
+| Grant / Session | follow refresh | same as refresh |
+
+Keep access at 1 hour unless you have a reason to shorten it. Lengthening access only grows the stolen-token window; clients should refresh. Grant and Session must stay at least as long as refresh or a rotated refresh dies when the grant expires.
+
+Signer session JWTs from RFC 8693 exchange stay **5 minutes** and are not env-driven.
 
 ---
 

--- a/docs/livepeer-mcp.md
+++ b/docs/livepeer-mcp.md
@@ -16,6 +16,8 @@ User-scoped MCP on PymtHouse (`GET/POST /api/v1/mcp`). Auth with the caller’s 
 
 `create_signer_session` with M2M Basic requires `sign:job` on both the M2M client and the public app client (same gates as OIDC `client_credentials` owner `sign:job`).
 
+OIDC user JWTs from DCR / device login expire in **1 hour** by default (`OIDC_ACCESS_TOKEN_TTL_SECONDS`). MCP clients should use the rotating **refresh token** (default **90 days**, `OIDC_REFRESH_TOKEN_TTL_SECONDS`; grant/session follow refresh). Do not mint day-long access tokens. Signer session JWTs from `create_signer_session` stay **5 minutes**.
+
 No platform-fixed M2M behind the MCP. Optional: `DISCOVERY_SERVICE_URL` for orchestrator query / freshness.
 
 ```bash

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -305,6 +305,8 @@ In your Vercel project dashboard, go to "Settings" → "Environment Variables" a
 | `NEXT_PUBLIC_TURNKEY_GOOGLE_CLIENT_ID` | Google OAuth Web client ID | Optional; usually set in Auth Proxy dashboard |
 | `TURNKEY_ALLOWED_ORGANIZATION_IDS` | Optional comma-separated org UUIDs | Restrict which orgs’ session JWTs are accepted |
 | `OIDC_DEBUG_LOGS` | `1` to enable | Debug OIDC flows |
+| `OIDC_ACCESS_TOKEN_TTL_SECONDS` | Seconds (default `3600`) | Interactive OIDC access JWT TTL. Keep at 1 hour; clients refresh. |
+| `OIDC_REFRESH_TOKEN_TTL_SECONDS` | Seconds (default `7776000` = 90 days) | Interactive OIDC refresh TTL. Grant and Session follow this so a rotated refresh stays valid. Does not change programmatic mint (`POST …/users/{eu}/token`, 15m/30d) or signer JWTs (5m). |
 
 **Turnkey social logins (wallets for all funders):** enable Google (etc.) under
 Embedded Wallets → Configuration → Social logins. Redirect URL and Google’s

--- a/src/lib/oidc/mint-user-signer-token.ts
+++ b/src/lib/oidc/mint-user-signer-token.ts
@@ -32,7 +32,8 @@ import { buildDiscoverOrchestratorsUrl } from "@/lib/discovery-service-url";
 import { getClientSignerApiUrl } from "@/lib/signer-proxy";
 
 export { SIGN_MINT_USER_TOKEN_SCOPE };
-const SIGNER_JWT_TTL_SECONDS = 300;
+// Signer session JWTs stay 5 minutes. Do not follow OIDC access/refresh env TTLs.
+export const SIGNER_JWT_TTL_SECONDS = 300;
 
 export class MintUserSignerTokenError extends Error {
   code: string;

--- a/src/lib/oidc/programmatic-tokens.ts
+++ b/src/lib/oidc/programmatic-tokens.ts
@@ -19,8 +19,10 @@ import {
   resolveOpenMeterBillingIdentity,
 } from "@/lib/openmeter/billing-identity";
 
-const ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
-const REFRESH_TOKEN_TTL_DAYS = 30;
+// Independent of node-oidc-provider TTLs (`OIDC_*_TOKEN_TTL_SECONDS`). Builder
+// mint stays 15m access + 30d refresh even when interactive OIDC refresh is 90d.
+export const PROGRAMMATIC_ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
+export const PROGRAMMATIC_REFRESH_TOKEN_TTL_DAYS = 30;
 
 export class ProgrammaticTokenError extends Error {
   code: string;
@@ -135,21 +137,21 @@ export async function issueProgrammaticTokens(input: {
     .setJti(uuidv4())
     .setIssuedAt(nowSeconds)
     .setNotBefore(nowSeconds)
-    .setExpirationTime(nowSeconds + ACCESS_TOKEN_TTL_SECONDS)
+    .setExpirationTime(nowSeconds + PROGRAMMATIC_ACCESS_TOKEN_TTL_SECONDS)
     .sign(keyPair.privateKey);
 
   const refresh = await createSession({
     appId: binding.oauthClientId,
     label: `app_user_refresh:${binding.appUserId}`,
     scopes: scope,
-    expiresInDays: REFRESH_TOKEN_TTL_DAYS,
+    expiresInDays: PROGRAMMATIC_REFRESH_TOKEN_TTL_DAYS,
   });
 
   return {
     access_token: accessToken,
     refresh_token: refresh.token,
     token_type: "Bearer",
-    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+    expires_in: PROGRAMMATIC_ACCESS_TOKEN_TTL_SECONDS,
     scope,
     subject_type: "app_user",
   };

--- a/src/lib/oidc/provider.ts
+++ b/src/lib/oidc/provider.ts
@@ -9,6 +9,7 @@ import type { Configuration, ClientMetadata, KoaContextWithOIDC } from "oidc-pro
 import { consentPromptNeeded } from "@/lib/oidc/consent-prompt";
 import { oidcInteractionPath } from "@/lib/oidc/customer-service-id";
 import { loadExistingGrant } from "@/lib/oidc/load-existing-grant";
+import { resolveOidcProviderTtls } from "@/lib/oidc/ttl";
 import { PostgresOidcAdapter } from "./adapter";
 import { findAccount } from "./account";
 import { getIssuer } from "./issuer-urls";
@@ -294,6 +295,7 @@ export async function getProvider(): Promise<Provider> {
 async function buildProvider(): Promise<Provider> {
   const issuer = getIssuer();
   const [jwks, clients] = await Promise.all([loadJWKS(), loadClients()]);
+  const oidcTtls = resolveOidcProviderTtls();
 
   const configuration: Configuration = {
     adapter: PostgresOidcAdapter,
@@ -445,7 +447,7 @@ async function buildProvider(): Promise<Provider> {
             scope: "openid email profile sign:job users:read users:write users:token device:approve admin",
             audience: issuer,
             accessTokenFormat: "jwt" as const,
-            accessTokenTTL: 3600,
+            accessTokenTTL: oidcTtls.accessToken,
             jwt: {
               sign: { alg: "RS256" as const },
             },
@@ -455,16 +457,17 @@ async function buildProvider(): Promise<Provider> {
       },
     },
 
-    // TTLs matching the current implementation
+    // Access default 1h; refresh/grant/session share OIDC_REFRESH_TOKEN_TTL_SECONDS
+    // (default 90d). Programmatic mint and signer JWTs do not use these values.
     ttl: {
-      AccessToken: 3600,          // 1 hour
+      AccessToken: oidcTtls.accessToken,
       AuthorizationCode: 600,     // 10 minutes
       DeviceCode: 600,            // 10 minutes
       IdToken: 3600,              // 1 hour
-      RefreshToken: 30 * 24 * 3600, // 30 days
+      RefreshToken: oidcTtls.refreshToken,
       Interaction: 1800,          // 30 minutes — gives users time to complete login without timing out
-      Session: 14 * 24 * 3600,   // 14 days
-      Grant: 14 * 24 * 3600,     // 14 days
+      Session: oidcTtls.session,
+      Grant: oidcTtls.grant,
     },
 
     // Interaction URL — redirect to our custom consent/login pages

--- a/src/lib/oidc/ttl.test.ts
+++ b/src/lib/oidc/ttl.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_OIDC_ACCESS_TOKEN_TTL_SECONDS,
+  DEFAULT_OIDC_REFRESH_TOKEN_TTL_SECONDS,
+  OIDC_ACCESS_TOKEN_TTL_ENV,
+  OIDC_REFRESH_TOKEN_TTL_ENV,
+  resolveOidcAccessTokenTtlSeconds,
+  resolveOidcProviderTtls,
+  resolveOidcRefreshTokenTtlSeconds,
+  resolvePositiveIntegerSecondsEnv,
+} from "./ttl";
+
+const NINETY_DAYS = 90 * 24 * 3600;
+const THIRTY_DAYS = 30 * 24 * 3600;
+
+function withEnv(name: string, value: string | undefined, run: () => void): void {
+  const previous = process.env[name];
+  try {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+    run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previous;
+    }
+  }
+}
+
+test("resolvePositiveIntegerSecondsEnv uses fallback when unset", () => {
+  withEnv("OIDC_TTL_TEST_UNSET", undefined, () => {
+    assert.equal(resolvePositiveIntegerSecondsEnv("OIDC_TTL_TEST_UNSET", 42), 42);
+  });
+});
+
+test("resolvePositiveIntegerSecondsEnv prefers a valid positive integer", () => {
+  withEnv("OIDC_TTL_TEST_SET", "7776000", () => {
+    assert.equal(
+      resolvePositiveIntegerSecondsEnv("OIDC_TTL_TEST_SET", 3600),
+      7776000,
+    );
+  });
+});
+
+test("resolvePositiveIntegerSecondsEnv ignores invalid, zero, and negative values", () => {
+  for (const value of ["", "  ", "not-a-number", "0", "-1", "3600.5", "1e3"]) {
+    withEnv("OIDC_TTL_TEST_INVALID", value, () => {
+      assert.equal(
+        resolvePositiveIntegerSecondsEnv("OIDC_TTL_TEST_INVALID", 99),
+        99,
+        `expected fallback for ${JSON.stringify(value)}`,
+      );
+    });
+  }
+});
+
+test("access JWT defaults to 1 hour unless OIDC_ACCESS_TOKEN_TTL_SECONDS is set", () => {
+  withEnv(OIDC_ACCESS_TOKEN_TTL_ENV, undefined, () => {
+    assert.equal(
+      resolveOidcAccessTokenTtlSeconds(),
+      DEFAULT_OIDC_ACCESS_TOKEN_TTL_SECONDS,
+    );
+    assert.equal(resolveOidcAccessTokenTtlSeconds(), 3600);
+  });
+  withEnv(OIDC_ACCESS_TOKEN_TTL_ENV, "7200", () => {
+    assert.equal(resolveOidcAccessTokenTtlSeconds(), 7200);
+  });
+});
+
+test("refresh defaults to 90 days and can be set to 90 days via env", () => {
+  withEnv(OIDC_REFRESH_TOKEN_TTL_ENV, undefined, () => {
+    assert.equal(resolveOidcRefreshTokenTtlSeconds(), NINETY_DAYS);
+    assert.equal(
+      resolveOidcRefreshTokenTtlSeconds(),
+      DEFAULT_OIDC_REFRESH_TOKEN_TTL_SECONDS,
+    );
+  });
+  withEnv(OIDC_REFRESH_TOKEN_TTL_ENV, String(NINETY_DAYS), () => {
+    assert.equal(resolveOidcRefreshTokenTtlSeconds(), NINETY_DAYS);
+  });
+  withEnv(OIDC_REFRESH_TOKEN_TTL_ENV, String(THIRTY_DAYS), () => {
+    assert.equal(resolveOidcRefreshTokenTtlSeconds(), THIRTY_DAYS);
+  });
+});
+
+test("grant and session TTLs are at least as long as refresh", () => {
+  withEnv(OIDC_ACCESS_TOKEN_TTL_ENV, undefined, () => {
+    withEnv(OIDC_REFRESH_TOKEN_TTL_ENV, String(NINETY_DAYS), () => {
+      const ttls = resolveOidcProviderTtls();
+      assert.equal(ttls.accessToken, 3600);
+      assert.equal(ttls.refreshToken, NINETY_DAYS);
+      assert.ok(ttls.grant >= ttls.refreshToken);
+      assert.ok(ttls.session >= ttls.refreshToken);
+      assert.equal(ttls.grant, ttls.refreshToken);
+      assert.equal(ttls.session, ttls.refreshToken);
+    });
+  });
+});
+
+test("programmatic mint and signer JWTs stay on their own TTLs", async () => {
+  const { PROGRAMMATIC_ACCESS_TOKEN_TTL_SECONDS, PROGRAMMATIC_REFRESH_TOKEN_TTL_DAYS } =
+    await import("./programmatic-tokens");
+  const { SIGNER_JWT_TTL_SECONDS } = await import("./mint-user-signer-token");
+
+  withEnv(OIDC_ACCESS_TOKEN_TTL_ENV, "7200", () => {
+    withEnv(OIDC_REFRESH_TOKEN_TTL_ENV, String(NINETY_DAYS), () => {
+      const ttls = resolveOidcProviderTtls();
+      assert.equal(PROGRAMMATIC_ACCESS_TOKEN_TTL_SECONDS, 15 * 60);
+      assert.equal(PROGRAMMATIC_REFRESH_TOKEN_TTL_DAYS, 30);
+      assert.equal(SIGNER_JWT_TTL_SECONDS, 300);
+      assert.notEqual(PROGRAMMATIC_ACCESS_TOKEN_TTL_SECONDS, ttls.accessToken);
+      assert.notEqual(
+        PROGRAMMATIC_REFRESH_TOKEN_TTL_DAYS * 24 * 3600,
+        ttls.refreshToken,
+      );
+    });
+  });
+});

--- a/src/lib/oidc/ttl.ts
+++ b/src/lib/oidc/ttl.ts
@@ -1,0 +1,74 @@
+/**
+ * OIDC provider token TTLs (node-oidc-provider `ttl.*` and resource-indicator
+ * `accessTokenTTL`). Programmatic mint (`POST …/users/{eu}/token`) and signer
+ * session JWTs keep their own hardcoded lifetimes and must not read these env
+ * vars.
+ */
+
+export const OIDC_ACCESS_TOKEN_TTL_ENV = "OIDC_ACCESS_TOKEN_TTL_SECONDS";
+export const OIDC_REFRESH_TOKEN_TTL_ENV = "OIDC_REFRESH_TOKEN_TTL_SECONDS";
+
+/** Access JWT default: 1 hour. Keep short; clients refresh. */
+export const DEFAULT_OIDC_ACCESS_TOKEN_TTL_SECONDS = 3600;
+
+/**
+ * Refresh default: 90 days. Grant and Session follow this so a rotated refresh
+ * stays valid for the full window (they used to be 14 days while refresh was 30).
+ */
+export const DEFAULT_OIDC_REFRESH_TOKEN_TTL_SECONDS = 90 * 24 * 3600;
+
+export type OidcProviderTtls = {
+  accessToken: number;
+  refreshToken: number;
+  grant: number;
+  session: number;
+};
+
+/**
+ * Positive whole seconds from env, otherwise `fallback`. Invalid, zero, and
+ * negative values are ignored so a bad deploy cannot mint zero-lifetime tokens.
+ */
+export function resolvePositiveIntegerSecondsEnv(
+  name: string,
+  fallback: number,
+): number {
+  const raw = process.env[name]?.trim();
+  if (!raw || !/^[1-9]\d*$/.test(raw)) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export function resolveOidcAccessTokenTtlSeconds(): number {
+  return resolvePositiveIntegerSecondsEnv(
+    OIDC_ACCESS_TOKEN_TTL_ENV,
+    DEFAULT_OIDC_ACCESS_TOKEN_TTL_SECONDS,
+  );
+}
+
+export function resolveOidcRefreshTokenTtlSeconds(): number {
+  return resolvePositiveIntegerSecondsEnv(
+    OIDC_REFRESH_TOKEN_TTL_ENV,
+    DEFAULT_OIDC_REFRESH_TOKEN_TTL_SECONDS,
+  );
+}
+
+/**
+ * Access / refresh from env; Grant and Session are at least the refresh TTL so
+ * consent does not expire while a rotated refresh is still in the advertised
+ * window.
+ */
+export function resolveOidcProviderTtls(): OidcProviderTtls {
+  const accessToken = resolveOidcAccessTokenTtlSeconds();
+  const refreshToken = resolveOidcRefreshTokenTtlSeconds();
+  return {
+    accessToken,
+    refreshToken,
+    grant: refreshToken,
+    session: refreshToken,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #486

## Context

Claude Desktop and other MCP clients hold a PymtHouse OIDC user JWT plus a rotating refresh token after DCR. Access, refresh, grant, and session lifetimes were hardcoded in `src/lib/oidc/provider.ts` (1h / 30d / 14d / 14d). Grant was shorter than refresh, so a 90-day refresh would die at day 14.

## Changes

- **`OIDC_ACCESS_TOKEN_TTL_SECONDS`** — interactive access JWT (default **1 hour**). Also drives resource-indicator `accessTokenTTL`.
- **`OIDC_REFRESH_TOKEN_TTL_SECONDS`** — interactive refresh TTL (default **90 days**). `ttl.Grant` and `ttl.Session` follow this so a rotated refresh stays valid for the full window.
- Invalid / zero / negative env values fall back to the defaults.
- **Unchanged:** programmatic mint (`POST …/users/{eu}/token`) stays 15m access + 30d refresh. Signer session JWTs stay 5 minutes.

Documented in `.env.example`, `.env.vercel.template`, `docs/vercel-deployment.md`, `docs/builder-api.md`, and `docs/livepeer-mcp.md`.

## Acceptance

- [x] Access JWT still expires in 1 hour unless explicitly overridden
- [x] Refresh token defaults to 90 days (also settable via env)
- [x] Grant/session lifetime is at least as long as refresh
- [x] Signer JWTs unchanged (5 minutes)

## Local verification

- `npx tsc --noEmit` passed
- ESLint on changed OIDC files: no findings
- `src/lib/oidc/*.test.ts`: 183 passed, 22 skipped (DB-backed), 0 failed
- Snyk / SonarQube: no local CLI tokens in this environment; relying on PR checks

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31e1fae9-7181-43af-bad9-f69705f5d700?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31e1fae9-7181-43af-bad9-f69705f5d700&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

