### PR TITLE
fix(signer-dmz): stop git clone of libjwt on Railway

### DIFF
--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -38,7 +38,8 @@ WORKDIR /build
 # Fetch commit archives over HTTPS (not git clone). Railway builders get
 # GitHub credential prompts on anonymous git-over-HTTPS:
 #   fatal: could not read Username for 'https://github.com'
-RUN curl -fsSL "https://github.com/benmcollins/libjwt/archive/${LIBJWT_COMMIT}.tar.gz" \
+RUN curl --proto '=https' --tlsv1.2 -fsSL \
+      "https://github.com/benmcollins/libjwt/archive/${LIBJWT_COMMIT}.tar.gz" \
       | tar -xz && \
     cd "libjwt-${LIBJWT_COMMIT}" && \
     autoreconf -i && \
@@ -47,7 +48,8 @@ RUN curl -fsSL "https://github.com/benmcollins/libjwt/archive/${LIBJWT_COMMIT}.t
     make install && \
     ldconfig
 
-RUN curl -fsSL "https://github.com/AnthonyDeroche/mod_authnz_jwt/archive/${MOD_AUTHNZ_JWT_COMMIT}.tar.gz" \
+RUN curl --proto '=https' --tlsv1.2 -fsSL \
+      "https://github.com/AnthonyDeroche/mod_authnz_jwt/archive/${MOD_AUTHNZ_JWT_COMMIT}.tar.gz" \
       | tar -xz && \
     cd "mod_authnz_jwt-${MOD_AUTHNZ_JWT_COMMIT}" && \
     autoreconf -ivf && \

--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -18,9 +18,9 @@ ARG MOD_AUTHNZ_JWT_COMMIT=ba43b3f0c7a98603eb83ccbe83a37f0d33bc0700
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     make \
     automake \
-    git \
     g++ \
     libtool \
     pkg-config \
@@ -35,20 +35,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 
-RUN git clone https://github.com/benmcollins/libjwt.git && \
-    cd libjwt && \
-    git -c advice.detachedHead=false checkout "${LIBJWT_COMMIT}" && \
-    git rev-parse --verify "${LIBJWT_COMMIT}^{commit}" >/dev/null && \
+# Fetch commit archives over HTTPS (not git clone). Railway builders get
+# GitHub credential prompts on anonymous git-over-HTTPS:
+#   fatal: could not read Username for 'https://github.com'
+RUN curl -fsSL "https://github.com/benmcollins/libjwt/archive/${LIBJWT_COMMIT}.tar.gz" \
+      | tar -xz && \
+    cd "libjwt-${LIBJWT_COMMIT}" && \
     autoreconf -i && \
     ./configure && \
     make && \
     make install && \
     ldconfig
 
-RUN git clone https://github.com/AnthonyDeroche/mod_authnz_jwt.git && \
-    cd mod_authnz_jwt && \
-    git -c advice.detachedHead=false checkout "${MOD_AUTHNZ_JWT_COMMIT}" && \
-    git rev-parse --verify "${MOD_AUTHNZ_JWT_COMMIT}^{commit}" >/dev/null && \
+RUN curl -fsSL "https://github.com/AnthonyDeroche/mod_authnz_jwt/archive/${MOD_AUTHNZ_JWT_COMMIT}.tar.gz" \
+      | tar -xz && \
+    cd "mod_authnz_jwt-${MOD_AUTHNZ_JWT_COMMIT}" && \
     autoreconf -ivf && \
     PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure && \
     make && \


### PR DESCRIPTION
## Summary
- Railway `main` builds for the remote signer fail at `git clone https://github.com/benmcollins/libjwt.git` with `could not read Username for 'https://github.com'` (anonymous git-over-HTTPS prompts for credentials on Railway builders).
- Fetch the same pinned commits as HTTPS tarballs from GitHub archives (`curl --proto '=https'` + `tar`), which does not use git's credential helper.

## Test plan
- [x] `docker build --target build-mod -f docker/signer-dmz/Dockerfile` succeeds locally (libjwt + `mod_authnz_jwt` install)
- [x] Railway rebuild of the signer-dmz service on this branch / after merge to `main` gets past `build-mod`