### PR TITLE
Accept from/to on end-user request history

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -452,7 +452,7 @@ End users can read **their own** usage with the credential they already hold (no
 | --- | --- |
 | `GET /api/v1/user/usage` | Aggregates for the authenticated subject; app resolved from the Bearer credential |
 | `GET /api/v1/user/usage/balance` | Plan included-usage allowance for that subject |
-| `GET /api/v1/user/usage/requests` | Signed-ticket history (`groupBy=session\|request`, `manifestId`, `cursor`, `limit`) |
+| `GET /api/v1/user/usage/requests` | Signed-ticket history (`groupBy=session\|request`, `manifestId`, `from`/`to`, `cursor`, `limit`) |
 | `GET /api/v1/apps/{clientId}/me/usage` | Same aggregates with path-scoped app (`{clientId}` must match the credential) |
 | `GET /api/v1/apps/{clientId}/me/usage/balance` | Same balance, path-scoped |
 | `GET /api/v1/apps/{clientId}/me/usage/requests` | Same request history, path-scoped |
@@ -522,14 +522,18 @@ Plan included-usage allowance for the Bearer subject (`balanceUsdMicros` / `rema
 
 **Endpoint:** `GET /api/v1/user/usage/requests` (or `GET /api/v1/apps/{clientId}/me/usage/requests`)
 
-Lists signed-ticket CloudEvents for the **token subject only** — newest first. Supports `groupBy=session|request` and `manifestId` (same semantics as `/api/v1/me/usage/requests`).
+Lists signed-ticket CloudEvents for the **token subject only** — newest first. Supports `groupBy=session|request` and `manifestId` (same semantics as `/api/v1/me/usage/requests`). Optional `from`/`to` override the default window.
 
 | Query | Description |
 | --- | --- |
 | `groupBy` | `session` or `request` (default `request`) |
 | `manifestId` | When `groupBy=request`, filter to one session mid |
+| `from` | Inclusive lower bound (ISO 8601). Required together with `to`. |
+| `to` | Inclusive upper bound (ISO 8601). Required together with `from`. |
 | `cursor` | Opaque pagination cursor from a prior response |
 | `limit` | Page size (default 25, max 50) |
+
+When `from`/`to` are omitted, the server uses the current UTC calendar month. The pair must satisfy `from <= to` within `MAX_DATE_RANGE_DAYS` (365). A lone `from` or `to` returns **400**.
 
 Responses include `items`, `nextCursor`, `openMeterConfigured`, `groupBy`, plus `clientId` / `externalUserId` echoed from the credential.
 

--- a/src/lib/openapi/openapi-document.test.ts
+++ b/src/lib/openapi/openapi-document.test.ts
@@ -35,6 +35,22 @@ test("buildPublicOpenApiDocument includes Builder + End-user and omits Internal"
   assert.ok(doc.paths["/api/v1/apps/{clientId}/me/usage/balance"]?.get);
   assert.ok(doc.paths["/api/v1/apps/{clientId}/me/usage/requests"]?.get);
   assert.ok(doc.paths["/api/v1/user/usage"]?.get);
+  assert.match(
+    doc.paths["/api/v1/apps/{clientId}/me/usage/requests"]?.get?.responses?.[400]
+      ?.description ?? "",
+    /invalid date range/i,
+  );
+  assert.match(
+    doc.paths["/api/v1/user/usage/requests"]?.get?.description ?? "",
+    /from.*to/i,
+  );
+  const fromParam = doc.paths["/api/v1/user/usage/requests"]?.get?.parameters?.find(
+    (param) => "name" in param && param.name === "from",
+  );
+  assert.match(
+    fromParam && "description" in fromParam ? fromParam.description ?? "" : "",
+    /365 days/,
+  );
   assert.equal(doc.paths["/api/v1/user/usage"]?.get?.deprecated, undefined);
   assert.equal(doc.paths["/api/v1/signer"], undefined);
 

--- a/src/lib/openapi/routes/end-user.ts
+++ b/src/lib/openapi/routes/end-user.ts
@@ -65,6 +65,21 @@ const endUserRequestsQueryParams = z.object({
       param: { name: "limit", in: "query" },
       description: "Page size (default 25, max 50).",
     }),
+  from: z
+    .string()
+    .optional()
+    .openapi({
+      param: { name: "from", in: "query" },
+      description:
+        "Inclusive lower bound (ISO 8601). Must be paired with `to`. Console uses the last 7 days.",
+    }),
+  to: z
+    .string()
+    .optional()
+    .openapi({
+      param: { name: "to", in: "query" },
+      description: "Inclusive upper bound (ISO 8601). Must be paired with `from`.",
+    }),
 });
 
 const meUsagePath = (suffix: string) =>
@@ -122,6 +137,7 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
     "Chronological signed-ticket history for the authenticated subject. " +
     "`groupBy=session` lists per-manifest sessions; `groupBy=request` (default) " +
     "lists CloudEvents (optionally filtered by `manifestId`). " +
+    "Optional `from`/`to` (ISO 8601, together) override the default calendar-month window. " +
     "Do not pass `userId` / `externalUserId`.",
   security: endUserSecurity,
   request: {

--- a/src/lib/openapi/routes/end-user.ts
+++ b/src/lib/openapi/routes/end-user.ts
@@ -1,3 +1,4 @@
+import { MAX_DATE_RANGE_DAYS } from "@/lib/billing-utils";
 import { defineRouteMetadata } from "@/lib/openapi/route-metadata";
 import {
   builderErrorResponses,
@@ -6,6 +7,9 @@ import {
 } from "@/lib/openapi/routes/shared";
 import { OPENAPI_TAGS } from "@/lib/openapi/tags";
 import { z } from "@/lib/openapi/zod";
+
+const requestsDateRangeBadRequest =
+  "Disallowed cross-user filter, invalid groupBy, or invalid date range";
 
 const endUserSecurity: Array<Record<string, string[]>> = [{ endUserBearer: [] }];
 
@@ -71,14 +75,18 @@ const endUserRequestsQueryParams = z.object({
     .openapi({
       param: { name: "from", in: "query" },
       description:
-        "Inclusive lower bound (ISO 8601). Must be paired with `to`. Console uses the last 7 days.",
+        `Inclusive lower bound (ISO 8601). Must be paired with \`to\`. ` +
+        `Maximum span is ${MAX_DATE_RANGE_DAYS} days. ` +
+        "Omitted pair defaults to the current UTC calendar month.",
     }),
   to: z
     .string()
     .optional()
     .openapi({
       param: { name: "to", in: "query" },
-      description: "Inclusive upper bound (ISO 8601). Must be paired with `from`.",
+      description:
+        `Inclusive upper bound (ISO 8601). Must be paired with \`from\`. ` +
+        `Maximum span is ${MAX_DATE_RANGE_DAYS} days.`,
     }),
 });
 
@@ -137,7 +145,8 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
     "Chronological signed-ticket history for the authenticated subject. " +
     "`groupBy=session` lists per-manifest sessions; `groupBy=request` (default) " +
     "lists CloudEvents (optionally filtered by `manifestId`). " +
-    "Optional `from`/`to` (ISO 8601, together) override the default calendar-month window. " +
+    "Optional `from`/`to` (ISO 8601, together) override the default " +
+    `calendar-month window (max ${MAX_DATE_RANGE_DAYS} days). ` +
     "Do not pass `userId` / `externalUserId`.",
   security: endUserSecurity,
   request: {
@@ -149,7 +158,7 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
     ...builderErrorResponses,
     400: {
       ...builderErrorResponses[400],
-      description: "Disallowed cross-user filter or invalid groupBy",
+      description: requestsDateRangeBadRequest,
     },
     401: {
       ...builderErrorResponses[401],
@@ -166,7 +175,11 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
 const defineUserUsageRoute = (
   suffix: string,
   summary: string,
-  query?: typeof endUserUsageQueryParams | typeof endUserRequestsQueryParams,
+  options?: {
+    query?: typeof endUserUsageQueryParams | typeof endUserRequestsQueryParams;
+    descriptionExtra?: string;
+    badRequestDescription?: string;
+  },
 ) => {
   defineRouteMetadata("get", `/api/v1/user/usage${suffix}`, {
     tags: [OPENAPI_TAGS.endUserUsage],
@@ -175,21 +188,34 @@ const defineUserUsageRoute = (
       "Usage for the authenticated subject. The app is resolved from the " +
       "Bearer credential (bare `pmth_*` key, optional composite, or user/signer JWT). " +
       "Do not pass `userId` / `externalUserId`. " +
+      (options?.descriptionExtra ? `${options.descriptionExtra} ` : "") +
       `App-scoped equivalent: \`GET ${meUsagePath(suffix)}\`.`,
     security: endUserSecurity,
-    ...(query ? { request: { query } } : {}),
+    ...(options?.query ? { request: { query: options.query } } : {}),
     responses: {
       200: jsonSuccess,
       ...builderErrorResponses,
+      ...(options?.badRequestDescription
+        ? {
+            400: {
+              ...builderErrorResponses[400],
+              description: options.badRequestDescription,
+            },
+          }
+        : {}),
       503: { description: "OpenMeter not configured" },
     },
   });
 };
 
-defineUserUsageRoute("", "End-user usage summary", endUserUsageQueryParams);
+defineUserUsageRoute("", "End-user usage summary", {
+  query: endUserUsageQueryParams,
+});
 defineUserUsageRoute("/balance", "End-user usage balance");
-defineUserUsageRoute(
-  "/requests",
-  "End-user signed-ticket request history",
-  endUserRequestsQueryParams,
-);
+defineUserUsageRoute("/requests", "End-user signed-ticket request history", {
+  query: endUserRequestsQueryParams,
+  descriptionExtra:
+    "Optional `from`/`to` (ISO 8601, together) override the default " +
+    `calendar-month window (max ${MAX_DATE_RANGE_DAYS} days).`,
+  badRequestDescription: requestsDateRangeBadRequest,
+});

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -4,6 +4,7 @@ import {
   authenticateEndUser,
   endUserSubjectOverrideError,
 } from "@/lib/auth/end-user";
+import { isValidBoundedDateRange, MAX_DATE_RANGE_DAYS } from "@/lib/billing-utils";
 import {
   listEndUserSignedTicketRequests,
   listEndUserSignedTicketSessions,
@@ -95,10 +96,27 @@ export async function handleEndUserMeUsageRequestsGet(
   const groupBy = params.get("groupBy")?.trim().toLowerCase() || "request";
   const limitRaw = params.get("limit");
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+  const from = params.get("from")?.trim() || undefined;
+  const to = params.get("to")?.trim() || undefined;
 
   if (groupBy !== "request" && groupBy !== "session") {
     return NextResponse.json(
       { error: "Invalid groupBy; use request or session" },
+      { status: 400 },
+    );
+  }
+
+  if ((from && !to) || (to && !from)) {
+    return NextResponse.json(
+      { error: "from and to must be supplied together" },
+      { status: 400 },
+    );
+  }
+  if (from && to && !isValidBoundedDateRange(from, to)) {
+    return NextResponse.json(
+      {
+        error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
+      },
       { status: 400 },
     );
   }
@@ -109,6 +127,8 @@ export async function handleEndUserMeUsageRequestsGet(
       clientId: auth.publicClientId,
       cursor,
       limit: Number.isFinite(limit) ? limit : undefined,
+      from,
+      to,
     });
 
     return NextResponse.json({
@@ -127,6 +147,8 @@ export async function handleEndUserMeUsageRequestsGet(
     manifestId,
     cursor,
     limit: Number.isFinite(limit) ? limit : undefined,
+    from,
+    to,
   });
 
   return NextResponse.json({

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -4,7 +4,6 @@ import {
   authenticateEndUser,
   endUserSubjectOverrideError,
 } from "@/lib/auth/end-user";
-import { isValidBoundedDateRange, MAX_DATE_RANGE_DAYS } from "@/lib/billing-utils";
 import {
   listEndUserSignedTicketRequests,
   listEndUserSignedTicketSessions,
@@ -13,6 +12,7 @@ import {
   handleAppUsageBalanceGet,
   handleAppUsageGet,
 } from "@/lib/usage/app-usage-handlers";
+import { parseOptionalDateRange } from "@/lib/usage/optional-date-range";
 
 /**
  * `publicClientId` is the app the credential must belong to. Omit it for the
@@ -96,8 +96,6 @@ export async function handleEndUserMeUsageRequestsGet(
   const groupBy = params.get("groupBy")?.trim().toLowerCase() || "request";
   const limitRaw = params.get("limit");
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
-  const from = params.get("from")?.trim() || undefined;
-  const to = params.get("to")?.trim() || undefined;
 
   if (groupBy !== "request" && groupBy !== "session") {
     return NextResponse.json(
@@ -106,19 +104,9 @@ export async function handleEndUserMeUsageRequestsGet(
     );
   }
 
-  if ((from && !to) || (to && !from)) {
-    return NextResponse.json(
-      { error: "from and to must be supplied together" },
-      { status: 400 },
-    );
-  }
-  if (from && to && !isValidBoundedDateRange(from, to)) {
-    return NextResponse.json(
-      {
-        error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
-      },
-      { status: 400 },
-    );
+  const dateRange = parseOptionalDateRange(params);
+  if ("error" in dateRange) {
+    return NextResponse.json({ error: dateRange.error }, { status: 400 });
   }
 
   if (groupBy === "session") {
@@ -127,8 +115,8 @@ export async function handleEndUserMeUsageRequestsGet(
       clientId: auth.publicClientId,
       cursor,
       limit: Number.isFinite(limit) ? limit : undefined,
-      from,
-      to,
+      from: dateRange.from,
+      to: dateRange.to,
     });
 
     return NextResponse.json({
@@ -147,8 +135,8 @@ export async function handleEndUserMeUsageRequestsGet(
     manifestId,
     cursor,
     limit: Number.isFinite(limit) ? limit : undefined,
-    from,
-    to,
+    from: dateRange.from,
+    to: dateRange.to,
   });
 
   return NextResponse.json({

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   authenticateEndUser,
   endUserSubjectOverrideError,
+  type EndUserAuth,
 } from "@/lib/auth/end-user";
 import {
   listEndUserSignedTicketRequests,
@@ -14,6 +15,35 @@ import {
 } from "@/lib/usage/app-usage-handlers";
 import { parseOptionalDateRange } from "@/lib/usage/optional-date-range";
 
+type AuthenticateEndUser = typeof authenticateEndUser;
+type ListRequests = typeof listEndUserSignedTicketRequests;
+type ListSessions = typeof listEndUserSignedTicketSessions;
+
+const requestsDeps = {
+  authenticateEndUser,
+  listEndUserSignedTicketRequests,
+  listEndUserSignedTicketSessions,
+};
+
+/** Swap auth + OpenMeter list helpers in NODE_ENV=test only. */
+export function __testSetEndUserUsageRequestsDeps(deps: {
+  authenticateEndUser?: AuthenticateEndUser;
+  listEndUserSignedTicketRequests?: ListRequests;
+  listEndUserSignedTicketSessions?: ListSessions;
+} | null): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      "__testSetEndUserUsageRequestsDeps is only available in test",
+    );
+  }
+  requestsDeps.authenticateEndUser =
+    deps?.authenticateEndUser ?? authenticateEndUser;
+  requestsDeps.listEndUserSignedTicketRequests =
+    deps?.listEndUserSignedTicketRequests ?? listEndUserSignedTicketRequests;
+  requestsDeps.listEndUserSignedTicketSessions =
+    deps?.listEndUserSignedTicketSessions ?? listEndUserSignedTicketSessions;
+}
+
 /**
  * `publicClientId` is the app the credential must belong to. Omit it for the
  * pathless `/api/v1/user/usage*` routes, where the app is derived from the
@@ -23,10 +53,7 @@ async function requireEndUserAuth(
   request: NextRequest,
   publicClientId: string | undefined,
   resourceLabel: string,
-): Promise<
-  | { auth: NonNullable<Awaited<ReturnType<typeof authenticateEndUser>>> }
-  | { response: Response }
-> {
+): Promise<{ auth: EndUserAuth } | { response: Response }> {
   const override = endUserSubjectOverrideError(
     request.nextUrl.searchParams,
     resourceLabel,
@@ -35,7 +62,7 @@ async function requireEndUserAuth(
     return { response: override };
   }
 
-  const auth = await authenticateEndUser(request, {
+  const auth = await requestsDeps.authenticateEndUser(request, {
     expectedPublicClientId: publicClientId,
   });
   if (!auth) {
@@ -110,7 +137,7 @@ export async function handleEndUserMeUsageRequestsGet(
   }
 
   if (groupBy === "session") {
-    const result = await listEndUserSignedTicketSessions({
+    const result = await requestsDeps.listEndUserSignedTicketSessions({
       externalUserId: auth.externalUserId,
       clientId: auth.publicClientId,
       cursor,
@@ -129,7 +156,7 @@ export async function handleEndUserMeUsageRequestsGet(
     });
   }
 
-  const result = await listEndUserSignedTicketRequests({
+  const result = await requestsDeps.listEndUserSignedTicketRequests({
     externalUserId: auth.externalUserId,
     clientId: auth.publicClientId,
     manifestId,

--- a/src/lib/usage/end-user-usage-requests.route.test.ts
+++ b/src/lib/usage/end-user-usage-requests.route.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { NextRequest } from "next/server";
+
+import { MAX_DATE_RANGE_DAYS } from "@/lib/billing-utils";
+import {
+  __testSetEndUserUsageRequestsDeps,
+  handleEndUserMeUsageRequestsGet,
+} from "@/lib/usage/end-user-usage-handlers";
+
+const AUTH = {
+  publicClientId: "app_testclientid000000000001",
+  developerAppId: "dev-app-1",
+  externalUserId: "eu_subject",
+};
+
+function requestsUrl(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/apps/${AUTH.publicClientId}/me/usage/requests${query}`,
+    { headers: { Authorization: "Bearer test-token" } },
+  );
+}
+
+function stubEmptyList() {
+  return Promise.resolve({
+    items: [],
+    nextCursor: null,
+    openMeterConfigured: true,
+  });
+}
+
+test.afterEach(() => {
+  __testSetEndUserUsageRequestsDeps(null);
+});
+
+test("handleEndUserMeUsageRequestsGet returns 400 for a lone from or to", async () => {
+  let listCalls = 0;
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+    listEndUserSignedTicketRequests: async () => {
+      listCalls += 1;
+      return stubEmptyList();
+    },
+  });
+
+  const loneFrom = await handleEndUserMeUsageRequestsGet(
+    requestsUrl("?from=2026-09-01T00:00:00.000Z"),
+    AUTH.publicClientId,
+  );
+  assert.equal(loneFrom.status, 400);
+  assert.deepEqual(await loneFrom.json(), {
+    error: "from and to must be supplied together",
+  });
+
+  const loneTo = await handleEndUserMeUsageRequestsGet(
+    requestsUrl("?to=2026-09-05T00:00:00.000Z"),
+    AUTH.publicClientId,
+  );
+  assert.equal(loneTo.status, 400);
+  assert.deepEqual(await loneTo.json(), {
+    error: "from and to must be supplied together",
+  });
+  assert.equal(listCalls, 0);
+});
+
+test("handleEndUserMeUsageRequestsGet returns 400 for an overlong range", async () => {
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+  });
+
+  const res = await handleEndUserMeUsageRequestsGet(
+    requestsUrl("?from=2025-01-01T00:00:00.000Z&to=2026-09-01T00:00:00.000Z"),
+    AUTH.publicClientId,
+  );
+  assert.equal(res.status, 400);
+  assert.deepEqual(await res.json(), {
+    error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
+  });
+});
+
+test("handleEndUserMeUsageRequestsGet forwards the parsed window to OpenMeter", async () => {
+  const seen: unknown[] = [];
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+    listEndUserSignedTicketRequests: async (input) => {
+      seen.push(input);
+      return stubEmptyList();
+    },
+  });
+
+  const from = "2026-09-01T00:00:00.000Z";
+  const to = "2026-09-05T23:59:59.999Z";
+  const res = await handleEndUserMeUsageRequestsGet(
+    requestsUrl(`?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`),
+    AUTH.publicClientId,
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { groupBy: string; clientId: string };
+  assert.equal(body.groupBy, "request");
+  assert.equal(body.clientId, AUTH.publicClientId);
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0], {
+    externalUserId: AUTH.externalUserId,
+    clientId: AUTH.publicClientId,
+    manifestId: undefined,
+    cursor: undefined,
+    limit: undefined,
+    from,
+    to,
+  });
+});
+
+test("handleEndUserMeUsageRequestsGet forwards from/to for groupBy=session", async () => {
+  const seen: unknown[] = [];
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+    listEndUserSignedTicketSessions: async (input) => {
+      seen.push(input);
+      return stubEmptyList();
+    },
+  });
+
+  const from = "2026-08-01T00:00:00.000Z";
+  const to = "2026-08-31T23:59:59.999Z";
+  const res = await handleEndUserMeUsageRequestsGet(
+    requestsUrl(
+      `?groupBy=session&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+    ),
+    AUTH.publicClientId,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0], {
+    externalUserId: AUTH.externalUserId,
+    clientId: AUTH.publicClientId,
+    cursor: undefined,
+    limit: undefined,
+    from,
+    to,
+  });
+});
+
+test("handleEndUserMeUsageRequestsGet omits from/to when the pair is absent", async () => {
+  const seen: unknown[] = [];
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+    listEndUserSignedTicketRequests: async (input) => {
+      seen.push(input);
+      return stubEmptyList();
+    },
+  });
+
+  const res = await handleEndUserMeUsageRequestsGet(
+    requestsUrl(),
+    AUTH.publicClientId,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(seen.length, 1);
+  const input = seen[0] as { from?: string; to?: string };
+  assert.equal(input.from, undefined);
+  assert.equal(input.to, undefined);
+});

--- a/src/lib/usage/me-usage-requests-handler.ts
+++ b/src/lib/usage/me-usage-requests-handler.ts
@@ -8,14 +8,11 @@ import {
   listDeveloperSignedTicketRequests,
   listDeveloperSignedTicketSessions,
 } from "@/lib/openmeter/signed-ticket-events";
+import { parseOptionalDateRange } from "@/lib/usage/optional-date-range";
 import {
   resolveViewerUsageClientScopes,
   type ViewerUsageClientScopes,
 } from "@/lib/viewer-usage-clients";
-import {
-  isValidBoundedDateRange,
-  MAX_DATE_RANGE_DAYS,
-} from "@/lib/billing-utils";
 
 type MeUsageGroupBy = "request" | "session";
 type MeUsageScope = "own" | "all";
@@ -95,34 +92,6 @@ function validateMeUsageRequestsParams(
   return { scope, groupBy };
 }
 
-function parseOptionalDateRange(
-  params: URLSearchParams,
-): { error: NextResponse } | { from?: string; to?: string } {
-  // Optional date range for the requests table's range picker. Both bounds are
-  // required together and are span-limited before hitting OpenMeter.
-  const from = params.get("from")?.trim() || undefined;
-  const to = params.get("to")?.trim() || undefined;
-  if ((from && !to) || (to && !from)) {
-    return {
-      error: NextResponse.json(
-        { error: "from and to must be supplied together" },
-        { status: 400 },
-      ),
-    };
-  }
-  if (from && to && !isValidBoundedDateRange(from, to)) {
-    return {
-      error: NextResponse.json(
-        {
-          error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
-        },
-        { status: 400 },
-      ),
-    };
-  }
-  return { from, to };
-}
-
 /** Session-authenticated viewer signed-ticket history (Internal API). */
 export async function handleMeUsageRequestsGet(
   request: NextRequest,
@@ -162,7 +131,7 @@ export async function handleMeUsageRequestsGet(
 
   const dateRange = parseOptionalDateRange(params);
   if ("error" in dateRange) {
-    return dateRange.error;
+    return NextResponse.json({ error: dateRange.error }, { status: 400 });
   }
 
   const listInput = {

--- a/src/lib/usage/optional-date-range.test.ts
+++ b/src/lib/usage/optional-date-range.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MAX_DATE_RANGE_DAYS } from "@/lib/billing-utils";
+import { parseOptionalDateRange } from "@/lib/usage/optional-date-range";
+
+test("parseOptionalDateRange allows omitting both bounds", () => {
+  assert.deepEqual(parseOptionalDateRange(new URLSearchParams()), {
+    from: undefined,
+    to: undefined,
+  });
+});
+
+test("parseOptionalDateRange rejects a lone from or to", () => {
+  assert.deepEqual(
+    parseOptionalDateRange(new URLSearchParams({ from: "2026-09-01T00:00:00.000Z" })),
+    { error: "from and to must be supplied together" },
+  );
+  assert.deepEqual(
+    parseOptionalDateRange(new URLSearchParams({ to: "2026-09-05T00:00:00.000Z" })),
+    { error: "from and to must be supplied together" },
+  );
+});
+
+test("parseOptionalDateRange accepts a paired bounded range", () => {
+  const from = "2026-09-01T00:00:00.000Z";
+  const to = "2026-09-05T23:59:59.999Z";
+  assert.deepEqual(parseOptionalDateRange(new URLSearchParams({ from, to })), {
+    from,
+    to,
+  });
+});
+
+test("parseOptionalDateRange trims whitespace around bounds", () => {
+  const from = "2026-09-01T00:00:00.000Z";
+  const to = "2026-09-05T23:59:59.999Z";
+  assert.deepEqual(
+    parseOptionalDateRange(new URLSearchParams({ from: `  ${from}  `, to: ` ${to}` })),
+    { from, to },
+  );
+});
+
+test("parseOptionalDateRange treats blank bounds as omitted", () => {
+  assert.deepEqual(
+    parseOptionalDateRange(new URLSearchParams({ from: "  ", to: "\t" })),
+    { from: undefined, to: undefined },
+  );
+});
+
+test("parseOptionalDateRange rejects inverted or overlong ranges", () => {
+  const error = {
+    error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
+  };
+  assert.deepEqual(
+    parseOptionalDateRange(
+      new URLSearchParams({
+        from: "2026-09-05T00:00:00.000Z",
+        to: "2026-09-01T00:00:00.000Z",
+      }),
+    ),
+    error,
+  );
+  assert.deepEqual(
+    parseOptionalDateRange(
+      new URLSearchParams({
+        from: "2025-01-01T00:00:00.000Z",
+        to: "2026-09-01T00:00:00.000Z",
+      }),
+    ),
+    error,
+  );
+  assert.deepEqual(
+    parseOptionalDateRange(
+      new URLSearchParams({
+        from: "not-a-date",
+        to: "2026-09-01T00:00:00.000Z",
+      }),
+    ),
+    error,
+  );
+});

--- a/src/lib/usage/optional-date-range.ts
+++ b/src/lib/usage/optional-date-range.ts
@@ -1,0 +1,28 @@
+import {
+  isValidBoundedDateRange,
+  MAX_DATE_RANGE_DAYS,
+} from "@/lib/billing-utils";
+
+export type ParsedOptionalDateRange =
+  | { error: string }
+  | { from?: string; to?: string };
+
+/**
+ * Optional `from`/`to` query pair for signed-ticket history.
+ * Both bounds are required together and span-limited before OpenMeter.
+ */
+export function parseOptionalDateRange(
+  params: URLSearchParams,
+): ParsedOptionalDateRange {
+  const from = params.get("from")?.trim() || undefined;
+  const to = params.get("to")?.trim() || undefined;
+  if ((from && !to) || (to && !from)) {
+    return { error: "from and to must be supplied together" };
+  }
+  if (from && to && !isValidBoundedDateRange(from, to)) {
+    return {
+      error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
+    };
+  }
+  return { from, to };
+}


### PR DESCRIPTION
## Summary

- Forward optional `from`/`to` on `GET /api/v1/user/usage/requests` and `/apps/{clientId}/me/usage/requests`.
- Required together and bounded by `MAX_DATE_RANGE_DAYS`. When omitted, behavior is unchanged (calendar month).
- Needed so Console can page a rolling 7-day history that still works at the start of a month.

## Test plan

- [ ] `GET /api/v1/user/usage/requests?from=<now-7d>&to=<now>` returns only that window
- [ ] Omitting both params still returns the calendar-month default
- [ ] Only `from` or only `to` → 400
- [ ] OpenAPI lists the new query params