### PR TITLE
Bump remote signer to go-livepeer PR #4028

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,7 @@ DATABASE_URL=postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neond
 # Start the full stack so Kafka events reach the OpenMeter collector:
 #   docker compose -f docker-compose.clearinghouse.railway.yml --env-file .env.local up -d --build
 # go-livepeer binary source for signer-dmz-local build (published CI image by default):
-# LIVEPEER_IMAGE=livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad
+# LIVEPEER_IMAGE=livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23
 # Or build DMZ only: ./scripts/build-local-signer.sh
 # Standalone signer (no kafka): docker compose up -d signer-dmz
 # The local compose image is signer-dmz: Apache validates RS256 bearer tokens

--- a/config/railway/stack.json
+++ b/config/railway/stack.json
@@ -28,7 +28,7 @@
       "manifest": "deploy/pymthouse-signer-test/railway.json",
       "environments": ["preview", "production"],
       "description": "A/B 'latest' remote signer DMZ, deployed in both preview and production. Same webhook/OIDC/Kafka and signing identity as pymthouse (the 'stable' signer); LIVEPEER_IMAGE matches the prod Dockerfile default. Entrypoint defaults BYOC_PER_CAP_PRICING=on for this service name. Apps opt in via LATEST_SIGNER_APPS on the Next app.",
-      "livepeerImage": "livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad",
+      "livepeerImage": "livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23",
       "byocPerCapPricing": true
     },
     "pymthouse-signer-test-preview-only": {
@@ -36,7 +36,7 @@
       "manifest": "deploy/pymthouse-signer-test-preview-only/railway.json",
       "environments": ["preview"],
       "description": "Preview-only A/B signer DMZ. Shares pymthouse signing identity; must receive the same ETH_RPC_URL / OIDC / webhook env as other signers via railway-apply-stack-env.sh. Never deploy to production.",
-      "livepeerImage": "livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad",
+      "livepeerImage": "livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23",
       "byocPerCapPricing": true
     }
   }

--- a/docker-compose.clearinghouse.railway.yml
+++ b/docker-compose.clearinghouse.railway.yml
@@ -58,7 +58,7 @@ services:
       dockerfile: docker/signer-dmz/Dockerfile
       target: signer-dmz-local
       args:
-        LIVEPEER_IMAGE: ${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad}
+        LIVEPEER_IMAGE: ${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23}
     restart: unless-stopped
     ports:
       - target: 8080

--- a/docker/signer-dmz/Dockerfile
+++ b/docker/signer-dmz/Dockerfile
@@ -5,7 +5,7 @@
 #   signer-dmz      — production; livepeer from livepeer/go-livepeer Docker image (Railway single service).
 
 # Base image for signer-dmz-local (override: docker build --build-arg LIVEPEER_IMAGE=...).
-ARG LIVEPEER_IMAGE=livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad
+ARG LIVEPEER_IMAGE=livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23
 
 FROM debian:bookworm-slim AS build-mod
 

--- a/docker/signer-dmz/Dockerfile.signer
+++ b/docker/signer-dmz/Dockerfile.signer
@@ -2,7 +2,7 @@
 # Copies livepeer + required CUDA NPP libs from the official image — do not wget
 # a bare binary into debian:slim; the binary links libnppig.so and other NPP libs.
 
-FROM livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad AS livepeer-src
+FROM livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23 AS livepeer-src
 
 FROM debian:bookworm-slim
 

--- a/docker/signer-dmz/README.md
+++ b/docker/signer-dmz/README.md
@@ -16,8 +16,8 @@ Everything needed to run the go-livepeer signer with an optional **Apache + mod_
 | Image | Dockerfile | go-livepeer source | Use |
 |-------|------------|--------------------|-----|
 | `pymthouse/signer-dmz:local` | `Dockerfile` → `signer-dmz-local` | `../go-livepeer` via `lpclearinghouse` | **Local dev** with PymtHouse (`docker-compose.yml`) |
-| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad` (v0.9.2) | **Production** (Railway / Render) and prod smoke tests |
-| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad` (v0.9.2) | **Livepeer only** (no Apache; not for public deploy) |
+| `pymthouse/signer-dmz:latest` | `Dockerfile` → `signer-dmz` (default) | `livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23` (go-livepeer#4028) | **Production** (Railway / Render) and prod smoke tests |
+| `pymthouse-signer:local` | `Dockerfile.signer` | `livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23` (go-livepeer#4028) | **Livepeer only** (no Apache; not for public deploy) |
 
 ### Force rebuild
 
@@ -33,7 +33,7 @@ docker build --pull --no-cache -f docker/signer-dmz/Dockerfile.signer -t pymthou
 # Verify version after rebuild
 docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse-signer:local -version
 docker run --rm --entrypoint /usr/local/bin/livepeer pymthouse/signer-dmz:latest -version
-# expect: Livepeer Node Version: 0.9.2-38eb47d1
+# expect: Livepeer Node Version: 0.9.2-d4d6fb86
 ```
 
 ### Local dev

--- a/docs/signer-deployment-options.md
+++ b/docs/signer-deployment-options.md
@@ -122,8 +122,8 @@ app = "pymthouse-signer"
 
 [build]
   [build.args]
-    LIVEPEER_COMMIT = "38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad"
-    LIVEPEER_SHA256 = "823cf8bf19963b959cbc4f8139c619af41eebcd2fdd8481de92af1d15d38700d"
+    LIVEPEER_COMMIT = "d4d6fb8670d2026b59cf471d3afd08c2f3cd1d51"
+    LIVEPEER_SHA256 = "fe90a0f0e29e41d9c6ec5aa46728fa913ad5a6996191060a328510e37bb4d46c"
 
 [env]
   SIGNER_NETWORK = "arbitrum-one-mainnet"

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -90,7 +90,7 @@ Create a `fly.toml` file (separate from this Next.js app):
 app = "pymthouse-signer"
 
 [build]
-  image = "livepeer/go-livepeer:v0.9.2"
+  image = "livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23"
 
 [env]
   SIGNER_NETWORK = "arbitrum-one-mainnet"

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -6,8 +6,8 @@ nixPkgs = ["wget", "gnutar", "coreutils"]
 
 [phases.install]
 cmds = [
-  "wget -q https://build.livepeer.live/go-livepeer/38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad/livepeer-linux-amd64.tar.gz -O livepeer-linux-amd64.tar.gz",
-  "echo '823cf8bf19963b959cbc4f8139c619af41eebcd2fdd8481de92af1d15d38700d  livepeer-linux-amd64.tar.gz' | sha256sum -c -",
+  "wget -q https://build.livepeer.live/go-livepeer/d4d6fb8670d2026b59cf471d3afd08c2f3cd1d51/livepeer-linux-amd64.tar.gz -O livepeer-linux-amd64.tar.gz",
+  "echo 'fe90a0f0e29e41d9c6ec5aa46728fa913ad5a6996191060a328510e37bb4d46c  livepeer-linux-amd64.tar.gz' | sha256sum -c -",
   "tar -xzf livepeer-linux-amd64.tar.gz",
   "mv livepeer-linux-amd64/livepeer ./livepeer",
   "chmod +x livepeer",

--- a/scripts/build-local-signer.sh
+++ b/scripts/build-local-signer.sh
@@ -3,7 +3,7 @@
 #
 # Default (fast): pull a published go-livepeer image and copy livepeer into the DMZ.
 #   ./scripts/build-local-signer.sh
-#   LIVEPEER_IMAGE=livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad ./scripts/build-local-signer.sh
+#   LIVEPEER_IMAGE=livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23 ./scripts/build-local-signer.sh
 #
 # From local checkout (slow — full CGO/FFmpeg build via lpclearinghouse):
 #   LIVEPEER_IMAGE= ./scripts/build-local-signer.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GO_LIVEPEER_DIR="${GO_LIVEPEER_DIR:-${ROOT}/../go-livepeer}"
 LPCLEARINGHOUSE_DIR="${LPCLEARINGHOUSE_DIR:-${ROOT}/../lpclearinghouse}"
-LIVEPEER_IMAGE="${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-38eb47d12ab1d2d874fc4c7c061aa1900b7c0bad}"
+LIVEPEER_IMAGE="${LIVEPEER_IMAGE:-livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23}"
 SIGNER_DMZ_IMAGE="${SIGNER_DMZ_IMAGE:-pymthouse/signer-dmz:local}"
 
 if [[ -n "${LIVEPEER_IMAGE}" ]]; then


### PR DESCRIPTION
## Summary
- Pin remote-signer go-livepeer image to `livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23`, the Docker Hub tag published by [go-livepeer#4028](https://github.com/livepeer/go-livepeer/pull/4028) (binary reports `0.9.2-d4d6fb86`).
- Update nixpacks / Fly docs tarball to `d4d6fb8670d2026b59cf471d3afd08c2f3cd1d51` on `build.livepeer.live` (PR head; matches the binary version string).
- Carries the signer fix that refreshes ticket params when nonces reach ≥ 500 so sessions do not die at the orchestrator 600-nonce cap ([python-gateway#62](https://github.com/livepeer/livepeer-python-gateway/issues/62)).

## Notes
- PR Docker builds tag `sha-<GITHUB_SHA>` with the Actions merge commit (`e60d2bc…`), while binary uploads use the branch HEAD (`d4d6fb86…`). Both artifacts are from the same successful CI run on that PR.
- go-livepeer#4028 is still open; this pins the published PR build intentionally.

## Test plan
- [x] Confirm `docker pull livepeer/go-livepeer:sha-e60d2bcaea498b73b1f203ef2fa34ba71daf9d23` and `livepeer -version` → `0.9.2-d4d6fb86`
- [x] Redeploy Railway signer (`pymthouse` / `pymthouse-signer-test`) so `LIVEPEER_IMAGE` picks up the new pin
- [ ] Smoke a long-lived metered session past ~600 tickets and confirm params rotate (no hard fail at nonce cap)