### PR TITLE
fix(usage): prefer Live Runner app over model_id for capability labels

### DIFF
--- a/deploy/openmeter-collector/collector.yaml
+++ b/deploy/openmeter-collector/collector.yaml
@@ -36,13 +36,13 @@
 #   producers start emitting payer#actor.
 # - Extra data.* fields are CloudEvent-only; Konnect meters ignore unknown paths.
 #
-# Pipeline / model (wire -> CloudEvent dims):
-# - Preferred: Kafka pipeline is "base:model" (e.g. live-video-to-video:comfyui). Split on
+# Pipeline / capability (wire -> CloudEvent dims):
+# - Preferred: Kafka `app` (Live Runner app, e.g. live-video-to-video/scope). Copied into
+#   data.model_id when model_id is absent so existing meters still group by capability.
+# - Legacy: Kafka pipeline is "base:model" (e.g. live-video-to-video:comfyui). Split on
 #   the first ':' into data.pipeline + data.model_id.
-# - Legacy: separate Kafka model_id (pre-encode images) is still accepted and preferred
-#   when present.
-# - Also passthrough (CloudEvent data only, not meter dimensions): app, session_status,
-#   orch_address, num_tickets.
+# - Legacy: separate Kafka model_id (pre-encode images) is still accepted when present.
+# - data.app is always passthrough when present (session_status, orch_address, num_tickets too).
 
 
 cache_resources:
@@ -227,7 +227,7 @@ pipeline:
         }
         let manifest_id_out = if $manifest_id != "" { $manifest_id } else { "unknown" }
 
-        # Pipeline / model: prefer legacy Kafka model_id; else split base:model.
+        # Pipeline / capability: prefer Kafka app when model_id is absent.
         let pipeline_raw = if $data.pipeline != "" && $data.pipeline != null {
           $data.pipeline.string().trim()
         } else {
@@ -238,6 +238,7 @@ pipeline:
         } else {
           ""
         }
+        let app_out = $data.app.or("").string().trim()
         let pipeline_colon = $pipeline_raw.index_of(":")
         let pipeline_has_model = $pipeline_colon > 0 && $pipeline_colon < $pipeline_raw.length() - 1
         let pipeline_out = if $pipeline_raw == "" {
@@ -253,11 +254,11 @@ pipeline:
           $legacy_model_id
         } else if $pipeline_has_model {
           $pipeline_raw.slice($pipeline_colon + 1)
+        } else if $app_out != "" {
+          $app_out
         } else {
           "unknown"
         }
-
-        let app_out = $data.app.or("").string()
         let session_status_out = $data.session_status.or("").string()
         let orch_address_out = $data.orch_address.or("").string()
         let num_tickets_out = $data.num_tickets.number().or(0)

--- a/src/components/BillingUsageDashboard.helpers.tsx
+++ b/src/components/BillingUsageDashboard.helpers.tsx
@@ -10,6 +10,7 @@ import type {
   BillingUserUsageRow,
 } from "@/lib/billing-usage-dashboard-data";
 import { formatUsdMicrosString } from "@/lib/format-usd-micros";
+import { formatUsageCapabilityLabel } from "@/lib/openmeter/usage-capability";
 import { PLATFORM_DEFAULT_USAGE_DISPLAY_NAME } from "@/lib/platform-default-labels";
 
 type AppUsageEntry = BillingAppUsageSummary;
@@ -243,8 +244,7 @@ export function AppUsageSection({
                   className="text-xs bg-zinc-800 text-zinc-300 px-2 py-0.5 rounded"
                   title={`${pm.requestCount} requests · ${formatUsdMicrosString(pm.networkFeeUsdMicros, 6) ?? "—"}`}
                 >
-                  {pm.pipeline} /{" "}
-                  {pm.modelId.length > 20 ? `${pm.modelId.slice(0, 18)}…` : pm.modelId}
+                  {formatUsageCapabilityLabel(pm.pipeline, pm.modelId)}
                 </span>
               ))}
             </div>
@@ -265,9 +265,7 @@ export function AppUsageSection({
 }
 
 function formatPipelineModelLabel(pipeline: string, modelId: string): string {
-  const model =
-    modelId.length > 24 ? `${modelId.slice(0, 22)}…` : modelId;
-  return `${pipeline} / ${model}`;
+  return formatUsageCapabilityLabel(pipeline, modelId);
 }
 
 function AppUsageUserTable({

--- a/src/components/SignedTicketRequestHistory.tsx
+++ b/src/components/SignedTicketRequestHistory.tsx
@@ -26,6 +26,7 @@ import type {
   SignedTicketRequestRow,
   SignedTicketSessionRow,
 } from "@/lib/openmeter/signed-ticket-events";
+import { formatUsageCapabilityLabel } from "@/lib/openmeter/usage-capability";
 
 type RequestsResponse = {
   items: SignedTicketRequestRow[];
@@ -128,7 +129,7 @@ function historyCopy(
 }
 
 function pipelineModelLabel(pipeline: string, modelId: string): string {
-  return modelId && modelId !== "unknown" ? `${pipeline} / ${modelId}` : pipeline;
+  return formatUsageCapabilityLabel(pipeline, modelId);
 }
 
 function requestFeeLabel(row: SignedTicketRequestRow): string {

--- a/src/lib/billing-usage-dashboard-data.ts
+++ b/src/lib/billing-usage-dashboard-data.ts
@@ -10,6 +10,7 @@ import {
   listOwnerPaymentMethods,
   type OwnerPaymentMethodListItem,
 } from "@/lib/openmeter/owner-payment-method";
+import { formatUsageCapabilityLabel } from "@/lib/openmeter/usage-capability";
 import {
   listOwnerActiveSubscriptions,
   type OwnerBillingSubscriptionRow,
@@ -137,13 +138,9 @@ export type BillingChartSeries = {
   points: { date: string; value: number; feeUsdMicros?: string }[];
 };
 
-/** Chart legend label from OpenMeter pipeline + model_id (signer constraint). */
+/** Chart legend label from pipeline + Live Runner app (optional model_id fallback). */
 export function formatUsageJobTypeLabel(pipeline: string, modelId: string): string {
-  const pipe = (pipeline || "unknown").trim() || "unknown";
-  const model = (modelId || "").trim();
-  if (!model || model === "unknown") return pipe;
-  const shortModel = model.length > 40 ? `${model.slice(0, 38)}…` : model;
-  return `${pipe} / ${shortModel}`;
+  return formatUsageCapabilityLabel(pipeline, modelId);
 }
 
 export type BillingUsageDashboardPayload = {

--- a/src/lib/billing/test-usage-event.ts
+++ b/src/lib/billing/test-usage-event.ts
@@ -105,7 +105,7 @@ export async function ingestTestUsageEvent(input: {
       requestId,
       networkFeeUsdMicros: amountUsdMicros,
       pipeline: "live-video-to-video",
-      modelId: "noop",
+      app: "noop",
       manifestId: `test-usage-${requestId.slice(0, 18)}`,
       billableSecs: 1,
       pixels: "0",

--- a/src/lib/openmeter/entitlements.ts
+++ b/src/lib/openmeter/entitlements.ts
@@ -21,6 +21,7 @@ import {
   usdMicrosToDecimalDollars,
 } from "./konnect-credits";
 import { shouldUseKonnectRoutes } from "./route-mode";
+import { capabilityFromUsageFields } from "./usage-capability";
 
 export type { OpenMeterCustomerIdentity } from "./customers";
 export { ensureOpenMeterCustomer } from "./customers";
@@ -244,7 +245,10 @@ export type SignedTicketOpenMeterEvent = {
   feeWei?: string;
   pixels?: string;
   pipeline?: string;
+  /** Optional; Live Runner traffic uses `app` instead. */
   modelId?: string;
+  /** Live Runner app name from the signed-ticket event (preferred capability). */
+  app?: string;
   manifestId?: string;
   billableSecs?: number;
   gatewayRequestId?: string;
@@ -313,7 +317,11 @@ export async function ingestSignedTicketEvent(input: {
       fee_wei: feeWei,
       pixels: input.event.pixels,
       pipeline: input.event.pipeline || "unknown",
-      model_id: input.event.modelId || "unknown",
+      model_id: capabilityFromUsageFields({
+        app: input.event.app,
+        modelId: input.event.modelId,
+      }),
+      app: input.event.app?.trim() || "",
       manifest_id: input.event.manifestId?.trim() || "unknown",
       billable_secs: billableSecs,
       gateway_request_id: input.event.gatewayRequestId,

--- a/src/lib/openmeter/openmeter.test.ts
+++ b/src/lib/openmeter/openmeter.test.ts
@@ -204,6 +204,40 @@ test("aggregatePipelineModelRows sums fee and count by pipeline/model", () => {
   assert.equal(row.networkFeeUsdMicros, "1500");
 });
 
+test("aggregatePipelineModelRows prefers app over unknown model_id", () => {
+  const rows = aggregatePipelineModelRows({
+    clientId: "app_1",
+    feeRows: [
+      {
+        value: 1000,
+        windowStart: new Date("2026-05-01"),
+        groupBy: {
+          client_id: "app_1",
+          pipeline: "live-video-to-video",
+          model_id: "unknown",
+          app: "live-video-to-video/scope",
+        },
+      },
+    ] as never,
+    countRows: [
+      {
+        value: 4,
+        windowStart: new Date("2026-05-01"),
+        groupBy: {
+          client_id: "app_1",
+          pipeline: "live-video-to-video",
+          model_id: "unknown",
+          app: "live-video-to-video/scope",
+        },
+      },
+    ] as never,
+  });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.pipeline, "live-video-to-video");
+  assert.equal(rows[0]?.modelId, "live-video-to-video/scope");
+  assert.equal(rows[0]?.requestCount, 4);
+});
+
 test("owner_rollup actors cannot see each other's pipeline_model rows", () => {
   const feeRows = [
     {

--- a/src/lib/openmeter/signed-ticket-events.test.ts
+++ b/src/lib/openmeter/signed-ticket-events.test.ts
@@ -233,6 +233,21 @@ test("normalizeSignedTicketEvent maps CloudEvent fields", () => {
   assert.equal(row?.time, "2026-07-11T12:00:00.000Z");
 });
 
+test("normalizeSignedTicketEvent prefers event app over empty model_id", () => {
+  const row = normalizeSignedTicketEvent(
+    sampleEvent({
+      data: {
+        pipeline: "live-video-to-video",
+        model_id: "unknown",
+        app: "live-video-to-video/scope",
+      },
+    }),
+  );
+  assert.ok(row);
+  assert.equal(row?.pipeline, "live-video-to-video");
+  assert.equal(row?.modelId, "live-video-to-video/scope");
+});
+
 test("coerceIngestedEvent accepts wrapped IngestedEvent", () => {
   const coerced = coerceIngestedEvent(sampleEvent());
   assert.ok(coerced);
@@ -836,4 +851,33 @@ test("enrichSessionRowWithEventStats attaches times and resolves duration", () =
   assert.equal(enriched.startedAt, "2026-07-20T15:00:00.000Z");
   assert.equal(enriched.endedAt, "2026-07-20T15:01:00.000Z");
   assert.equal(enriched.billableSecs, "12.5");
+});
+
+test("enrichSessionRowWithEventStats overlays app when meter model_id is unknown", () => {
+  const base = manifestMeterRowToSessionRow(
+    {
+      manifestId: "mid-1",
+      networkFeeUsdMicros: "1",
+      networkFeeUsdExact: "1",
+      feeWei: "1",
+      billableSecs: "0",
+      pipeline: "live-video-to-video",
+      modelId: "unknown",
+    },
+    "app_abc",
+  );
+  const stats = new Map([
+    [
+      sessionEventStatsKey("app_abc", "mid-1"),
+      {
+        firstSeen: "2026-07-20T15:00:00.000Z",
+        lastSeen: "2026-07-20T15:01:00.000Z",
+        billableSecs: 12.5,
+        pipeline: "live-video-to-video",
+        app: "live-video-to-video/scope",
+      },
+    ],
+  ]);
+  const enriched = enrichSessionRowWithEventStats(base, stats);
+  assert.equal(enriched.modelId, "live-video-to-video/scope");
 });

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -22,6 +22,10 @@ import {
   parseOpenMeterCustomerKey,
   parseOwnerCustomerKey,
 } from "@/lib/openmeter/customer-key";
+import {
+  capabilityFromUsageFields,
+  isUnknownUsageCapability,
+} from "@/lib/openmeter/usage-capability";
 import { millisToSecsString } from "@/lib/openmeter/usage-read";
 import { PLATFORM_DEFAULT_USAGE_DISPLAY_NAME } from "@/lib/platform-default-labels";
 
@@ -120,6 +124,8 @@ export type ManifestSessionEventStats = {
   firstSeen: string;
   lastSeen: string;
   billableSecs: number;
+  pipeline?: string;
+  app?: string;
 };
 
 export type ListSignedTicketSessionsResult = {
@@ -392,7 +398,10 @@ export function normalizeSignedTicketEvent(
     externalUserId,
     gatewayRequestId,
     pipeline: stringField(data, "pipeline") || "unknown",
-    modelId: stringField(data, "model_id") || "unknown",
+    modelId: capabilityFromUsageFields({
+      app: stringField(data, "app"),
+      modelId: stringField(data, "model_id"),
+    }),
     networkFeeUsdMicros,
     feeWei: stringField(data, "fee_wei") || undefined,
     pixels: stringField(data, "pixels") || undefined,
@@ -1015,8 +1024,18 @@ export function enrichSessionRowWithEventStats(
   const stats = eventStats.get(sessionEventStatsKey(row.clientId, row.manifestId));
   const startedAt = stats?.firstSeen;
   const endedAt = stats?.lastSeen;
+  const pipeline =
+    stats?.pipeline && !isUnknownUsageCapability(stats.pipeline)
+      ? stats.pipeline
+      : row.pipeline;
+  const modelId = capabilityFromUsageFields({
+    app: stats?.app,
+    modelId: row.modelId,
+  });
   return {
     ...row,
+    pipeline,
+    modelId,
     startedAt,
     endedAt,
     billableSecs: resolveSessionBillableSecs(
@@ -1089,6 +1108,11 @@ export function aggregateManifestSessionEventStats(
       sessionEventStatsKey(clientId, manifestId),
       time,
       secs,
+      stringField(data, "pipeline"),
+      capabilityFromUsageFields({
+        app: stringField(data, "app"),
+        modelId: stringField(data, "model_id"),
+      }),
     );
   }
   return out;
@@ -1155,6 +1179,8 @@ function accumulateSessionEventStat(
   key: string,
   time: string,
   secs: number,
+  pipeline?: string | null,
+  app?: string | null,
 ): void {
   const prev = out.get(key);
   if (!prev) {
@@ -1162,12 +1188,18 @@ function accumulateSessionEventStat(
       firstSeen: time,
       lastSeen: time,
       billableSecs: secs,
+      pipeline: pipeline?.trim() || undefined,
+      app: isUnknownUsageCapability(app) ? undefined : app?.trim(),
     });
     return;
   }
   if (time < prev.firstSeen) prev.firstSeen = time;
   if (time > prev.lastSeen) prev.lastSeen = time;
   if (secs > 0) prev.billableSecs += secs;
+  if (!prev.pipeline && pipeline?.trim()) prev.pipeline = pipeline.trim();
+  if (isUnknownUsageCapability(prev.app) && !isUnknownUsageCapability(app)) {
+    prev.app = app?.trim();
+  }
 }
 
 /** Prefer meter SUM; fall back to event SUM or wall-clock span when meter is 0. */

--- a/src/lib/openmeter/usage-capability.test.ts
+++ b/src/lib/openmeter/usage-capability.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  capabilityFromUsageFields,
+  formatUsageCapabilityLabel,
+  isUnknownUsageCapability,
+} from "./usage-capability";
+
+test("capabilityFromUsageFields prefers app over empty or unknown model_id", () => {
+  assert.equal(
+    capabilityFromUsageFields({
+      app: "live-video-to-video/scope",
+      modelId: "unknown",
+    }),
+    "live-video-to-video/scope",
+  );
+  assert.equal(
+    capabilityFromUsageFields({
+      app: " flux-schnell ",
+      modelId: "",
+    }),
+    "flux-schnell",
+  );
+  assert.equal(
+    capabilityFromUsageFields({
+      app: "",
+      modelId: "sdxl",
+    }),
+    "sdxl",
+  );
+  assert.equal(capabilityFromUsageFields({}), "unknown");
+});
+
+test("isUnknownUsageCapability treats blank and unknown as missing", () => {
+  assert.equal(isUnknownUsageCapability(null), true);
+  assert.equal(isUnknownUsageCapability(""), true);
+  assert.equal(isUnknownUsageCapability("unknown"), true);
+  assert.equal(isUnknownUsageCapability("Unknown"), true);
+  assert.equal(isUnknownUsageCapability("sdxl"), false);
+});
+
+test("formatUsageCapabilityLabel hides unknown model and keeps pipeline", () => {
+  assert.equal(
+    formatUsageCapabilityLabel("live-video-to-video", "unknown"),
+    "live-video-to-video",
+  );
+  assert.equal(
+    formatUsageCapabilityLabel("live-video-to-video", "live-video-to-video/scope"),
+    "live-video-to-video / live-video-to-video/scope",
+  );
+});

--- a/src/lib/openmeter/usage-capability.ts
+++ b/src/lib/openmeter/usage-capability.ts
@@ -1,0 +1,35 @@
+/**
+ * Live Runner `app` on create_signed_ticket events is the capability name
+ * (e.g. `live-video-to-video/scope`). `model_id` is optional and often empty.
+ */
+
+export function isUnknownUsageCapability(
+  value: string | null | undefined,
+): boolean {
+  const trimmed = value?.trim() ?? "";
+  return !trimmed || trimmed.toLowerCase() === "unknown";
+}
+
+/** Prefer event `app` when `model_id` is missing or unknown. */
+export function capabilityFromUsageFields(input: {
+  app?: string | null;
+  modelId?: string | null;
+}): string {
+  const app = input.app?.trim() ?? "";
+  if (!isUnknownUsageCapability(app)) return app;
+  const modelId = input.modelId?.trim() ?? "";
+  if (!isUnknownUsageCapability(modelId)) return modelId;
+  return "unknown";
+}
+
+/** Chart / table label: pipeline, plus app (or model_id) when present. */
+export function formatUsageCapabilityLabel(
+  pipeline: string,
+  capability: string,
+): string {
+  const pipe = (pipeline || "unknown").trim() || "unknown";
+  if (isUnknownUsageCapability(capability)) return pipe;
+  const model = capability.trim();
+  const shortModel = model.length > 40 ? `${model.slice(0, 38)}…` : model;
+  return `${pipe} / ${shortModel}`;
+}

--- a/src/lib/openmeter/usage-read.ts
+++ b/src/lib/openmeter/usage-read.ts
@@ -17,6 +17,7 @@ import {
   requireOpenMeterForUsageReads,
   SIGNED_TICKET_COUNT_METER,
 } from "@/lib/openmeter/constants";
+import { capabilityFromUsageFields } from "@/lib/openmeter/usage-capability";
 import type { MeterQueryRow } from "@openmeter/sdk";
 
 function avoidOpenMeterNetworkInTests(): boolean {
@@ -181,6 +182,7 @@ type MeterWindowSize = "DAY" | "MONTH";
 
 /** OpenMeter meter query dimensions (must match ingest event + meter groupBy). */
 const METER_GROUP_BY_USER = ["client_id", "external_user_id"] as const;
+/** `model_id` is filled from event `app` at ingest when model_id is absent. */
 const METER_GROUP_BY_DETAIL = [
   "client_id",
   "external_user_id",
@@ -446,6 +448,14 @@ function groupByString(
   return fallback;
 }
 
+/** Meter/event capability: Live Runner `app`, with optional `model_id` fallback. */
+function capabilityFromGroup(group: Record<string, unknown>): string {
+  return capabilityFromUsageFields({
+    app: groupByString(group, "app", ""),
+    modelId: groupByString(group, "model_id", ""),
+  });
+}
+
 function clientIdFromGroup(
   group: Record<string, unknown>,
   fallbackClientId: string,
@@ -564,7 +574,7 @@ export function aggregatePipelineModelRows(input: {
       continue;
     }
     const pipeline = groupByString(group, "pipeline", "unknown");
-    const modelId = groupByString(group, "model_id", "unknown");
+    const modelId = capabilityFromGroup(group);
     const key = `${pipeline}|${modelId}`;
     metaByKey.set(key, { pipeline, modelId });
     countByKey.set(
@@ -587,7 +597,7 @@ export function aggregatePipelineModelRows(input: {
       continue;
     }
     const pipeline = groupByString(group, "pipeline", "unknown");
-    const modelId = groupByString(group, "model_id", "unknown");
+    const modelId = capabilityFromGroup(group);
     const key = `${pipeline}|${modelId}`;
     metaByKey.set(key, { pipeline, modelId });
     feeByKey.set(
@@ -658,7 +668,7 @@ export function aggregateManifestRows(input: {
       if (!metaByManifest.has(manifestId)) {
         metaByManifest.set(manifestId, {
           pipeline: groupByString(group, "pipeline", "unknown"),
-          modelId: groupByString(group, "model_id", "unknown"),
+          modelId: capabilityFromGroup(group),
         });
       }
       target.set(
@@ -749,7 +759,7 @@ function resolveUserPipelineModelMeta(
     matchKeys,
   );
   const pipeline = groupByString(group, "pipeline", "unknown");
-  const modelId = groupByString(group, "model_id", "unknown");
+  const modelId = capabilityFromGroup(group);
   return {
     externalUserId,
     pipeline,
@@ -995,7 +1005,7 @@ export function aggregateDailyPipelineModelRows(input: {
       continue;
     }
     const pipeline = groupByString(group, "pipeline", "unknown");
-    const modelId = groupByString(group, "model_id", "unknown");
+    const modelId = capabilityFromGroup(group);
     const day = dateKeyFromMeterWindow(row);
     if (!day) continue;
     const key = `${pipeline}|${modelId}|${day}`;
@@ -1023,7 +1033,7 @@ export function aggregateDailyPipelineModelRows(input: {
       continue;
     }
     const pipeline = groupByString(group, "pipeline", "unknown");
-    const modelId = groupByString(group, "model_id", "unknown");
+    const modelId = capabilityFromGroup(group);
     const day = dateKeyFromMeterWindow(row);
     if (!day) continue;
     const key = `${pipeline}|${modelId}|${day}`;
@@ -1165,6 +1175,7 @@ export function __testAccumulateOpenMeterUsage(input: {
   networkFeeUsdMicros: string;
   pipeline?: string;
   modelId?: string;
+  app?: string;
 }): void {
   if (process.env.NODE_ENV !== "test") {
     throw new Error("__testAccumulateOpenMeterUsage is only available in test");
@@ -1176,7 +1187,10 @@ export function __testAccumulateOpenMeterUsage(input: {
   }
 
   const pipeline = input.pipeline?.trim() || "unknown";
-  const modelId = input.modelId?.trim() || "unknown";
+  const modelId = capabilityFromUsageFields({
+    app: input.app,
+    modelId: input.modelId,
+  });
   const rows = testUsageRowsByClient.get(input.clientId) ?? [];
   const existing = rows.find((row) => row.externalUserId === input.externalUserId);
   if (existing) {


### PR DESCRIPTION
## Summary
- Treat Live Runner `app` as the usage capability when `model_id` is missing or `unknown`, so OpenMeter ingest, meters, and dashboards stop grouping Live Runner traffic as `unknown`.
- Centralize that preference in `capabilityFromUsageFields` / `formatUsageCapabilityLabel` and use it for signed-ticket events, collector CloudEvents, charts, and request history.
- Keep the legacy `model_id` / `pipeline:model` fallback so older producers still label correctly.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (1560 pass)
- [x] Sonar snippet analysis on `usage-capability.ts` (no issues)
- [x] Snyk Code on `usage-capability.ts` (no issues); SCA findings are pre-existing transitive `qs` via `@modelcontextprotocol/sdk`, not introduced here
- [x] Confirm a Live Runner signed-ticket event with `app` and empty `model_id` shows the app name on usage charts and request history
- [x] Confirm a legacy event with only `model_id` still labels as `pipeline / model_id`