### PR TITLE
feat(billing): view prior cycles and manage identity subscriptions

### DIFF
--- a/src/app/api/v1/billing/dashboard/route.ts
+++ b/src/app/api/v1/billing/dashboard/route.ts
@@ -5,13 +5,15 @@ import { getBillingUsageDashboardData } from "@/lib/billing-usage-dashboard-data
 
 /**
  * JSON billing/usage dashboard payload for the Usage page.
- * Query: appId (optional single app), scope=own|all (all = platform-wide for admins).
+ * Query: appId (optional single app), scope=own|all (all = platform-wide for admins),
+ * cycle=YYYY-MM (UTC month; omitted = current month).
  * Bigints are stringified for transport.
  */
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const appId = url.searchParams.get("appId");
   const scopeParam = url.searchParams.get("scope");
+  const cycleKey = url.searchParams.get("cycle");
 
   const session = await getServerSession(authOptions);
   const role = (session?.user as Record<string, unknown> | undefined)?.role as
@@ -22,6 +24,7 @@ export async function GET(request: NextRequest) {
 
   const result = await getBillingUsageDashboardData(appId || undefined, {
     ownAppsOnly: appId ? false : ownAppsOnly,
+    cycleKey,
   });
 
   if (!result.ok) {

--- a/src/app/apps/[id]/identities/[externalUserId]/page.tsx
+++ b/src/app/apps/[id]/identities/[externalUserId]/page.tsx
@@ -4,16 +4,19 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import AppSectionBreadcrumb from "@/components/apps/AppSectionBreadcrumb";
+import BillingCyclePicker from "@/components/billing/BillingCyclePicker";
+import IdentityBillingPanel from "@/components/identities/IdentityBillingPanel";
 import IdentityLifecycleActions from "@/components/identities/IdentityLifecycleActions";
 import IdentityRequestLog from "@/components/identities/IdentityRequestLog";
 import UsageBreakdownChart from "@/components/UsageBreakdownChart";
 import { formatBillableDuration } from "@/lib/billing-format";
-import { calendarMonthBoundsUtc, dateKeysInclusiveUtc } from "@/lib/billing-utils";
+import { dateKeysInclusiveUtc, resolveBillingCycle } from "@/lib/billing-utils";
 import {
   formatUsageJobTypeLabel,
   type BillingChartSeries,
 } from "@/lib/billing-usage-dashboard-data";
 import { formatUsdMicrosString } from "@/lib/format-usd-micros";
+import { getAppBillingConfig } from "@/lib/openmeter/billing-profiles";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
 import {
   canEditProviderApp,
@@ -79,8 +82,13 @@ function SummaryTile({
 
 export default async function AppIdentityDetailPage({
   params,
-}: Readonly<{ params: Promise<{ id: string; externalUserId: string }> }>) {
+  searchParams,
+}: Readonly<{
+  params: Promise<{ id: string; externalUserId: string }>;
+  searchParams: Promise<{ cycle?: string }>;
+}>) {
   const { id, externalUserId: rawExternalUserId } = await params;
+  const query = await searchParams;
   // Next.js already decodes dynamic segments — do not decodeURIComponent again.
   const externalUserId = rawExternalUserId.trim();
   if (!externalUserId) {
@@ -104,8 +112,12 @@ export default async function AppIdentityDetailPage({
 
   const canManage = await canEditProviderApp(providerAuth);
   const app = providerAuth.app;
-  const cycle = calendarMonthBoundsUtc(new Date());
+  const selectedCycle = resolveBillingCycle(query.cycle);
+  const cycle = { start: selectedCycle.start, end: selectedCycle.end };
   const openMeterConfigured = requireOpenMeterForUsageReads();
+  const billingConfig = await getAppBillingConfig(app.id).catch(() => null);
+  const billingMode =
+    billingConfig?.billingMode === "merchant" ? "merchant" : "owner_rollup";
 
   const [identities, dailyRows] = await Promise.all([
     openMeterConfigured
@@ -149,17 +161,25 @@ export default async function AppIdentityDetailPage({
       <AppSectionBreadcrumb
         appId={id}
         appName={app.name}
-        parentSection={{ label: "Identities", href: `/apps/${id}/identities` }}
+        parentSection={{
+          label: "Identities",
+          href: `/apps/${id}/identities${
+            selectedCycle.isCurrent ? "" : `?cycle=${selectedCycle.key}`
+          }`,
+        }}
         section="Identity"
       />
 
-      <div className="mb-6 sm:mb-8">
-        <h1 className="break-all font-mono text-lg font-bold text-zinc-100 sm:text-xl">
-          {externalUserId}
-        </h1>
-        <p className="mt-1 text-xs text-zinc-500 sm:text-sm">
-          Usage for this identity in the current billing cycle.
-        </p>
+      <div className="mb-6 flex flex-col gap-3 sm:mb-8 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="break-all font-mono text-lg font-bold text-zinc-100 sm:text-xl">
+            {externalUserId}
+          </h1>
+          <p className="mt-1 text-xs text-zinc-500 sm:text-sm">
+            Usage for this identity in the selected billing cycle.
+          </p>
+        </div>
+        <BillingCyclePicker />
       </div>
 
       <div className="mb-6 grid grid-cols-2 gap-3 sm:mb-8 sm:grid-cols-4">
@@ -195,6 +215,16 @@ export default async function AppIdentityDetailPage({
         </div>
       ) : null}
 
+      <div className="mb-6 sm:mb-8">
+        <IdentityBillingPanel
+          appId={id}
+          externalUserId={externalUserId}
+          billingMode={billingMode}
+          canManage={canManage}
+          cycle={cycle}
+        />
+      </div>
+
       {identity?.apiKey ? (
         <div className="mb-6 rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3 text-sm sm:mb-8">
           <span className="text-zinc-500">API key</span>
@@ -220,7 +250,7 @@ export default async function AppIdentityDetailPage({
         </p>
         {series.length === 0 ? (
           <p className="py-6 text-center text-sm text-zinc-500">
-            No metered usage for this identity in the current cycle.
+            No metered usage for this identity in this cycle.
           </p>
         ) : (
           <UsageBreakdownChart
@@ -233,7 +263,12 @@ export default async function AppIdentityDetailPage({
         )}
       </section>
 
-      <IdentityRequestLog appId={id} externalUserId={externalUserId} />
+      <IdentityRequestLog
+        appId={id}
+        externalUserId={externalUserId}
+        from={cycle.start}
+        to={cycle.end}
+      />
     </>
   );
 }

--- a/src/app/apps/[id]/identities/page.tsx
+++ b/src/app/apps/[id]/identities/page.tsx
@@ -4,16 +4,23 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import AppSectionBreadcrumb from "@/components/apps/AppSectionBreadcrumb";
+import BillingCyclePicker from "@/components/billing/BillingCyclePicker";
 import IdentitiesTable from "@/components/identities/IdentitiesTable";
-import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
+import { BILLING_CYCLE_PARAM, resolveBillingCycle } from "@/lib/billing-utils";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
 import { getAuthorizedProviderApp } from "@/lib/provider-apps";
 import { listAppIdentities } from "@/lib/usage/identity-rollup";
 
 export default async function AppIdentitiesPage({
   params,
-}: Readonly<{ params: Promise<{ id: string }> }>) {
+  searchParams,
+}: Readonly<{
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ cycle?: string }>;
+}>) {
   const { id } = await params;
+  const query = await searchParams;
+  const selectedCycle = resolveBillingCycle(query.cycle);
 
   let providerAuth: Awaited<ReturnType<typeof getAuthorizedProviderApp>> | null = null;
   try {
@@ -31,7 +38,7 @@ export default async function AppIdentitiesPage({
   }
 
   const app = providerAuth.app;
-  const cycle = calendarMonthBoundsUtc(new Date());
+  const cycle = { start: selectedCycle.start, end: selectedCycle.end };
   const openMeterConfigured = requireOpenMeterForUsageReads();
   const identities = openMeterConfigured
     ? await listAppIdentities({
@@ -57,20 +64,29 @@ export default async function AppIdentitiesPage({
           <h1 className="text-xl font-bold text-zinc-100 sm:text-2xl">Identities</h1>
           <p className="mt-1 text-xs text-zinc-500 sm:text-sm">
             Every M2M identity billed under this app, sorted by network fee for the
-            current cycle. Open an identity to deactivate or reactivate it — only
-            active identities count toward the end-user cap.
+            selected cycle. Open an identity to manage its account, subscription, and
+            discounts — only active identities count toward the end-user cap.
           </p>
         </div>
-        <Link
-          href={`/apps/${id}/usage`}
-          className="shrink-0 text-sm text-emerald-400 transition-colors hover:text-emerald-300"
-        >
-          View app usage →
-        </Link>
+        <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
+          <BillingCyclePicker />
+          <Link
+            href={`/apps/${id}/usage${
+              selectedCycle.isCurrent ? "" : `?${BILLING_CYCLE_PARAM}=${selectedCycle.key}`
+            }`}
+            className="text-sm text-emerald-400 transition-colors hover:text-emerald-300"
+          >
+            View app usage →
+          </Link>
+        </div>
       </div>
 
       {openMeterConfigured ? (
-        <IdentitiesTable appId={id} identities={identities} />
+        <IdentitiesTable
+          appId={id}
+          identities={identities}
+          cycleKey={selectedCycle.isCurrent ? null : selectedCycle.key}
+        />
       ) : (
         <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-5 text-sm text-zinc-500">
           Usage metering is not configured, so per-identity usage is unavailable.

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -22,10 +22,10 @@ function isTurnkeyFundingConfigured(): boolean {
 export default async function BillingPage({
   searchParams,
 }: Readonly<{
-  searchParams: Promise<{ pm?: string }>;
+  searchParams: Promise<{ pm?: string; cycle?: string }>;
 }>) {
   const params = await searchParams;
-  const result = await getOwnerBillingData();
+  const result = await getOwnerBillingData(undefined, { cycleKey: params.cycle });
   if (!result.ok) {
     if (result.reason === "no_session") {
       redirect("/login");

--- a/src/components/BillingUsageDashboard.helpers.tsx
+++ b/src/components/BillingUsageDashboard.helpers.tsx
@@ -82,8 +82,8 @@ export function BillingDashboardHeader({
             ) : null}
           </h1>
           <p className="text-xs sm:text-sm text-zinc-500 mt-1">
-            Usage and per-identity breakdown for this application in the current billing
-            cycle.
+            Usage and per-identity breakdown for this application in the selected
+            billing cycle.
           </p>
           {cycleLine}
         </div>
@@ -112,7 +112,8 @@ export function BillingDashboardHeader({
       <h1 className="text-xl sm:text-2xl font-bold text-zinc-100">Usage</h1>
       <p className="text-xs sm:text-sm text-zinc-500 mt-1">
         Applications are ordered by requests this billing cycle; apps owned by Test User appear
-        after all others, with per-user billing breakdowns.
+        after all others, with per-user billing breakdowns. Pick a prior month to review
+        closed cycles.
       </p>
       {cycleLine}
     </>

--- a/src/components/BillingUsageDashboard.tsx
+++ b/src/components/BillingUsageDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import DashboardLayout from "@/components/DashboardLayout";
 import AppFilterDropdown from "@/components/AppFilterDropdown";
@@ -10,6 +10,7 @@ import AllowanceProgressBar from "@/components/AllowanceProgressBar";
 import CostWaterfall from "@/components/billing/CostWaterfall";
 import UsageBreakdownChart from "@/components/UsageBreakdownChart";
 import SignedTicketRequestHistory from "@/components/SignedTicketRequestHistory";
+import BillingCyclePicker from "@/components/billing/BillingCyclePicker";
 import {
   AppUsageSection,
   BillingDashboardHeader,
@@ -22,6 +23,10 @@ import type {
 import { resolveOwnerBillingPressure } from "@/lib/billing/owner-billing-pressure";
 import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
 import type { OwnerBillingSubscriptionRow } from "@/lib/owner-billing-data";
+import {
+  BILLING_CYCLE_PARAM,
+  resolveBillingCycle,
+} from "@/lib/billing-utils";
 import {
   deriveFilteredView,
   type ChartDimension,
@@ -237,7 +242,7 @@ function chartEmptyMessage(selectedCount: number): string {
   if (selectedCount === 0) {
     return "Select at least one application to view the chart.";
   }
-  return "No usage in the current billing period yet.";
+  return "No usage in this billing period yet.";
 }
 
 function SignedTicketsBlock({
@@ -248,6 +253,7 @@ function SignedTicketsBlock({
   historyClientIds,
   historyIdentityIds,
   onClearIdentityFilter,
+  cycle,
 }: Readonly<{
   needsSelection: boolean;
   scope: "all" | "single";
@@ -258,6 +264,7 @@ function SignedTicketsBlock({
   /** Identity filter from the Identities dropdown; empty means all. */
   historyIdentityIds: string[];
   onClearIdentityFilter: () => void;
+  cycle: { start: string; end: string };
 }>) {
   if (needsSelection) {
     return (
@@ -277,6 +284,8 @@ function SignedTicketsBlock({
         historyScope={historyScope}
         externalUserIds={historyIdentityIds}
         onClearIdentityFilter={onClearIdentityFilter}
+        from={cycle.start}
+        to={cycle.end}
       />
     </div>
   );
@@ -384,7 +393,7 @@ function BillingPeriodPanel({
 }>) {
   const periodCopy =
     activeTab === "all" && showTabs
-      ? "Platform-wide usage for the current cycle."
+      ? "Platform-wide usage for the selected cycle."
       : "Usage for apps you own or administer.";
   const showMineSubscriptions = activeTab === "mine" || !showTabs;
 
@@ -392,7 +401,7 @@ function BillingPeriodPanel({
     <div className="mb-6 sm:mb-8 rounded-xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-sm p-5">
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h3 className="font-semibold text-zinc-100">This billing period</h3>
+          <h3 className="font-semibold text-zinc-100">Billing period</h3>
           <p className="text-xs text-zinc-500 mt-1">{periodCopy}</p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -561,6 +570,11 @@ function BillingUsageBody({
     allIdentityIds,
   );
 
+  const cycleKey = cycle.start.slice(0, 7);
+  const cycleQuery = resolveBillingCycle(cycleKey).isCurrent
+    ? ""
+    : `?${BILLING_CYCLE_PARAM}=${cycleKey}`;
+
   return (
     <>
       <div className="mb-6 sm:mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -571,16 +585,19 @@ function BillingUsageBody({
           isOpenMeter={isOpenMeter}
           appId={scope === "single" ? orderedApps[0]?.id : null}
         />
-        {showTabs ? (
-          <div className="flex shrink-0 items-center gap-1 self-start rounded-lg bg-black/20 p-0.5">
-            <TabLink active={activeTab === "mine"} href="/usage">
-              My Usage
-            </TabLink>
-            <TabLink active={activeTab === "all"} href="/usage/all">
-              All Usage
-            </TabLink>
-          </div>
-        ) : null}
+        <div className="flex shrink-0 flex-col items-start gap-3 sm:items-end">
+          {showTabs ? (
+            <div className="flex items-center gap-1 rounded-lg bg-black/20 p-0.5">
+              <TabLink active={activeTab === "mine"} href={`/usage${cycleQuery}`}>
+                My Usage
+              </TabLink>
+              <TabLink active={activeTab === "all"} href={`/usage/all${cycleQuery}`}>
+                All Usage
+              </TabLink>
+            </div>
+          ) : null}
+          <BillingCyclePicker />
+        </div>
       </div>
 
       <BillingPeriodPanel
@@ -607,6 +624,7 @@ function BillingUsageBody({
         historyClientIds={derived.historyClientIds}
         historyIdentityIds={derived.historyIdentityIds}
         onClearIdentityFilter={() => setSelectedIdentityIds(allIdentityIds)}
+        cycle={cycle}
       />
 
       <AppUsageList
@@ -640,6 +658,7 @@ export default function BillingUsageDashboard({
   const { data: session, status: authStatus } = useSession();
   const pathname = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const role = (session?.user as Record<string, unknown> | undefined)?.role as
     | string
     | undefined;
@@ -647,6 +666,7 @@ export default function BillingUsageDashboard({
   const showTabs = isAdmin && !filterAppId;
   const wantsAllUsage = !filterAppId && pathname.startsWith("/usage/all");
   const activeTab: UsageTab = showTabs && wantsAllUsage ? "all" : "mine";
+  const cycleKey = resolveBillingCycle(searchParams.get(BILLING_CYCLE_PARAM)).key;
 
   const [state, setState] = useState<LoadState>({ status: "loading" });
   const [retryToken, setRetryToken] = useState(0);
@@ -673,6 +693,10 @@ export default function BillingUsageDashboard({
         params.set("scope", "all");
       } else {
         params.set("scope", "own");
+      }
+      const selectedCycle = resolveBillingCycle(cycleKey);
+      if (!selectedCycle.isCurrent) {
+        params.set(BILLING_CYCLE_PARAM, selectedCycle.key);
       }
       const url = `/api/v1/billing/dashboard?${params.toString()}`;
 
@@ -709,25 +733,34 @@ export default function BillingUsageDashboard({
     return () => {
       cancelled = true;
     };
-  }, [filterAppId, activeTab, retryToken, showTabs]);
+  }, [filterAppId, activeTab, retryToken, showTabs, cycleKey]);
 
   const body = (
     <>
       {fundPanel}
       {state.status === "loading" ? (
         <>
-          {showTabs ? (
-            <div className="mb-4 flex justify-end">
+          <div className="mb-4 flex flex-col items-end gap-3">
+            {showTabs ? (
               <div className="flex shrink-0 items-center gap-1 rounded-lg bg-black/20 p-0.5">
-                <TabLink active={activeTab === "mine"} href="/usage">
+                <TabLink active={activeTab === "mine"} href={`/usage${
+                  resolveBillingCycle(cycleKey).isCurrent
+                    ? ""
+                    : `?${BILLING_CYCLE_PARAM}=${cycleKey}`
+                }`}>
                   My Usage
                 </TabLink>
-                <TabLink active={activeTab === "all"} href="/usage/all">
+                <TabLink active={activeTab === "all"} href={`/usage/all${
+                  resolveBillingCycle(cycleKey).isCurrent
+                    ? ""
+                    : `?${BILLING_CYCLE_PARAM}=${cycleKey}`
+                }`}>
                   All Usage
                 </TabLink>
               </div>
-            </div>
-          ) : null}
+            ) : null}
+            <BillingCyclePicker />
+          </div>
           <UsageLoadingShell
             filterAppId={filterAppId}
             showingAll={activeTab === "all"}

--- a/src/components/OwnerBillingView.tsx
+++ b/src/components/OwnerBillingView.tsx
@@ -12,6 +12,7 @@ import OwnerPaidUpgradePanel from "@/components/OwnerPaidUpgradeEffect";
 import OwnerPaymentMethodsCard from "@/components/OwnerPaymentMethodsCard";
 import OwnerResumePendingDowngradeButton from "@/components/OwnerResumePendingDowngradeButton";
 import CycleRange from "@/components/billing/CycleRange";
+import BillingCyclePicker from "@/components/billing/BillingCyclePicker";
 import { allocateCreditBalancesForSubscriptions } from "@/lib/billing/cost-waterfall";
 import {
   ownerCanChangePaidPlan,
@@ -25,6 +26,7 @@ import {
 } from "@/lib/billing/owner-billing-copy";
 import { resolveOwnerBillingPressure } from "@/lib/billing/owner-billing-pressure";
 import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
+import { BILLING_CYCLE_PARAM, resolveBillingCycle } from "@/lib/billing-utils";
 import { isOwnerPaidPlanKey } from "@/lib/openmeter/owner-paid-key";
 import type { CreditAllowanceSummary } from "@/lib/openmeter/credit-allowance-summary";
 import type { OwnerBillingPayload } from "@/lib/owner-billing-data";
@@ -456,6 +458,10 @@ export default function OwnerBillingView({
       isOwnerPaidPlanKey(row.openMeterPlanKey),
     )?.planName ??
     null;
+  const selectedCycle = resolveBillingCycle(data.cycle.start.slice(0, 7));
+  const usageHref = selectedCycle.isCurrent
+    ? "/usage"
+    : `/usage?${BILLING_CYCLE_PARAM}=${selectedCycle.key}`;
 
   return (
     <DashboardLayout>
@@ -470,16 +476,19 @@ export default function OwnerBillingView({
           })}
         </p>
         {data.openMeterConfigured ? (
-          <p className="mt-2 text-xs text-zinc-600">
-            Cycle: <CycleRange start={data.cycle.start} end={data.cycle.end} />
-            <span className="mx-2 text-zinc-700">·</span>
-            <Link
-              href="/usage"
-              className="text-emerald-400 hover:text-emerald-300 transition-colors"
-            >
-              View usage →
-            </Link>
-          </p>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+            <p className="text-xs text-zinc-600">
+              Cycle: <CycleRange start={data.cycle.start} end={data.cycle.end} />
+              <span className="mx-2 text-zinc-700">·</span>
+              <Link
+                href={usageHref}
+                className="text-emerald-400 hover:text-emerald-300 transition-colors"
+              >
+                View usage →
+              </Link>
+            </p>
+            <BillingCyclePicker />
+          </div>
         ) : (
           <p className="mt-2 text-sm text-amber-400/90">
             Usage metering is not configured — billing balances are unavailable.
@@ -539,11 +548,12 @@ export default function OwnerBillingView({
               invoices={data.invoices}
               stripeInvoices={data.stripeInvoices}
               invoicesDegraded={data.invoicesDegraded}
+              cycle={data.cycle}
             />
           </section>
 
           <section className="mt-8">
-            <TransactionsLedger entries={data.ledger} />
+            <TransactionsLedger entries={data.ledger} cycle={data.cycle} />
           </section>
         </>
       ) : null}

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -799,6 +799,8 @@ export default function SignedTicketRequestHistory({
   historyScope = "own",
   externalUserIds,
   onClearIdentityFilter,
+  from,
+  to,
 }: Readonly<{
   /** Public OIDC client_id when scoped to a single app. */
   clientId?: string | null;
@@ -813,7 +815,12 @@ export default function SignedTicketRequestHistory({
   externalUserIds?: string[] | null;
   /** Resets the page-level Identities filter from inside this panel. */
   onClearIdentityFilter?: () => void;
+  /** Optional cycle bounds (ISO). Seeds the date range and API window. */
+  from?: string | null;
+  to?: string | null;
 }>) {
+  const cycleFromKey = from?.slice(0, 10) ?? "";
+  const cycleToKey = to?.slice(0, 10) ?? "";
   const [viewMode, setViewMode] = useState<ViewMode>("session");
   const [sessions, setSessions] = useState<SignedTicketSessionRow[]>([]);
   const [requests, setRequests] = useState<SignedTicketRequestRow[]>([]);
@@ -822,8 +829,17 @@ export default function SignedTicketRequestHistory({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [fromDate, setFromDate] = useState("");
-  const [toDate, setToDate] = useState("");
+  const [fromDate, setFromDate] = useState(cycleFromKey);
+  const [toDate, setToDate] = useState(cycleToKey);
+  const [prevCycleRange, setPrevCycleRange] = useState(
+    `${cycleFromKey}\0${cycleToKey}`,
+  );
+  const cycleRangeKey = `${cycleFromKey}\0${cycleToKey}`;
+  if (prevCycleRange !== cycleRangeKey) {
+    setPrevCycleRange(cycleRangeKey);
+    setFromDate(cycleFromKey);
+    setToDate(cycleToKey);
+  }
 
   const resolvedIdentityIds = useMemo(
     () =>
@@ -860,8 +876,11 @@ export default function SignedTicketRequestHistory({
         params.set("cursor", cursor);
       }
       if (fromDate && toDate) {
-        params.set("from", fromDate);
-        params.set("to", toDate);
+        params.set(
+          "from",
+          from && fromDate === cycleFromKey ? from : fromDate,
+        );
+        params.set("to", to && toDate === cycleToKey ? to : toDate);
       }
       for (const id of resolvedClientIds) {
         params.append("clientId", id);
@@ -891,7 +910,7 @@ export default function SignedTicketRequestHistory({
         mode,
       };
     },
-    [resolvedClientIds, resolvedIdentityIds, historyScope, fromDate, toDate],
+    [resolvedClientIds, resolvedIdentityIds, historyScope, fromDate, toDate, from, to, cycleFromKey, cycleToKey],
   );
 
   useEffect(() => {

--- a/src/components/billing/BillingCyclePicker.tsx
+++ b/src/components/billing/BillingCyclePicker.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import {
+  BILLING_CYCLE_PARAM,
+  billingCycleSelectOptions,
+  formatBillingCycleMonthLabel,
+  resolveBillingCycle,
+} from "@/lib/billing-utils";
+
+/**
+ * UTC month selector persisted in `?cycle=YYYY-MM`.
+ * The current month omits the query param so existing bookmarks stay current.
+ */
+export default function BillingCyclePicker({
+  className,
+}: Readonly<{ className?: string }>) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const selected = resolveBillingCycle(searchParams.get(BILLING_CYCLE_PARAM));
+  const options = billingCycleSelectOptions({ selectedKey: selected.key });
+  const selectedIndex = options.findIndex((option) => option.key === selected.key);
+  const newer = selectedIndex > 0 ? options[selectedIndex - 1] : null;
+  const older =
+    selectedIndex >= 0 && selectedIndex < options.length - 1
+      ? options[selectedIndex + 1]
+      : null;
+
+  function navigateTo(key: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    const next = resolveBillingCycle(key);
+    if (next.isCurrent) {
+      params.delete(BILLING_CYCLE_PARAM);
+    } else {
+      params.set(BILLING_CYCLE_PARAM, next.key);
+    }
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname);
+  }
+
+  return (
+    <div className={`flex flex-wrap items-center gap-1.5 ${className ?? ""}`}>
+      <span className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+        Cycle
+      </span>
+      <button
+        type="button"
+        disabled={!older}
+        onClick={() => older && navigateTo(older.key)}
+        aria-label="Previous billing cycle"
+        className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-300 transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30"
+      >
+        ←
+      </button>
+      <label className="sr-only" htmlFor="billing-cycle-select">
+        Billing cycle
+      </label>
+      <select
+        id="billing-cycle-select"
+        value={selected.key}
+        onChange={(event) => navigateTo(event.target.value)}
+        className="max-w-[11rem] rounded-md border border-white/10 bg-black/40 px-2 py-1 text-xs font-medium text-zinc-100"
+      >
+        {options.map((option) => (
+          <option key={option.key} value={option.key}>
+            {option.isCurrent ? `${option.label} (current)` : option.label}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        disabled={!newer}
+        onClick={() => newer && navigateTo(newer.key)}
+        aria-label="Next billing cycle"
+        className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-300 transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30"
+      >
+        →
+      </button>
+      {selected.isCurrent ? null : (
+        <span className="text-[11px] text-zinc-500">
+          {formatBillingCycleMonthLabel(selected.key)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/billing/BillingCyclePicker.tsx
+++ b/src/components/billing/BillingCyclePicker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense, useId } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import {
@@ -9,16 +10,22 @@ import {
   resolveBillingCycle,
 } from "@/lib/billing-utils";
 
-/**
- * UTC month selector persisted in `?cycle=YYYY-MM`.
- * The current month omits the query param so existing bookmarks stay current.
- */
-export default function BillingCyclePicker({
+function BillingCyclePickerFallback({ className }: Readonly<{ className?: string }>) {
+  return (
+    <div
+      className={`h-7 w-52 animate-pulse rounded-md bg-white/5 ${className ?? ""}`}
+      aria-hidden
+    />
+  );
+}
+
+function BillingCyclePickerInner({
   className,
 }: Readonly<{ className?: string }>) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const selectId = useId();
   const selected = resolveBillingCycle(searchParams.get(BILLING_CYCLE_PARAM));
   const options = billingCycleSelectOptions({ selectedKey: selected.key });
   const selectedIndex = options.findIndex((option) => option.key === selected.key);
@@ -54,11 +61,11 @@ export default function BillingCyclePicker({
       >
         ←
       </button>
-      <label className="sr-only" htmlFor="billing-cycle-select">
+      <label className="sr-only" htmlFor={selectId}>
         Billing cycle
       </label>
       <select
-        id="billing-cycle-select"
+        id={selectId}
         value={selected.key}
         onChange={(event) => navigateTo(event.target.value)}
         className="max-w-[11rem] rounded-md border border-white/10 bg-black/40 px-2 py-1 text-xs font-medium text-zinc-100"
@@ -84,5 +91,19 @@ export default function BillingCyclePicker({
         </span>
       )}
     </div>
+  );
+}
+
+/**
+ * UTC month selector persisted in `?cycle=YYYY-MM`.
+ * The current month omits the query param so existing bookmarks stay current.
+ */
+export default function BillingCyclePicker({
+  className,
+}: Readonly<{ className?: string }>) {
+  return (
+    <Suspense fallback={<BillingCyclePickerFallback className={className} />}>
+      <BillingCyclePickerInner className={className} />
+    </Suspense>
   );
 }

--- a/src/components/billing/PlatformInvoicesTable.tsx
+++ b/src/components/billing/PlatformInvoicesTable.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/billing/platform-invoice-rows";
 import { formatInvoicePeriodLabel } from "@/lib/billing/transactions-ledger";
 import { formatBillingUtcDate } from "@/lib/billing-format";
+import { invoiceOverlapsCycle, resolveBillingCycle } from "@/lib/billing-utils";
 import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
 import type { TenantInvoiceDto } from "@/lib/openmeter/invoices";
 import type { OwnerStripeInvoiceItem } from "@/lib/stripe/owner-platform-invoices";
@@ -172,14 +173,30 @@ export default function PlatformInvoicesTable({
   invoices,
   stripeInvoices = [],
   invoicesDegraded = false,
+  cycle,
 }: Readonly<{
   invoices: TenantInvoiceDto[];
   stripeInvoices?: OwnerStripeInvoiceItem[];
   invoicesDegraded?: boolean;
+  /** When set, past months default to invoices that overlap this cycle. */
+  cycle?: { start: string; end: string };
 }>) {
+  const selectedCycle = cycle
+    ? resolveBillingCycle(cycle.start.slice(0, 7))
+    : null;
   const [showZero, setShowZero] = useState(false);
   const [visible, setVisible] = useState(PAGE_SIZE);
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [cycleOnly, setCycleOnly] = useState(
+    Boolean(selectedCycle && !selectedCycle.isCurrent),
+  );
+  const [prevCycleKey, setPrevCycleKey] = useState(selectedCycle?.key ?? "");
+  const nextCycleKey = selectedCycle?.key ?? "";
+  if (prevCycleKey !== nextCycleKey) {
+    setPrevCycleKey(nextCycleKey);
+    setCycleOnly(Boolean(selectedCycle && !selectedCycle.isCurrent));
+    setVisible(PAGE_SIZE);
+  }
 
   const merged = useMemo(
     () => mergePlatformInvoiceRows(invoices, stripeInvoices),
@@ -191,8 +208,14 @@ export default function PlatformInvoicesTable({
     [merged],
   );
   const filtered = useMemo(
-    () => (showZero ? merged : merged.filter((inv) => !isZeroInvoice(inv))),
-    [merged, showZero],
+    () => {
+      const withoutZero = showZero
+        ? merged
+        : merged.filter((inv) => !isZeroInvoice(inv));
+      if (!cycleOnly || !cycle) return withoutZero;
+      return withoutZero.filter((inv) => invoiceOverlapsCycle(inv, cycle));
+    },
+    [merged, showZero, cycleOnly, cycle],
   );
   const page = filtered.slice(0, visible);
 
@@ -214,24 +237,44 @@ export default function PlatformInvoicesTable({
           including Stripe receipts when available.
         </p>
       ) : null}
-      {zeroCount > 0 ? (
-        <label className="mb-3 flex items-center gap-2 text-xs text-zinc-500">
-          <input
-            type="checkbox"
-            checked={showZero}
-            onChange={(e) => {
-              setShowZero(e.target.checked);
-              setVisible(PAGE_SIZE);
-            }}
-            className="h-3.5 w-3.5 rounded border-zinc-700 bg-black/20"
-          />
-          Show $0 invoices ({zeroCount})
-        </label>
+      {zeroCount > 0 || (selectedCycle && !selectedCycle.isCurrent) ? (
+        <div className="mb-3 flex flex-wrap items-center gap-4">
+          {zeroCount > 0 ? (
+            <label className="flex items-center gap-2 text-xs text-zinc-500">
+              <input
+                type="checkbox"
+                checked={showZero}
+                onChange={(e) => {
+                  setShowZero(e.target.checked);
+                  setVisible(PAGE_SIZE);
+                }}
+                className="h-3.5 w-3.5 rounded border-zinc-700 bg-black/20"
+              />
+              Show $0 invoices ({zeroCount})
+            </label>
+          ) : null}
+          {selectedCycle && !selectedCycle.isCurrent ? (
+            <label className="flex items-center gap-2 text-xs text-zinc-500">
+              <input
+                type="checkbox"
+                checked={cycleOnly}
+                onChange={(e) => {
+                  setCycleOnly(e.target.checked);
+                  setVisible(PAGE_SIZE);
+                }}
+                className="h-3.5 w-3.5 rounded border-zinc-700 bg-black/20"
+              />
+              This cycle only
+            </label>
+          ) : null}
+        </div>
       ) : null}
 
       {filtered.length === 0 ? (
         <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-5 text-sm text-zinc-500">
-          No invoices with charges yet.
+          {cycleOnly
+            ? "No invoices overlap this billing cycle."
+            : "No invoices with charges yet."}
         </div>
       ) : (
         <div className="overflow-x-auto rounded-xl border border-white/[0.06] bg-white/[0.02]">

--- a/src/components/billing/TransactionsLedger.tsx
+++ b/src/components/billing/TransactionsLedger.tsx
@@ -8,6 +8,7 @@ import {
   type LedgerEntryType,
 } from "@/lib/billing/transactions-ledger";
 import { formatBillingUtcDate } from "@/lib/billing-format";
+import { resolveBillingCycle } from "@/lib/billing-utils";
 import {
   formatUsdMicrosExactTitle,
   formatUsdMicrosSummary,
@@ -119,11 +120,32 @@ function LedgerInvoiceDescription({ entry }: Readonly<{ entry: LedgerEntry }>) {
  */
 export default function TransactionsLedger({
   entries,
-}: Readonly<{ entries: LedgerEntry[] }>) {
+  cycle,
+}: Readonly<{
+  entries: LedgerEntry[];
+  cycle?: { start: string; end: string };
+}>) {
+  const selectedCycle = cycle
+    ? resolveBillingCycle(cycle.start.slice(0, 7))
+    : null;
+  const cycleFrom = selectedCycle && !selectedCycle.isCurrent
+    ? selectedCycle.start.slice(0, 10)
+    : "";
+  const cycleTo = selectedCycle && !selectedCycle.isCurrent
+    ? selectedCycle.end.slice(0, 10)
+    : "";
   const [typeFilter, setTypeFilter] = useState<LedgerEntryType | "all">("all");
-  const [from, setFrom] = useState("");
-  const [to, setTo] = useState("");
+  const [from, setFrom] = useState(cycleFrom);
+  const [to, setTo] = useState(cycleTo);
   const [visible, setVisible] = useState(PAGE_SIZE);
+  const cycleBoundKey = `${cycleFrom}\0${cycleTo}`;
+  const [prevCycleBoundKey, setPrevCycleBoundKey] = useState(cycleBoundKey);
+  if (prevCycleBoundKey !== cycleBoundKey) {
+    setPrevCycleBoundKey(cycleBoundKey);
+    setFrom(cycleFrom);
+    setTo(cycleTo);
+    setVisible(PAGE_SIZE);
+  }
 
   const filtered = useMemo(
     () =>
@@ -286,7 +308,7 @@ export default function TransactionsLedger({
 
       {hasDerived ? (
         <p className="mt-2 text-[11px] text-zinc-600">
-          Usage rows are derived from metered spend for the current cycle and settle
+          Usage rows are derived from metered spend for the selected cycle and settle
           against the plan allowance before prepaid credits.
         </p>
       ) : null}

--- a/src/components/identities/IdentitiesTable.tsx
+++ b/src/components/identities/IdentitiesTable.tsx
@@ -122,9 +122,17 @@ function IdentityApiKeyCell({
 export default function IdentitiesTable({
   appId,
   identities,
-}: Readonly<{ appId: string; identities: AppIdentityRow[] }>) {
+  cycleKey,
+}: Readonly<{
+  appId: string;
+  identities: AppIdentityRow[];
+  /** UTC `YYYY-MM` when viewing a prior cycle; omitted for the current month. */
+  cycleKey?: string | null;
+}>) {
   const [sortKey, setSortKey] = useState<SortKey>(DEFAULT_SORT);
   const sorted = useMemo(() => sortIdentities(identities, sortKey), [identities, sortKey]);
+  const cycleQuery =
+    cycleKey && cycleKey.trim() ? `?cycle=${encodeURIComponent(cycleKey)}` : "";
 
   if (identities.length === 0) {
     return (
@@ -180,7 +188,7 @@ export default function IdentitiesTable({
             >
               <td className="px-4 py-3 sm:px-5">
                 <Link
-                  href={`/apps/${appId}/identities/${encodeURIComponent(row.externalUserId)}`}
+                  href={`/apps/${appId}/identities/${encodeURIComponent(row.externalUserId)}${cycleQuery}`}
                   className="font-mono text-xs text-zinc-200 hover:text-emerald-400 transition-colors"
                   title={row.externalUserId}
                 >

--- a/src/components/identities/IdentityBillingPanel.tsx
+++ b/src/components/identities/IdentityBillingPanel.tsx
@@ -1,0 +1,550 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { formatUsdMicrosSummary } from "@/lib/format-usd-micros";
+import { formatBillingUtcDate } from "@/lib/billing-format";
+import { invoiceOverlapsCycle } from "@/lib/billing-utils";
+
+type BillingMode = "owner_rollup" | "merchant";
+
+type IncludedUsage = {
+  usdMicros: string;
+  usd: string;
+} | null;
+
+type PlanSurface = {
+  id: string | null;
+  name: string | null;
+  type: string | null;
+  includedUsage: IncludedUsage;
+  effectiveAt: string | null;
+};
+
+type PendingCancel = {
+  subscriptionId: string;
+  planName: string | null;
+  effectiveAt: string | null;
+} | null;
+
+type SubscriptionPayload = {
+  externalUserId: string;
+  subscription: {
+    id: string;
+    status: string;
+    planId: string | null;
+    planName: string | null;
+    planType: string | null;
+    currentPeriodStart: string | null;
+    currentPeriodEnd: string | null;
+  } | null;
+  pendingCancel: PendingCancel;
+  livePlan: PlanSurface | null;
+  pendingPlan: PlanSurface | null;
+};
+
+type CatalogPlan = {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+  priceAmount: string;
+  priceCurrency: string;
+  includedUsdMicros: string | null;
+  isStarterDefault?: boolean;
+};
+
+type InvoiceItem = {
+  id: string;
+  number?: string;
+  status: string;
+  currency?: string;
+  totalAmount: string;
+  issuedAt?: string;
+  periodStart?: string;
+  periodEnd?: string;
+  invoiceType?: string;
+};
+
+type AllowancePayload = {
+  live?: string;
+  settled?: string;
+  currency?: string;
+};
+
+function includedLabel(included: IncludedUsage | string | null | undefined): string | null {
+  if (!included) return null;
+  if (typeof included === "string") {
+    return formatUsdMicrosSummary(included);
+  }
+  if (!included.usdMicros) return null;
+  return formatUsdMicrosSummary(included.usdMicros);
+}
+
+function planPriceLabel(plan: CatalogPlan): string {
+  const amount = plan.priceAmount?.trim() || "0";
+  const currency = (plan.priceCurrency || "USD").toUpperCase();
+  if (plan.type === "free" || plan.isStarterDefault || amount === "0" || amount === "0.00") {
+    return "Free";
+  }
+  return currency === "USD" ? `$${amount}` : `${amount} ${currency}`;
+}
+
+/**
+ * Merchant-mode identity billing: current plan, included usage discount,
+ * plan change / cancel, prepaid balance, and invoice history.
+ */
+export default function IdentityBillingPanel({
+  appId,
+  externalUserId,
+  billingMode,
+  canManage,
+  cycle,
+}: Readonly<{
+  appId: string;
+  externalUserId: string;
+  billingMode: BillingMode;
+  canManage: boolean;
+  cycle: { start: string; end: string };
+}>) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [subscription, setSubscription] = useState<SubscriptionPayload | null>(null);
+  const [plans, setPlans] = useState<CatalogPlan[]>([]);
+  const [invoices, setInvoices] = useState<InvoiceItem[]>([]);
+  const [allowance, setAllowance] = useState<AllowancePayload | null>(null);
+  const [selectedPlanId, setSelectedPlanId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [cycleOnly, setCycleOnly] = useState(true);
+
+  const base = `/api/v1/apps/${encodeURIComponent(appId)}/users/${encodeURIComponent(externalUserId)}`;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [subRes, plansRes, invoicesRes, allowanceRes] = await Promise.all([
+        fetch(`${base}/subscription`, { credentials: "same-origin" }),
+        fetch(`/api/v1/apps/${encodeURIComponent(appId)}/plans`, {
+          credentials: "same-origin",
+        }),
+        fetch(`${base}/invoices?page=1&pageSize=50`, { credentials: "same-origin" }),
+        fetch(`${base}/allowances`, { credentials: "same-origin" }),
+      ]);
+
+      const subBody = (await subRes.json().catch(() => null)) as
+        | SubscriptionPayload
+        | { error?: string }
+        | null;
+      if (!subRes.ok) {
+        throw new Error(
+          (subBody && "error" in subBody && subBody.error) ||
+            `Subscription lookup failed (${subRes.status})`,
+        );
+      }
+      setSubscription(subBody as SubscriptionPayload);
+
+      const plansBody = (await plansRes.json().catch(() => null)) as {
+        plans?: CatalogPlan[];
+      } | null;
+      const catalog = (plansBody?.plans ?? []).filter(
+        (plan) => plan.status === "active" || plan.status === "phase_out",
+      );
+      setPlans(catalog);
+
+      const invoicesBody = (await invoicesRes.json().catch(() => null)) as {
+        items?: InvoiceItem[];
+      } | null;
+      setInvoices(invoicesBody?.items ?? []);
+
+      if (allowanceRes.ok) {
+        setAllowance((await allowanceRes.json()) as AllowancePayload);
+      } else {
+        setAllowance(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load billing");
+    } finally {
+      setLoading(false);
+    }
+  }, [appId, base]);
+
+  useEffect(() => {
+    if (billingMode === "owner_rollup") {
+      setLoading(false);
+      return;
+    }
+    void load();
+  }, [billingMode, load]);
+
+  const livePlanId = subscription?.livePlan?.id ?? subscription?.subscription?.planId ?? "";
+  useEffect(() => {
+    if (!selectedPlanId && livePlanId) {
+      setSelectedPlanId(livePlanId);
+    }
+  }, [livePlanId, selectedPlanId]);
+
+  const selectablePlans = useMemo(
+    () => plans.filter((plan) => plan.status === "active"),
+    [plans],
+  );
+
+  const visibleInvoices = useMemo(
+    () =>
+      cycleOnly
+        ? invoices.filter((invoice) => invoiceOverlapsCycle(invoice, cycle))
+        : invoices,
+    [invoices, cycle, cycleOnly],
+  );
+
+  async function readError(res: Response): Promise<string> {
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+      detail?: string;
+      title?: string;
+    } | null;
+    return body?.detail || body?.title || body?.error || `HTTP ${res.status}`;
+  }
+
+  async function changePlan() {
+    if (!selectedPlanId || selectedPlanId === livePlanId) return;
+    setBusy(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`${base}/subscription/change`, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          planId: selectedPlanId,
+          successUrl: globalThis.location.href,
+          cancelUrl: globalThis.location.href,
+        }),
+      });
+      const body = (await res.json().catch(() => null)) as {
+        checkoutUrl?: string;
+        subscriptionId?: string;
+        error?: string;
+      } | null;
+      if (!res.ok) {
+        throw new Error(body?.error || `HTTP ${res.status}`);
+      }
+      if (body?.checkoutUrl && !body.subscriptionId) {
+        globalThis.location.href = body.checkoutUrl;
+        return;
+      }
+      await load();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Plan change failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function cancelSubscription() {
+    setBusy(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`${base}/subscription`, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: true }),
+      });
+      if (!res.ok) throw new Error(await readError(res));
+      await load();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Cancel failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function resumeSubscription() {
+    setBusy(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`${base}/subscription/pending-change`, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: true }),
+      });
+      if (!res.ok) throw new Error(await readError(res));
+      await load();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Resume failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function openInvoice(invoiceId: string) {
+    const res = await fetch(`${base}/invoices/${encodeURIComponent(invoiceId)}/hosted-url`, {
+      credentials: "same-origin",
+    });
+    const body = (await res.json().catch(() => null)) as {
+      hostedInvoiceUrl?: string | null;
+      invoicePdf?: string | null;
+      error?: string;
+    } | null;
+    const url = body?.hostedInvoiceUrl || body?.invoicePdf;
+    if (!res.ok || !url) return;
+    globalThis.open(url, "_blank", "noopener,noreferrer");
+  }
+
+  if (billingMode === "owner_rollup") {
+    return (
+      <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4 sm:px-5">
+        <h2 className="text-sm font-semibold text-zinc-200">Subscription &amp; billing</h2>
+        <p className="mt-1 text-xs text-zinc-500">
+          This identity rolls up to your platform wallet. Network usage is billed on
+          your owner plan, not as a separate M2M customer.
+        </p>
+        <Link
+          href="/billing"
+          className="mt-3 inline-block text-sm text-emerald-400 transition-colors hover:text-emerald-300"
+        >
+          Open Billing →
+        </Link>
+      </section>
+    );
+  }
+
+  if (loading) {
+    return (
+      <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4 sm:px-5">
+        <h2 className="text-sm font-semibold text-zinc-200">Subscription &amp; billing</h2>
+        <div className="mt-3 animate-pulse space-y-2">
+          <div className="h-4 w-48 rounded bg-zinc-800" />
+          <div className="h-4 w-32 rounded bg-zinc-800" />
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4 sm:px-5">
+        <h2 className="text-sm font-semibold text-zinc-200">Subscription &amp; billing</h2>
+        <p className="mt-2 text-sm text-red-400">{error}</p>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="mt-3 text-sm text-emerald-400 hover:text-emerald-300"
+        >
+          Retry
+        </button>
+      </section>
+    );
+  }
+
+  const live = subscription?.livePlan;
+  const pending = subscription?.pendingPlan;
+  const pendingCancel = subscription?.pendingCancel;
+  const discount = includedLabel(live?.includedUsage);
+  const prepaid = allowance?.live ?? allowance?.settled ?? null;
+
+  return (
+    <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4 sm:px-5">
+      <h2 className="text-sm font-semibold text-zinc-200">Subscription &amp; billing</h2>
+      <p className="mt-1 text-xs text-zinc-500">
+        Merchant customer for this M2M identity — plan, included usage discount, and
+        payment history.
+      </p>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <div className="rounded-lg border border-white/[0.05] bg-black/20 px-3 py-3">
+          <p className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-zinc-500">
+            Plan
+          </p>
+          <p className="mt-1 text-sm text-zinc-100">
+            {live?.name || subscription?.subscription?.planName || "None"}
+          </p>
+          <p className="mt-0.5 text-[11px] uppercase tracking-wider text-zinc-500">
+            {subscription?.subscription?.status || "unsubscribed"}
+          </p>
+        </div>
+        <div className="rounded-lg border border-white/[0.05] bg-black/20 px-3 py-3">
+          <p className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-zinc-500">
+            Included usage
+          </p>
+          <p className="mt-1 font-mono text-sm tabular-nums text-zinc-100">
+            {discount ?? "None"}
+          </p>
+          <p className="mt-0.5 text-[11px] text-zinc-500">Per billing cycle discount</p>
+        </div>
+        <div className="rounded-lg border border-white/[0.05] bg-black/20 px-3 py-3">
+          <p className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-zinc-500">
+            Prepaid credits
+          </p>
+          <p className="mt-1 font-mono text-sm tabular-nums text-zinc-100">
+            {prepaid != null && prepaid !== ""
+              ? prepaid.startsWith("$")
+                ? prepaid
+                : `$${prepaid}`
+              : "—"}
+          </p>
+        </div>
+      </div>
+
+      {pending ? (
+        <p className="mt-3 text-xs text-amber-200/90">
+          Scheduled: {pending.name || "new plan"}
+          {pending.effectiveAt
+            ? ` on ${formatBillingUtcDate(pending.effectiveAt, { year: "numeric" })}`
+            : " at the end of this cycle"}
+          {pending.includedUsage
+            ? ` · ${includedLabel(pending.includedUsage)} included`
+            : ""}
+        </p>
+      ) : null}
+
+      {pendingCancel ? (
+        <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-3">
+          <p className="text-sm text-amber-100">
+            Cancel scheduled
+            {pendingCancel.effectiveAt
+              ? ` for ${formatBillingUtcDate(pendingCancel.effectiveAt, { year: "numeric" })}`
+              : " at period end"}
+            {pendingCancel.planName ? ` · ${pendingCancel.planName}` : ""}
+          </p>
+          {canManage ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void resumeSubscription()}
+              className="mt-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-1.5 text-sm font-medium text-emerald-300 hover:bg-emerald-500/20 disabled:opacity-40"
+            >
+              {busy ? "Working…" : "Keep current plan"}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {canManage && selectablePlans.length > 0 ? (
+        <div className="mt-4 rounded-lg border border-white/[0.05] bg-black/10 px-3 py-3">
+          <p className="text-xs font-medium text-zinc-300">Change plan</p>
+          <p className="mt-0.5 text-[11px] text-zinc-500">
+            Switching plans updates this customer&apos;s included usage discount.
+            Paid upgrades may send the customer through checkout.
+          </p>
+          <div className="mt-3 flex flex-wrap items-end gap-2">
+            <label className="min-w-[12rem] flex-1 text-xs text-zinc-500">
+              Plan
+              <select
+                value={selectedPlanId}
+                onChange={(event) => setSelectedPlanId(event.target.value)}
+                className="mt-1 w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-sm text-zinc-100"
+              >
+                {selectablePlans.map((plan) => (
+                  <option key={plan.id} value={plan.id}>
+                    {plan.name} · {planPriceLabel(plan)}
+                    {plan.includedUsdMicros
+                      ? ` · ${formatUsdMicrosSummary(plan.includedUsdMicros)} included`
+                      : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              disabled={busy || !selectedPlanId || selectedPlanId === livePlanId}
+              onClick={() => void changePlan()}
+              className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-1.5 text-sm font-medium text-emerald-300 hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {busy ? "Updating…" : "Apply plan"}
+            </button>
+            {subscription?.subscription && !pendingCancel ? (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void cancelSubscription()}
+                className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-300 hover:bg-red-500/20 disabled:opacity-40"
+              >
+                Cancel at period end
+              </button>
+            ) : null}
+          </div>
+          {actionError ? (
+            <p className="mt-2 text-xs text-red-400">{actionError}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="mt-5">
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+            Payment history
+          </h3>
+          <label className="flex items-center gap-2 text-[11px] text-zinc-500">
+            <input
+              type="checkbox"
+              checked={cycleOnly}
+              onChange={(event) => setCycleOnly(event.target.checked)}
+              className="h-3.5 w-3.5 rounded border-zinc-700 bg-black/20"
+            />
+            This cycle only
+          </label>
+        </div>
+        {visibleInvoices.length === 0 ? (
+          <p className="rounded-lg border border-white/[0.04] px-3 py-4 text-sm text-zinc-500">
+            {invoices.length === 0
+              ? "No invoices or payments for this identity yet."
+              : "No invoices overlap this billing cycle."}
+          </p>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-white/[0.06]">
+            <table className="w-full min-w-[32rem] text-sm">
+              <thead>
+                <tr className="border-b border-white/[0.06] text-[10px] uppercase tracking-wider text-zinc-500">
+                  <th className="px-3 py-2 text-left font-medium">Invoice</th>
+                  <th className="px-3 py-2 text-left font-medium">Issued</th>
+                  <th className="px-3 py-2 text-right font-medium">Amount</th>
+                  <th className="px-3 py-2 text-left font-medium">Status</th>
+                  <th className="px-3 py-2 text-right font-medium"> </th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleInvoices.map((invoice) => (
+                  <tr
+                    key={invoice.id}
+                    className="border-b border-white/[0.04] last:border-b-0"
+                  >
+                    <td className="px-3 py-2 font-mono text-xs text-zinc-300">
+                      {invoice.number || invoice.id}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-zinc-400">
+                      {invoice.issuedAt
+                        ? formatBillingUtcDate(invoice.issuedAt, { year: "numeric" })
+                        : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-xs text-zinc-200">
+                      {invoice.currency?.toUpperCase() === "USD" || !invoice.currency
+                        ? `$${invoice.totalAmount}`
+                        : `${invoice.totalAmount} ${invoice.currency}`}
+                    </td>
+                    <td className="px-3 py-2 text-[11px] uppercase tracking-wider text-zinc-500">
+                      {invoice.status}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => void openInvoice(invoice.id)}
+                        className="text-xs text-emerald-400 hover:text-emerald-300"
+                      >
+                        View
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/identities/IdentityRequestLog.tsx
+++ b/src/components/identities/IdentityRequestLog.tsx
@@ -20,7 +20,14 @@ type RequestsResponse = {
 export default function IdentityRequestLog({
   appId,
   externalUserId,
-}: Readonly<{ appId: string; externalUserId: string }>) {
+  from,
+  to,
+}: Readonly<{
+  appId: string;
+  externalUserId: string;
+  from?: string | null;
+  to?: string | null;
+}>) {
   const [items, setItems] = useState<SignedTicketRequestRow[]>([]);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [openMeterConfigured, setOpenMeterConfigured] = useState(true);
@@ -35,6 +42,8 @@ export default function IdentityRequestLog({
       const params = new URLSearchParams();
       params.set("limit", "25");
       if (cursor) params.set("cursor", cursor);
+      if (from) params.set("from", from);
+      if (to) params.set("to", to);
 
       const res = await fetch(`${endpoint}?${params.toString()}`, {
         method: "GET",
@@ -48,7 +57,7 @@ export default function IdentityRequestLog({
         body ?? { items: [], nextCursor: null, openMeterConfigured: true }
       );
     },
-    [endpoint],
+    [endpoint, from, to],
   );
 
   useEffect(() => {
@@ -117,7 +126,7 @@ export default function IdentityRequestLog({
         ) : null}
         {openMeterConfigured && !loading && !error && items.length === 0 ? (
           <p className="py-6 text-center text-sm text-zinc-500">
-            No requests for this identity in the current cycle.
+            No requests for this identity in this cycle.
           </p>
         ) : null}
         {openMeterConfigured && !loading && !error && items.length > 0 ? (

--- a/src/lib/billing-usage-dashboard-data.test.ts
+++ b/src/lib/billing-usage-dashboard-data.test.ts
@@ -365,3 +365,32 @@ test("admin All Usage keeps full tenant aggregate on platform default", async (t
     assert.equal(usage.byUser.length, 2);
   });
 });
+
+test("usage dashboard reads the requested UTC billing month", async (t) => {
+  const owned = await seedDeveloperAppWithClient({
+    name: `Cycle ${randomUUID().slice(0, 8)}`,
+  });
+  t.after(async () => {
+    await cleanupTestApp(owned);
+  });
+
+  __testSetOpenMeterDashboardUsage(owned.clientId, {
+    byUser: [],
+    byPipelineModel: [],
+    byUserPipelineModel: [],
+    byDailyPipeline: [],
+    requestsByDay: new Map(),
+  });
+  t.after(() => __testClearOpenMeterUsageStubs());
+
+  const result = await getBillingUsageDashboardDataForUser(
+    owned.userId,
+    "developer",
+    undefined,
+    { ownAppsOnly: true, cycleKey: "2026-01" },
+  );
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.data.cycle.start, "2026-01-01T00:00:00.000Z");
+  assert.equal(result.data.cycle.end, "2026-01-31T23:59:59.999Z");
+});

--- a/src/lib/billing-usage-dashboard-data.ts
+++ b/src/lib/billing-usage-dashboard-data.ts
@@ -3,7 +3,10 @@ import { eq, inArray, or } from "drizzle-orm";
 import { authOptions } from "@/lib/next-auth-options";
 import { db } from "@/db/index";
 import { developerApps, oidcClients, providerAdmins, users } from "@/db/schema";
-import { calendarMonthBoundsUtc, dateKeysInclusiveUtc } from "@/lib/billing-utils";
+import {
+  dateKeysInclusiveUtc,
+  resolveBillingCycle,
+} from "@/lib/billing-utils";
 import { requireOpenMeterForUsageReads } from "@/lib/openmeter/constants";
 import { getOwnerPrepaidCreditBalance } from "@/lib/openmeter/credit-allowance-summary";
 import {
@@ -185,7 +188,7 @@ export type BillingUsageDashboardResult =
 
 export async function getBillingUsageDashboardData(
   filterAppId?: string | null,
-  options?: { ownAppsOnly?: boolean },
+  options?: { ownAppsOnly?: boolean; cycleKey?: string | null },
 ): Promise<BillingUsageDashboardResult> {
   const session = await getServerSession(authOptions);
   const sessionUser = session?.user as Record<string, unknown> | undefined;
@@ -307,7 +310,7 @@ export async function getBillingUsageDashboardDataForUser(
   userId: string,
   role: string | undefined,
   filterAppId?: string | null,
-  options?: { ownAppsOnly?: boolean },
+  options?: { ownAppsOnly?: boolean; cycleKey?: string | null },
 ): Promise<BillingUsageDashboardResult> {
   const isAdmin = role === "admin";
   const ownAppsOnly = options?.ownAppsOnly === true;
@@ -330,7 +333,11 @@ export async function getBillingUsageDashboardDataForUser(
     scope = "all";
   }
 
-  const cycleBounds = calendarMonthBoundsUtc(new Date());
+  const selectedCycle = resolveBillingCycle(options?.cycleKey);
+  const cycleBounds = {
+    start: selectedCycle.start,
+    end: selectedCycle.end,
+  };
   const cycle = { start: cycleBounds.start, end: cycleBounds.end };
 
   if (!requireOpenMeterForUsageReads()) {
@@ -408,7 +415,7 @@ async function buildOpenMeterBillingDashboard(input: {
   const [omResults, activeSubscriptions, creditAllowance, paymentMethods] =
     await Promise.all([
       queryDashboardUsagePaged(input.orderedApps, input.cycle, input.userId),
-      listOwnerActiveSubscriptions(input.userId).catch((err) => {
+      listOwnerActiveSubscriptions(input.userId, { cycle: input.cycle }).catch((err) => {
         console.warn(
           "billing-usage-dashboard: subscription summary failed",
           err instanceof Error ? err.message : String(err),

--- a/src/lib/billing-utils.test.ts
+++ b/src/lib/billing-utils.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BILLING_CYCLE_LOOKBACK_MONTHS,
+  billingCycleSelectOptions,
+  calendarMonthBoundsForYearMonth,
+  calendarMonthBoundsUtc,
+  formatBillingCycleMonthLabel,
+  invoiceOverlapsCycle,
+  listRecentBillingCycleKeys,
+  resolveBillingCycle,
+  utcYearMonthKey,
+} from "@/lib/billing-utils";
+
+const NOW = new Date("2026-09-15T12:00:00.000Z");
+
+test("utcYearMonthKey is UTC YYYY-MM", () => {
+  assert.equal(utcYearMonthKey(NOW), "2026-09");
+  assert.equal(utcYearMonthKey(new Date("2026-01-01T00:00:00.000Z")), "2026-01");
+});
+
+test("calendarMonthBoundsForYearMonth matches calendarMonthBoundsUtc", () => {
+  const fromKey = calendarMonthBoundsForYearMonth("2026-07");
+  assert.ok(fromKey);
+  assert.deepEqual(fromKey, calendarMonthBoundsUtc(new Date("2026-07-15T00:00:00.000Z")));
+});
+
+test("calendarMonthBoundsForYearMonth rejects malformed keys", () => {
+  assert.equal(calendarMonthBoundsForYearMonth("2026-13"), null);
+  assert.equal(calendarMonthBoundsForYearMonth("2026-7"), null);
+  assert.equal(calendarMonthBoundsForYearMonth("july"), null);
+  assert.equal(calendarMonthBoundsForYearMonth(""), null);
+});
+
+test("resolveBillingCycle falls back to the current UTC month", () => {
+  const current = resolveBillingCycle(null, NOW);
+  assert.equal(current.key, "2026-09");
+  assert.equal(current.isCurrent, true);
+
+  const malformed = resolveBillingCycle("nope", NOW);
+  assert.equal(malformed.key, "2026-09");
+  assert.equal(malformed.isCurrent, true);
+
+  const future = resolveBillingCycle("2026-10", NOW);
+  assert.equal(future.key, "2026-09");
+  assert.equal(future.isCurrent, true);
+});
+
+test("resolveBillingCycle accepts a prior UTC month", () => {
+  const july = resolveBillingCycle("2026-07", NOW);
+  assert.equal(july.key, "2026-07");
+  assert.equal(july.isCurrent, false);
+  assert.equal(july.start, "2026-07-01T00:00:00.000Z");
+  assert.equal(july.end, "2026-07-31T23:59:59.999Z");
+});
+
+test("listRecentBillingCycleKeys is newest-first and includes the current month", () => {
+  const keys = listRecentBillingCycleKeys(NOW, 3);
+  assert.deepEqual(keys, ["2026-09", "2026-08", "2026-07"]);
+  assert.equal(listRecentBillingCycleKeys(NOW).length, BILLING_CYCLE_LOOKBACK_MONTHS);
+});
+
+test("formatBillingCycleMonthLabel uses a long UTC month name", () => {
+  assert.equal(formatBillingCycleMonthLabel("2026-07"), "July 2026");
+  assert.equal(formatBillingCycleMonthLabel("bad"), "bad");
+});
+
+test("billingCycleSelectOptions keeps a bookmarked month that fell off the lookback", () => {
+  const options = billingCycleSelectOptions({
+    selectedKey: "2025-01",
+    now: NOW,
+    count: 2,
+  });
+  assert.deepEqual(
+    options.map((option) => option.key),
+    ["2026-09", "2026-08", "2025-01"],
+  );
+  assert.equal(options[0]?.isCurrent, true);
+  assert.equal(options[2]?.isCurrent, false);
+});
+
+test("invoiceOverlapsCycle uses the billing period when present", () => {
+  const july = resolveBillingCycle("2026-07", NOW);
+  assert.equal(
+    invoiceOverlapsCycle(
+      {
+        periodStart: "2026-07-01T00:00:00.000Z",
+        periodEnd: "2026-07-31T23:59:59.999Z",
+        issuedAt: "2026-08-02T00:00:00.000Z",
+      },
+      july,
+    ),
+    true,
+  );
+  assert.equal(
+    invoiceOverlapsCycle(
+      {
+        periodStart: "2026-06-01T00:00:00.000Z",
+        periodEnd: "2026-06-30T23:59:59.999Z",
+      },
+      july,
+    ),
+    false,
+  );
+});
+
+test("invoiceOverlapsCycle falls back to issuedAt", () => {
+  const july = resolveBillingCycle("2026-07", NOW);
+  assert.equal(
+    invoiceOverlapsCycle({ issuedAt: "2026-07-15T12:00:00.000Z" }, july),
+    true,
+  );
+  assert.equal(
+    invoiceOverlapsCycle({ issuedAt: "2026-08-01T00:00:00.000Z" }, july),
+    false,
+  );
+  assert.equal(invoiceOverlapsCycle({}, july), false);
+});

--- a/src/lib/billing-utils.ts
+++ b/src/lib/billing-utils.ts
@@ -10,6 +10,156 @@ export function calendarMonthBoundsUtc(now: Date): { start: string; end: string 
   };
 }
 
+/** Query/path key for a UTC billing month (`YYYY-MM`). */
+export const BILLING_CYCLE_PARAM = "cycle";
+
+/** How many past months the cycle picker lists, including the current month. */
+export const BILLING_CYCLE_LOOKBACK_MONTHS = 12;
+
+const YEAR_MONTH_RE = /^(\d{4})-(\d{2})$/;
+
+export type BillingCycleSelection = {
+  /** UTC year-month, e.g. `2026-07`. */
+  key: string;
+  start: string;
+  end: string;
+  isCurrent: boolean;
+};
+
+/** UTC `YYYY-MM` for `date`. */
+export function utcYearMonthKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+/** Calendar-month UTC bounds for a `YYYY-MM` key, or null when malformed. */
+export function calendarMonthBoundsForYearMonth(
+  yearMonth: string,
+): { start: string; end: string } | null {
+  const match = YEAR_MONTH_RE.exec(yearMonth.trim());
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (month < 1 || month > 12) return null;
+  return calendarMonthBoundsUtc(new Date(Date.UTC(year, month - 1, 15)));
+}
+
+/**
+ * Resolve a `cycle=YYYY-MM` query value to UTC month bounds.
+ * Missing, future, or malformed keys fall back to the current UTC month.
+ */
+export function resolveBillingCycle(
+  raw: string | null | undefined,
+  now: Date = new Date(),
+): BillingCycleSelection {
+  const currentKey = utcYearMonthKey(now);
+  const current = calendarMonthBoundsUtc(now);
+  const requested = raw?.trim() ?? "";
+  if (!requested) {
+    return {
+      key: currentKey,
+      start: current.start,
+      end: current.end,
+      isCurrent: true,
+    };
+  }
+  const bounds = calendarMonthBoundsForYearMonth(requested);
+  if (!bounds || requested > currentKey) {
+    return {
+      key: currentKey,
+      start: current.start,
+      end: current.end,
+      isCurrent: true,
+    };
+  }
+  return {
+    key: requested,
+    start: bounds.start,
+    end: bounds.end,
+    isCurrent: requested === currentKey,
+  };
+}
+
+/** Recent UTC months newest-first, including the current month. */
+export function listRecentBillingCycleKeys(
+  now: Date = new Date(),
+  count: number = BILLING_CYCLE_LOOKBACK_MONTHS,
+): string[] {
+  const size = Number.isFinite(count) && count > 0 ? Math.floor(count) : BILLING_CYCLE_LOOKBACK_MONTHS;
+  const year = now.getUTCFullYear();
+  const monthIndex = now.getUTCMonth();
+  const keys: string[] = [];
+  for (let offset = 0; offset < size; offset += 1) {
+    keys.push(utcYearMonthKey(new Date(Date.UTC(year, monthIndex - offset, 1))));
+  }
+  return keys;
+}
+
+/** `2026-07` → `July 2026`. */
+export function formatBillingCycleMonthLabel(yearMonth: string): string {
+  const bounds = calendarMonthBoundsForYearMonth(yearMonth);
+  if (!bounds) return yearMonth;
+  return new Date(bounds.start).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export type BillingCycleOption = {
+  key: string;
+  label: string;
+  isCurrent: boolean;
+};
+
+/** Picker options: recent months plus a bookmarked key that fell off the list. */
+export function billingCycleSelectOptions(input: {
+  selectedKey: string;
+  now?: Date;
+  count?: number;
+}): BillingCycleOption[] {
+  const now = input.now ?? new Date();
+  const currentKey = utcYearMonthKey(now);
+  const keys = listRecentBillingCycleKeys(now, input.count);
+  const selected = input.selectedKey.trim();
+  if (selected && !keys.includes(selected) && calendarMonthBoundsForYearMonth(selected)) {
+    keys.push(selected);
+    keys.sort((a, b) => b.localeCompare(a));
+  }
+  return keys.map((key) => ({
+    key,
+    label: formatBillingCycleMonthLabel(key),
+    isCurrent: key === currentKey,
+  }));
+}
+
+/**
+ * True when an invoice's billing period (or issued-at fallback) overlaps the
+ * cycle. Used to highlight a month on Billing / identity payment history.
+ */
+export function invoiceOverlapsCycle(
+  invoice: {
+    issuedAt?: string | null;
+    periodStart?: string | null;
+    periodEnd?: string | null;
+  },
+  cycle: { start: string; end: string },
+): boolean {
+  const cycleStart = Date.parse(cycle.start);
+  const cycleEnd = Date.parse(cycle.end);
+  if (Number.isNaN(cycleStart) || Number.isNaN(cycleEnd)) return false;
+
+  const periodStart = invoice.periodStart ? Date.parse(invoice.periodStart) : Number.NaN;
+  const periodEnd = invoice.periodEnd ? Date.parse(invoice.periodEnd) : Number.NaN;
+  if (!Number.isNaN(periodStart) && !Number.isNaN(periodEnd)) {
+    return periodStart <= cycleEnd && periodEnd >= cycleStart;
+  }
+  const issued = invoice.issuedAt ? Date.parse(invoice.issuedAt) : Number.NaN;
+  if (Number.isNaN(issued)) return false;
+  return issued >= cycleStart && issued <= cycleEnd;
+}
+
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /** Safety limit for inclusive date-range iteration / API query spans. */

--- a/src/lib/openmeter/app-user-subscription-lifecycle.test.ts
+++ b/src/lib/openmeter/app-user-subscription-lifecycle.test.ts
@@ -32,6 +32,9 @@ function sub(partial: Partial<OpenMeterSubscriptionView> & { id: string }): Open
   };
 }
 
+/** Occupying cancel-at-period-end must be after Date.now(); keep this far-future. */
+const OCCUPYING_UNTIL = "2099-01-01T00:00:00.000Z";
+
 test("cancelAppUserSubscription rejects without confirm", async () => {
   await assert.rejects(
     () =>
@@ -278,7 +281,7 @@ test("resolveAppUserResumeTarget prefers canceled paid, else live paid + schedul
         id: "paid_canceled",
         planKey: "paid",
         status: "canceled",
-        activeTo: "2026-09-01T00:00:00.000Z",
+        activeTo: OCCUPYING_UNTIL,
       }),
     ],
     "app_starter",
@@ -314,7 +317,7 @@ test("deriveAppUserPendingCancel returns canceled paid row", () => {
         id: "paid_canceled",
         planKey: "paid",
         status: "canceled",
-        activeTo: "2026-09-01T00:00:00.000Z",
+        activeTo: OCCUPYING_UNTIL,
       }),
       planId: "local_plan",
       planName: "Pro",
@@ -324,7 +327,7 @@ test("deriveAppUserPendingCancel returns canceled paid row", () => {
       planId: "local_plan",
       planKey: "paid",
       planName: "Pro",
-      effectiveAt: "2026-09-01T00:00:00.000Z",
+      effectiveAt: OCCUPYING_UNTIL,
     },
   );
 });
@@ -336,7 +339,7 @@ test("deriveAppUserPendingCancel surfaces cancel-at-period-end Starter", () => {
         id: "starter_canceled",
         planKey: "app_starter",
         status: "canceled",
-        activeTo: "2026-09-07T17:35:18.109Z",
+        activeTo: OCCUPYING_UNTIL,
       }),
       planId: "starter_local",
       planName: "Starter",
@@ -346,7 +349,7 @@ test("deriveAppUserPendingCancel surfaces cancel-at-period-end Starter", () => {
       planId: "starter_local",
       planKey: "app_starter",
       planName: "Starter",
-      effectiveAt: "2026-09-07T17:35:18.109Z",
+      effectiveAt: OCCUPYING_UNTIL,
     },
   );
 });
@@ -362,7 +365,7 @@ test("deriveAppUserPendingCancel dates the banner from the enriched window", () 
         planKey: "a6c95d934_plan_397fcf2f",
         status: "canceled",
         activeFrom: "2026-08-06T23:02:17.378589Z",
-        activeTo: "2026-09-06T23:02:17.378589Z",
+        activeTo: OCCUPYING_UNTIL,
       }),
       planId: "397fcf2f",
       planName: "Pay as you go",
@@ -372,7 +375,7 @@ test("deriveAppUserPendingCancel dates the banner from the enriched window", () 
       planId: "397fcf2f",
       planKey: "a6c95d934_plan_397fcf2f",
       planName: "Pay as you go",
-      effectiveAt: "2026-09-06T23:02:17.378589Z",
+      effectiveAt: OCCUPYING_UNTIL,
     },
   );
 });
@@ -411,13 +414,13 @@ test("resolveAppUserResumeTarget resumes CAPE primary when a scheduled successor
       planKey: "paid",
       status: "canceled",
       activeFrom: "2026-08-08T03:00:31.842771Z",
-      activeTo: "2026-09-08T03:00:31.842771Z",
+      activeTo: OCCUPYING_UNTIL,
     }),
     sub({
       id: "starter_scheduled",
       planKey: "app_starter",
       status: "scheduled",
-      activeFrom: "2026-09-08T03:00:31.842771Z",
+      activeFrom: OCCUPYING_UNTIL,
     }),
     sub({ id: "superseded", planKey: "app_starter", status: "inactive" }),
   ];
@@ -439,13 +442,13 @@ test("resolveAppUserResumeTarget resumes CAPE when scheduled successor is paid",
       planKey: "paid_a",
       status: "canceled",
       activeFrom: "2026-08-11T00:35:58.500843Z",
-      activeTo: "2026-09-10T23:08:53.491143Z",
+      activeTo: OCCUPYING_UNTIL,
     }),
     sub({
       id: "sched_paid_b",
       planKey: "paid_b",
       status: "scheduled",
-      activeFrom: "2026-09-10T23:08:53.491143Z",
+      activeFrom: OCCUPYING_UNTIL,
     }),
   ];
   const resume = resolveAppUserResumeTarget(listed, "app_starter", null);
@@ -461,7 +464,7 @@ test("resolveAppUserResumeTarget keeps a cancel-at-period-end primary resumable"
     planKey: "paid",
     status: "canceled",
     activeFrom: "2026-08-08T03:00:31.842771Z",
-    activeTo: "2026-09-08T03:00:31.842771Z",
+    activeTo: OCCUPYING_UNTIL,
   });
   const listed = [
     canceled,
@@ -483,7 +486,7 @@ test("resolveAppUserResumeTarget resumes occupying CAPE after paid→paid change
     planKey: "paid_b",
     status: "canceled",
     activeFrom: "2026-08-08T03:00:31.842771Z",
-    activeTo: "2026-09-08T03:00:31.842771Z",
+    activeTo: OCCUPYING_UNTIL,
   });
   const listed = [
     sub({ id: "paid_a_ended", planKey: "paid_a", status: "inactive" }),
@@ -666,13 +669,13 @@ test("resumeAppUserSubscriptionFromList restores when a scheduled successor exis
       id: "paid_cape",
       planKey: "paid",
       status: "canceled",
-      activeTo: "2026-09-01T00:00:00.000Z",
+      activeTo: OCCUPYING_UNTIL,
     }),
     sub({
       id: "sched_starter",
       planKey: "app_starter",
       status: "scheduled",
-      activeFrom: "2026-09-01T00:00:00.000Z",
+      activeFrom: OCCUPYING_UNTIL,
     }),
   ];
 
@@ -706,7 +709,7 @@ test("resumeAppUserSubscriptionFromList unschedules when no successor exists", a
       id: "paid_cape",
       planKey: "paid",
       status: "canceled",
-      activeTo: "2026-09-01T00:00:00.000Z",
+      activeTo: OCCUPYING_UNTIL,
     }),
   ];
 
@@ -748,7 +751,7 @@ test("resumeAppUserSubscriptionFromList falls back to restore on unschedule 409"
       id: "paid_cape",
       planKey: "paid",
       status: "canceled",
-      activeTo: "2026-09-01T00:00:00.000Z",
+      activeTo: OCCUPYING_UNTIL,
     }),
   ];
 
@@ -794,7 +797,7 @@ test("immediateCancelOccupyingCapePaid restores then changes onto Starter", asyn
       id: "paid_cape",
       planKey: "paid",
       status: "canceled",
-      activeTo: "2026-09-01T00:00:00.000Z",
+      activeTo: OCCUPYING_UNTIL,
     }),
     scheduledIds: ["sched_starter"],
     clientId: "app_missing_plans_ok",

--- a/src/lib/openmeter/subscription-state.test.ts
+++ b/src/lib/openmeter/subscription-state.test.ts
@@ -55,6 +55,9 @@ function sub(
 const isStarter = (s: OpenMeterSubscriptionView) =>
   s.planKey === "app_starter" || s.planKey === "pymthouse_owner_starter";
 
+/** Occupying cancel-at-period-end must be after Date.now(); keep this far-future. */
+const OCCUPYING_UNTIL = "2099-01-01T00:00:00.000Z";
+
 test("status predicates: live excludes scheduled", () => {
   assert.equal(isLiveSubscriptionStatus("active"), true);
   assert.equal(isLiveSubscriptionStatus("trialing"), true);
@@ -121,7 +124,7 @@ test("isOccupyingCanceledSubscription requires future activeTo", async () => {
       id: "starter_canceled",
       planKey: "app_starter",
       status: "canceled",
-      activeTo: "2026-09-07T17:35:18.109Z",
+      activeTo: OCCUPYING_UNTIL,
     }),
   ]);
   assert.equal(picked?.id, "starter_canceled");
@@ -303,7 +306,7 @@ test("resolveResumeTarget prefers canceled paid, else live + scheduled starter",
         id: "paid_canceled",
         planKey: "paid",
         status: "canceled",
-        activeTo: "2026-09-01T00:00:00.000Z",
+        activeTo: OCCUPYING_UNTIL,
       }),
     ],
     isStarter,
@@ -372,7 +375,7 @@ test("resolveResumeTarget skips ended predecessor ahead of occupying CAPE paid",
     id: "paid_b_cape",
     planKey: "paid_b",
     status: "canceled",
-    activeTo: "2026-09-08T00:00:00.000Z",
+    activeTo: OCCUPYING_UNTIL,
   });
   assert.equal(
     resolveResumeTarget(

--- a/src/lib/owner-billing-data.ts
+++ b/src/lib/owner-billing-data.ts
@@ -4,7 +4,7 @@ import type { OpenMeter } from "@openmeter/sdk";
 
 import { db } from "@/db/index";
 import { appBillingConfig, developerApps, oidcClients, plans } from "@/db/schema";
-import { calendarMonthBoundsUtc } from "@/lib/billing-utils";
+import { calendarMonthBoundsUtc, resolveBillingCycle } from "@/lib/billing-utils";
 import { authOptions } from "@/lib/next-auth-options";
 import {
   getHostedAdminClient,
@@ -703,6 +703,7 @@ export async function listOwnerActiveSubscriptions(
   options?: Readonly<{
     ownedApps?: OwnedApp[];
     ownerWalletSubjects?: string[];
+    cycle?: { start: string; end: string };
   }>,
 ): Promise<OwnerBillingSubscriptionRow[]> {
   const trimmed = userId.trim();
@@ -714,7 +715,7 @@ export async function listOwnerActiveSubscriptions(
   }
 
   const client = getHostedAdminClient();
-  const cycleBounds = calendarMonthBoundsUtc(new Date());
+  const cycleBounds = options?.cycle ?? calendarMonthBoundsUtc(new Date());
   const cycle = { start: cycleBounds.start, end: cycleBounds.end };
   const ownedApps = options?.ownedApps ?? (await listOwnedApps(trimmed));
   const ownerWalletSubjects =
@@ -792,6 +793,7 @@ export async function listOwnerActiveSubscriptions(
  */
 export async function getOwnerBillingData(
   rawUserId?: string,
+  options?: Readonly<{ cycleKey?: string | null }>,
 ): Promise<OwnerBillingResult> {
   let userId = rawUserId?.trim() ?? "";
   if (!userId) {
@@ -807,8 +809,8 @@ export async function getOwnerBillingData(
     return { ok: false, reason: "no_session" };
   }
 
-  const cycleBounds = calendarMonthBoundsUtc(new Date());
-  const cycle = { start: cycleBounds.start, end: cycleBounds.end };
+  const selectedCycle = resolveBillingCycle(options?.cycleKey);
+  const cycle = { start: selectedCycle.start, end: selectedCycle.end };
 
   if (!requireOpenMeterForUsageReads() || !isHostedAdminClientAvailable()) {
     return { ok: false, reason: "openmeter_unconfigured" };
@@ -866,6 +868,7 @@ export async function getOwnerBillingData(
         listOwnerActiveSubscriptions(userId, {
           ownedApps,
           ownerWalletSubjects,
+          cycle,
         }),
         8_000,
         [] as OwnerBillingSubscriptionRow[],

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -12,6 +12,7 @@ import {
   handleAppUsageBalanceGet,
   handleAppUsageGet,
 } from "@/lib/usage/app-usage-handlers";
+import { parseOptionalDateRange } from "@/lib/usage/parse-optional-date-range";
 
 /**
  * `publicClientId` is the app the credential must belong to. Omit it for the
@@ -96,6 +97,11 @@ export async function handleEndUserMeUsageRequestsGet(
   const limitRaw = params.get("limit");
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
 
+  const dateRange = parseOptionalDateRange(params);
+  if ("error" in dateRange) {
+    return dateRange.error;
+  }
+
   if (groupBy !== "request" && groupBy !== "session") {
     return NextResponse.json(
       { error: "Invalid groupBy; use request or session" },
@@ -109,6 +115,8 @@ export async function handleEndUserMeUsageRequestsGet(
       clientId: auth.publicClientId,
       cursor,
       limit: Number.isFinite(limit) ? limit : undefined,
+      from: dateRange.from,
+      to: dateRange.to,
     });
 
     return NextResponse.json({
@@ -127,6 +135,8 @@ export async function handleEndUserMeUsageRequestsGet(
     manifestId,
     cursor,
     limit: Number.isFinite(limit) ? limit : undefined,
+    from: dateRange.from,
+    to: dateRange.to,
   });
 
   return NextResponse.json({

--- a/src/lib/usage/me-usage-requests-handler.ts
+++ b/src/lib/usage/me-usage-requests-handler.ts
@@ -12,10 +12,7 @@ import {
   resolveViewerUsageClientScopes,
   type ViewerUsageClientScopes,
 } from "@/lib/viewer-usage-clients";
-import {
-  isValidBoundedDateRange,
-  MAX_DATE_RANGE_DAYS,
-} from "@/lib/billing-utils";
+import { parseOptionalDateRange } from "@/lib/usage/parse-optional-date-range";
 
 type MeUsageGroupBy = "request" | "session";
 type MeUsageScope = "own" | "all";
@@ -93,34 +90,6 @@ function validateMeUsageRequestsParams(
     };
   }
   return { scope, groupBy };
-}
-
-function parseOptionalDateRange(
-  params: URLSearchParams,
-): { error: NextResponse } | { from?: string; to?: string } {
-  // Optional date range for the requests table's range picker. Both bounds are
-  // required together and are span-limited before hitting OpenMeter.
-  const from = params.get("from")?.trim() || undefined;
-  const to = params.get("to")?.trim() || undefined;
-  if ((from && !to) || (to && !from)) {
-    return {
-      error: NextResponse.json(
-        { error: "from and to must be supplied together" },
-        { status: 400 },
-      ),
-    };
-  }
-  if (from && to && !isValidBoundedDateRange(from, to)) {
-    return {
-      error: NextResponse.json(
-        {
-          error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
-        },
-        { status: 400 },
-      ),
-    };
-  }
-  return { from, to };
 }
 
 /** Session-authenticated viewer signed-ticket history (Internal API). */

--- a/src/lib/usage/parse-optional-date-range.test.ts
+++ b/src/lib/usage/parse-optional-date-range.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseOptionalDateRange } from "@/lib/usage/parse-optional-date-range";
+
+test("parseOptionalDateRange accepts a matching pair", async () => {
+  const result = parseOptionalDateRange(
+    new URLSearchParams({
+      from: "2026-08-06T00:00:00.000Z",
+      to: "2026-09-04T23:59:59.999Z",
+    }),
+  );
+  assert.equal("error" in result, false);
+  if ("error" in result) return;
+  assert.equal(result.from, "2026-08-06T00:00:00.000Z");
+  assert.equal(result.to, "2026-09-04T23:59:59.999Z");
+});
+
+test("parseOptionalDateRange rejects a lone bound", async () => {
+  const result = parseOptionalDateRange(
+    new URLSearchParams({ from: "2026-08-06T00:00:00.000Z" }),
+  );
+  assert.equal("error" in result, true);
+  if (!("error" in result)) return;
+  assert.equal(result.error.status, 400);
+});
+
+test("parseOptionalDateRange rejects a span over MAX_DATE_RANGE_DAYS", async () => {
+  const result = parseOptionalDateRange(
+    new URLSearchParams({
+      from: "2025-01-01T00:00:00.000Z",
+      to: "2026-09-04T23:59:59.999Z",
+    }),
+  );
+  assert.equal("error" in result, true);
+  if (!("error" in result)) return;
+  assert.equal(result.error.status, 400);
+});
+
+test("parseOptionalDateRange allows omitted bounds", async () => {
+  const result = parseOptionalDateRange(new URLSearchParams());
+  assert.equal("error" in result, false);
+  if ("error" in result) return;
+  assert.equal(result.from, undefined);
+  assert.equal(result.to, undefined);
+});

--- a/src/lib/usage/parse-optional-date-range.ts
+++ b/src/lib/usage/parse-optional-date-range.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import {
+  isValidBoundedDateRange,
+  MAX_DATE_RANGE_DAYS,
+} from "@/lib/billing-utils";
+
+/**
+ * Optional date range for signed-ticket history. Both bounds are required
+ * together and are span-limited before hitting OpenMeter.
+ */
+export function parseOptionalDateRange(
+  params: URLSearchParams,
+): { error: NextResponse } | { from?: string; to?: string } {
+  const from = params.get("from")?.trim() || undefined;
+  const to = params.get("to")?.trim() || undefined;
+  if ((from && !to) || (to && !from)) {
+    return {
+      error: NextResponse.json(
+        { error: "from and to must be supplied together" },
+        { status: 400 },
+      ),
+    };
+  }
+  if (from && to && !isValidBoundedDateRange(from, to)) {
+    return {
+      error: NextResponse.json(
+        {
+          error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
+        },
+        { status: 400 },
+      ),
+    };
+  }
+  return {
+    from,
+    to,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds prior billing-cycle views for owners and admins, plus merchant identity subscription, discount, and payment-history management.

## Why

Usage and Billing were locked to the current UTC month, so owners and admins could not inspect a closed cycle. Application owners could deactivate identities but could not manage that M2M customer’s plan, included-usage discount, or invoices.

## What changed

- Shared UTC month picker (`?cycle=YYYY-MM`) on Usage (My Usage and admin All Usage), Billing, Identities, and identity detail.
- Dashboard and owner-billing reads honor the selected month for usage, cycle spend, and request history.
- Past months default invoice/ledger filters to that cycle, with a toggle to show all.
- Identity detail (owners and app admins) can change/cancel/resume a merchant customer’s subscription, see included usage, prepaid credits, and invoice history. Owner-rollup identities still link to the platform wallet.

## Testing

- `npx tsc --noEmit` passed.
- `npx eslint` on changed files passed.
- Unit tests in `src/lib/billing-utils.test.ts` passed (cycle parsing, lookback, invoice overlap).
- Resume / pending-cancel occupancy fixtures now use a far-future `activeTo` so they stay valid after `Date.now()` (the previous `2026-09-01` dates started failing on 1 Sep 2026).
- DB-backed usage dashboard tests were skipped in this environment (no `DATABASE_URL`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee48f56c-7038-450a-9c21-d730c340d005?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee48f56c-7038-450a-9c21-d730c340d005&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

