### PR TITLE
fix(auth): accept bare personal API keys as remote-signer Bearer tokens

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -62,7 +62,7 @@ M2M secret rotation remains at `POST /api/v1/apps/{clientId}/credentials` (provi
 | Prefix | Role | RFC usage |
 | --- | --- | --- |
 | Stored API key (`pmth_<hex>`) | Per-app-user **API key** (hashed at rest) | Personal mint returns bare `pmth_*`; Builder mint returns composite presentation of the same secret |
-| `app_<24hex>_<secret>` | **Presented** Builder API key (issuance + remote-signer Bearer) | Same secret as the stored key; `app_*` segment routes pathless exchange / webhooks |
+| `app_<24hex>_<secret>` | **Presented** Builder API key (issuance + remote-signer Bearer) | Same secret as the stored key; `app_*` segment routes path-scoped exchange without a DB lookup |
 | Client secret (`*_cs_*`) | Confidential client secret | HTTP Basic / `client_secret_post` with the matching client id (RFC 6749 §2.3.1) — never the API-key bearer exchange |
 | `app_…` | Public interactive client | Path params and token endpoint `client_id`; `token_endpoint_auth_method=none` (device / SDK; **no** authorization-code redirects) |
 | `m2m_…` | Confidential M2M sibling | `client_credentials` only — Builder API / machine tokens |
@@ -88,12 +88,13 @@ Newly issued **personal** keys are returned as bare `pmth_<hex>`. Builder-minted
 - Self-serve usage (path-scoped app): `GET /api/v1/apps/{clientId}/me/usage*` with bare or composite Bearer
 - Signer session exchange (RFC 8693): `POST /api/v1/oidc/token` or `POST /api/v1/apps/{clientId}/oidc/token` with `subject_token` = bare `pmth_…` or composite and `subject_token_type=urn:pymthouse:oauth:token-type:api_key`
 
-Composite remains the default presentation for Builder keys so pathless callers (e.g. remote-signer identity webhook) can recover the public client id from a single Bearer. Personal network keys keep a bare `apiKey` for usage, but mint `sdkToken` with the same composite Authorization header.
+Composite remains the default presentation for Builder keys so pathless callers can recover the public client id from a single Bearer without a DB lookup. Personal network keys stay bare `pmth_*`; the remote-signer identity webhook exchanges that Bearer on the issuer path (`POST /api/v1/oidc/token`) by resolving the stored key. `sdkToken` still embeds the composite Authorization header for older webhook deployments.
 
 **Design notes**
 
-- Personal keys stay bare for usage/self-serve; `sdkToken` (livepeer-python-sdk `--token`) embeds the composite `app_*_*` form so pathless signer webhooks can recover `{clientId}`.
-- Builder app-user mint returns composite as the presented `apiKey` (and in `sdkToken`) for the same reason.
+- Personal keys stay bare for usage/self-serve and as `Authorization: Bearer` on the remote signer. The webhook treats `pmth_*` as an API key (not a JWT) and resolves the app from the credential.
+- `sdkToken` (livepeer-python-sdk `--token`) still embeds the composite `app_*_*` form for older webhook deployments that only parse a client id from the Bearer.
+- Builder app-user mint returns composite as the presented `apiKey` (and in `sdkToken`) so pathless callers can recover `{clientId}` without a lookup.
 - Tenancy also lives in the URL for Builder and end-user self-serve routes; the bare secret segment alone is enough there.
 - `formatCompositeApiKey` / `splitCompositeApiKey` parse the composite presentation form.
 
@@ -104,6 +105,7 @@ Do not pass M2M client secrets as `subject_token` on the signer session exchange
 - [x] Issue bare `pmth_*` from personal key mint; composite `app_*_*` from Builder app-user key mint.
 - [x] Publish `@pymthouse/clearinghouse-identity-webhook` with the matching composite parser (`0.4.2`).
 - [x] End-user usage at `/api/v1/user/usage*` (app from credential) and `/api/v1/apps/{clientId}/me/usage*` (path-scoped).
+- [x] Remote-signer webhook exchanges bare personal `pmth_*` Bearers via issuer-path RFC 8693 (app from the stored key).
 
 ## Authentication
 

--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -88,12 +88,11 @@ Newly issued **personal** keys are returned as bare `pmth_<hex>`. Builder-minted
 - Self-serve usage (path-scoped app): `GET /api/v1/apps/{clientId}/me/usage*` with bare or composite Bearer
 - Signer session exchange (RFC 8693): `POST /api/v1/oidc/token` or `POST /api/v1/apps/{clientId}/oidc/token` with `subject_token` = bare `pmth_…` or composite and `subject_token_type=urn:pymthouse:oauth:token-type:api_key`
 
-Composite remains the default presentation for Builder keys so pathless callers can recover the public client id from a single Bearer without a DB lookup. Personal network keys stay bare `pmth_*`; the remote-signer identity webhook exchanges that Bearer on the issuer path (`POST /api/v1/oidc/token`) by resolving the stored key. `sdkToken` still embeds the composite Authorization header for older webhook deployments.
+Composite remains the default presentation for Builder keys so pathless callers can recover the public client id from a single Bearer without a DB lookup. Personal network keys stay bare `pmth_*`; the remote-signer identity webhook exchanges that Bearer on the issuer path (`POST /api/v1/oidc/token`) by resolving the stored key. Personal `sdkToken` embeds the same bare Authorization header.
 
 **Design notes**
 
-- Personal keys stay bare for usage/self-serve and as `Authorization: Bearer` on the remote signer. The webhook treats `pmth_*` as an API key (not a JWT) and resolves the app from the credential.
-- `sdkToken` (livepeer-python-sdk `--token`) still embeds the composite `app_*_*` form for older webhook deployments that only parse a client id from the Bearer.
+- Personal keys stay bare for usage/self-serve, as `Authorization: Bearer` on the remote signer, and inside personal `sdkToken` (`--token`). The webhook treats `pmth_*` as an API key (not a JWT) and resolves the app from the credential.
 - Builder app-user mint returns composite as the presented `apiKey` (and in `sdkToken`) so pathless callers can recover `{clientId}` without a lookup.
 - Tenancy also lives in the URL for Builder and end-user self-serve routes; the bare secret segment alone is enough there.
 - `formatCompositeApiKey` / `splitCompositeApiKey` parse the composite presentation form.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -43,7 +43,7 @@ curl -X POST "$BASE/api/v1/network/key" \
   -H "Cookie: …"
 ```
 
-Response includes `clientId` (public `app_…` only), bare `apiKey` (`pmth_*`), and optional `sdkToken` for livepeer-python-sdk. Use the key as `Authorization: Bearer` on the remote signer and on `/api/v1/user/usage*` (or `/api/v1/apps/{clientId}/me/usage*`).
+Response includes `clientId` (public `app_…` only), bare `apiKey` (`pmth_*`), and optional `sdkToken` for livepeer-python-sdk (`Authorization: Bearer pmth_…` inside the bundle). Use the key as `Authorization: Bearer` on the remote signer and on `/api/v1/user/usage*` (or `/api/v1/apps/{clientId}/me/usage*`).
 
 Do **not** treat the default `clientId` as a target for confidential Builder API backends. The Personal Access Token card on My Apps exposes the same flow in the dashboard.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -43,7 +43,7 @@ curl -X POST "$BASE/api/v1/network/key" \
   -H "Cookie: …"
 ```
 
-Response includes `clientId` (public `app_…` only), bare `apiKey` (`pmth_*`), and optional `sdkToken` for livepeer-python-sdk. Use the key as `Authorization: Bearer` on `/api/v1/user/usage*` (or `/api/v1/apps/{clientId}/me/usage*`).
+Response includes `clientId` (public `app_…` only), bare `apiKey` (`pmth_*`), and optional `sdkToken` for livepeer-python-sdk. Use the key as `Authorization: Bearer` on the remote signer and on `/api/v1/user/usage*` (or `/api/v1/apps/{clientId}/me/usage*`).
 
 Do **not** treat the default `clientId` as a target for confidential Builder API backends. The Personal Access Token card on My Apps exposes the same flow in the dashboard.
 

--- a/src/app/webhooks/remote-signer/route.test.ts
+++ b/src/app/webhooks/remote-signer/route.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { SignJWT, createLocalJWKSet, exportJWK, generateKeyPair } from "jose";
 import { handleAuthorize } from "@pymthouse/clearinghouse-identity-webhook/protocol";
 import { createOidcVerifier } from "@pymthouse/clearinghouse-identity-webhook/verifiers";
+import { withPersonalApiKeyExchange } from "@/lib/oidc/personal-api-key-webhook-exchange";
 import { buildRemoteSignerWebhookConfig } from "@/lib/oidc/remote-signer-webhook-config";
 
 const WEBHOOK_SECRET = "test-webhook-secret";
@@ -128,4 +129,90 @@ test("remote-signer webhook authorizes composite app_*_* via mocked exchange", a
   const body = await response.json();
   assert.equal(body.status, 200);
   assert.equal(body.auth_id, "app_3b386c81a1db1169fd2c3986:user-456");
+});
+
+test("remote-signer webhook authorizes bare pmth_* personal key via issuer exchange", async () => {
+  const { publicKey, privateKey } = await generateKeyPair("RS256");
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = "pymthouse-test";
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+  const jwks = createLocalJWKSet({ keys: [jwk] });
+  const clientId = "app_444013b9d984f62f5572a282";
+  const bare = "pmth_28daa486391e5366261107f8175c2cfcba01a12940fd86d99d6f72ee1532a57b";
+  const minted = await new SignJWT({
+    client_id: clientId,
+    external_user_id: "user-789",
+    scope: "sign:job",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: "pymthouse-test" })
+    .setIssuer(OIDC_ISSUER)
+    .setAudience(OIDC_ISSUER)
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(privateKey);
+
+  const oidc = createOidcVerifier({
+    jwtIssuer: OIDC_ISSUER,
+    jwtAudience: OIDC_ISSUER,
+    issuer: OIDC_ISSUER,
+    jwks,
+    clientClaim: "client_id",
+    subjectClaim: "external_user_id",
+    subjectTypeValue: "external_user_id",
+    requiredScopes: ["sign:job"],
+  });
+  const config = {
+    webhookSecret: WEBHOOK_SECRET,
+    endUserAuth: withPersonalApiKeyExchange(oidc, {
+      exchange: async (input) => {
+        assert.equal(input.subjectToken, bare);
+        return {
+          access_token: minted,
+          token_type: "Bearer" as const,
+          expires_in: 300,
+          scope: "sign:job",
+        };
+      },
+    }),
+  };
+
+  const unwrapped = await handleAuthorize(
+    new Request("http://localhost/webhooks/remote-signer", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${WEBHOOK_SECRET}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        headers: { Authorization: [`Bearer ${bare}`] },
+      }),
+    }),
+    {
+      webhookSecret: WEBHOOK_SECRET,
+      endUserAuth: oidc,
+    },
+  );
+  assert.equal(unwrapped.status, 200);
+  const unwrappedBody = await unwrapped.json();
+  assert.equal(unwrappedBody.status, 401);
+  assert.equal(unwrappedBody.reason, "not a JWT");
+
+  const response = await handleAuthorize(
+    new Request("http://localhost/webhooks/remote-signer", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${WEBHOOK_SECRET}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        headers: { Authorization: [`Bearer ${bare}`] },
+      }),
+    }),
+    config,
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.status, 200);
+  assert.equal(body.auth_id, `${clientId}:user-789`);
 });

--- a/src/lib/app-api-keys.ts
+++ b/src/lib/app-api-keys.ts
@@ -32,7 +32,7 @@ export function maskApiKeySuffix(keyPrefix: string | null | undefined): string {
 
 /** Shown once at mint time for personal / network bare `pmth_*` keys. */
 export const PERSONAL_API_KEY_STORE_MESSAGE =
-  "Store this API key securely. It will not be shown again. Use Authorization: Bearer <pmth_…> on /api/v1/user/usage* (or /api/v1/apps/{clientId}/me/usage*), and as subject_token with subject_token_type=urn:pymthouse:oauth:token-type:api_key on POST /api/v1/oidc/token or POST /api/v1/apps/{clientId}/oidc/token, or use sdkToken as --token with livepeer-python-sdk.";
+  "Store this API key securely. It will not be shown again. Use Authorization: Bearer <pmth_…> on the remote signer and /api/v1/user/usage* (or /api/v1/apps/{clientId}/me/usage*), as subject_token with subject_token_type=urn:pymthouse:oauth:token-type:api_key on POST /api/v1/oidc/token or POST /api/v1/apps/{clientId}/oidc/token, or use sdkToken as --token with livepeer-python-sdk.";
 
 /**
  * Shown once at mint time for Builder-issued app-user keys (composite

--- a/src/lib/livepeer-python-sdk-token.ts
+++ b/src/lib/livepeer-python-sdk-token.ts
@@ -70,7 +70,7 @@ export function encodeLivepeerPythonSdkToken(
   return Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
 }
 
-/** Build and encode a `--token` for the minted composite API key. */
+/** Build and encode a `--token` for the minted API key (`pmth_*` or composite). */
 export function createLivepeerPythonSdkToken(input: {
   apiKey: string;
   signer?: string;

--- a/src/lib/oidc/personal-api-key-webhook-exchange.test.ts
+++ b/src/lib/oidc/personal-api-key-webhook-exchange.test.ts
@@ -1,0 +1,172 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  REMOTE_SIGNER_ERROR_CODE,
+  REMOTE_SIGNER_HTTP_STATUS,
+  WebhookError,
+  type EndUserAuthVerifier,
+} from "@pymthouse/clearinghouse-identity-webhook/protocol";
+
+import {
+  AppScopedSignerTokenExchangeError,
+  SUBJECT_API_KEY_TOKEN_TYPE,
+} from "@/lib/oidc/app-scoped-signer-token-exchange";
+import {
+  isBarePersonalApiKeyBearer,
+  webhookErrorFromPersonalApiKeyExchange,
+  withPersonalApiKeyExchange,
+} from "@/lib/oidc/personal-api-key-webhook-exchange";
+
+const PUBLIC_ID = "app_444013b9d984f62f5572a282";
+const BARE_KEY = "pmth_28daa486391e5366261107f8175c2cfcba01a12940fd86d99d6f72ee1532a57b";
+const COMPOSITE_KEY = `${PUBLIC_ID}_${BARE_KEY}`;
+
+function stubVerifier(
+  verify: EndUserAuthVerifier["verify"],
+): EndUserAuthVerifier {
+  return { kind: "oidc", verify };
+}
+
+function verifyInput(authorization: string) {
+  return {
+    authorization,
+    payload: {},
+    request: new Request("http://localhost/webhooks/remote-signer"),
+  };
+}
+
+test("isBarePersonalApiKeyBearer accepts stored pmth_ keys only", () => {
+  assert.equal(isBarePersonalApiKeyBearer(BARE_KEY), true);
+  assert.equal(isBarePersonalApiKeyBearer(` ${BARE_KEY} `), true);
+  assert.equal(isBarePersonalApiKeyBearer(COMPOSITE_KEY), false);
+  assert.equal(isBarePersonalApiKeyBearer("pmth_cs_notanapikey"), false);
+  assert.equal(isBarePersonalApiKeyBearer("eyJhbGciOiJSUzI1NiJ9.e30.sig"), false);
+  assert.equal(isBarePersonalApiKeyBearer(""), false);
+});
+
+test("webhookErrorFromPersonalApiKeyExchange maps billing and grant failures", () => {
+  const billing = webhookErrorFromPersonalApiKeyExchange(
+    new AppScopedSignerTokenExchangeError(
+      "billing_unavailable",
+      "billing balance unavailable",
+      503,
+    ),
+  );
+  assert.equal(billing.status, REMOTE_SIGNER_HTTP_STATUS.BILLING_UNAVAILABLE);
+  assert.equal(billing.code, REMOTE_SIGNER_ERROR_CODE.BILLING_UNAVAILABLE);
+
+  const exhausted = webhookErrorFromPersonalApiKeyExchange(
+    new AppScopedSignerTokenExchangeError(
+      "trial_credits_exhausted",
+      "out of credit",
+      402,
+    ),
+  );
+  assert.equal(exhausted.status, REMOTE_SIGNER_HTTP_STATUS.INSUFFICIENT_BALANCE);
+  assert.equal(exhausted.code, REMOTE_SIGNER_ERROR_CODE.INSUFFICIENT_BALANCE);
+
+  const unknown = webhookErrorFromPersonalApiKeyExchange(
+    new AppScopedSignerTokenExchangeError(
+      "invalid_grant",
+      "subject_token is not a valid API key for this issuer",
+    ),
+  );
+  assert.equal(unknown.status, 401);
+  assert.equal(unknown.code, "invalid_token");
+});
+
+test("withPersonalApiKeyExchange passes JWTs and composite keys through", async () => {
+  const seen: string[] = [];
+  const inner = stubVerifier(async ({ authorization }) => {
+    seen.push(authorization);
+    return {
+      identity: {
+        issuer: "https://idp.example/api/v1/oidc",
+        client_id: PUBLIC_ID,
+        usage_subject: "user-1",
+        usage_subject_type: "external_user_id",
+      },
+      expiry: Math.floor(Date.now() / 1000) + 60,
+    };
+  });
+
+  const wrapped = withPersonalApiKeyExchange(inner, {
+    exchange: async () => {
+      throw new Error("issuer exchange must not run for JWT or composite");
+    },
+  });
+
+  await wrapped.verify(verifyInput("Bearer eyJhbGciOiJSUzI1NiJ9.e30.sig"));
+  await wrapped.verify(verifyInput(`Bearer ${COMPOSITE_KEY}`));
+  assert.deepEqual(seen, [
+    "Bearer eyJhbGciOiJSUzI1NiJ9.e30.sig",
+    `Bearer ${COMPOSITE_KEY}`,
+  ]);
+});
+
+test("withPersonalApiKeyExchange exchanges a bare personal key then verifies the JWT", async () => {
+  const minted = "eyJhbGciOiJSUzI1NiJ9.e30.minted";
+  let exchangeCalls = 0;
+  const inner = stubVerifier(async ({ authorization }) => {
+    assert.equal(authorization, `Bearer ${minted}`);
+    return {
+      identity: {
+        issuer: "https://idp.example/api/v1/oidc",
+        client_id: PUBLIC_ID,
+        usage_subject: "user-456",
+        usage_subject_type: "external_user_id",
+      },
+      expiry: Math.floor(Date.now() / 1000) + 120,
+    };
+  });
+
+  const wrapped = withPersonalApiKeyExchange(inner, {
+    exchange: async (input) => {
+      exchangeCalls += 1;
+      assert.equal(input.subjectToken, BARE_KEY);
+      assert.equal(input.subjectTokenType, SUBJECT_API_KEY_TOKEN_TYPE);
+      return {
+        access_token: minted,
+        token_type: "Bearer",
+        issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        expires_in: 300,
+        scope: "sign:job",
+        balanceUsdMicros: "0",
+        lifetimeGrantedUsdMicros: "0",
+      };
+    },
+  });
+
+  const first = await wrapped.verify(verifyInput(`Bearer ${BARE_KEY}`));
+  const second = await wrapped.verify(verifyInput(`Bearer ${BARE_KEY}`));
+  assert.equal(first.identity.usage_subject, "user-456");
+  assert.equal(first.identity.client_id, PUBLIC_ID);
+  assert.equal(second.identity.usage_subject, "user-456");
+  assert.equal(exchangeCalls, 1);
+});
+
+test("withPersonalApiKeyExchange maps unknown personal keys to invalid_token", async () => {
+  const inner = stubVerifier(async () => {
+    throw new Error("inner verifier must not run when exchange fails");
+  });
+  const wrapped = withPersonalApiKeyExchange(inner, {
+    exchange: async () => {
+      throw new AppScopedSignerTokenExchangeError(
+        "invalid_grant",
+        "subject_token is not a valid API key for this issuer",
+      );
+    },
+  });
+
+  await assert.rejects(
+    () => wrapped.verify(verifyInput(`Bearer ${BARE_KEY}`)),
+    (err: unknown) => {
+      assert.ok(err instanceof WebhookError);
+      assert.equal(err.status, 401);
+      assert.equal(err.code, "invalid_token");
+      assert.match(err.message, /not a valid API key/);
+      return true;
+    },
+  );
+});

--- a/src/lib/oidc/personal-api-key-webhook-exchange.ts
+++ b/src/lib/oidc/personal-api-key-webhook-exchange.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+
+import {
+  bearerToken,
+  REMOTE_SIGNER_ERROR_CODE,
+  REMOTE_SIGNER_HTTP_STATUS,
+  WebhookError,
+  type EndUserAuthVerifier,
+} from "@pymthouse/clearinghouse-identity-webhook/protocol";
+import { createCompositeExchangeCache } from "@pymthouse/clearinghouse-identity-webhook/verifiers";
+
+import { splitCompositeApiKey } from "@/lib/app-api-keys";
+import { createCorrelationId } from "@/lib/audit";
+import {
+  AppScopedSignerTokenExchangeError,
+  GRANT_TYPE_TOKEN_EXCHANGE,
+  handleIssuerApiKeySignerTokenExchange,
+  SUBJECT_API_KEY_TOKEN_TYPE,
+} from "@/lib/oidc/app-scoped-signer-token-exchange";
+
+export type PersonalApiKeyExchange = typeof handleIssuerApiKeySignerTokenExchange;
+
+/**
+ * True for a stored personal / app-user API key presented without an
+ * `app_<24hex>_` prefix. Composite keys stay on the package's path-scoped
+ * exchange; client secrets are never subjects.
+ */
+export function isBarePersonalApiKeyBearer(token: string): boolean {
+  const trimmed = token.trim();
+  if (!trimmed.startsWith("pmth_") || trimmed.startsWith("pmth_cs_")) {
+    return false;
+  }
+  return splitCompositeApiKey(trimmed) == null;
+}
+
+function cacheKeyForToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function webhookErrorFromPersonalApiKeyExchange(
+  err: AppScopedSignerTokenExchangeError,
+): WebhookError {
+  if (
+    err.status === REMOTE_SIGNER_HTTP_STATUS.BILLING_UNAVAILABLE ||
+    err.code === REMOTE_SIGNER_ERROR_CODE.BILLING_UNAVAILABLE
+  ) {
+    return new WebhookError(err.message || "billing balance unavailable", {
+      status: REMOTE_SIGNER_HTTP_STATUS.BILLING_UNAVAILABLE,
+      code: REMOTE_SIGNER_ERROR_CODE.BILLING_UNAVAILABLE,
+    });
+  }
+
+  if (
+    err.status === 402 ||
+    err.code === "trial_credits_exhausted" ||
+    err.code === REMOTE_SIGNER_ERROR_CODE.INSUFFICIENT_BALANCE
+  ) {
+    return new WebhookError(err.message || "insufficient balance", {
+      status: REMOTE_SIGNER_HTTP_STATUS.INSUFFICIENT_BALANCE,
+      code: REMOTE_SIGNER_ERROR_CODE.INSUFFICIENT_BALANCE,
+    });
+  }
+
+  return new WebhookError(err.message || "token exchange failed", {
+    status: 401,
+    code: "invalid_token",
+  });
+}
+
+/**
+ * Exchange a bare `pmth_*` personal API key through the issuer-path RFC 8693
+ * handler (app resolved from the stored key), then verify the minted JWT with
+ * the inner OIDC verifier.
+ *
+ * `@pymthouse/clearinghouse-identity-webhook` only token-exchanges composite
+ * `app_<24hex>_<secret>` Bearers; a bare personal key otherwise fails as
+ * "not a JWT".
+ */
+export function withPersonalApiKeyExchange(
+  verifier: EndUserAuthVerifier,
+  inject: {
+    exchange?: PersonalApiKeyExchange;
+  } = {},
+): EndUserAuthVerifier {
+  const exchange = inject.exchange ?? handleIssuerApiKeySignerTokenExchange;
+  const exchangeCache = createCompositeExchangeCache();
+
+  return {
+    ...verifier,
+    verify: async (input) => {
+      const token = bearerToken(input.authorization);
+      if (!isBarePersonalApiKeyBearer(token)) {
+        return verifier.verify(input);
+      }
+
+      const cacheKey = cacheKeyForToken(token);
+      const cached = exchangeCache.get(cacheKey);
+      if (cached != null) {
+        return cached as ReturnType<EndUserAuthVerifier["verify"]>;
+      }
+
+      let inflight!: ReturnType<EndUserAuthVerifier["verify"]>;
+      inflight = (async () => {
+        let accessToken: string;
+        try {
+          const session = await exchange({
+            clientId: "",
+            clientSecret: "",
+            grantType: GRANT_TYPE_TOKEN_EXCHANGE,
+            subjectToken: token,
+            subjectTokenType: SUBJECT_API_KEY_TOKEN_TYPE,
+            requestedTokenType: "",
+            resource: "",
+            audiences: [],
+            correlationId: createCorrelationId(),
+          });
+          accessToken = session.access_token.trim();
+        } catch (err) {
+          if (err instanceof AppScopedSignerTokenExchangeError) {
+            throw webhookErrorFromPersonalApiKeyExchange(err);
+          }
+          throw err;
+        }
+
+        if (!accessToken) {
+          throw new WebhookError("token exchange returned no access_token", {
+            status: 401,
+            code: "invalid_token",
+          });
+        }
+
+        const verified = await verifier.verify({
+          ...input,
+          authorization: `Bearer ${accessToken}`,
+        });
+        const ttl = Math.max(1, verified.expiry - Math.floor(Date.now() / 1000));
+        exchangeCache.setResultForInflight(cacheKey, inflight, verified, ttl);
+        return verified;
+      })().catch((err: unknown) => {
+        exchangeCache.clearInflight(cacheKey, inflight);
+        throw err;
+      });
+
+      exchangeCache.setInflight(cacheKey, inflight);
+      return inflight;
+    },
+  };
+}

--- a/src/lib/oidc/remote-signer-webhook-config.ts
+++ b/src/lib/oidc/remote-signer-webhook-config.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/oidc/issuer-urls";
 import { createLocalSignerJwksResolver } from "@/lib/oidc/local-signer-jwks";
 import { createLocalTokenExchangeFetch } from "@/lib/oidc/local-token-exchange-fetch";
+import { withPersonalApiKeyExchange } from "@/lib/oidc/personal-api-key-webhook-exchange";
 import { buildSignerBalanceCheck } from "@/lib/oidc/signer-balance-gate";
 import { timeSignerWebhookPhase } from "@/lib/oidc/signer-webhook-metrics";
 import { wireUsageSubjectFromJwt } from "@/lib/openmeter/billing-identity";
@@ -182,25 +183,27 @@ function buildEndUserVerifier(
     isSelfIssuedJwtIssuer(jwtIssuer, resolveAppOrigin(source, original));
 
   if (!selfIssued) {
-    return createEndUserVerifierFromEnv(source);
+    return withPersonalApiKeyExchange(createEndUserVerifierFromEnv(source));
   }
 
   const appOrigin = resolveAppOrigin(source, original);
-  return createOidcVerifier({
-    jwtIssuer,
-    jwtAudience: trimEnv(source, "OIDC_AUDIENCE") || jwtIssuer,
-    jwks: createLocalSignerJwksResolver() as OidcVerifierJwks,
-    issuer: trimEnv(source, "IDENTITY_ISSUER") || jwtIssuer,
-    clientClaim: trimEnv(source, "OIDC_CLIENT_CLAIM") || undefined,
-    subjectClaim: trimEnv(source, "OIDC_SUBJECT_CLAIM") || undefined,
-    subjectTypeValue: trimEnv(source, "OIDC_SUBJECT_TYPE") || undefined,
-    requiredScopes: parseRequiredScopes(source),
-    tokenExchangeBaseUrl: trimEnv(source, "OIDC_TOKEN_EXCHANGE_BASE_URL") || undefined,
-    exchangeM2mClientId: trimEnv(source, "OIDC_EXCHANGE_M2M_CLIENT_ID") || undefined,
-    exchangeM2mClientSecret:
-      trimEnv(source, "OIDC_EXCHANGE_M2M_CLIENT_SECRET") || undefined,
-    fetchImpl: createLocalTokenExchangeFetch(appOrigin),
-  });
+  return withPersonalApiKeyExchange(
+    createOidcVerifier({
+      jwtIssuer,
+      jwtAudience: trimEnv(source, "OIDC_AUDIENCE") || jwtIssuer,
+      jwks: createLocalSignerJwksResolver() as OidcVerifierJwks,
+      issuer: trimEnv(source, "IDENTITY_ISSUER") || jwtIssuer,
+      clientClaim: trimEnv(source, "OIDC_CLIENT_CLAIM") || undefined,
+      subjectClaim: trimEnv(source, "OIDC_SUBJECT_CLAIM") || undefined,
+      subjectTypeValue: trimEnv(source, "OIDC_SUBJECT_TYPE") || undefined,
+      requiredScopes: parseRequiredScopes(source),
+      tokenExchangeBaseUrl: trimEnv(source, "OIDC_TOKEN_EXCHANGE_BASE_URL") || undefined,
+      exchangeM2mClientId: trimEnv(source, "OIDC_EXCHANGE_M2M_CLIENT_ID") || undefined,
+      exchangeM2mClientSecret:
+        trimEnv(source, "OIDC_EXCHANGE_M2M_CLIENT_SECRET") || undefined,
+      fetchImpl: createLocalTokenExchangeFetch(appOrigin),
+    }),
+  );
 }
 
 function withPhaseTiming(verifier: EndUserVerifier): EndUserVerifier {

--- a/src/lib/onboarding.test.ts
+++ b/src/lib/onboarding.test.ts
@@ -76,7 +76,7 @@ test("mintDefaultAppNetworkKey creates app_users not provider_admins", async (t)
     ) as { signer_headers?: { Authorization?: string } };
     assert.equal(
       sdkPayload.signer_headers?.Authorization,
-      `Bearer ${app.clientId}_${result.apiKey}`,
+      `Bearer ${result.apiKey}`,
     );
 
     const membership = await db

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -235,9 +235,9 @@ export async function mintDefaultAppNetworkKey(input: {
     });
   }
 
-  // Personal apiKey stays bare for usage/self-serve; sdkToken must use the
-  // composite presentation so pathless remote-signer webhooks can recover
-  // {clientId} and exchange to a JWT (bare pmth_* → 401 "not a JWT").
+  // Personal apiKey stays bare (`pmth_*`). The remote-signer webhook exchanges
+  // that Bearer via issuer-path RFC 8693 (app resolved from the stored key).
+  // sdkToken still embeds the composite form for older webhook deployments.
   let sdkToken: string | null = null;
   try {
     sdkToken = createLivepeerPythonSdkToken({

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -2,10 +2,7 @@ import { and, eq, isNull, ne } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db/index";
 import { appUsers, developerApps, users } from "@/db/schema";
-import {
-  createAppUserApiKey,
-  formatCompositeApiKey,
-} from "@/lib/app-api-keys";
+import { createAppUserApiKey } from "@/lib/app-api-keys";
 import { createCorrelationId, writeAuditLog } from "@/lib/audit";
 import { provisionAppUserBilling } from "@/lib/billing/provision-app-user";
 import { createLivepeerPythonSdkToken } from "@/lib/livepeer-python-sdk-token";
@@ -235,13 +232,12 @@ export async function mintDefaultAppNetworkKey(input: {
     });
   }
 
-  // Personal apiKey stays bare (`pmth_*`). The remote-signer webhook exchanges
-  // that Bearer via issuer-path RFC 8693 (app resolved from the stored key).
-  // sdkToken still embeds the composite form for older webhook deployments.
+  // Personal apiKey and sdkToken Authorization both stay bare (`pmth_*`).
+  // The remote-signer webhook exchanges that Bearer via issuer-path RFC 8693.
   let sdkToken: string | null = null;
   try {
     sdkToken = createLivepeerPythonSdkToken({
-      apiKey: formatCompositeApiKey(clientId, created.apiKey),
+      apiKey: created.apiKey,
       signer: getClientSignerApiUrl(clientId),
     });
   } catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Personal API keys (`pmth_<hex>`) used as `Authorization: Bearer` against the remote signer failed with **not a JWT**. Composite keys (`app_<24hex>_pmth_<hex>`) worked, and so did the livepeer-python-sdk `--token` bundle (which embeds the composite Authorization header).

The identity webhook (`@pymthouse/clearinghouse-identity-webhook` 0.5.0-rc.0) only RFC 8693-exchanges composite Bearers so it can recover `{clientId}` from the prefix. A bare personal key is not JWT-shaped, so verification stopped before Builder/issuer lookup.

## Fix

Wrap the remote-signer OIDC verifier with `withPersonalApiKeyExchange`:

1. Detect a bare `pmth_*` personal key (not `pmth_cs_*`, not composite `app_*_*`).
2. Exchange it on the **issuer path** via existing `handleIssuerApiKeySignerTokenExchange` (app resolved from the stored key).
3. Verify the minted signer JWT with the inner OIDC verifier (scopes, billing subject rewrite unchanged).
4. Cache the verified identity for the JWT TTL (capped at 60s), matching the composite-exchange cache.

Composite keys and JWTs still take the existing package path.

## Verification

- `npx tsc --noEmit` — clean
- New unit tests for classification, pass-through, exchange + cache, and grant/billing error mapping
- Webhook authorize regression: unwrapped verifier still returns `not a JWT` for `pmth_*`; wrapped verifier authorizes after issuer exchange

[Webhook tests: bare personal key exchanges, composite still works](https://cursor.com/agents/bc-7f790b5a-0658-46b3-bb03-34bbd644c8c2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpersonal_api_key_bearer_tests.log)

SonarQube Cloud and Snyk are CI-only in this repo (no local scanners).

## Docs

- Personal `Authorization: Bearer pmth_…` is documented as valid on the remote signer
- `sdkToken` still embeds composite form for older webhook deployments


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f790b5a-0658-46b3-bb03-34bbd644c8c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f790b5a-0658-46b3-bb03-34bbd644c8c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

