### PR TITLE
docs(usage): document from/to and cover requests route wiring

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -452,7 +452,7 @@ End users can read **their own** usage with the credential they already hold (no
 | --- | --- |
 | `GET /api/v1/user/usage` | Aggregates for the authenticated subject; app resolved from the Bearer credential |
 | `GET /api/v1/user/usage/balance` | Plan included-usage allowance for that subject |
-| `GET /api/v1/user/usage/requests` | Signed-ticket history (`groupBy=session\|request`, `manifestId`, `cursor`, `limit`) |
+| `GET /api/v1/user/usage/requests` | Signed-ticket history (`groupBy=session\|request`, `manifestId`, `from`/`to`, `cursor`, `limit`) |
 | `GET /api/v1/apps/{clientId}/me/usage` | Same aggregates with path-scoped app (`{clientId}` must match the credential) |
 | `GET /api/v1/apps/{clientId}/me/usage/balance` | Same balance, path-scoped |
 | `GET /api/v1/apps/{clientId}/me/usage/requests` | Same request history, path-scoped |
@@ -522,14 +522,18 @@ Plan included-usage allowance for the Bearer subject (`balanceUsdMicros` / `rema
 
 **Endpoint:** `GET /api/v1/user/usage/requests` (or `GET /api/v1/apps/{clientId}/me/usage/requests`)
 
-Lists signed-ticket CloudEvents for the **token subject only** — newest first. Supports `groupBy=session|request` and `manifestId` (same semantics as `/api/v1/me/usage/requests`).
+Lists signed-ticket CloudEvents for the **token subject only** — newest first. Supports `groupBy=session|request` and `manifestId` (same semantics as `/api/v1/me/usage/requests`). Optional `from`/`to` override the default window.
 
 | Query | Description |
 | --- | --- |
 | `groupBy` | `session` or `request` (default `request`) |
 | `manifestId` | When `groupBy=request`, filter to one session mid |
+| `from` | Inclusive lower bound (ISO 8601). Required together with `to`. |
+| `to` | Inclusive upper bound (ISO 8601). Required together with `from`. |
 | `cursor` | Opaque pagination cursor from a prior response |
 | `limit` | Page size (default 25, max 50) |
+
+When `from`/`to` are omitted, the server uses the current UTC calendar month. The pair must satisfy `from <= to` within `MAX_DATE_RANGE_DAYS` (365). A lone `from` or `to` returns **400**.
 
 Responses include `items`, `nextCursor`, `openMeterConfigured`, `groupBy`, plus `clientId` / `externalUserId` echoed from the credential.
 

--- a/src/lib/openapi/openapi-document.test.ts
+++ b/src/lib/openapi/openapi-document.test.ts
@@ -44,6 +44,13 @@ test("buildPublicOpenApiDocument includes Builder + End-user and omits Internal"
     doc.paths["/api/v1/user/usage/requests"]?.get?.description ?? "",
     /from.*to/i,
   );
+  const fromParam = doc.paths["/api/v1/user/usage/requests"]?.get?.parameters?.find(
+    (param) => "name" in param && param.name === "from",
+  );
+  assert.match(
+    fromParam && "description" in fromParam ? fromParam.description ?? "" : "",
+    /365 days/,
+  );
   assert.equal(doc.paths["/api/v1/user/usage"]?.get?.deprecated, undefined);
   assert.equal(doc.paths["/api/v1/signer"], undefined);
 

--- a/src/lib/openapi/openapi-document.test.ts
+++ b/src/lib/openapi/openapi-document.test.ts
@@ -35,6 +35,15 @@ test("buildPublicOpenApiDocument includes Builder + End-user and omits Internal"
   assert.ok(doc.paths["/api/v1/apps/{clientId}/me/usage/balance"]?.get);
   assert.ok(doc.paths["/api/v1/apps/{clientId}/me/usage/requests"]?.get);
   assert.ok(doc.paths["/api/v1/user/usage"]?.get);
+  assert.match(
+    doc.paths["/api/v1/apps/{clientId}/me/usage/requests"]?.get?.responses?.[400]
+      ?.description ?? "",
+    /invalid date range/i,
+  );
+  assert.match(
+    doc.paths["/api/v1/user/usage/requests"]?.get?.description ?? "",
+    /from.*to/i,
+  );
   assert.equal(doc.paths["/api/v1/user/usage"]?.get?.deprecated, undefined);
   assert.equal(doc.paths["/api/v1/signer"], undefined);
 

--- a/src/lib/openapi/routes/end-user.ts
+++ b/src/lib/openapi/routes/end-user.ts
@@ -1,3 +1,4 @@
+import { MAX_DATE_RANGE_DAYS } from "@/lib/billing-utils";
 import { defineRouteMetadata } from "@/lib/openapi/route-metadata";
 import {
   builderErrorResponses,
@@ -6,6 +7,9 @@ import {
 } from "@/lib/openapi/routes/shared";
 import { OPENAPI_TAGS } from "@/lib/openapi/tags";
 import { z } from "@/lib/openapi/zod";
+
+const requestsDateRangeBadRequest =
+  "Disallowed cross-user filter, invalid groupBy, or invalid date range";
 
 const endUserSecurity: Array<Record<string, string[]>> = [{ endUserBearer: [] }];
 
@@ -71,14 +75,18 @@ const endUserRequestsQueryParams = z.object({
     .openapi({
       param: { name: "from", in: "query" },
       description:
-        "Inclusive lower bound (ISO 8601). Must be paired with `to`. Console uses the last 7 days.",
+        `Inclusive lower bound (ISO 8601). Must be paired with \`to\`. ` +
+        `Maximum span is ${MAX_DATE_RANGE_DAYS} days. ` +
+        "Omitted pair defaults to the current UTC calendar month.",
     }),
   to: z
     .string()
     .optional()
     .openapi({
       param: { name: "to", in: "query" },
-      description: "Inclusive upper bound (ISO 8601). Must be paired with `from`.",
+      description:
+        `Inclusive upper bound (ISO 8601). Must be paired with \`from\`. ` +
+        `Maximum span is ${MAX_DATE_RANGE_DAYS} days.`,
     }),
 });
 
@@ -137,7 +145,8 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
     "Chronological signed-ticket history for the authenticated subject. " +
     "`groupBy=session` lists per-manifest sessions; `groupBy=request` (default) " +
     "lists CloudEvents (optionally filtered by `manifestId`). " +
-    "Optional `from`/`to` (ISO 8601, together) override the default calendar-month window. " +
+    "Optional `from`/`to` (ISO 8601, together) override the default " +
+    `calendar-month window (max ${MAX_DATE_RANGE_DAYS} days). ` +
     "Do not pass `userId` / `externalUserId`.",
   security: endUserSecurity,
   request: {
@@ -149,7 +158,7 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
     ...builderErrorResponses,
     400: {
       ...builderErrorResponses[400],
-      description: "Disallowed cross-user filter or invalid groupBy",
+      description: requestsDateRangeBadRequest,
     },
     401: {
       ...builderErrorResponses[401],
@@ -166,7 +175,11 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
 const defineUserUsageRoute = (
   suffix: string,
   summary: string,
-  query?: typeof endUserUsageQueryParams | typeof endUserRequestsQueryParams,
+  options?: {
+    query?: typeof endUserUsageQueryParams | typeof endUserRequestsQueryParams;
+    descriptionExtra?: string;
+    badRequestDescription?: string;
+  },
 ) => {
   defineRouteMetadata("get", `/api/v1/user/usage${suffix}`, {
     tags: [OPENAPI_TAGS.endUserUsage],
@@ -175,21 +188,34 @@ const defineUserUsageRoute = (
       "Usage for the authenticated subject. The app is resolved from the " +
       "Bearer credential (bare `pmth_*` key, optional composite, or user/signer JWT). " +
       "Do not pass `userId` / `externalUserId`. " +
+      (options?.descriptionExtra ? `${options.descriptionExtra} ` : "") +
       `App-scoped equivalent: \`GET ${meUsagePath(suffix)}\`.`,
     security: endUserSecurity,
-    ...(query ? { request: { query } } : {}),
+    ...(options?.query ? { request: { query: options.query } } : {}),
     responses: {
       200: jsonSuccess,
       ...builderErrorResponses,
+      ...(options?.badRequestDescription
+        ? {
+            400: {
+              ...builderErrorResponses[400],
+              description: options.badRequestDescription,
+            },
+          }
+        : {}),
       503: { description: "OpenMeter not configured" },
     },
   });
 };
 
-defineUserUsageRoute("", "End-user usage summary", endUserUsageQueryParams);
+defineUserUsageRoute("", "End-user usage summary", {
+  query: endUserUsageQueryParams,
+});
 defineUserUsageRoute("/balance", "End-user usage balance");
-defineUserUsageRoute(
-  "/requests",
-  "End-user signed-ticket request history",
-  endUserRequestsQueryParams,
-);
+defineUserUsageRoute("/requests", "End-user signed-ticket request history", {
+  query: endUserRequestsQueryParams,
+  descriptionExtra:
+    "Optional `from`/`to` (ISO 8601, together) override the default " +
+    `calendar-month window (max ${MAX_DATE_RANGE_DAYS} days).`,
+  badRequestDescription: requestsDateRangeBadRequest,
+});

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -1,12 +1,48 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import * as endUserAuth from "@/lib/auth/end-user";
-import * as signedTicketEvents from "@/lib/openmeter/signed-ticket-events";
+import {
+  authenticateEndUser,
+  endUserSubjectOverrideError,
+  type EndUserAuth,
+} from "@/lib/auth/end-user";
+import {
+  listEndUserSignedTicketRequests,
+  listEndUserSignedTicketSessions,
+} from "@/lib/openmeter/signed-ticket-events";
 import {
   handleAppUsageBalanceGet,
   handleAppUsageGet,
 } from "@/lib/usage/app-usage-handlers";
 import { parseOptionalDateRange } from "@/lib/usage/optional-date-range";
+
+type AuthenticateEndUser = typeof authenticateEndUser;
+type ListRequests = typeof listEndUserSignedTicketRequests;
+type ListSessions = typeof listEndUserSignedTicketSessions;
+
+const requestsDeps = {
+  authenticateEndUser,
+  listEndUserSignedTicketRequests,
+  listEndUserSignedTicketSessions,
+};
+
+/** Swap auth + OpenMeter list helpers in NODE_ENV=test only. */
+export function __testSetEndUserUsageRequestsDeps(deps: {
+  authenticateEndUser?: AuthenticateEndUser;
+  listEndUserSignedTicketRequests?: ListRequests;
+  listEndUserSignedTicketSessions?: ListSessions;
+} | null): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      "__testSetEndUserUsageRequestsDeps is only available in test",
+    );
+  }
+  requestsDeps.authenticateEndUser =
+    deps?.authenticateEndUser ?? authenticateEndUser;
+  requestsDeps.listEndUserSignedTicketRequests =
+    deps?.listEndUserSignedTicketRequests ?? listEndUserSignedTicketRequests;
+  requestsDeps.listEndUserSignedTicketSessions =
+    deps?.listEndUserSignedTicketSessions ?? listEndUserSignedTicketSessions;
+}
 
 /**
  * `publicClientId` is the app the credential must belong to. Omit it for the
@@ -17,15 +53,8 @@ async function requireEndUserAuth(
   request: NextRequest,
   publicClientId: string | undefined,
   resourceLabel: string,
-): Promise<
-  | {
-      auth: NonNullable<
-        Awaited<ReturnType<typeof endUserAuth.authenticateEndUser>>
-      >;
-    }
-  | { response: Response }
-> {
-  const override = endUserAuth.endUserSubjectOverrideError(
+): Promise<{ auth: EndUserAuth } | { response: Response }> {
+  const override = endUserSubjectOverrideError(
     request.nextUrl.searchParams,
     resourceLabel,
   );
@@ -33,7 +62,7 @@ async function requireEndUserAuth(
     return { response: override };
   }
 
-  const auth = await endUserAuth.authenticateEndUser(request, {
+  const auth = await requestsDeps.authenticateEndUser(request, {
     expectedPublicClientId: publicClientId,
   });
   if (!auth) {
@@ -108,7 +137,7 @@ export async function handleEndUserMeUsageRequestsGet(
   }
 
   if (groupBy === "session") {
-    const result = await signedTicketEvents.listEndUserSignedTicketSessions({
+    const result = await requestsDeps.listEndUserSignedTicketSessions({
       externalUserId: auth.externalUserId,
       clientId: auth.publicClientId,
       cursor,
@@ -127,7 +156,7 @@ export async function handleEndUserMeUsageRequestsGet(
     });
   }
 
-  const result = await signedTicketEvents.listEndUserSignedTicketRequests({
+  const result = await requestsDeps.listEndUserSignedTicketRequests({
     externalUserId: auth.externalUserId,
     clientId: auth.publicClientId,
     manifestId,

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -1,13 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import {
-  authenticateEndUser,
-  endUserSubjectOverrideError,
-} from "@/lib/auth/end-user";
-import {
-  listEndUserSignedTicketRequests,
-  listEndUserSignedTicketSessions,
-} from "@/lib/openmeter/signed-ticket-events";
+import * as endUserAuth from "@/lib/auth/end-user";
+import * as signedTicketEvents from "@/lib/openmeter/signed-ticket-events";
 import {
   handleAppUsageBalanceGet,
   handleAppUsageGet,
@@ -24,10 +18,14 @@ async function requireEndUserAuth(
   publicClientId: string | undefined,
   resourceLabel: string,
 ): Promise<
-  | { auth: NonNullable<Awaited<ReturnType<typeof authenticateEndUser>>> }
+  | {
+      auth: NonNullable<
+        Awaited<ReturnType<typeof endUserAuth.authenticateEndUser>>
+      >;
+    }
   | { response: Response }
 > {
-  const override = endUserSubjectOverrideError(
+  const override = endUserAuth.endUserSubjectOverrideError(
     request.nextUrl.searchParams,
     resourceLabel,
   );
@@ -35,7 +33,7 @@ async function requireEndUserAuth(
     return { response: override };
   }
 
-  const auth = await authenticateEndUser(request, {
+  const auth = await endUserAuth.authenticateEndUser(request, {
     expectedPublicClientId: publicClientId,
   });
   if (!auth) {
@@ -110,7 +108,7 @@ export async function handleEndUserMeUsageRequestsGet(
   }
 
   if (groupBy === "session") {
-    const result = await listEndUserSignedTicketSessions({
+    const result = await signedTicketEvents.listEndUserSignedTicketSessions({
       externalUserId: auth.externalUserId,
       clientId: auth.publicClientId,
       cursor,
@@ -129,7 +127,7 @@ export async function handleEndUserMeUsageRequestsGet(
     });
   }
 
-  const result = await listEndUserSignedTicketRequests({
+  const result = await signedTicketEvents.listEndUserSignedTicketRequests({
     externalUserId: auth.externalUserId,
     clientId: auth.publicClientId,
     manifestId,

--- a/src/lib/usage/end-user-usage-requests.route.test.ts
+++ b/src/lib/usage/end-user-usage-requests.route.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+
+import { NextRequest } from "next/server";
+
+import * as endUserAuth from "@/lib/auth/end-user";
+import { MAX_DATE_RANGE_DAYS } from "@/lib/billing-utils";
+import * as signedTicketEvents from "@/lib/openmeter/signed-ticket-events";
+import { handleEndUserMeUsageRequestsGet } from "@/lib/usage/end-user-usage-handlers";
+
+const AUTH = {
+  publicClientId: "app_testclientid000000000001",
+  developerAppId: "dev-app-1",
+  externalUserId: "eu_subject",
+};
+
+type ListResult = {
+  items: unknown[];
+  nextCursor: string | null;
+  openMeterConfigured: boolean;
+};
+
+function requestsUrl(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/apps/${AUTH.publicClientId}/me/usage/requests${query}`,
+    { headers: { Authorization: "Bearer test-token" } },
+  );
+}
+
+function stubEmptyList(): Promise<ListResult> {
+  return Promise.resolve({
+    items: [],
+    nextCursor: null,
+    openMeterConfigured: true,
+  });
+}
+
+function mockAuthedLists(
+  t: TestContext,
+  list: {
+    requests?: (input: unknown) => Promise<ListResult>;
+    sessions?: (input: unknown) => Promise<ListResult>;
+  } = {},
+): void {
+  t.mock.method(endUserAuth, "authenticateEndUser", async () => AUTH);
+  t.mock.method(
+    signedTicketEvents,
+    "listEndUserSignedTicketRequests",
+    list.requests ?? stubEmptyList,
+  );
+  t.mock.method(
+    signedTicketEvents,
+    "listEndUserSignedTicketSessions",
+    list.sessions ?? stubEmptyList,
+  );
+}
+
+test("handleEndUserMeUsageRequestsGet returns 400 for a lone from or to", async (t) => {
+  mockAuthedLists(t);
+
+  const loneFrom = await handleEndUserMeUsageRequestsGet(
+    requestsUrl("?from=2026-09-01T00:00:00.000Z"),
+    AUTH.publicClientId,
+  );
+  assert.equal(loneFrom.status, 400);
+  assert.deepEqual(await loneFrom.json(), {
+    error: "from and to must be supplied together",
+  });
+
+  const loneTo = await handleEndUserMeUsageRequestsGet(
+    requestsUrl("?to=2026-09-05T00:00:00.000Z"),
+    AUTH.publicClientId,
+  );
+  assert.equal(loneTo.status, 400);
+  assert.deepEqual(await loneTo.json(), {
+    error: "from and to must be supplied together",
+  });
+
+  assert.equal(
+    signedTicketEvents.listEndUserSignedTicketRequests.mock.calls.length,
+    0,
+  );
+});
+
+test("handleEndUserMeUsageRequestsGet returns 400 for an overlong range", async (t) => {
+  mockAuthedLists(t);
+
+  const res = await handleEndUserMeUsageRequestsGet(
+    requestsUrl("?from=2025-01-01T00:00:00.000Z&to=2026-09-01T00:00:00.000Z"),
+    AUTH.publicClientId,
+  );
+  assert.equal(res.status, 400);
+  assert.deepEqual(await res.json(), {
+    error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
+  });
+});
+
+test("handleEndUserMeUsageRequestsGet forwards the parsed window to OpenMeter", async (t) => {
+  const seen: unknown[] = [];
+  mockAuthedLists(t, {
+    requests: async (input) => {
+      seen.push(input);
+      return stubEmptyList();
+    },
+  });
+
+  const from = "2026-09-01T00:00:00.000Z";
+  const to = "2026-09-05T23:59:59.999Z";
+  const res = await handleEndUserMeUsageRequestsGet(
+    requestsUrl(`?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`),
+    AUTH.publicClientId,
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { groupBy: string; clientId: string };
+  assert.equal(body.groupBy, "request");
+  assert.equal(body.clientId, AUTH.publicClientId);
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0], {
+    externalUserId: AUTH.externalUserId,
+    clientId: AUTH.publicClientId,
+    manifestId: undefined,
+    cursor: undefined,
+    limit: undefined,
+    from,
+    to,
+  });
+});
+
+test("handleEndUserMeUsageRequestsGet forwards from/to for groupBy=session", async (t) => {
+  const seen: unknown[] = [];
+  mockAuthedLists(t, {
+    sessions: async (input) => {
+      seen.push(input);
+      return stubEmptyList();
+    },
+  });
+
+  const from = "2026-08-01T00:00:00.000Z";
+  const to = "2026-08-31T23:59:59.999Z";
+  const res = await handleEndUserMeUsageRequestsGet(
+    requestsUrl(
+      `?groupBy=session&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+    ),
+    AUTH.publicClientId,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0], {
+    externalUserId: AUTH.externalUserId,
+    clientId: AUTH.publicClientId,
+    cursor: undefined,
+    limit: undefined,
+    from,
+    to,
+  });
+});
+
+test("handleEndUserMeUsageRequestsGet omits from/to when the pair is absent", async (t) => {
+  const seen: unknown[] = [];
+  mockAuthedLists(t, {
+    requests: async (input) => {
+      seen.push(input);
+      return stubEmptyList();
+    },
+  });
+
+  const res = await handleEndUserMeUsageRequestsGet(
+    requestsUrl(),
+    AUTH.publicClientId,
+  );
+  assert.equal(res.status, 200);
+  assert.equal(seen.length, 1);
+  const input = seen[0] as { from?: string; to?: string };
+  assert.equal(input.from, undefined);
+  assert.equal(input.to, undefined);
+});

--- a/src/lib/usage/end-user-usage-requests.route.test.ts
+++ b/src/lib/usage/end-user-usage-requests.route.test.ts
@@ -1,23 +1,18 @@
 import assert from "node:assert/strict";
-import test, { type TestContext } from "node:test";
+import test from "node:test";
 
 import { NextRequest } from "next/server";
 
-import * as endUserAuth from "@/lib/auth/end-user";
 import { MAX_DATE_RANGE_DAYS } from "@/lib/billing-utils";
-import * as signedTicketEvents from "@/lib/openmeter/signed-ticket-events";
-import { handleEndUserMeUsageRequestsGet } from "@/lib/usage/end-user-usage-handlers";
+import {
+  __testSetEndUserUsageRequestsDeps,
+  handleEndUserMeUsageRequestsGet,
+} from "@/lib/usage/end-user-usage-handlers";
 
 const AUTH = {
   publicClientId: "app_testclientid000000000001",
   developerAppId: "dev-app-1",
   externalUserId: "eu_subject",
-};
-
-type ListResult = {
-  items: unknown[];
-  nextCursor: string | null;
-  openMeterConfigured: boolean;
 };
 
 function requestsUrl(query = ""): NextRequest {
@@ -27,7 +22,7 @@ function requestsUrl(query = ""): NextRequest {
   );
 }
 
-function stubEmptyList(): Promise<ListResult> {
+function stubEmptyList() {
   return Promise.resolve({
     items: [],
     nextCursor: null,
@@ -35,28 +30,19 @@ function stubEmptyList(): Promise<ListResult> {
   });
 }
 
-function mockAuthedLists(
-  t: TestContext,
-  list: {
-    requests?: (input: unknown) => Promise<ListResult>;
-    sessions?: (input: unknown) => Promise<ListResult>;
-  } = {},
-): void {
-  t.mock.method(endUserAuth, "authenticateEndUser", async () => AUTH);
-  t.mock.method(
-    signedTicketEvents,
-    "listEndUserSignedTicketRequests",
-    list.requests ?? stubEmptyList,
-  );
-  t.mock.method(
-    signedTicketEvents,
-    "listEndUserSignedTicketSessions",
-    list.sessions ?? stubEmptyList,
-  );
-}
+test.afterEach(() => {
+  __testSetEndUserUsageRequestsDeps(null);
+});
 
-test("handleEndUserMeUsageRequestsGet returns 400 for a lone from or to", async (t) => {
-  mockAuthedLists(t);
+test("handleEndUserMeUsageRequestsGet returns 400 for a lone from or to", async () => {
+  let listCalls = 0;
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+    listEndUserSignedTicketRequests: async () => {
+      listCalls += 1;
+      return stubEmptyList();
+    },
+  });
 
   const loneFrom = await handleEndUserMeUsageRequestsGet(
     requestsUrl("?from=2026-09-01T00:00:00.000Z"),
@@ -75,15 +61,13 @@ test("handleEndUserMeUsageRequestsGet returns 400 for a lone from or to", async 
   assert.deepEqual(await loneTo.json(), {
     error: "from and to must be supplied together",
   });
-
-  assert.equal(
-    signedTicketEvents.listEndUserSignedTicketRequests.mock.calls.length,
-    0,
-  );
+  assert.equal(listCalls, 0);
 });
 
-test("handleEndUserMeUsageRequestsGet returns 400 for an overlong range", async (t) => {
-  mockAuthedLists(t);
+test("handleEndUserMeUsageRequestsGet returns 400 for an overlong range", async () => {
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+  });
 
   const res = await handleEndUserMeUsageRequestsGet(
     requestsUrl("?from=2025-01-01T00:00:00.000Z&to=2026-09-01T00:00:00.000Z"),
@@ -95,10 +79,11 @@ test("handleEndUserMeUsageRequestsGet returns 400 for an overlong range", async 
   });
 });
 
-test("handleEndUserMeUsageRequestsGet forwards the parsed window to OpenMeter", async (t) => {
+test("handleEndUserMeUsageRequestsGet forwards the parsed window to OpenMeter", async () => {
   const seen: unknown[] = [];
-  mockAuthedLists(t, {
-    requests: async (input) => {
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+    listEndUserSignedTicketRequests: async (input) => {
       seen.push(input);
       return stubEmptyList();
     },
@@ -126,10 +111,11 @@ test("handleEndUserMeUsageRequestsGet forwards the parsed window to OpenMeter", 
   });
 });
 
-test("handleEndUserMeUsageRequestsGet forwards from/to for groupBy=session", async (t) => {
+test("handleEndUserMeUsageRequestsGet forwards from/to for groupBy=session", async () => {
   const seen: unknown[] = [];
-  mockAuthedLists(t, {
-    sessions: async (input) => {
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+    listEndUserSignedTicketSessions: async (input) => {
       seen.push(input);
       return stubEmptyList();
     },
@@ -155,10 +141,11 @@ test("handleEndUserMeUsageRequestsGet forwards from/to for groupBy=session", asy
   });
 });
 
-test("handleEndUserMeUsageRequestsGet omits from/to when the pair is absent", async (t) => {
+test("handleEndUserMeUsageRequestsGet omits from/to when the pair is absent", async () => {
   const seen: unknown[] = [];
-  mockAuthedLists(t, {
-    requests: async (input) => {
+  __testSetEndUserUsageRequestsDeps({
+    authenticateEndUser: async () => AUTH,
+    listEndUserSignedTicketRequests: async (input) => {
       seen.push(input);
       return stubEmptyList();
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the non-blocking review notes on the end-user `from`/`to` Usage API work.

## Changes

- **Integrator docs** (`docs/builder-api.md`): end-user requests table and query table now include `from`/`to` (required together, ISO 8601, max `MAX_DATE_RANGE_DAYS` / 365, default UTC calendar month).
- **HTTP-level tests**: `end-user-usage-requests.route.test.ts` asserts `handleEndUserMeUsageRequestsGet` returns 400 for a lone `from`/`to` or overlong range, and forwards the parsed window to the OpenMeter list helpers (including `groupBy=session`).
- **OpenAPI**: path-scoped `/requests` 400 mentions an invalid date range; pathless `/user/usage/requests` operation description mentions `from`/`to`; `from` description drops the Console-specific “last 7 days” note and documents the 365-day cap.

## Test plan

- [x] Unit + handler tests for optional date-range parsing and route wiring
- [x] OpenAPI document assertions for 400 / operation copy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-529f5d6b-9f06-4d7a-bd20-a237fbb9be7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-529f5d6b-9f06-4d7a-bd20-a237fbb9be7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

