### PR TITLE
fix(usage): list owner-rollup tickets and clamp end-user from/to

### DIFF
--- a/docs/builder-api.md
+++ b/docs/builder-api.md
@@ -454,7 +454,7 @@ End users can read **their own** usage with the credential they already hold (no
 | --- | --- |
 | `GET /api/v1/user/usage` | Aggregates for the authenticated subject; app resolved from the Bearer credential |
 | `GET /api/v1/user/usage/balance` | Plan included-usage allowance for that subject |
-| `GET /api/v1/user/usage/requests` | Signed-ticket history (`groupBy=session\|request`, `manifestId`, `cursor`, `limit`) |
+| `GET /api/v1/user/usage/requests` | Signed-ticket history (`groupBy=session\|request`, `manifestId`, `gatewayRequestId`, `cursor`, `limit`) |
 | `GET /api/v1/apps/{clientId}/me/usage` | Same aggregates with path-scoped app (`{clientId}` must match the credential) |
 | `GET /api/v1/apps/{clientId}/me/usage/balance` | Same balance, path-scoped |
 | `GET /api/v1/apps/{clientId}/me/usage/requests` | Same request history, path-scoped |
@@ -524,12 +524,13 @@ Plan included-usage allowance for the Bearer subject (`balanceUsdMicros` / `rema
 
 **Endpoint:** `GET /api/v1/user/usage/requests` (or `GET /api/v1/apps/{clientId}/me/usage/requests`)
 
-Lists signed-ticket CloudEvents for the **token subject only** — newest first. Supports `groupBy=session|request` and `manifestId` (same semantics as `/api/v1/me/usage/requests`).
+Lists signed-ticket CloudEvents for the **token subject only** — newest first. Supports `groupBy=session|request`, `manifestId`, and `gatewayRequestId` (same session/request semantics as `/api/v1/me/usage/requests`).
 
 | Query | Description |
 | --- | --- |
 | `groupBy` | `session` or `request` (default `request`) |
 | `manifestId` | When `groupBy=request`, filter to one session mid |
+| `gatewayRequestId` | Repeatable. When `groupBy=request`, return only rows whose `gateway_request_id` matches (max 50) |
 | `cursor` | Opaque pagination cursor from a prior response |
 | `limit` | Page size (default 25, max 50) |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1242,9 +1242,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -1260,13 +1260,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -1282,20 +1282,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1305,9 +1305,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -1321,9 +1321,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -1337,11 +1337,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1353,11 +1356,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1369,11 +1375,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1385,11 +1394,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1401,11 +1413,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1417,11 +1432,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1433,11 +1451,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1449,11 +1470,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1465,12 +1489,15 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1483,15 +1510,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1505,16 +1535,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1527,16 +1560,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1549,16 +1585,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1571,15 +1610,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1593,16 +1635,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1615,15 +1660,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1637,17 +1685,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1657,16 +1705,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1676,9 +1724,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -1695,9 +1743,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -1714,9 +1762,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -10042,9 +10090,9 @@
       "license": "MIT"
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -10059,31 +10107,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "ws": "8.21.1",
     "@hono/node-server": "2.0.11",
     "hono": "4.13.5",
-    "sharp": "0.35.3",
+    "sharp": "0.35.4",
     "fast-uri": "3.1.7"
   },
   "devDependencies": {

--- a/src/lib/billing-utils.test.ts
+++ b/src/lib/billing-utils.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clampDateRangeToMaxDays,
+  isValidBoundedDateRange,
+  MAX_DATE_RANGE_DAYS,
+  parseUsageRequestDateRange,
+} from "@/lib/billing-utils";
+
+test("isValidBoundedDateRange accepts a span of MAX_DATE_RANGE_DAYS", () => {
+  assert.equal(
+    isValidBoundedDateRange(
+      "2025-09-10T00:00:00.000Z",
+      "2026-09-09T15:53:00.000Z",
+    ),
+    true,
+  );
+});
+
+test("isValidBoundedDateRange rejects epoch to now", () => {
+  assert.equal(
+    isValidBoundedDateRange(
+      "1970-01-01T00:00:00.000Z",
+      "2026-09-09T15:53:00.000Z",
+    ),
+    false,
+  );
+});
+
+test("clampDateRangeToMaxDays shortens epoch to now from the start", () => {
+  const to = "2026-09-09T15:53:00.000Z";
+  const clamped = clampDateRangeToMaxDays("1970-01-01T00:00:00.000Z", to);
+  assert.ok(clamped);
+  assert.equal(clamped.to, to);
+  assert.equal(clamped.from, "2025-09-10T00:00:00.000Z");
+  assert.equal(isValidBoundedDateRange(clamped.from, clamped.to), true);
+});
+
+test("clampDateRangeToMaxDays leaves a valid range unchanged", () => {
+  const from = "2026-09-01T00:00:00.000Z";
+  const to = "2026-09-09T15:53:00.000Z";
+  assert.deepEqual(clampDateRangeToMaxDays(from, to), { from, to });
+});
+
+test("clampDateRangeToMaxDays returns null when from is after to", () => {
+  assert.equal(
+    clampDateRangeToMaxDays(
+      "2026-09-10T00:00:00.000Z",
+      "2026-09-09T00:00:00.000Z",
+    ),
+    null,
+  );
+});
+
+test("parseUsageRequestDateRange requires both bounds together", () => {
+  const onlyFrom = parseUsageRequestDateRange("2026-09-01T00:00:00.000Z", null);
+  assert.equal(onlyFrom.ok, false);
+  if (!onlyFrom.ok) {
+    assert.match(onlyFrom.error, /together/);
+  }
+});
+
+test("parseUsageRequestDateRange omits bounds when both are empty", () => {
+  assert.deepEqual(parseUsageRequestDateRange(null, null), { ok: true });
+});
+
+test("parseUsageRequestDateRange rejects oversize ranges unless clamped", () => {
+  const rejected = parseUsageRequestDateRange(
+    "1970-01-01T00:00:00.000Z",
+    "2026-09-09T15:53:00.000Z",
+  );
+  assert.equal(rejected.ok, false);
+  if (!rejected.ok) {
+    assert.match(rejected.error, new RegExp(String(MAX_DATE_RANGE_DAYS)));
+  }
+
+  const clamped = parseUsageRequestDateRange(
+    "1970-01-01T00:00:00.000Z",
+    "2026-09-09T15:53:00.000Z",
+    { clampOversize: true },
+  );
+  assert.deepEqual(clamped, {
+    ok: true,
+    from: "2025-09-10T00:00:00.000Z",
+    to: "2026-09-09T15:53:00.000Z",
+  });
+});

--- a/src/lib/billing-utils.ts
+++ b/src/lib/billing-utils.ts
@@ -16,6 +16,28 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 export const MAX_DATE_RANGE_DAYS = 365;
 
 /**
+ * Inclusive UTC calendar-day span between two ISO timestamps (noon-anchored).
+ * `null` when either bound is unparseable or `start > end`.
+ */
+export function inclusiveUtcDaySpan(
+  startDate: string,
+  endDate: string,
+): number | null {
+  const startMs = Date.parse(startDate);
+  const endMs = Date.parse(endDate);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs) || startMs > endMs) {
+    return null;
+  }
+  return (
+    Math.floor(
+      (new Date(`${endDate.slice(0, 10)}T12:00:00.000Z`).getTime() -
+        new Date(`${startDate.slice(0, 10)}T12:00:00.000Z`).getTime()) /
+        MS_PER_DAY,
+    ) + 1
+  );
+}
+
+/**
  * True when both bounds parse and `start <= end` within {@link MAX_DATE_RANGE_DAYS}.
  * Used by identity/usage routes before hitting OpenMeter.
  */
@@ -23,18 +45,70 @@ export function isValidBoundedDateRange(
   startDate: string,
   endDate: string,
 ): boolean {
-  const startMs = Date.parse(startDate);
-  const endMs = Date.parse(endDate);
-  if (Number.isNaN(startMs) || Number.isNaN(endMs) || startMs > endMs) {
-    return false;
+  const daySpan = inclusiveUtcDaySpan(startDate, endDate);
+  return daySpan != null && daySpan > 0 && daySpan <= MAX_DATE_RANGE_DAYS;
+}
+
+/**
+ * Clamp an oversize `[from, to]` so the inclusive UTC day span is at most
+ * {@link MAX_DATE_RANGE_DAYS}. Invalid bounds (`from > to`, unparseable) return
+ * `null`. Already-valid ranges are returned unchanged.
+ */
+export function clampDateRangeToMaxDays(
+  from: string,
+  to: string,
+): { from: string; to: string } | null {
+  const daySpan = inclusiveUtcDaySpan(from, to);
+  if (daySpan == null || daySpan <= 0) {
+    return null;
   }
-  const daySpan =
-    Math.floor(
-      (new Date(`${endDate.slice(0, 10)}T12:00:00.000Z`).getTime() -
-        new Date(`${startDate.slice(0, 10)}T12:00:00.000Z`).getTime()) /
-        MS_PER_DAY,
-    ) + 1;
-  return daySpan > 0 && daySpan <= MAX_DATE_RANGE_DAYS;
+  if (daySpan <= MAX_DATE_RANGE_DAYS) {
+    return { from, to };
+  }
+  const endDay = new Date(`${to.slice(0, 10)}T12:00:00.000Z`);
+  const minStart = new Date(
+    endDay.getTime() - (MAX_DATE_RANGE_DAYS - 1) * MS_PER_DAY,
+  );
+  minStart.setUTCHours(0, 0, 0, 0);
+  return { from: minStart.toISOString(), to };
+}
+
+export type ParsedUsageDateRange =
+  | { ok: true; from?: string; to?: string }
+  | { ok: false; error: string };
+
+/**
+ * Parse optional `from`/`to` query params for signed-ticket history.
+ * Both must be supplied together. When `clampOversize` is true, spans longer
+ * than {@link MAX_DATE_RANGE_DAYS} are shortened from the start instead of
+ * rejected (Console sends epoch→now).
+ */
+export function parseUsageRequestDateRange(
+  fromRaw: string | null | undefined,
+  toRaw: string | null | undefined,
+  options?: { clampOversize?: boolean },
+): ParsedUsageDateRange {
+  const from = fromRaw?.trim() || undefined;
+  const to = toRaw?.trim() || undefined;
+  if ((from && !to) || (to && !from)) {
+    return { ok: false, error: "from and to must be supplied together" };
+  }
+  if (!from || !to) {
+    return { ok: true };
+  }
+  if (isValidBoundedDateRange(from, to)) {
+    return { ok: true, from, to };
+  }
+  if (options?.clampOversize) {
+    const clamped = clampDateRangeToMaxDays(from, to);
+    if (clamped) {
+      return { ok: true, from: clamped.from, to: clamped.to };
+    }
+  }
+  return {
+    ok: false,
+    error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
+  };
 }
 
 /** Decode a route/query segment; returns null when the escape sequence is invalid. */

--- a/src/lib/openapi/routes/end-user.ts
+++ b/src/lib/openapi/routes/end-user.ts
@@ -46,6 +46,15 @@ const endUserRequestsQueryParams = z.object({
       description:
         "When groupBy=request, restrict to one session manifest ID.",
     }),
+  gatewayRequestId: z
+    .union([z.string().min(1).max(512), z.array(z.string().min(1).max(512))])
+    .optional()
+    .openapi({
+      param: { name: "gatewayRequestId", in: "query" },
+      description:
+        "Repeatable. When `groupBy=request`, return only signed-ticket rows " +
+        "whose `gateway_request_id` matches (max 50).",
+    }),
   cursor: z
     .string()
     .min(1)
@@ -139,7 +148,7 @@ defineRouteMetadata("get", meUsagePath("/requests"), {
   description:
     "Chronological signed-ticket history for the authenticated subject. " +
     "`groupBy=session` lists per-manifest sessions; `groupBy=request` (default) " +
-    "lists CloudEvents (optionally filtered by `manifestId`). " +
+    "lists CloudEvents (optionally filtered by `manifestId` or `gatewayRequestId`). " +
     "Do not pass `userId` / `externalUserId`.",
   security: endUserSecurity,
   request: {

--- a/src/lib/openapi/routes/end-user.ts
+++ b/src/lib/openapi/routes/end-user.ts
@@ -65,6 +65,24 @@ const endUserRequestsQueryParams = z.object({
       param: { name: "limit", in: "query" },
       description: "Page size (default 25, max 50).",
     }),
+  from: z
+    .string()
+    .min(1)
+    .optional()
+    .openapi({
+      param: { name: "from", in: "query" },
+      description:
+        "Inclusive lower bound (ISO 8601). Required with `to`. Spans longer than 365 days are clamped.",
+    }),
+  to: z
+    .string()
+    .min(1)
+    .optional()
+    .openapi({
+      param: { name: "to", in: "query" },
+      description:
+        "Inclusive upper bound (ISO 8601). Required with `from`.",
+    }),
 });
 
 const meUsagePath = (suffix: string) =>

--- a/src/lib/openmeter/signed-ticket-events.test.ts
+++ b/src/lib/openmeter/signed-ticket-events.test.ts
@@ -1184,4 +1184,25 @@ dbTest("listEndUserSignedTicketRequests keeps the actor on owner-rollup tickets"
     ["req-keep"],
   );
   assert.equal(result.items[0]?.pipeline, "fixed");
+
+  const byId = await listEndUserSignedTicketRequests({
+    externalUserId: "eu_keep",
+    clientId: app.clientId,
+    gatewayRequestIds: ["req-keep"],
+    from: "2026-09-01T00:00:00.000Z",
+    to: "2026-09-30T23:59:59.999Z",
+  });
+  assert.deepEqual(
+    byId.items.map((row) => row.gatewayRequestId),
+    ["req-keep"],
+  );
+
+  const miss = await listEndUserSignedTicketRequests({
+    externalUserId: "eu_keep",
+    clientId: app.clientId,
+    gatewayRequestIds: ["req-other"],
+    from: "2026-09-01T00:00:00.000Z",
+    to: "2026-09-30T23:59:59.999Z",
+  });
+  assert.deepEqual(miss.items, []);
 });

--- a/src/lib/openmeter/signed-ticket-events.test.ts
+++ b/src/lib/openmeter/signed-ticket-events.test.ts
@@ -2,6 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { CREATE_SIGNED_TICKET_EVENT_TYPE } from "./constants";
+import { test as dbTest } from "@/test-utils/db-guard";
+import { cleanupTestApp, seedDeveloperAppWithClient } from "@/test-utils/fixtures";
+
 import {
   aggregateManifestSessionEventStats,
   buildSubjectMatchKeys,
@@ -20,11 +23,13 @@ import {
   listAdminSignedTicketSessions,
   listDeveloperSignedTicketRequests,
   listDeveloperSignedTicketSessions,
+  listEndUserSignedTicketRequests,
   listEndUserSignedTicketSessions,
   manifestMeterRowToSessionRow,
   normalizeSignedTicketEvent,
   resolveSessionBillableSecs,
   sessionEventStatsKey,
+  SignedTicketEventsListError,
   signedTicketSessionSortKey,
 } from "./signed-ticket-events";
 
@@ -739,16 +744,51 @@ test("eventMatchesUsageSubjectKeys gates on the event actor", () => {
 /** OpenMeter double: meter discovery plus per-subject event listing. */
 function fakeOpenMeterClient(
   eventsBySubject: Record<string, ReturnType<typeof sampleEvent>[]>,
-  meterRows: { subject: string; value: number; groupBy: Record<string, string> }[],
+  meterRows: {
+    subject?: string | null;
+    value: number;
+    groupBy: Record<string, string>;
+  }[],
+  options?: {
+    listThrows?: boolean;
+    listV2Throws?: boolean;
+    listV2BySubject?: Record<string, ReturnType<typeof sampleEvent>[]>;
+    onListV2?: (args: {
+      filter?: string;
+      from?: string;
+      to?: string;
+    }) => void;
+  },
 ) {
   return {
     meters: {
       query: async () => ({ data: meterRows }),
     },
     events: {
-      list: async ({ subject }: { subject?: string }) =>
-        eventsBySubject[subject ?? ""] ?? [],
-      listV2: async () => ({ items: [] }),
+      list: async ({ subject }: { subject?: string }) => {
+        if (options?.listThrows) {
+          throw new Error("events.list unavailable");
+        }
+        return eventsBySubject[subject ?? ""] ?? [];
+      },
+      listV2: async (args?: {
+        filter?: string;
+        from?: string;
+        to?: string;
+      }) => {
+        options?.onListV2?.(args ?? {});
+        if (options?.listV2Throws) {
+          throw new Error("events.listV2 unavailable");
+        }
+        const filter = args?.filter ?? "";
+        const bySubject = options?.listV2BySubject ?? {};
+        for (const [subject, items] of Object.entries(bySubject)) {
+          if (filter.includes(subject)) {
+            return { items };
+          }
+        }
+        return { items: [] };
+      },
     },
   };
 }
@@ -949,4 +989,199 @@ test("enrichSessionRowWithEventStats uses live-video-to-video pipeline when app 
   ]);
   const enriched = enrichSessionRowWithEventStats(base, stats);
   assert.equal(enriched.modelId, "live-video-to-video");
+});
+
+test("listDeveloperSignedTicketRequests falls through empty list to listV2 with from/to", async (t) => {
+  const { __testSetHostedOpenMeterClient, resetHostedOpenMeterClientForTests } =
+    await import("./client");
+  const ticket = sampleEvent({
+    id: "evt-v2",
+    subject: "app_abc:eu_tenant",
+    data: {
+      client_id: "app_abc",
+      external_user_id: "eu_tenant",
+      usage_subject: "eu_tenant",
+      gateway_request_id: "req-v2",
+    },
+  });
+  const listV2Calls: Array<{ filter?: string; from?: string; to?: string }> = [];
+  __testSetHostedOpenMeterClient(
+    fakeOpenMeterClient(
+      {},
+      [
+        {
+          subject: "app_abc:eu_tenant",
+          value: 1,
+          groupBy: { client_id: "app_abc", external_user_id: "eu_tenant" },
+        },
+      ],
+      {
+        listThrows: true,
+        listV2BySubject: { "app_abc:eu_tenant": [ticket] },
+        onListV2: (args) => listV2Calls.push(args),
+      },
+    ) as never,
+  );
+  t.after(() => resetHostedOpenMeterClientForTests());
+
+  const from = "2026-07-01T00:00:00.000Z";
+  const to = "2026-08-01T00:00:00.000Z";
+  const result = await listDeveloperSignedTicketRequests({
+    userId: "00000000-0000-0000-0000-000000000000",
+    managedClientIds: ["app_abc"],
+    memberClientIds: [],
+    from,
+    to,
+  });
+  assert.deepEqual(
+    result.items.map((row) => row.gatewayRequestId),
+    ["req-v2"],
+  );
+  assert.ok(listV2Calls.length > 0);
+  assert.ok(listV2Calls.some((call) => call.from === from && call.to === to));
+  assert.ok(
+    listV2Calls.some(
+      (call) =>
+        typeof call.filter === "string" &&
+        call.filter.includes(from) &&
+        call.filter.includes(to),
+    ),
+  );
+});
+
+test("listDeveloperSignedTicketRequests throws when every event fetch fails", async (t) => {
+  const { __testSetHostedOpenMeterClient, resetHostedOpenMeterClientForTests } =
+    await import("./client");
+  __testSetHostedOpenMeterClient(
+    fakeOpenMeterClient(
+      {},
+      [
+        {
+          subject: "app_abc:eu_tenant",
+          value: 1,
+          groupBy: { client_id: "app_abc", external_user_id: "eu_tenant" },
+        },
+      ],
+      { listThrows: true, listV2Throws: true },
+    ) as never,
+  );
+  t.after(() => resetHostedOpenMeterClientForTests());
+
+  await assert.rejects(
+    () =>
+      listDeveloperSignedTicketRequests({
+        userId: "00000000-0000-0000-0000-000000000000",
+        managedClientIds: ["app_abc"],
+        memberClientIds: [],
+        from: "2026-07-01T00:00:00.000Z",
+        to: "2026-08-01T00:00:00.000Z",
+      }),
+    (err: unknown) => err instanceof SignedTicketEventsListError,
+  );
+});
+
+dbTest("listDeveloperSignedTicketRequests finds owner-rollup tickets by payer subject", async (t) => {
+  const { __testSetHostedOpenMeterClient, resetHostedOpenMeterClientForTests } =
+    await import("./client");
+  const app = await seedDeveloperAppWithClient({ name: "rollup-requests" });
+  t.after(async () => {
+    resetHostedOpenMeterClientForTests();
+    await cleanupTestApp(app);
+  });
+
+  const ticket = sampleEvent({
+    id: "evt-schnell",
+    subject: app.userId,
+    time: "2026-09-09T15:00:00.000Z",
+    data: {
+      client_id: app.clientId,
+      external_user_id: "eu_51fba6419832421c9a56f6bee25cc68b",
+      usage_subject: app.userId,
+      gateway_request_id: "job_fd7d4bec9c3643cc",
+      pipeline: "fixed",
+      app: "livepeer-example/fal-flux-schnell",
+      network_fee_usd_micros: "3000",
+    },
+  });
+  __testSetHostedOpenMeterClient(
+    fakeOpenMeterClient(
+      { [app.userId]: [ticket] },
+      [
+        {
+          subject: null,
+          value: 1,
+          groupBy: {
+            client_id: app.clientId,
+            external_user_id: "eu_51fba6419832421c9a56f6bee25cc68b",
+          },
+        },
+      ],
+    ) as never,
+  );
+
+  const result = await listDeveloperSignedTicketRequests({
+    userId: app.userId,
+    managedClientIds: [app.clientId],
+    memberClientIds: [],
+    from: "2026-09-01T00:00:00.000Z",
+    to: "2026-09-30T23:59:59.999Z",
+  });
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0]?.gatewayRequestId, "job_fd7d4bec9c3643cc");
+  assert.equal(result.items[0]?.pipeline, "fixed");
+  assert.equal(result.items[0]?.modelId, "livepeer-example/fal-flux-schnell");
+  assert.equal(
+    result.items[0]?.externalUserId,
+    "eu_51fba6419832421c9a56f6bee25cc68b",
+  );
+});
+
+dbTest("listEndUserSignedTicketRequests keeps the actor on owner-rollup tickets", async (t) => {
+  const { __testSetHostedOpenMeterClient, resetHostedOpenMeterClientForTests } =
+    await import("./client");
+  const app = await seedDeveloperAppWithClient({ name: "rollup-end-user" });
+  t.after(async () => {
+    resetHostedOpenMeterClientForTests();
+    await cleanupTestApp(app);
+  });
+
+  const keep = sampleEvent({
+    id: "evt-keep",
+    subject: app.userId,
+    data: {
+      client_id: app.clientId,
+      external_user_id: "eu_keep",
+      usage_subject: app.userId,
+      gateway_request_id: "req-keep",
+      pipeline: "fixed",
+      app: "livepeer-example/fal-flux-schnell",
+    },
+  });
+  const other = sampleEvent({
+    id: "evt-other",
+    subject: app.userId,
+    data: {
+      client_id: app.clientId,
+      external_user_id: "eu_other",
+      usage_subject: app.userId,
+      gateway_request_id: "req-other",
+      pipeline: "live",
+      app: "comfystream",
+    },
+  });
+  __testSetHostedOpenMeterClient(
+    fakeOpenMeterClient({ [app.userId]: [keep, other] }, []) as never,
+  );
+
+  const result = await listEndUserSignedTicketRequests({
+    externalUserId: "eu_keep",
+    clientId: app.clientId,
+    from: "2026-09-01T00:00:00.000Z",
+    to: "2026-09-30T23:59:59.999Z",
+  });
+  assert.deepEqual(
+    result.items.map((row) => row.gatewayRequestId),
+    ["req-keep"],
+  );
+  assert.equal(result.items[0]?.pipeline, "fixed");
 });

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -36,6 +36,14 @@ const LIST_FETCH_LIMIT = 100;
 /** Cap meter-discovered subjects so admin event fan-out stays bounded. */
 const MAX_ADMIN_DISCOVERED_SUBJECTS = 40;
 
+/** Every `events.list` / `listV2` attempt failed — handlers map this to 502. */
+export class SignedTicketEventsListError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SignedTicketEventsListError";
+  }
+}
+
 export type SignedTicketRequestRow = {
   time: string;
   clientId: string;
@@ -1273,33 +1281,17 @@ async function fetchSignedTicketEvents(input: {
 }): Promise<IngestedEventLike[]> {
   const subjectQueries = buildSubjectQueries(input.subjects, input.clientIds);
   const batches = await Promise.all(
-    subjectQueries.map(async (subject) => {
-      try {
-        const listed = await input.client.events.list({
-          subject,
-          from: input.from,
-          to: input.to,
-          limit: LIST_FETCH_LIMIT,
-        });
-        return coerceIngestedEvents(listed);
-      } catch {
-        // listV2 fallback when list is unavailable (some Konnect deployments).
-        try {
-          const listedV2 = await input.client.events.listV2({
-            limit: LIST_FETCH_LIMIT,
-            filter: JSON.stringify({
-              type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
-              subject: { contains: subject },
-            }),
-          });
-          return coerceIngestedEvents(listedV2?.items ?? listedV2);
-        } catch {
-          return [];
-        }
-      }
-    }),
+    subjectQueries.map((subject) =>
+      listSignedTicketEventsForSubject({
+        client: input.client,
+        subject,
+        from: input.from,
+        to: input.to,
+        subjectMatch: "contains",
+      }),
+    ),
   );
-  return batches.flat();
+  return flattenListedEventBatches(batches, "fetchSignedTicketEvents");
 }
 
 /**
@@ -1330,8 +1322,8 @@ async function fetchPlatformSignedTicketEvents(input: {
       to: input.to,
     });
     if (subjects.size > 0) {
-      // Exact subjects from meter discovery — do not re-expand via
-      // buildSubjectQueries (that would explode fan-out).
+      // Exact subjects from meter discovery + owner payer keys — do not
+      // re-expand via buildSubjectQueries (that would explode fan-out).
       return fetchEventsForExactSubjects({
         client: input.client,
         subjects,
@@ -1368,12 +1360,18 @@ async function listRecentPlatformSignedTicketEvents(
   try {
     const listedV2 = await client.events.listV2({
       limit: LIST_FETCH_LIMIT,
-      filter: JSON.stringify({
-        type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
-      }),
-    });
+      from,
+      to,
+      filter: signedTicketListV2Filter({ from, to }),
+    } as { limit: number; from: string; to: string; filter: string });
     return coerceIngestedEvents(listedV2?.items ?? listedV2);
-  } catch {
+  } catch (err) {
+    console.warn("[signed-ticket-events] events.listV2 failed", {
+      subject: null,
+      from,
+      to,
+      err,
+    });
     try {
       const listed = await client.events.list({
         from,
@@ -1381,9 +1379,111 @@ async function listRecentPlatformSignedTicketEvents(
         limit: LIST_FETCH_LIMIT,
       } as { from: string; to: string; limit: number });
       return coerceIngestedEvents(listed).filter(eventIsSignedTicket);
-    } catch {
-      return [];
+    } catch (listErr) {
+      console.warn("[signed-ticket-events] events.list failed", {
+        subject: null,
+        from,
+        to,
+        err: listErr,
+      });
+      throw new SignedTicketEventsListError(
+        "OpenMeter events.list failed for platform signed-ticket history",
+      );
     }
+  }
+}
+
+type ListedEventBatch = {
+  events: IngestedEventLike[];
+  listed: boolean;
+};
+
+function signedTicketListV2Filter(input: {
+  from: string;
+  to: string;
+  subject?: { eq?: string; contains?: string };
+}): string {
+  return JSON.stringify({
+    type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
+    ...(input.subject ? { subject: input.subject } : {}),
+    time: { gte: input.from, lte: input.to },
+  });
+}
+
+function flattenListedEventBatches(
+  batches: readonly ListedEventBatch[],
+  context: string,
+): IngestedEventLike[] {
+  if (batches.length > 0 && batches.every((batch) => !batch.listed)) {
+    throw new SignedTicketEventsListError(
+      `OpenMeter events.list failed for all subjects (${context})`,
+    );
+  }
+  return batches.flatMap((batch) => batch.events);
+}
+
+async function listSignedTicketEventsForSubject(input: {
+  client: OpenMeter;
+  subject: string;
+  from: string;
+  to: string;
+  subjectMatch: "eq" | "contains";
+}): Promise<ListedEventBatch> {
+  try {
+    const listed = await input.client.events.list({
+      subject: input.subject,
+      from: input.from,
+      to: input.to,
+      limit: LIST_FETCH_LIMIT,
+    });
+    const events = coerceIngestedEvents(listed).filter(eventIsSignedTicket);
+    if (events.length > 0) {
+      return { events, listed: true };
+    }
+    if (input.subjectMatch === "eq") {
+      console.warn("[signed-ticket-events] events.list empty", {
+        subject: input.subject,
+        from: input.from,
+        to: input.to,
+      });
+    }
+  } catch (err) {
+    console.warn("[signed-ticket-events] events.list failed", {
+      subject: input.subject,
+      from: input.from,
+      to: input.to,
+      err,
+    });
+  }
+
+  try {
+    const listedV2 = await input.client.events.listV2({
+      limit: LIST_FETCH_LIMIT,
+      from: input.from,
+      to: input.to,
+      filter: signedTicketListV2Filter({
+        from: input.from,
+        to: input.to,
+        subject:
+          input.subjectMatch === "eq"
+            ? { eq: input.subject }
+            : { contains: input.subject },
+      }),
+    } as { limit: number; from: string; to: string; filter: string });
+    return {
+      events: coerceIngestedEvents(listedV2?.items ?? listedV2).filter(
+        eventIsSignedTicket,
+      ),
+      listed: true,
+    };
+  } catch (err) {
+    console.warn("[signed-ticket-events] events.listV2 failed", {
+      subject: input.subject,
+      from: input.from,
+      to: input.to,
+      err,
+    });
+    return { events: [], listed: false };
   }
 }
 
@@ -1399,32 +1499,17 @@ async function fetchEventsForExactSubjects(input: {
     .filter(Boolean)
     .slice(0, MAX_ADMIN_DISCOVERED_SUBJECTS);
   const batches = await Promise.all(
-    subjectList.map(async (subject) => {
-      try {
-        const listed = await input.client.events.list({
-          subject,
-          from: input.from,
-          to: input.to,
-          limit: LIST_FETCH_LIMIT,
-        });
-        return coerceIngestedEvents(listed).filter(eventIsSignedTicket);
-      } catch {
-        try {
-          const listedV2 = await input.client.events.listV2({
-            limit: LIST_FETCH_LIMIT,
-            filter: JSON.stringify({
-              type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
-              subject: { eq: subject },
-            }),
-          });
-          return coerceIngestedEvents(listedV2?.items ?? listedV2);
-        } catch {
-          return [];
-        }
-      }
-    }),
+    subjectList.map((subject) =>
+      listSignedTicketEventsForSubject({
+        client: input.client,
+        subject,
+        from: input.from,
+        to: input.to,
+        subjectMatch: "eq",
+      }),
+    ),
   );
-  return batches.flat();
+  return flattenListedEventBatches(batches, "fetchEventsForExactSubjects");
 }
 
 async function listSignedTicketEventsForSubjectContains(
@@ -1433,28 +1518,17 @@ async function listSignedTicketEventsForSubjectContains(
   from: string,
   to: string,
 ): Promise<IngestedEventLike[]> {
-  try {
-    const listedV2 = await client.events.listV2({
-      limit: LIST_FETCH_LIMIT,
-      filter: JSON.stringify({
-        type: { eq: CREATE_SIGNED_TICKET_EVENT_TYPE },
-        subject: { contains: subjectFragment },
-      }),
-    });
-    return coerceIngestedEvents(listedV2?.items ?? listedV2);
-  } catch {
-    try {
-      const listed = await client.events.list({
-        subject: subjectFragment,
-        from,
-        to,
-        limit: LIST_FETCH_LIMIT,
-      });
-      return coerceIngestedEvents(listed).filter(eventIsSignedTicket);
-    } catch {
-      return [];
-    }
-  }
+  const batch = await listSignedTicketEventsForSubject({
+    client,
+    subject: subjectFragment,
+    from,
+    to,
+    subjectMatch: "contains",
+  });
+  return flattenListedEventBatches(
+    [batch],
+    "listSignedTicketEventsForSubjectContains",
+  );
 }
 
 /**
@@ -1546,32 +1620,76 @@ function meterValueToCount(value: unknown): number {
   return 0;
 }
 
+/**
+ * Owner-rollup CloudEvents use the bare owner `users.id` as `subject`.
+ * Meter groupBy `external_user_id` is the actor (`eu_…`), so listing only
+ * those keys misses the tickets.
+ */
+export async function resolveOwnerPayerSubjectsForClientIds(
+  clientIds: ReadonlySet<string>,
+): Promise<string[]> {
+  const unique = [...clientIds].map((id) => id.trim()).filter(Boolean);
+  if (unique.length === 0) {
+    return [];
+  }
+  try {
+    const rows = await db
+      .select({
+        ownerId: developerApps.ownerId,
+      })
+      .from(oidcClients)
+      .innerJoin(developerApps, eq(developerApps.oidcClientId, oidcClients.id))
+      .where(inArray(oidcClients.clientId, unique));
+    const subjects = new Set<string>();
+    for (const row of rows) {
+      const ownerId = row.ownerId?.trim();
+      if (ownerId) {
+        subjects.add(buildOwnerCustomerKey(ownerId));
+      }
+    }
+    return [...subjects];
+  } catch {
+    return [];
+  }
+}
+
 async function discoverAdminUsageSubjects(input: {
   client: OpenMeter;
   clientIds: ReadonlySet<string>;
   from: string;
   to: string;
 }): Promise<Set<string>> {
-  const batches = await Promise.all(
-    [...input.clientIds].map(async (clientId) => {
-      try {
-        const result = await input.client.meters.query(SIGNED_TICKET_COUNT_METER, {
-          from: new Date(input.from),
-          to: new Date(input.to),
-          windowSize: "MONTH",
-          clientId,
-          groupBy: ["client_id", "external_user_id"],
-        });
-        return result?.data ?? [];
-      } catch {
-        return [];
-      }
-    }),
-  );
+  const [batches, ownerPayers] = await Promise.all([
+    Promise.all(
+      [...input.clientIds].map(async (clientId) => {
+        try {
+          const result = await input.client.meters.query(SIGNED_TICKET_COUNT_METER, {
+            from: new Date(input.from),
+            to: new Date(input.to),
+            windowSize: "MONTH",
+            clientId,
+            groupBy: ["client_id", "external_user_id"],
+          });
+          return result?.data ?? [];
+        } catch {
+          return [];
+        }
+      }),
+    ),
+    resolveOwnerPayerSubjectsForClientIds(input.clientIds),
+  ]);
 
-  return new Set(
-    collectAdminSubjectsFromMeterRows(batches.flat(), input.clientIds),
-  );
+  const merged: string[] = [...ownerPayers];
+  const seen = new Set(merged);
+  for (const subject of collectAdminSubjectsFromMeterRows(
+    batches.flat(),
+    input.clientIds,
+  )) {
+    if (seen.has(subject)) continue;
+    seen.add(subject);
+    merged.push(subject);
+  }
+  return new Set(merged.slice(0, MAX_ADMIN_DISCOVERED_SUBJECTS));
 }
 
 function normalizeClientIdFilter(

--- a/src/lib/openmeter/signed-ticket-events.ts
+++ b/src/lib/openmeter/signed-ticket-events.ts
@@ -432,6 +432,7 @@ async function listSignedTicketRequestsForSubjects(input: {
   clientId?: string | null;
   clientIds?: string[] | null;
   manifestId?: string | null;
+  gatewayRequestIds?: ReadonlySet<string> | null;
   cursor?: string | null;
   limit?: number;
   from?: string;
@@ -454,7 +455,8 @@ async function listSignedTicketRequestsForSubjects(input: {
   const from = input.from?.trim() || cycle.start;
   const to = input.to?.trim() || cycle.end;
   const limit = clampLimit(input.limit);
-  const offset = decodeOffsetCursor(input.cursor);
+  const idFilter = normalizeGatewayRequestIdFilter(input.gatewayRequestIds);
+  const offset = idFilter ? 0 : decodeOffsetCursor(input.cursor);
   const clientIdFilter = normalizeClientIdFilter(input.clientId, input.clientIds);
 
   const rawEvents = await fetchSignedTicketEvents({
@@ -472,7 +474,13 @@ async function listSignedTicketRequestsForSubjects(input: {
       eventMatchesUsageSubjectKeys(ev, actorKeys),
   );
 
-  return pageSignedTicketEvents(matching, limit, offset, input.manifestId);
+  return pageSignedTicketEvents(
+    matching,
+    limit,
+    offset,
+    input.manifestId,
+    idFilter,
+  );
 }
 
 /**
@@ -589,11 +597,24 @@ export async function listDeveloperSignedTicketRequests(
   return pageSignedTicketEvents(matching, limit, offset, input.manifestId);
 }
 
+function normalizeGatewayRequestIdFilter(
+  ids?: ReadonlySet<string> | readonly string[] | null,
+): Set<string> | null {
+  if (!ids) return null;
+  const out = new Set<string>();
+  for (const id of ids) {
+    const trimmed = id.trim();
+    if (trimmed) out.add(trimmed);
+  }
+  return out.size > 0 ? out : null;
+}
+
 async function pageSignedTicketEvents(
   matching: IngestedEventLike[],
   limit: number,
   offset: number,
   manifestId?: string | null,
+  gatewayRequestIds?: ReadonlySet<string> | null,
 ): Promise<ListViewerSignedTicketRequestsResult> {
   const appNames = await loadAppNames(
     matching.map((ev) => eventClientId(ev)).filter((id): id is string => Boolean(id)),
@@ -605,6 +626,13 @@ async function pageSignedTicketEvents(
     .map((ev) => normalizeSignedTicketEvent(ev, appNames))
     .filter((row): row is SignedTicketRequestRow => row != null)
     .filter((row) => {
+      if (
+        gatewayRequestIds &&
+        gatewayRequestIds.size > 0 &&
+        !gatewayRequestIds.has(row.gatewayRequestId)
+      ) {
+        return false;
+      }
       if (!manifestFilter) return true;
       const mid = row.manifestId?.trim() || "unknown";
       return mid === manifestFilter;
@@ -643,6 +671,7 @@ export type ListEndUserSignedTicketRequestsInput = {
   /** Public OIDC client_id (app_…), not developer_apps.id. */
   clientId: string;
   manifestId?: string | null;
+  gatewayRequestIds?: readonly string[] | null;
   cursor?: string | null;
   limit?: number;
   from?: string;
@@ -698,6 +727,7 @@ export async function listEndUserSignedTicketRequests(
     actorExternalUserIds: new Set([externalUserId]),
     clientId,
     manifestId: input.manifestId,
+    gatewayRequestIds: normalizeGatewayRequestIdFilter(input.gatewayRequestIds),
     cursor: input.cursor,
     limit: input.limit,
     from: input.from,

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -93,6 +93,26 @@ export async function handleEndUserMeUsageRequestsGet(
   const params = request.nextUrl.searchParams;
   const cursor = params.get("cursor")?.trim() || undefined;
   const manifestId = params.get("manifestId")?.trim() || undefined;
+  const gatewayRequestIds = [
+    ...new Set(
+      params
+        .getAll("gatewayRequestId")
+        .map((id) => id.trim())
+        .filter(Boolean),
+    ),
+  ];
+  if (gatewayRequestIds.length > 50) {
+    return NextResponse.json(
+      { error: "at most 50 gatewayRequestId values" },
+      { status: 400 },
+    );
+  }
+  if (gatewayRequestIds.some((id) => id.length > 512)) {
+    return NextResponse.json(
+      { error: "gatewayRequestId too long" },
+      { status: 400 },
+    );
+  }
   const groupBy = params.get("groupBy")?.trim().toLowerCase() || "request";
   const limitRaw = params.get("limit");
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
@@ -137,6 +157,8 @@ export async function handleEndUserMeUsageRequestsGet(
       externalUserId: auth.externalUserId,
       clientId: auth.publicClientId,
       manifestId,
+      gatewayRequestIds:
+        gatewayRequestIds.length > 0 ? gatewayRequestIds : undefined,
       cursor,
       limit: Number.isFinite(limit) ? limit : undefined,
       from: dateRange.from,

--- a/src/lib/usage/end-user-usage-handlers.ts
+++ b/src/lib/usage/end-user-usage-handlers.ts
@@ -4,6 +4,7 @@ import {
   authenticateEndUser,
   endUserSubjectOverrideError,
 } from "@/lib/auth/end-user";
+import { parseUsageRequestDateRange } from "@/lib/billing-utils";
 import {
   listEndUserSignedTicketRequests,
   listEndUserSignedTicketSessions,
@@ -95,6 +96,14 @@ export async function handleEndUserMeUsageRequestsGet(
   const groupBy = params.get("groupBy")?.trim().toLowerCase() || "request";
   const limitRaw = params.get("limit");
   const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+  const dateRange = parseUsageRequestDateRange(
+    params.get("from"),
+    params.get("to"),
+    { clampOversize: true },
+  );
+  if (!dateRange.ok) {
+    return NextResponse.json({ error: dateRange.error }, { status: 400 });
+  }
 
   if (groupBy !== "request" && groupBy !== "session") {
     return NextResponse.json(
@@ -103,12 +112,35 @@ export async function handleEndUserMeUsageRequestsGet(
     );
   }
 
-  if (groupBy === "session") {
-    const result = await listEndUserSignedTicketSessions({
+  try {
+    if (groupBy === "session") {
+      const result = await listEndUserSignedTicketSessions({
+        externalUserId: auth.externalUserId,
+        clientId: auth.publicClientId,
+        cursor,
+        limit: Number.isFinite(limit) ? limit : undefined,
+        from: dateRange.from,
+        to: dateRange.to,
+      });
+
+      return NextResponse.json({
+        items: result.items,
+        nextCursor: result.nextCursor,
+        openMeterConfigured: result.openMeterConfigured,
+        clientId: auth.publicClientId,
+        externalUserId: auth.externalUserId,
+        groupBy: "session",
+      });
+    }
+
+    const result = await listEndUserSignedTicketRequests({
       externalUserId: auth.externalUserId,
       clientId: auth.publicClientId,
+      manifestId,
       cursor,
       limit: Number.isFinite(limit) ? limit : undefined,
+      from: dateRange.from,
+      to: dateRange.to,
     });
 
     return NextResponse.json({
@@ -117,24 +149,13 @@ export async function handleEndUserMeUsageRequestsGet(
       openMeterConfigured: result.openMeterConfigured,
       clientId: auth.publicClientId,
       externalUserId: auth.externalUserId,
-      groupBy: "session",
+      groupBy: "request",
     });
+  } catch (err) {
+    console.error("[end-user-usage-requests] OpenMeter list failed:", err);
+    return NextResponse.json(
+      { error: "Failed to load usage requests" },
+      { status: 502 },
+    );
   }
-
-  const result = await listEndUserSignedTicketRequests({
-    externalUserId: auth.externalUserId,
-    clientId: auth.publicClientId,
-    manifestId,
-    cursor,
-    limit: Number.isFinite(limit) ? limit : undefined,
-  });
-
-  return NextResponse.json({
-    items: result.items,
-    nextCursor: result.nextCursor,
-    openMeterConfigured: result.openMeterConfigured,
-    clientId: auth.publicClientId,
-    externalUserId: auth.externalUserId,
-    groupBy: "request",
-  });
 }

--- a/src/lib/usage/me-usage-requests-handler.ts
+++ b/src/lib/usage/me-usage-requests-handler.ts
@@ -12,10 +12,7 @@ import {
   resolveViewerUsageClientScopes,
   type ViewerUsageClientScopes,
 } from "@/lib/viewer-usage-clients";
-import {
-  isValidBoundedDateRange,
-  MAX_DATE_RANGE_DAYS,
-} from "@/lib/billing-utils";
+import { parseUsageRequestDateRange } from "@/lib/billing-utils";
 
 type MeUsageGroupBy = "request" | "session";
 type MeUsageScope = "own" | "all";
@@ -98,29 +95,14 @@ function validateMeUsageRequestsParams(
 function parseOptionalDateRange(
   params: URLSearchParams,
 ): { error: NextResponse } | { from?: string; to?: string } {
-  // Optional date range for the requests table's range picker. Both bounds are
-  // required together and are span-limited before hitting OpenMeter.
-  const from = params.get("from")?.trim() || undefined;
-  const to = params.get("to")?.trim() || undefined;
-  if ((from && !to) || (to && !from)) {
-    return {
-      error: NextResponse.json(
-        { error: "from and to must be supplied together" },
-        { status: 400 },
-      ),
-    };
+  const parsed = parseUsageRequestDateRange(
+    params.get("from"),
+    params.get("to"),
+  );
+  if (!parsed.ok) {
+    return { error: NextResponse.json({ error: parsed.error }, { status: 400 }) };
   }
-  if (from && to && !isValidBoundedDateRange(from, to)) {
-    return {
-      error: NextResponse.json(
-        {
-          error: `Invalid range; supply from <= to within ${MAX_DATE_RANGE_DAYS} days`,
-        },
-        { status: 400 },
-      ),
-    };
-  }
-  return { from, to };
+  return { from: parsed.from, to: parsed.to };
 }
 
 /** Session-authenticated viewer signed-ticket history (Internal API). */


### PR DESCRIPTION
## Summary
- All requests now queries each managed app’s **owner payer** CloudEvent subject (bare `users.id`) instead of only meter-discovered actor keys (`eu_…`). Owner-rollup tickets were stored under the owner and listed as empty.
- Empty or failed `events.list` falls through to `listV2` with the same `from`/`to`. If every fetch fails, Usage returns **502** instead of a fake empty page.
- End-user `GET /api/v1/user/usage/requests` (and `/apps/{id}/me/usage/requests`) honors `from`/`to`. Spans longer than 365 days are **clamped**, so Console’s epoch→now range does not 400.

Supersedes #506 (that PR would 400 Console).

## Test plan
- [ ] `npx tsc --noEmit` and eslint on the touched files
- [ ] `node --import ./src/test-env.ts --import tsx --test --test-force-exit src/lib/billing-utils.test.ts src/lib/openmeter/signed-ticket-events.test.ts` (owner-rollup ticket, actor filter, listV2 window, clamp)
- [ ] After deploy: PymtHouse Usage → All requests on an owner-rollup app shows a `fixed` FAL ticket with `gateway_request_id`
- [ ] Sessions tab still meter-backed / unchanged
- [ ] Console `/home` Cost fills for that `gateway_request_id` after refresh (join is ticket-backed, not `billable_units`)
- [ ] Close #506 so it cannot merge after this