### PR TITLE
Bump remote signer to go-livepeer v0.9.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,7 @@ DATABASE_URL=postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neond
 # Start the full stack so Kafka events reach the OpenMeter collector:
 #   docker compose -f docker-compose.clearinghouse.railway.yml --env-file .env.local up -d --build
 # go-livepeer binary source for signer-dmz-local build (published CI image by default):
-# LIVEPEER_IMAGE=livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577
+# LIVEPEER_IMAGE=livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad
 # Or build DMZ only: ./scripts/build-local-signer.sh
 # Standalone signer (no kafka): docker compose up -d signer-dmz
 # The local compose image is signer-dmz: Apache validates RS256 bearer tokens

--- a/config/railway/stack.json
+++ b/config/railway/stack.json
@@ -28,7 +28,7 @@
       "manifest": "deploy/pymthouse-signer-test/railway.json",
       "environments": ["preview", "production"],
       "description": "A/B 'latest' remote signer DMZ, deployed in both preview and production. Same webhook/OIDC/Kafka and signing identity as pymthouse (the 'stable' signer); LIVEPEER_IMAGE matches the prod Dockerfile default. Entrypoint defaults BYOC_PER_CAP_PRICING=on for this service name. Apps opt in via LATEST_SIGNER_APPS on the Next app.",
-      "livepeerImage": "livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577",
+      "livepeerImage": "livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad",
       "byocPerCapPricing": true
     },
     "pymthouse-signer-test-preview-only": {
@@ -36,7 +36,7 @@
       "manifest": "deploy/pymthouse-signer-test-preview-only/railway.json",
       "environments": ["preview"],
       "description": "Preview-only A/B signer DMZ. Shares pymthouse signing identity; must receive the same ETH_RPC_URL / OIDC / webhook env as other signers via railway-apply-stack-env.sh. Never deploy to production.",
-      "livepeerImage": "livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577",
+      "livepeerImage": "livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad",
       "byocPerCapPricing": true
     }
   }

--- a/docker-compose.clearinghouse.railway.yml
+++ b/docker-compose.clearinghouse.railway.yml
@@ -58,7 +58,7 @@ services:
       dockerfile: docker/signer-dmz/Dockerfile
       target: signer-dmz-local
       args:
-        LIVEPEER_IMAGE: ${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577}
+        LIVEPEER_IMAGE: ${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad}
     restart: unless-stopped
     ports:
       - target: 8080

--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -5,7 +5,7 @@
 #   signer-dmz      — production; livepeer from livepeer/go-livepeer Docker image (Railway single service).
 
 # Base image for signer-dmz-local (override: docker build --build-arg LIVEPEER_IMAGE=...).
-ARG LIVEPEER_IMAGE=livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577
+ARG LIVEPEER_IMAGE=livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad
 
 FROM debian:bookworm-slim AS build-mod
 

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -2,7 +2,7 @@
 # Copies livepeer + required CUDA NPP libs from the official image — do not wget
 # a bare binary into debian:slim; the binary links libnppig.so and other NPP libs.
 
-FROM livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577 AS livepeer-src
+FROM livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad AS livepeer-src
 
 FROM debian:bookworm-slim
 

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -16,8 +16,8 @@ Everything needed to run the go-livepeer signer with an optional **Apache + mod_
 | Image | Dockerfile | go-livepeer source | Use |
 |-------|------------|--------------------|-----|
 | `pymthouse/signer-dmz:local` | `Dockerfile` → `signer-dmz-local` | `../go-livepeer` via `lpclearinghouse` | **Local dev** with PymtHouse (`docker-compose.yml`) |
-| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577` | **Production** (Railway / Render) and prod smoke tests |
-| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577` | **Livepeer only** (no Apache; not for public deploy) |
+| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad` (v0.9.2) | **Production** (Railway / Render) and prod smoke tests |
+| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad` (v0.9.2) | **Livepeer only** (no Apache; not for public deploy) |
 
 ### Force rebuild
 
@@ -33,7 +33,7 @@ docker build --pull --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthou
 # Verify version after rebuild
 docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse-signer:local -version
 docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse/signer-dmz:latest -version
-# expect: Livepeer Node Version: 0.8.10-e1e784f0
+# expect: Livepeer Node Version: 0.9.2-38eb47d1
 ```
 
 ### Local dev

--- a/docs/signer-deployment-options.md
+++ b/docs/signer-deployment-options.md
@@ -122,8 +122,8 @@ app = "pymthouse-signer"
 
 [build]
   [build.args]
-    LIVEPEER_COMMIT = "0a1919e0c58986375df158433445563a45a04df8"
-    LIVEPEER_SHA256 = "0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade"
+    LIVEPEER_COMMIT = "38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad"
+    LIVEPEER_SHA256 = "823cf8bf19963b959cbc4f8139c619af41eebcd2fdd8481de92af1d15d38700d"
 
 [env]
   SIGNER_NETWORK = "arbitrum-one-mainnet"

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -90,7 +90,7 @@ Create a `fly.toml` file (separate from this Next.js app):
 app = "pymthouse-signer"
 
 [build]
-  image = "livepeer/go-livepeer:0.8.10"
+  image = "livepeer/go-livepeer:v0.9.2"
 
 [env]
   SIGNER_NETWORK = "arbitrum-one-mainnet"

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -6,8 +6,8 @@ nixPkgs = ["wget", "gnutar", "coreutils"]
 
 [phases.install]
 cmds = [
-  "wget -q https://build.livepeer.live/go-livepeer/0a1919e0c58986375df158433445563a45a04df8/livepeer-linux-amd64.tar.gz -O livepeer-linux-amd64.tar.gz",
-  "echo '0ba7b032a95bf1969b6983dfe065bc802105d982242e141840df422be1a6bade  livepeer-linux-amd64.tar.gz' | sha256sum -c -",
+  "wget -q https://build.livepeer.live/go-livepeer/38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad/livepeer-linux-amd64.tar.gz -O livepeer-linux-amd64.tar.gz",
+  "echo '823cf8bf19963b959cbc4f8139c619af41eebcd2fdd8481de92af1d15d38700d  livepeer-linux-amd64.tar.gz' | sha256sum -c -",
   "tar -xzf livepeer-linux-amd64.tar.gz",
   "mv livepeer-linux-amd64/livepeer ./livepeer",
   "chmod +x livepeer",

--- a/scripts/build-local-signer.sh
+++ b/scripts/build-local-signer.sh
@@ -3,7 +3,7 @@
 #
 # Default (fast): pull a published go-livepeer image and copy livepeer into the DMZ.
 #   ./scripts/build-local-signer.sh
-#   LIVEPEER_IMAGE=livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577 ./scripts/build-local-signer.sh
+#   LIVEPEER_IMAGE=livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad ./scripts/build-local-signer.sh
 #
 # From local checkout (slow — full CGO/FFmpeg build via lpclearinghouse):
 #   LIVEPEER_IMAGE= ./scripts/build-local-signer.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GO_LIVEPEER_DIR="${GO_LIVEPEER_DIR:-${ROOT}/../go-livepeer}"
 LPCLEARINGHOUSE_DIR="${LPCLEARINGHOUSE_DIR:-${ROOT}/../lpclearinghouse}"
-LIVEPEER_IMAGE="${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-264fc6ba8c67c03cd53824d55b13a53721f07577}"
+LIVEPEER_IMAGE="${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad}"
 SIGNER_DMZ_IMAGE="${SIGNER_DMZ_IMAGE:-pymthouse/signer-dmz:local}"
 
 if [[ -n "${LIVEPEER_IMAGE}" ]]; then

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -39,6 +39,7 @@ export async function createTestUser(opts?: { id?: string; role?: string }): Pro
 export async function deleteTestUser(id: string): Promise<void> {
   await db.execute(sql`DELETE FROM sessions WHERE user_id = ${id}`);
   await db.execute(sql`DELETE FROM provider_admins WHERE user_id = ${id}`);
+  await db.execute(sql`DELETE FROM api_keys WHERE user_id = ${id}`);
   await db.execute(sql`DELETE FROM app_billing_oauth_states WHERE user_id = ${id}`);
   await db.execute(sql`DELETE FROM owner_billing_config WHERE owner_user_id = ${id}`);
   await db.execute(
@@ -57,6 +58,9 @@ export async function deleteTestUser(id: string): Promise<void> {
   await db.execute(
     sql`UPDATE subscriptions SET user_id = NULL WHERE user_id = ${id}`,
   );
+  await deleteFromOptionalTable("oidc_auth_codes", "user_id", id);
+  await deleteFromOptionalTable("oidc_device_codes", "user_id", id);
+  await deleteFromOptionalTable("oidc_refresh_tokens", "user_id", id);
   await db.execute(sql`DELETE FROM users WHERE id = ${id}`);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pin the PymtHouse remote signer to [go-livepeer v0.9.2](https://github.com/livepeer/go-livepeer/releases/tag/v0.9.2) (`38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad`).

The published image is [`livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad`](https://hub.docker.com/r/livepeer/go-livepeer/tags?name=sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad) (also tagged `v0.9.2`). Docker Hub digest `sha256:972870bed3f302ee69ada1e719d7767274a77d2e752be1ab82581ddf2365dfe7`. CI linux-amd64 binary reports `Livepeer Node Version: 0.9.2-38eb47d1`.

## Changes

- `docker/signer-dmz/Dockerfile` and `Dockerfile.signer` default/FROM pin
- `docker-compose.clearinghouse.railway.yml` `LIVEPEER_IMAGE` default
- `config/railway/stack.json` `livepeerImage` for `pymthouse-signer-test` and `pymthouse-signer-test-preview-only`
- `scripts/build-local-signer.sh` default
- `nixpacks.toml` binary download: commit `38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad`, sha256 `823cf8bf19963b959cbc4f8139c619af41eebcd2fdd8481de92af1d15d38700d` (GCS artifact at `build.livepeer.live`; not the GitHub release tarball checksum)
- Docs: `docker/signer-dmz/README.md`, `.env.example`, `docs/signer-deployment-options.md`, `docs/vercel-deployment.md`
- `deleteTestUser` now also drops `api_keys` and OIDC grant rows that FK to `users.id` (CI teardown flake on `checkAppAccess allows the reserved customer-service RP`)

## Note on previous pin

The previous pin (`sha-264fc6ba…`) was a preview of unmerged [go-livepeer#3947](https://github.com/livepeer/go-livepeer/pull/3947) (`encodeMeterPipeline` / constrained model ID in Kafka `pipeline`). That PR is still open and is not in v0.9.2. Kafka `create_signed_ticket` events will use the v0.9.2 pipeline slug until that feature lands in a later go-livepeer release. The OpenMeter collector still splits `pipeline:model` when present.

## Verification

- `npx tsc --noEmit` passed
- GitHub CI on this PR: Test, Snyk, SonarQube, and CodeQL passed
- Docker Hub tag `livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad` is active (`amd64`, digest `sha256:972870bed3f302ee69ada1e719d7767274a77d2e752be1ab82581ddf2365dfe7`)
- GCS linux-amd64 tarball sha256 matches `823cf8bf…`; `livepeer -version` prints `0.9.2-38eb47d1`
- Image contains `/usr/local/bin/livepeer` and CUDA NPP libs under `/usr/local/cuda-12.0/targets/x86_64-linux/lib/` (`libnppc` / `libnppig` / `libnppicc`)
- Railway preview `PymtHouse - pymthouse` succeeded after a retry: `Success - pymthouse-preview.up.railway.app`
- No remaining `sha-264fc6ba…` or `0.8.10` pins

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab287943-263f-4579-8f15-9d56df7bffd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab287943-263f-4579-8f15-9d56df7bffd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

