### PR TITLE
fix(security): bump fast-uri override to 3.1.7 (code scanning 148/149)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6693,9 +6693,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@hono/node-server": "2.0.11",
     "hono": "4.13.5",
     "sharp": "0.35.3",
-    "fast-uri": "3.1.6"
+    "fast-uri": "3.1.7"
   },
   "devDependencies": {
     "@redocly/cli": "^2.47.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bumps the existing `fast-uri` npm override from `3.1.6` → `3.1.7` so the MCP SDK (`@modelcontextprotocol/sdk` → `ajv`) resolves the patched release.
- Clears the two high Snyk Open Source findings currently failing `main` and uploaded as GitHub Code Scanning:
  - [code scanning 148](https://github.com/pymthouse/pymthouse/security/code-scanning/148) / [SNYK-JS-FASTURI-19502739](https://security.snyk.io/vuln/SNYK-JS-FASTURI-19502739) (Improper Encoding or Escaping of Output)
  - [code scanning 149](https://github.com/pymthouse/pymthouse/security/code-scanning/149) / [SNYK-JS-FASTURI-19502854](https://security.snyk.io/vuln/SNYK-JS-FASTURI-19502854) (Host Confusion)
- Same override approach as #476 (which pinned `3.1.6` for the previous 3.1.5 advisories). One PR closes both alerts because they share the same package version.

## Test plan
- [x] `npm ls fast-uri` → `fast-uri@3.1.7 overridden` under `@modelcontextprotocol/sdk`
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npx tsc --noEmit` passes
- [x] CI Snyk Open Source (`severity-threshold=high`) passes on this PR
- [ ] Code scanning alerts 148 and 149 auto-close after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-966e8f56-b41c-4c80-a629-0c5474368955?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-966e8f56-b41c-4c80-a629-0c5474368955&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

